### PR TITLE
fix: address security and logic findings from Amazon Q review

### DIFF
--- a/.claude/hooks/check-design-canvas.sh
+++ b/.claude/hooks/check-design-canvas.sh
@@ -17,6 +17,11 @@ fi
 # Get current branch
 current_branch=$(git branch --show-current 2>/dev/null || echo "")
 
+# Exit early if not in a branch (e.g., detached HEAD)
+if [[ -z "$current_branch" ]]; then
+  exit 0
+fi
+
 # Skip for main/master branches and fix/hotfix branches
 if [[ "$current_branch" =~ ^(main|master|fix/|hotfix/) ]]; then
   exit 0
@@ -42,6 +47,7 @@ design_dir="$project_root/docs/designs"
 
 # If design document exists, auto-mark as complete
 if [[ -d "$design_dir" ]]; then
+  shopt -s nullglob
   for design_file in "$design_dir"/*.md; do
     [[ -f "$design_file" ]] || continue
     base_name=$(basename "$design_file" .md)

--- a/.claude/hooks/warn-skip-verification.sh
+++ b/.claude/hooks/warn-skip-verification.sh
@@ -10,13 +10,13 @@ command=$(parse_command "$input")
 
 # Check if command contains --no-verify with git push or commit
 if [[ ! "$command" =~ git[[:space:]]+(push|commit).*--no-verify ]] && \
-   [[ ! "$command" =~ git[[:space:]]+(push|commit).*-n[[:space:]] ]]; then
+   [[ ! "$command" =~ git[[:space:]]+(push|commit).* -n([[:space:]]|$) ]]; then
   exit 0
 fi
 
 # Output warning (non-blocking)
 cat >&2 <<'EOF'
-## ⚠️ Skipping Verification Detected
+## Warning: Skipping Verification Detected
 
 You're using `--no-verify` which skips pre-commit/pre-push hooks.
 

--- a/.claude/skills/github-workflow/scripts/reply-to-comments.sh
+++ b/.claude/skills/github-workflow/scripts/reply-to-comments.sh
@@ -31,7 +31,7 @@ COMMENT_ID=$(printf '%s' "$4" | sed 's/[^0-9]//g')
 MESSAGE="$5"
 
 # Validate inputs
-if [ -z "$OWNER" ] || [ -z "$REPO" ] || [ "$PR_NUMBER" -eq 0 ] || [ -z "$COMMENT_ID" ]; then
+if [ -z "$OWNER" ] || [ -z "$REPO" ] || [ "$PR_NUMBER" -eq 0 ] || [ -z "$COMMENT_ID" ] || [ -z "$MESSAGE" ]; then
     echo "Error: Invalid arguments provided"
     exit 1
 fi
@@ -42,6 +42,9 @@ gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments" \
   -X POST \
   -f body="$MESSAGE" \
   -F in_reply_to="$COMMENT_ID" \
-  --jq '{id: .id, url: .html_url}'
+  --jq '{id: .id, url: .html_url}' || {
+    echo "Error: Failed to post reply"
+    exit 1
+  }
 
 echo "Reply posted successfully!"


### PR DESCRIPTION
## Summary

- Fix security vulnerabilities and logic errors found by Amazon Q Developer when this template was used in a downstream project ([VidSyllabus PR #10](https://github.com/zxkane/VidSyllabus/pull/10))
- All findings were validated and fixes applied across 4 rounds of automated review

## Changes

### `resolve-threads.sh` (Security + Logic)
| Finding | Severity | Fix |
|---------|----------|-----|
| GraphQL injection in query - variables embedded via string interpolation | Critical (CWE-89) | Use `-F` flag for parameterized GraphQL variables |
| GraphQL injection in mutation - same pattern | Critical (CWE-89) | Use `-F threadId` with `mutation($threadId: ID!)` |
| Hard-coded 50 thread limit silently drops threads | Medium | Increased to 100 (GraphQL API max) |

### `reply-to-comments.sh` (Security + Robustness)
| Finding | Severity | Fix |
|---------|----------|-----|
| Missing error handling for `gh api` call | Medium (CWE-78) | Added `|| { echo "Error"; exit 1; }` |
| MESSAGE parameter not validated for empty | Medium (CWE-20) | Added `-z "$MESSAGE"` to validation check |

### `check-design-canvas.sh` (Logic)
| Finding | Severity | Fix |
|---------|----------|-----|
| Crash in detached HEAD state | Medium | Added early exit when `current_branch` is empty |
| Glob pattern iterates on literal when no matches | Low | Added `shopt -s nullglob` |

### `warn-skip-verification.sh` (Logic)
| Finding | Severity | Fix |
|---------|----------|-----|
| `-n` flag regex doesn't match end-of-command | Medium | Changed `.*-n[[:space:]]` to `.*-n([[:space:]]&#124;$)` |

## Test Plan
- [x] All fixes validated through 4 rounds of Amazon Q automated review
- [x] Scripts tested in downstream project (VidSyllabus)
- [x] No functional regressions observed