### PR TITLE
feat(skills): sync bot review integration and token refresh improvements

### DIFF
--- a/.claude/skills/autonomous-dev/SKILL.md
+++ b/.claude/skills/autonomous-dev/SKILL.md
@@ -25,6 +25,7 @@ This skill wraps the standard github-workflow for autonomous execution. You are 
 5. Execute Steps 1-12 of github-workflow autonomously with these adaptations:
    - Step 1 (Design): Create design doc, skip user approval
    - **After each requirement implemented**: Mark checkbox (see "Marking Requirements Progress")
+   - Step 7 (PR creation): Trigger bot review if configured (see "Bot Review Integration")
    - Step 12 (Verification): Run verification, then STOP (don't wait for user merge)
 6. Post progress comments to the issue at each major milestone:
    - After design canvas created
@@ -119,6 +120,74 @@ git commit -m "apply: pre-existing workspace changes from issue #<number>"
 - If cherry-pick or apply fails due to conflicts, log a warning in the issue comment and proceed with normal development
 - If the branch does not exist, skip silently
 - Always continue with normal development after applying (or failing to apply) pre-existing changes
+
+## Bot Review Integration
+
+After creating a PR, the dev agent should trigger and handle any configured bot reviewers (e.g., Amazon Q Developer, Codex).
+
+### Trigger Bot Review
+
+Some bot reviewers ignore comments posted by GitHub App bot accounts. If your project uses `scripts/gh-as-user.sh`, use it to trigger bot reviews so the comment is attributed to a real user:
+
+```bash
+bash scripts/gh-as-user.sh pr comment {pr_number} --body "/q review"
+```
+
+> **Do NOT use the default `gh` wrapper** (`gh-with-token-refresh.sh`) for bot review triggers — it authenticates as a bot, which some reviewers ignore. All other `gh` operations should continue using the default `gh` wrapper.
+
+### Wait for Bot Review
+
+Poll for bot review to appear (timeout 3 minutes):
+
+```bash
+# Poll every 30 seconds for up to 3 minutes
+for i in $(seq 1 6); do
+  REVIEWS=$(gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews \
+    --jq '[.[] | select(.user.login == "<bot-login>")] | length')
+  if [ "$REVIEWS" -gt 0 ]; then
+    echo "Bot review found"
+    break
+  fi
+  sleep 30
+done
+```
+
+### Handle Bot Review Findings
+
+After bot review appears, read and address all findings:
+
+1. **Read bot review comments**: Use `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments` and filter by bot author
+2. **For each finding**:
+   - **Real issue**: fix it, commit, push
+   - **False positive**: reply explaining why, resolve the thread
+3. **Re-trigger** bot review via `bash scripts/gh-as-user.sh pr comment {pr_number} --body "<trigger command>"` if fixes were pushed
+4. **Iterate** until no unresolved bot findings remain
+
+If bot review does not appear within 3 minutes, proceed without it — the review agent will re-trigger bot review during its verification step.
+
+## Local E2E Verification (Before Push)
+
+Before pushing changes that modify E2E tests or UI components, verify the changes are sound:
+
+1. **If E2E tests were modified**, run a quick local check:
+   ```bash
+   # Verify TypeScript compilation of E2E tests (if using TypeScript)
+   bunx tsc --noEmit --project tsconfig.json
+
+   # Verify test helper imports are correct
+   grep -l "takeScreenshot" e2e/*.spec.ts
+   ```
+
+2. **Screenshot generation will be verified in CI** — ensure your Playwright config includes a JSON reporter and screenshot helpers save to a known directory. CI should upload these as artifacts.
+
+3. **Local dev server**: For local E2E testing:
+   ```bash
+   # Option A: Let Playwright start the dev server automatically
+   bunx playwright test
+
+   # Option B: Start dev server manually first
+   PLAYWRIGHT_BASE_URL=http://localhost:3000 bunx playwright test
+   ```
 
 ## Decision Making Guidelines
 

--- a/scripts/gh-with-token-refresh.sh
+++ b/scripts/gh-with-token-refresh.sh
@@ -14,10 +14,24 @@ REAL_GH=$(PATH="$CLEAN_PATH" command -v gh 2>/dev/null) || {
   exit 1
 }
 
-# Read latest token from file if available
-if [[ -n "$GH_TOKEN_FILE" && -s "$GH_TOKEN_FILE" ]]; then
-  export GH_TOKEN=$(cat "$GH_TOKEN_FILE")
-  export GITHUB_PERSONAL_ACCESS_TOKEN="$GH_TOKEN"
+# Read latest token from file if available.
+# Retry briefly if the file is momentarily empty (race during daemon refresh).
+# IMPORTANT: Never fall through without a token — the host `gh auth` session
+# may be logged in as a different user (e.g., the repo owner), which would
+# cause comments to be attributed to that user instead of the bot.
+if [[ -n "${GH_TOKEN_FILE:-}" ]]; then
+  for _attempt in 1 2 3; do
+    if [[ -s "$GH_TOKEN_FILE" ]]; then
+      export GH_TOKEN=$(cat "$GH_TOKEN_FILE")
+      export GITHUB_PERSONAL_ACCESS_TOKEN="$GH_TOKEN"
+      break
+    fi
+    sleep 1
+  done
+  if [[ -z "${GH_TOKEN:-}" ]]; then
+    echo "ERROR: GH_TOKEN_FILE is set but token file is empty after retries: $GH_TOKEN_FILE" >&2
+    exit 1
+  fi
 fi
 
 exec "$REAL_GH" "$@"


### PR DESCRIPTION
## Summary

Syncs battle-tested improvements from the VidSyllabus production pipeline back to the public template repo:

- **autonomous-dev SKILL.md**: Add "Bot Review Integration" section (generalized from Amazon Q Developer workflow) and "Local E2E Verification" section for pre-push checks
- **gh-with-token-refresh.sh**: Add retry logic with 3 attempts for race condition during daemon token file refresh, plus safety guard to prevent wrong-user attribution

## Changes

### `.claude/skills/autonomous-dev/SKILL.md`

1. **Bot Review Integration** — New section documenting how the dev agent should trigger and handle bot reviewers after creating a PR:
   - Trigger via `gh-as-user.sh` (not the default `gh` wrapper, since bots ignore bot-authored comments)
   - Poll for review with timeout
   - Handle findings (fix or explain false positives)
   - Iterate until no unresolved findings remain

2. **Local E2E Verification** — New section with pre-push checklist for E2E test modifications:
   - TypeScript compilation check
   - Screenshot helper import verification
   - Local dev server options for Playwright

3. **Workflow step 7 adaptation** — Added note to trigger bot review during PR creation step

### `scripts/gh-with-token-refresh.sh`

- **Retry logic**: When `GH_TOKEN_FILE` is set but momentarily empty (race during daemon's atomic `mv` refresh), retry up to 3 times with 1s delay instead of silently proceeding without a token
- **Safety guard**: If token file remains empty after retries, exit with error instead of falling through to host `gh auth` session (which may be a different user, causing wrong attribution)
- **Defensive default**: Use `${GH_TOKEN_FILE:-}` to avoid unbound variable errors

## Context

These improvements were developed and validated in the VidSyllabus autonomous pipeline over multiple production cycles. The bot review workflow was originally Amazon Q-specific but has been generalized here to work with any bot reviewer.