### PR TITLE
fix(review): detect requirement changes in issue comments before approving

### DIFF
--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -237,6 +237,23 @@ Quick reference:
    \`git push --force-with-lease origin ${PR_BRANCH}\`. Then exit.
 5. If "UNKNOWN" — wait 10s and retry up to 3 times
 
+## Step 0.5: Requirement Drift Detection — MANDATORY PRE-REVIEW
+
+**Before reading the PR diff**, read ALL comments on issue #${ISSUE_NUMBER} to detect requirement changes posted after implementation:
+
+\`\`\`bash
+gh issue view ${ISSUE_NUMBER} --repo ${REPO} --json comments \\
+  -q '.comments[] | "\\(.author.login) [\\(.createdAt)]: \\(.body[0:500])"'
+\`\`\`
+
+Look for:
+- Scope changes ("remove", "no longer", "drop", "don't support", "instead of")
+- New requirements added after the original issue
+- Corrections or clarifications from the repo owner (@${REPO_OWNER})
+- Explicit instructions to the dev agent that may not yet be reflected in the PR code
+
+**If any requirement change is found that the PR code does NOT reflect, this is a [BLOCKING] Requirement drift finding.** Quote the comment and list the specific code that needs updating.
+
 ## Review Checklist
 Verify ALL of the following were completed:
 
@@ -269,12 +286,13 @@ Read the issue body for an \`## Acceptance Criteria\` section. For EACH criterio
 
 ## Review Process
 1. Read the issue body to understand requirements
-2. Read the PR diff to verify implementation
-3. Verify acceptance criteria (see above)
-4. Check that CI checks are passing: gh pr checks ${PR_NUMBER}
-5. Verify test coverage and quality
-6. Check for security issues, code quality, and best practices
-7. Trigger and verify Amazon Q Developer review (see below)
+2. Read ALL issue comments to detect requirement changes (Step 0.5 above)
+3. Read the PR diff to verify implementation
+4. Verify acceptance criteria (see above)
+5. Check that CI checks are passing: gh pr checks ${PR_NUMBER}
+6. Verify test coverage and quality
+7. Check for security issues, code quality, and best practices
+8. Trigger and verify Amazon Q Developer review (see below)
 
 ## Amazon Q Developer Review — MANDATORY
 
@@ -374,7 +392,7 @@ Post a structured comment on PR #${PR_NUMBER} (NOT the issue) with this format:
 
 ### Summary
 | Total | Passed | Failed | Skipped |
-|-------|--------|--------|---------|
+|-------|--------|--------|--------|
 | N     | X      | Y      | Z       |
 
 ### Happy Path Results
@@ -407,13 +425,13 @@ fi)
 ## Decision
 After thorough review:
 
-- If ALL checklist items pass AND code quality is good$(if [[ "${E2E_ENABLED:-false}" == "true" ]]; then echo " AND all E2E tests pass"; fi):
+- If ALL checklist items pass AND code quality is good$(if [[ "${E2E_ENABLED:-false}" == "true" ]]; then echo " AND all E2E tests pass"; fi) AND no requirement drift detected:
   Post a comment on issue #${ISSUE_NUMBER} with:
-  "Review PASSED - All checklist items verified, code quality good.$(if [[ "${E2E_ENABLED:-false}" == "true" ]]; then echo " E2E verification completed."; fi)
+  "Review PASSED - All checklist items verified, code quality good.$(if [[ "${E2E_ENABLED:-false}" == "true" ]]; then echo " E2E verification completed."; fi) No requirement drift.
   Review Session: \`${SESSION_ID}\`"
   Then exit.
 
-- If ANY item fails$(if [[ "${E2E_ENABLED:-false}" == "true" ]]; then echo " OR any E2E test fails OR preview URL is unavailable"; fi):
+- If ANY item fails$(if [[ "${E2E_ENABLED:-false}" == "true" ]]; then echo " OR any E2E test fails OR preview URL is unavailable"; fi) OR requirement drift is detected:
   Post a comment on issue #${ISSUE_NUMBER} with:
   "Review findings:"
   followed by a numbered list of each failing item with specific remediation instructions.$(if [[ "${E2E_ENABLED:-false}" == "true" ]]; then echo "

--- a/skills/autonomous-review/SKILL.md
+++ b/skills/autonomous-review/SKILL.md
@@ -98,15 +98,38 @@ MERGEABLE=$(gh pr view <PR_NUMBER> --repo <REPO> --json mergeable -q '.mergeable
 ## Review Process
 
 1. **Read the issue** to understand requirements
-2. **Read the PR diff** thoroughly (`gh pr diff <number>`)
-3. **Check CI status** (`gh pr checks <number>`)
-4. **Read the files** for design docs, test cases, etc. to verify they exist
-5. **Assess code quality** against the checklist above
-6. **Verify bot reviewer findings** (if configured — see checklist section 5)
-7. **Select happy path test cases** based on PR diff analysis (see below)
-8. **Perform E2E verification** (if configured — see procedure below)
-9. **Mark acceptance criteria** — for each verified criterion, mark its checkbox in the issue body (see "Marking Acceptance Criteria")
-10. **MANDATORY SELF-CHECK GATE** — execute the Findings->Decision Gate (see below) BEFORE submitting any review verdict
+2. **Read ALL issue comments** to detect requirement changes (see "Requirement Drift Detection" below)
+3. **Read the PR diff** thoroughly (`gh pr diff <number>`)
+4. **Check CI status** (`gh pr checks <number>`)
+5. **Read the files** for design docs, test cases, etc. to verify they exist
+6. **Assess code quality** against the checklist above
+7. **Verify bot reviewer findings** (if configured — see checklist section 5)
+8. **Select happy path test cases** based on PR diff analysis (see below)
+9. **Perform E2E verification** (if configured — see procedure below)
+10. **Mark acceptance criteria** — for each verified criterion, mark its checkbox in the issue body (see "Marking Acceptance Criteria")
+11. **MANDATORY SELF-CHECK GATE** — execute the Findings->Decision Gate (see below) BEFORE submitting any review verdict
+
+## Requirement Drift Detection — MANDATORY
+
+> **This step MUST be performed BEFORE reading the PR diff. Requirements can change after implementation via issue comments from the repo owner or maintainers.**
+
+Read ALL comments on the issue (not just the body) and look for:
+- Scope changes ("remove", "no longer", "drop", "don't support", "instead of")
+- New requirements added after the original issue was created
+- Corrections or clarifications from the repo owner
+- Explicit instructions to the dev agent that may not yet be reflected in the PR code
+
+```bash
+# Read all issue comments to check for requirement changes
+gh issue view <ISSUE_NUMBER> --repo <REPO> --json comments \
+  -q '.comments[] | "\(.author.login) [\(.createdAt)]: \(.body[0:500])"'
+```
+
+If any requirement change is found that the PR code does **NOT** reflect:
+- This is a **[BLOCKING] Requirement drift** finding
+- The PR must be sent back to dev with specific instructions about what changed
+- Quote the comment that changed the requirement
+- List the specific code/files that need to be updated
 
 ## Happy Path Test Cases
 

--- a/skills/autonomous-review/references/decision-gate.md
+++ b/skills/autonomous-review/references/decision-gate.md
@@ -2,20 +2,21 @@
 
 > **This gate is NON-NEGOTIABLE. Execute this self-check BEFORE submitting any PR review (APPROVE or REQUEST_CHANGES) and BEFORE posting the verdict comment on the issue. If this gate is skipped, the review is invalid.**
 
-After completing steps 1-9, all findings across checklist categories will have been collected. Before making the PASS/FAIL decision, execute the following self-check:
+After completing steps 1-11, all findings across checklist categories will have been collected. Before making the PASS/FAIL decision, execute the following self-check:
 
 ## Gate Procedure
 
-1. **Enumerate all findings** — list every issue identified during steps 3-9, no matter how minor. Include:
+1. **Enumerate all findings** — list every issue identified during steps 3-11, no matter how minor. Include:
    - Process compliance gaps (missing docs, missing tests, unchecked PR items)
    - Code quality issues
    - CI check failures or pending checks
    - E2E test failures
    - Acceptance criteria that could not be verified
+   - **Requirement drift** (issue comments show requirement changes not reflected in PR code)
 
 2. **Classify each finding** as BLOCKING or NON-BLOCKING:
    | Category | Blocking? | Examples |
-   |----------|-----------|---------|
+   |----------|-----------|--------|
    | Missing design doc | BLOCKING | No `docs/plans/` or `docs/designs/` file |
    | Missing test case doc | BLOCKING | No `docs/test-cases/` file |
    | Missing unit tests for new code | BLOCKING | New hook/component with 0 tests |
@@ -24,6 +25,7 @@ After completing steps 1-9, all findings across checklist categories will have b
    | Acceptance criteria not verified | BLOCKING | Any AC checkbox left unchecked |
    | Security vulnerability | BLOCKING | Credentials, injection, etc. |
    | PR checklist item unchecked | BLOCKING | Required items not marked |
+   | Requirement drift | BLOCKING | Issue comments show requirement changes (e.g. scope reduction, feature removal, new constraints) not reflected in PR code |
    | Minor style suggestion | NON-BLOCKING | Naming preference, optional refactor |
    | Bot review missing (after timeout) | NON-BLOCKING | Best-effort per existing policy |
 
@@ -37,10 +39,13 @@ After completing steps 1-9, all findings across checklist categories will have b
    - "Are all CI checks in 'pass' state (not 'pending', not 'fail')?" -> If NO -> FAIL
    - "Did I successfully mark ALL Acceptance Criteria checkboxes?" -> If NO -> FAIL
    - "Did I write the phrase 'must be resolved before this PR can be approved' or similar in my findings?" -> If YES -> that means I found blocking issues -> FAIL
+   - "Did I find any requirement changes in issue comments that are NOT reflected in the PR code?" -> If YES -> FAIL
 
 ## Why This Gate Exists
 
 In a previous review, the review agent posted multiple blocking findings (missing design doc, missing test cases, missing unit tests, CI pending, PR checklist unchecked) and then immediately approved the PR anyway. The E2E pass "felt" sufficient, but the skill explicitly requires ALL checklist items to be satisfied. This gate prevents that disconnect by forcing the agent to reconcile findings with the verdict before acting.
+
+In another incident, the repo owner posted a requirement change ("remove PDF support") as an issue comment after the PR was already implemented. The review agent approved the PR without reading the comment, because it only checked the issue body and PR diff — not the comment thread. The "requirement drift" category was added to catch this class of bugs.
 
 ## Decision Criteria
 
@@ -55,6 +60,7 @@ In a previous review, the review agent posted multiple blocking findings (missin
 - **All CI checks are in "pass" state** (not "pending", not "queued", not "fail")
 - E2E verification passes (if configured)
 - **All Acceptance Criteria checkboxes marked as checked in the issue body**
+- **No requirement drift detected** (issue comments don't contain unaddressed requirement changes)
 - **The Findings->Decision Gate produced ZERO blocking findings**
 
 ### FAIL (post "Review findings:" + do NOT approve the PR)
@@ -69,6 +75,7 @@ In a previous review, the review agent posted multiple blocking findings (missin
 - **Any happy path test case fails** (if E2E configured)
 - **Preview URL is not available** (if E2E configured)
 - **Any Acceptance Criteria checkbox remains unchecked**
+- **Requirement drift detected** (issue comments contain requirement changes not reflected in PR)
 - **The Findings->Decision Gate produced one or more blocking findings**
 
 When failing, provide SPECIFIC and ACTIONABLE feedback:
@@ -76,6 +83,7 @@ When failing, provide SPECIFIC and ACTIONABLE feedback:
 - Explain why it's an issue
 - Suggest the fix
 - Include E2E failure screenshots as evidence (if available)
+- **For requirement drift: quote the issue comment that changed the requirement and list specific files/code that need updating**
 
 ## Output Format
 
@@ -85,7 +93,7 @@ Post the review result as a comment on the issue (NOT the PR).
 
 **Action pairing — these MUST match:**
 | Verdict | Issue comment | PR review action |
-|---------|--------------|-----------------|
+|---------|--------------|------------------|
 | PASS | Post "Review PASSED" | Submit APPROVE review on PR |
 | FAIL | Post "Review findings:" | Do NOT submit any review (or submit REQUEST_CHANGES) |
 
@@ -104,6 +112,7 @@ Summary:
 - Code: Clean, follows project conventions
 - E2E: All N test cases passed (including M happy path), K regression checks passed
 - Happy path: TC-HP-XXX executed, plan generation verified
+- Requirement drift: None detected
 ```
 
 For FAIL:
