### PR TITLE
fix(review): guard against concurrent review race on approve/merge

### DIFF
--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -487,6 +487,20 @@ done
 if echo "$LATEST_COMMENT" | head -1 | grep -qi "^Review PASSED"; then
   log "Review PASSED for PR #${PR_NUMBER}."
 
+  # ---------------------------------------------------------------------------
+  # Guard: verify PR is still open before approving/merging.
+  # A concurrent review (e.g. manual `/q review` + dispatcher) may have already
+  # approved and merged the PR while this review was running.
+  # ---------------------------------------------------------------------------
+  PR_STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state -q '.state' 2>/dev/null || echo "UNKNOWN")
+  if [[ "$PR_STATE" != "OPEN" ]]; then
+    log "PR #${PR_NUMBER} is no longer open (state: ${PR_STATE}). Skipping approve/merge — another review likely completed first."
+    gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+      --remove-label "reviewing" 2>/dev/null || true
+    RESULT_PARSED=true
+    exit 0
+  fi
+
   # Formal PR approval from review agent
   if ! refresh_token_env; then
     log "ERROR: Token refresh failed — token daemon may have crashed. Attempting approval with current token..."


### PR DESCRIPTION
## Summary

Add a PR state check before the approve/merge path in `autonomous-review.sh` to prevent a race condition when multiple review agents run concurrently on the same PR.

### Problem

When a user manually triggers a review (e.g. `/q review` comment) and the autonomous dispatcher also detects the `pending-review` label, two review agents can run concurrently on the same PR. The first to finish approves and auto-merges the PR, while the second is still running against the now-dying preview environment. The second review may then produce false-positive failure reports after the PR is already merged, causing confusion.

### Fix

Add `gh pr view --json state` check immediately before the approve/merge path:
- If PR state is `OPEN` → proceed normally (approve + merge)
- If PR state is `MERGED` or `CLOSED` → skip approve/merge, clean up labels, exit cleanly

This is an idempotent server-side check that prevents the race regardless of how the review was triggered (dispatcher, manual `/q review`, or other mechanisms).

### Changes

- `skills/autonomous-dispatcher/scripts/autonomous-review.sh`: Add PR state guard before approve/merge section (14 lines added)

## Test Plan

- [ ] Verify normal review flow still works (single review, PR is OPEN → approve + merge)
- [ ] Verify concurrent review handling (second review finds PR already MERGED → skips approve, exits cleanly)
- [ ] Verify label cleanup (removes `reviewing` label when skipping)