### PR TITLE
fix(scripts): replace hardcoded sleep with polling loop in lib-auth.sh

### DIFF
--- a/scripts/lib-auth.sh
+++ b/scripts/lib-auth.sh
@@ -41,9 +41,17 @@ setup_github_auth() {
       "$GH_TOKEN_FILE" "$app_id" "$app_pem" "$REPO_OWNER" "$REPO_NAME" &
     TOKEN_DAEMON_PID=$!
 
-    sleep 1
+    # Poll for token file (token generation involves multiple API calls and
+    # can take >1s depending on network latency)
+    local _wait_max=10
+    local _waited=0
+    while [[ $_waited -lt $_wait_max ]] && [[ ! -s "$GH_TOKEN_FILE" ]]; do
+      sleep 1
+      _waited=$((_waited + 1))
+    done
+
     if [[ ! -s "$GH_TOKEN_FILE" ]]; then
-      echo "FATAL: Token daemon failed to write initial token" >&2
+      echo "FATAL: Token daemon failed to write initial token after ${_wait_max}s" >&2
       kill "$TOKEN_DAEMON_PID" 2>/dev/null || true
       return 1
     fi


### PR DESCRIPTION
## Summary

- Replace the single `sleep 1` + immediate check in `setup_github_auth()` with a polling loop that retries every 1s for up to 10s
- Prevents intermittent `FATAL: Token daemon failed to write initial token` failures when token generation takes longer than 1 second due to network latency or load
- Error message now includes the timeout duration for easier debugging

Cherry-picked from zxkane/contract-revise@b7a7e5ed (`scripts/lib-auth.sh` change only).

## Changes

- `scripts/lib-auth.sh`: Replace lines 44–47 with a bounded polling loop (max 10s, 1s intervals)