@@ -118,8 +127,10 @@ Findings->Decision Gate: N blocking finding(s) — FAIL.
    - Evidence: [inline screenshot in PR E2E report comment]
    - Action: Fix plan generation to respect duration requirements
 
-2. **[BLOCKING] Missing test cases** - No test case document found in docs/test-cases/
-   - Action: Create docs/test-cases/<feature>.md following the template in CLAUDE.md
+2. **[BLOCKING] Requirement drift** - PDF support removal not implemented
+   - Issue comment by @owner (2026-03-18): "移除 PDF 支持，转换效果不好"
+   - PR still contains PDF upload, conversion, and test code
+   - Action: Remove .pdf from frontend accept, backend API, Lambda handler, and tests
 
 3. **[BLOCKING] CI check pending** - Deploy Preview not yet passed
    - Action: Wait for deployment to complete before requesting review


### PR DESCRIPTION
## Summary

The review agent was approving PRs without checking for requirement changes posted as issue comments after the initial implementation. This caused a real-world bug where a "remove PDF support" requirement change was posted as an issue comment, but the review agent approved the PR multiple times without ever reading it — because it only checked the issue body and PR diff, not the comment thread.

## Root Cause

The review skill's "Review Process" told the agent to:
1. Read the issue **body** for requirements
2. Read the PR diff

