### PR TITLE
fix(skills): use gh-as-user.sh for bot review triggers

### DIFF
--- a/skills/autonomous-dev/SKILL.md
+++ b/skills/autonomous-dev/SKILL.md
@@ -420,13 +420,17 @@ Multiple review bots can provide automated code review findings on PRs:
 
 ### Retrigger Bot Reviews
 
+> **IMPORTANT:** Some bot reviewers (e.g., Amazon Q Developer) ignore `/q review` comments posted by GitHub App bot accounts. If your project uses `scripts/gh-as-user.sh`, you **MUST** use it to trigger bot reviews so the comment is attributed to a real user. Do NOT use the default `gh` wrapper for bot review triggers.
+
 ```bash
-# Amazon Q Developer
-gh pr comment {pr_number} --body "/q review"
+# Amazon Q Developer (use gh-as-user.sh to post as a real user)
+bash scripts/gh-as-user.sh pr comment {pr_number} --body "/q review"
 
 # Codex
-gh pr comment {pr_number} --body "/codex review"
+bash scripts/gh-as-user.sh pr comment {pr_number} --body "/codex review"
 ```
+
+If `scripts/gh-as-user.sh` is not available in your project, use `gh pr comment` directly as a fallback.
 
 Wait 60-90 seconds for the review to complete, then check for new comments.
 

--- a/skills/autonomous-dev/references/review-commands.md
+++ b/skills/autonomous-dev/references/review-commands.md
@@ -65,15 +65,17 @@ gh api repos/{owner}/{repo}/pulls/{pr}/reviews \
 
 ### Trigger Bot Reviews
 
-Add a comment to trigger bot rescans:
+> **IMPORTANT:** Some bot reviewers (e.g., Amazon Q Developer) ignore comments posted by GitHub App bot accounts. If your project has `scripts/gh-as-user.sh`, use it so the comment is attributed to a real user.
 
 ```bash
-# Amazon Q Developer
-gh pr comment {pr} --body "/q review"
+# Amazon Q Developer (post as real user — bots ignore bot-posted triggers)
+bash scripts/gh-as-user.sh pr comment {pr} --body "/q review"
 
 # Codex
-gh pr comment {pr} --body "/codex review"
+bash scripts/gh-as-user.sh pr comment {pr} --body "/codex review"
 ```
+
+If `scripts/gh-as-user.sh` is not available, fall back to `gh pr comment` directly.
 
 ### Monitor PR Checks
 
@@ -235,13 +237,13 @@ gh api repos/{owner}/{repo}/pulls/{pr}/comments \
 # Use the batch resolve script or loop above
 ```
 
-4. **Trigger new review** (use appropriate bot command):
+4. **Trigger new review** (use `gh-as-user.sh` so bots don't ignore the trigger):
 ```bash
 # Amazon Q
-gh pr comment {pr} --body "/q review"
+bash scripts/gh-as-user.sh pr comment {pr} --body "/q review"
 
 # Codex
-gh pr comment {pr} --body "/codex review"
+bash scripts/gh-as-user.sh pr comment {pr} --body "/codex review"
 ```
 
 5. **Wait and check for new comments**:

--- a/skills/autonomous-dev/references/review-threads.md
+++ b/skills/autonomous-dev/references/review-threads.md
@@ -79,7 +79,7 @@ The referenced file {filename} exists in the repository at {path}. This is a ref
 ## Quick Reference
 
 | Task | Command |
-|------|---------|
+|------|--------|
 | Create worktree | `git worktree add .worktrees/<branch> -b <branch>` |
 | List worktrees | `git worktree list` |
 | Remove worktree | `git worktree remove .worktrees/<branch>` |
@@ -90,8 +90,8 @@ The referenced file {filename} exists in the repository at {path}. This is a ref
 | Get comments | `gh api repos/{o}/{r}/pulls/{pr}/comments` |
 | Reply to comment | `gh api ... -X POST -F in_reply_to=<id>` |
 | Resolve thread | GraphQL `resolveReviewThread` mutation |
-| Trigger Q review | `gh pr comment {pr} --body "/q review"` |
-| Trigger Codex review | `gh pr comment {pr} --body "/codex review"` |
+| Trigger Q review | `bash scripts/gh-as-user.sh pr comment {pr} --body "/q review"` |
+| Trigger Codex review | `bash scripts/gh-as-user.sh pr comment {pr} --body "/codex review"` |
 | Reply to comment (script) | `scripts/reply-to-comments.sh {owner} {repo} {pr} {comment_id} "{message}"` |
 | Resolve all threads (script) | `scripts/resolve-threads.sh {owner} {repo} {pr}` |
 | Mark hook state | `hooks/state-manager.sh mark <action>` |

--- a/skills/autonomous-review/SKILL.md
+++ b/skills/autonomous-review/SKILL.md
@@ -68,7 +68,14 @@ Verify ALL of the following:
 ### 5. Optional: Bot Reviewer Verification
 - [ ] If configured bot reviewers have posted reviews, verify their findings are addressed
 - [ ] All bot review threads are resolved
-- [ ] If bot review is missing and configured, trigger it and wait
+- [ ] If bot review is missing and configured, trigger it using `scripts/gh-as-user.sh` (see below) and wait
+
+> **IMPORTANT:** Some bot reviewers (e.g., Amazon Q Developer) ignore trigger comments posted by GitHub App bot accounts. When triggering bot reviews, you **MUST** use `scripts/gh-as-user.sh` so the comment is attributed to a real user:
+> ```bash
+> bash scripts/gh-as-user.sh pr comment {pr_number} --body "/q review"
+> bash scripts/gh-as-user.sh pr comment {pr_number} --body "/codex review"
+> ```
+> Do NOT use the default `gh` wrapper for bot review triggers — it authenticates as a bot, which some reviewers ignore. If `scripts/gh-as-user.sh` is not available, fall back to `gh pr comment` directly.
 
 ### 6. E2E Verification via Chrome DevTools MCP
 


### PR DESCRIPTION
## Problem

Bot reviewers like Amazon Q Developer ignore `/q review` trigger comments posted by GitHub App bot accounts. The autonomous dev and review agents were using `gh pr comment` (which authenticates as the App bot) to trigger bot reviews, causing the triggers to be silently ignored.

**Evidence:** In a private project using this skill set, all `/q review` comments on a PR were posted by a GitHub App bot account, and Amazon Q Developer never responded to them.

## Root Cause

- `autonomous-dev/SKILL.md` Step 10 showed `gh pr comment` for retriggering bot reviews
- `autonomous-dev/references/review-commands.md` used `gh pr comment` in trigger examples and common workflows
- `autonomous-dev/references/review-threads.md` quick reference table used `gh pr comment`
- `autonomous-review/SKILL.md` had no guidance on how to trigger bot reviews at all

While `references/autonomous-mode.md` correctly documented the `gh-as-user.sh` requirement, agents primarily read the SKILL.md and reference files where the wrong commands were shown.

## Fix

Updated all bot review trigger commands across 4 files to use `scripts/gh-as-user.sh`:

| File | Change |
|------|--------|
| `autonomous-dev/SKILL.md` | Step 10 "Retrigger Bot Reviews" — added IMPORTANT warning, changed commands to `gh-as-user.sh` |
| `autonomous-dev/references/review-commands.md` | "Trigger Bot Reviews" section + "Common Workflows" step 4 |
| `autonomous-dev/references/review-threads.md` | Quick reference table entries |
| `autonomous-review/SKILL.md` | Added explicit bot review trigger guidance with `gh-as-user.sh` to section 5 |

All locations now include a fallback note for projects without `gh-as-user.sh`.