### PR TITLE
fix: resolve symlinks in SCRIPT_DIR for wrapper scripts

### DIFF
--- a/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$([ -L "$0" ] && readlink "$0" || echo "$0")")" && pwd)"
 source "${SCRIPT_DIR}/lib-agent.sh"
 source "${SCRIPT_DIR}/lib-auth.sh"
 

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -14,7 +14,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || echo "$0")")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$([ -L "$0" ] && readlink "$0" || echo "$0")")" && pwd)"
 source "${SCRIPT_DIR}/lib-agent.sh"
 source "${SCRIPT_DIR}/lib-auth.sh"
 


### PR DESCRIPTION
## Summary

Fix `SCRIPT_DIR` resolution in `autonomous-dev.sh` and `autonomous-review.sh` to follow symlinks, so `lib-agent.sh` and `lib-auth.sh` can be found when the wrapper scripts are symlinked from a project's `scripts/` directory.

Fixes #28

## Problem

When projects install these skills via `npx skills add` and create symlinks in their `scripts/` directory:

```
scripts/
├── autonomous-dev.sh -> ../.claude/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
├── autonomous-review.sh -> ../.claude/skills/autonomous-dispatcher/scripts/autonomous-review.sh
├── autonomous.conf
└── (no lib-agent.sh or lib-auth.sh here)
```

`dispatch-local.sh` calls `${PROJECT_DIR}/scripts/autonomous-dev.sh`. Since `$0` is the symlink path, `dirname "$0"` resolves to `scripts/` — not the target directory where `lib-agent.sh` lives. Every dispatch crashes immediately:

```
scripts/autonomous-dev.sh: line 18: /path/to/project/scripts/lib-agent.sh: No such file or directory
```

## Fix

```bash
# Before (line 17):
SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

# After (portable, works on GNU/Linux + macOS/BSD):
SCRIPT_DIR="$(cd "$(dirname "$([ -L "$0" ] && readlink "$0" || echo "$0")")" && pwd)"
```

Uses `[ -L "$0" ]` to check if `$0` is a symlink, then `readlink` (without `-f`) to resolve it portably. Falls back to `$0` for non-symlink invocations. Single-level resolution is sufficient since projects create direct symlinks to the skill scripts.

## Changed files

| File | Change |
|------|--------|
| `autonomous-dev.sh` | Line 17: resolve symlinks in `SCRIPT_DIR` |
| `autonomous-review.sh` | Line 17: resolve symlinks in `SCRIPT_DIR` |

## Test plan

```bash
# Create a symlink setup similar to project usage:
mkdir -p /tmp/test-project/scripts
ln -s /path/to/skills/autonomous-dispatcher/scripts/autonomous-dev.sh /tmp/test-project/scripts/autonomous-dev.sh

# Before fix: SCRIPT_DIR = /tmp/test-project/scripts (wrong)
# After fix:  SCRIPT_DIR = /path/to/skills/autonomous-dispatcher/scripts (correct)
```

Verified on Ubuntu 24.04 (bash 5.2, coreutils readlink).

## Amazon Q Review Notes

- **1st review**: Flagged `readlink -f` as GNU-specific portability issue → applied suggested portable pattern ✅
- **2nd review**: Flagged missing `-f` as logic error → false positive, contradicts 1st review. Single-level `readlink` is intentional for macOS/BSD portability. Symlink chains don't occur in this use case.