### PR TITLE
feat(scripts): add --name flag to agent sessions for descriptive display names

### DIFF
--- a/scripts/autonomous-dev.sh
+++ b/scripts/autonomous-dev.sh
@@ -203,10 +203,11 @@ If you encounter a blocking error, document it in a comment on issue #${ISSUE_NU
 EOF
 )"
 
-  log "Starting new session: ${SESSION_ID}"
+  SESSION_NAME="dev-issue-${ISSUE_NUMBER}"
+  log "Starting new session: ${SESSION_ID} (name: ${SESSION_NAME})"
   AGENT_RAN=true
   set +e
-  run_agent "$SESSION_ID" "$PROMPT" "$AGENT_DEV_MODEL" 2>&1
+  run_agent "$SESSION_ID" "$PROMPT" "$AGENT_DEV_MODEL" "$SESSION_NAME" 2>&1
   AGENT_EXIT=$?
   set -e
 
@@ -261,7 +262,7 @@ EOF
   log "Resuming session: ${SESSION_ID}"
   AGENT_RAN=true
   set +e
-  resume_agent "$SESSION_ID" "$RESUME_PROMPT" "$AGENT_DEV_MODEL" 2>&1
+  resume_agent "$SESSION_ID" "$RESUME_PROMPT" "$AGENT_DEV_MODEL" "" 2>&1
   AGENT_EXIT=$?
   set -e
 
@@ -274,6 +275,7 @@ EOF
       --body "Resume failed (session \`${SESSION_ID}\`). Starting new session \`${NEW_SESSION_ID}\`." 2>/dev/null || true
 
     SESSION_ID="$NEW_SESSION_ID"
+    SESSION_NAME="dev-issue-${ISSUE_NUMBER}-retry"
 
     # Re-fetch issue for full context
     ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title,body -q '.')
@@ -319,7 +321,7 @@ EOF
 
     AGENT_RAN=true
     set +e
-    run_agent "$SESSION_ID" "$FULL_PROMPT" "$AGENT_DEV_MODEL" 2>&1
+    run_agent "$SESSION_ID" "$FULL_PROMPT" "$AGENT_DEV_MODEL" "$SESSION_NAME" 2>&1
     AGENT_EXIT=$?
     set -e
   fi

--- a/scripts/autonomous-review.sh
+++ b/scripts/autonomous-review.sh
@@ -429,7 +429,8 @@ EOF
 # ---------------------------------------------------------------------------
 # Run review agent
 # ---------------------------------------------------------------------------
-log "Starting review session: ${SESSION_ID} (model: ${AGENT_REVIEW_MODEL:-sonnet})"
+SESSION_NAME="review-pr-${PR_NUMBER}-issue-${ISSUE_NUMBER}"
+log "Starting review session: ${SESSION_ID} (name: ${SESSION_NAME}, model: ${AGENT_REVIEW_MODEL:-sonnet})"
 
 # Export E2E credentials as env vars (not in prompt) for agent to read at runtime
 if [[ "${E2E_ENABLED:-false}" == "true" ]]; then
@@ -438,7 +439,7 @@ if [[ "${E2E_ENABLED:-false}" == "true" ]]; then
 fi
 
 set +e
-run_agent "$SESSION_ID" "$PROMPT" "${AGENT_REVIEW_MODEL:-sonnet}" 2>&1
+run_agent "$SESSION_ID" "$PROMPT" "${AGENT_REVIEW_MODEL:-sonnet}" "$SESSION_NAME" 2>&1
 AGENT_EXIT=$?
 set -e
 

--- a/scripts/lib-agent.sh
+++ b/scripts/lib-agent.sh
@@ -22,16 +22,18 @@ AGENT_PERMISSION_MODE="${AGENT_PERMISSION_MODE:-auto}"
 KIRO_AGENT_NAME="${KIRO_AGENT_NAME:-autonomous-dev}"
 
 # Run agent with a new session.
-# Args: $1=session_id, $2=prompt, $3=model (optional)
+# Args: $1=session_id, $2=prompt, $3=model (optional), $4=session_name (optional)
 run_agent() {
   local session_id="$1"
   local prompt="$2"
   local model="${3:-}"
+  local session_name="${4:-}"
 
   case "$AGENT_CMD" in
     claude)
       # Unset CLAUDECODE to allow launching from within an existing session
       env -u CLAUDECODE "$AGENT_CMD" --session-id "$session_id" \
+        ${session_name:+--name "$session_name"} \
         --permission-mode "$AGENT_PERMISSION_MODE" \
         ${model:+--model "$model"} \
         -p "$prompt" \
@@ -60,15 +62,20 @@ run_agent() {
 }
 
 # Resume an existing agent session.
-# Args: $1=session_id, $2=prompt, $3=model (optional)
+# Args: $1=session_id, $2=prompt, $3=model (optional), $4=session_name (optional)
+# Note: --name may not update the display name on resume (session was already
+# named at creation). It is still passed through for kiro/fallback paths that
+# start a new session instead of resuming.
 resume_agent() {
   local session_id="$1"
   local prompt="$2"
   local model="${3:-}"
+  local session_name="${4:-}"
 
   case "$AGENT_CMD" in
     claude)
       # Unset CLAUDECODE to allow launching from within an existing session
+      # --name is omitted: the session retains the name set at creation.
       env -u CLAUDECODE "$AGENT_CMD" --resume "$session_id" \
         --permission-mode "$AGENT_PERMISSION_MODE" \
         ${model:+--model "$model"} \
@@ -80,11 +87,11 @@ resume_agent() {
       # the resumed context sees "all done" and exits immediately.
       # Fall back to a new session so the full prompt (with review findings)
       # is treated as fresh instructions.
-      run_agent "$session_id" "$prompt" "$model"
+      run_agent "$session_id" "$prompt" "$model" "$session_name"
       ;;
     *)
       # Agents without resume support start a new session
-      run_agent "$session_id" "$prompt" "$model"
+      run_agent "$session_id" "$prompt" "$model" "$session_name"
       ;;
   esac
 }


### PR DESCRIPTION
## Summary
- Leverage Claude Code 2.1.76's new `-n`/`--name` CLI flag to give autonomous pipeline sessions human-readable display names instead of opaque UUIDs
- Session names: `dev-issue-{N}`, `dev-issue-{N}-retry`, `review-pr-{PR}-issue-{N}`
- Resume sessions retain the name set at creation (`--name` is not passed on `--resume`)

## Changes
| File | Change |
|------|--------|
| `scripts/lib-agent.sh` | Added optional `$4=session_name` to `run_agent()` and `resume_agent()` |
| `scripts/autonomous-dev.sh` | Sets `SESSION_NAME` for new/retry paths |
| `scripts/autonomous-review.sh` | Sets `SESSION_NAME` for review sessions |

## Test Plan
- [x] Verified `claude --name "dev-issue-99"` creates a named session
- [x] Verified `claude --resume <id>` retains the name without re-passing `--name`
- [x] Backward compatible — `$4` defaults to empty, existing callers unaffected
- [x] Code simplification review passed
- [x] PR review agent review passed
- [ ] CI checks pass