But requirement **changes** are posted as **issue comments** (not body edits). The agent had no instruction to scan comments for scope changes, so it never detected the drift between requirements and implementation.

## Changes

### 1. `SKILL.md` — Add "Requirement Drift Detection" step (High priority)
- New mandatory section: "Requirement Drift Detection — MANDATORY"
- Inserted as step 2 in Review Process (before reading PR diff)
- Instructs agent to read ALL issue comments and look for scope changes
- Classifies unaddressed requirement changes as BLOCKING findings

### 2. `autonomous-review.sh` — Add Step 0.5 to review prompt (High priority)
- New "Step 0.5: Requirement Drift Detection" in the prompt template
- Includes `gh issue view` command to read all comments
- Lists specific keywords to look for ("remove", "no longer", "drop", etc.)
- Explicitly states requirement drift = BLOCKING finding
- Updated Decision section to include "no requirement drift" in PASS criteria

### 3. `decision-gate.md` — Add "Requirement drift" BLOCKING category (Medium priority)
- New row in classification table: `Requirement drift | BLOCKING`
- New self-check question: "Did I find any requirement changes in issue comments that are NOT reflected in the PR code?"
- Added to PASS criteria: "No requirement drift detected"
- Added to FAIL criteria: "Requirement drift detected"
- New example in FAIL output format showing requirement drift finding
- Added historical context in "Why This Gate Exists" section

## Real-World Incident

During a feature implementation for `.doc` and `.pdf` upload support:
1. Dev agent implemented both formats, PR created
2. Repo owner posted issue comment: "remove PDF support, conversion quality is poor"
3. `dev-resume` restored old session context → exited immediately ("work complete")
4. `dev-new` made the code changes but couldn't commit (hook restrictions)
5. Review agent ran and approved the PR **without reading the comment** — multiple times
6. PDF code remained in the PR despite the requirement change

With this fix, the review agent would have:
- Read the issue comment about removing PDF
- Compared it against the PR code (which still had PDF support)
- Flagged `[BLOCKING] Requirement drift` and sent the PR back to dev

## Test Plan

- [ ] Deploy updated skill to a project with the autonomous pipeline
- [ ] Post a requirement change as an issue comment after PR is created
- [ ] Run review agent — verify it detects the drift and FAILs the review
- [ ] Verify normal reviews (no drift) still PASS correctly