### PR TITLE
fix(dispatcher): prevent stale detection crash loop on concurrent dispatch

### DIFF
--- a/docs/designs/fix-dispatcher-stale-detection.md
+++ b/docs/designs/fix-dispatcher-stale-detection.md
@@ -1,0 +1,44 @@
+# Fix: Dispatcher Stale Detection Crash Loop
+
+**Date:** 2026-03-25
+**Issue:** #32
+**Status:** Approved
+
+## Problem
+
+When multiple autonomous issues are dispatched in the same cron cycle, Step 5 (stale detection) immediately marks just-dispatched processes as DEAD because PID files haven't been written yet. This creates a crash loop that wastes hours.
+
+## Root Causes
+
+1. **Step 5 runs in same cycle as dispatch** — PID files aren't written yet when stale check runs
+2. **Crash transition ignores PR existence** — sends `in-progress` → `pending-review` even without a PR, causing review agent to fail immediately
+3. **Retry counter misses dispatcher crashes** — only counts Agent Session Report comments, not dispatcher-detected crashes
+4. **No duplicate-dispatch guard** — wrapper scripts don't check for existing running instances
+
+## Fixes
+
+### Fix 1: Skip stale detection for freshly dispatched issues (SKILL.md)
+
+Track issues dispatched in Steps 2/3/4 in a `JUST_DISPATCHED` array. Step 5 skips any issue in that array.
+
+### Fix 2: Smarter crash transition with PR existence check (SKILL.md)
+
+When `in-progress` is DEAD, check if a PR exists:
+- PR exists → `pending-review` (review can assess)
+- No PR → `pending-dev` (dev didn't finish, retry dev)
+
+### Fix 3: Count dispatcher crashes toward stalled threshold (SKILL.md)
+
+Combine Agent Session Report failures AND dispatcher crash comments (`"Task appears to have crashed"`) in the retry count for Step 4.
+
+### Fix 4: PID guard in wrapper scripts (autonomous-dev.sh, autonomous-review.sh)
+
+Before writing PID, check if another instance for the same issue is already running. If so, exit 0 gracefully.
+
+## Affected Files
+
+| File | Changes |
+|------|---------|
+| `skills/autonomous-dispatcher/SKILL.md` | Fixes 1, 2, 3 |
+| `skills/autonomous-dispatcher/scripts/autonomous-dev.sh` | Fix 4 |
+| `skills/autonomous-dispatcher/scripts/autonomous-review.sh` | Fix 4 |

--- a/docs/test-cases/fix-dispatcher-stale-detection.md
+++ b/docs/test-cases/fix-dispatcher-stale-detection.md
@@ -1,0 +1,79 @@
+# Test Cases: Fix Dispatcher Stale Detection Crash Loop (#32)
+
+## Fix 1: Skip stale detection for freshly dispatched issues
+
+### TC-STALE-001: Freshly dispatched issues are skipped in Step 5
+- **Precondition:** Dispatcher dispatches issue #10 in Step 2 of the current cycle
+- **Action:** Step 5 runs stale detection
+- **Expected:** Issue #10 is skipped (not checked for PID/stale status)
+
+### TC-STALE-002: Previously dispatched issues are still checked
+- **Precondition:** Issue #5 was dispatched in a previous cycle, has `in-progress` label
+- **Action:** Step 5 runs stale detection
+- **Expected:** Issue #5 is checked for PID/stale status normally
+
+### TC-STALE-003: Issues dispatched in Steps 3 and 4 are also skipped
+- **Precondition:** Issue #20 dispatched in Step 3 (review), Issue #30 dispatched in Step 4 (resume)
+- **Action:** Step 5 runs stale detection
+- **Expected:** Both #20 and #30 are skipped
+
+## Fix 2: Smarter crash transition with PR existence check
+
+### TC-CRASH-001: DEAD in-progress with no PR → pending-dev
+- **Precondition:** Issue #10 has `in-progress`, PID is dead, no open PR references #10
+- **Action:** Step 5 detects DEAD
+- **Expected:** Label changes to `pending-dev` (not `pending-review`)
+
+### TC-CRASH-002: DEAD in-progress with open PR → pending-review
+- **Precondition:** Issue #10 has `in-progress`, PID is dead, open PR exists referencing #10
+- **Action:** Step 5 detects DEAD
+- **Expected:** Label changes to `pending-review`
+
+### TC-CRASH-003: DEAD reviewing → pending-dev (unchanged behavior)
+- **Precondition:** Issue #10 has `reviewing`, PID is dead
+- **Action:** Step 5 detects DEAD
+- **Expected:** Label changes to `pending-dev` (behavior unchanged)
+
+## Fix 3: Count dispatcher crashes toward stalled threshold
+
+### TC-RETRY-001: Dispatcher crash comments count toward retry limit
+- **Precondition:** Issue has 3 comments matching "Task appears to have crashed" and 0 Agent Session Reports
+- **Action:** Step 4 evaluates retry count
+- **Expected:** RETRY_COUNT=3, issue marked as `stalled` (assuming MAX_RETRIES=3)
+
+### TC-RETRY-002: Combined agent failures and dispatcher crashes
+- **Precondition:** Issue has 1 failed Agent Session Report (exit code !=0) and 2 dispatcher crash comments
+- **Action:** Step 4 evaluates retry count
+- **Expected:** RETRY_COUNT=3, issue marked as `stalled`
+
+### TC-RETRY-003: Successful agent reports are not counted
+- **Precondition:** Issue has 2 successful Agent Session Reports (exit code 0) and 1 dispatcher crash
+- **Action:** Step 4 evaluates retry count
+- **Expected:** RETRY_COUNT=1, issue is NOT stalled
+
+## Fix 4: PID guard in wrapper scripts
+
+### TC-PID-001: First instance starts normally
+- **Precondition:** No PID file exists for issue #10
+- **Action:** autonomous-dev.sh starts for issue #10
+- **Expected:** PID file created, script runs normally
+
+### TC-PID-002: Second instance exits when first is running
+- **Precondition:** autonomous-dev.sh is running for issue #10 with valid PID file
+- **Action:** Another autonomous-dev.sh starts for issue #10
+- **Expected:** Second instance logs warning and exits 0
+
+### TC-PID-003: Instance starts if PID file exists but process is dead
+- **Precondition:** PID file exists for issue #10 but the process is not running
+- **Action:** autonomous-dev.sh starts for issue #10
+- **Expected:** PID file overwritten, script runs normally
+
+### TC-PID-004: Review script has same PID guard
+- **Precondition:** autonomous-review.sh is running for issue #10
+- **Action:** Another autonomous-review.sh starts for issue #10
+- **Expected:** Second instance logs warning and exits 0
+
+### TC-PID-005: PID guard rejects symlinked PID files
+- **Precondition:** PID file path is a symlink
+- **Action:** autonomous-dev.sh starts
+- **Expected:** Script exits with error about symlink attack

--- a/skills/autonomous-dispatcher/SKILL.md
+++ b/skills/autonomous-dispatcher/SKILL.md
@@ -87,7 +87,14 @@ All code changes happen via the autonomous-dev/review scripts. The dispatcher MU
 
 ## Dispatch Logic
 
-When triggered (cron every 5 minutes), execute the following steps IN ORDER:
+When triggered (cron every 5 minutes), execute the following steps IN ORDER.
+
+**Important:** Maintain a `JUST_DISPATCHED` array to track issue numbers dispatched in the current cycle. This prevents Step 5 from false-positive stale detection on freshly dispatched processes whose PID files haven't been written yet.
+
+```bash
+# Initialize at the start of each dispatch cycle
+JUST_DISPATCHED=()
+```
 
 ### Step 1: Check Concurrency
 
@@ -150,7 +157,8 @@ If any dependency issue is still open, **skip this issue silently** (do not add 
 ```bash
 bash "$PROJECT_DIR/scripts/dispatch-local.sh" dev-new ISSUE_NUM
 ```
-**5.** Re-check concurrency after each dispatch
+**5.** Track dispatched issue: `JUST_DISPATCHED+=(ISSUE_NUM)`
+**6.** Re-check concurrency after each dispatch
 
 ### Step 3: Scan for Review Tasks
 
@@ -162,12 +170,13 @@ gh issue list --repo "$REPO" --state open --limit 100 \
 ```
 
 For each found issue (respecting concurrency limit):
-1. Remove `pending-review`, add `reviewing`
-2. Comment: `Dispatching autonomous review...`
-3. Dispatch via helper script:
+**1.** Remove `pending-review`, add `reviewing`
+**2.** Comment: `Dispatching autonomous review...`
+**3.** Dispatch via helper script:
 ```bash
 bash "$PROJECT_DIR/scripts/dispatch-local.sh" review ISSUE_NUM
 ```
+**4.** Track dispatched issue: `JUST_DISPATCHED+=(ISSUE_NUM)`
 
 ### Step 4: Scan for Pending-Dev (Resume)
 
@@ -179,11 +188,17 @@ gh issue list --repo "$REPO" --state open --limit 100 \
 
 For each found issue (respecting concurrency limit):
 
-**1. Check retry count** — before dispatching, count the number of **failed** `Agent Session Report (Dev)` comments (exit code ≠ 0) on the issue. Successful dev completions (exit code 0) that were sent back by review do NOT count as retries:
+**1. Check retry count** — before dispatching, count BOTH **failed** `Agent Session Report (Dev)` comments (exit code ≠ 0) AND **dispatcher-detected crash** comments. Successful dev completions (exit code 0) that were sent back by review do NOT count as retries:
 ```bash
-RETRY_COUNT=$(gh issue view ISSUE_NUM --repo "$REPO" --json comments \
+# Count failed agent session reports
+AGENT_FAILURES=$(gh issue view ISSUE_NUM --repo "$REPO" --json comments \
   -q '[.comments[] | select((.body | test("Agent Session Report \\(Dev\\)")) and (.body | test("Exit code: 0") | not))] | length')
 
+# Count dispatcher-detected crashes (stale detection or review crash comments)
+DISPATCHER_CRASHES=$(gh issue view ISSUE_NUM --repo "$REPO" --json comments \
+  -q '[.comments[] | select(.body | test("Task appears to have crashed|process not found|crashed \\(no PR found\\)|crashed\\. PR found"))] | length')
+
+RETRY_COUNT=$((AGENT_FAILURES + DISPATCHER_CRASHES))
 MAX_RETRIES="${MAX_RETRIES:-3}"
 
 if [ "$RETRY_COUNT" -ge "$MAX_RETRIES" ]; then
@@ -192,12 +207,12 @@ if [ "$RETRY_COUNT" -ge "$MAX_RETRIES" ]; then
     --remove-label "pending-dev" \
     --add-label "stalled"
   gh issue comment ISSUE_NUM --repo "$REPO" \
-    --body "Issue has exceeded the maximum retry limit ($MAX_RETRIES failed attempts). Marking as stalled. @${REPO_OWNER} please investigate manually."
+    --body "Issue has exceeded the maximum retry limit ($MAX_RETRIES failed attempts: $AGENT_FAILURES agent failures + $DISPATCHER_CRASHES dispatcher-detected crashes). Marking as stalled. @${REPO_OWNER} please investigate manually."
   continue
 fi
 ```
 
-If failed retry count exceeds `MAX_RETRIES` (default 3), add `stalled` label, remove `pending-dev`, post a comment, and **skip this issue**.
+If combined retry count exceeds `MAX_RETRIES` (default 3), add `stalled` label, remove `pending-dev`, post a comment, and **skip this issue**.
 
 **2.** Extract latest dev session ID from issue comments (search for `Dev Session ID:` — do NOT match `Review Session ID:`):
 ```bash
@@ -211,12 +226,23 @@ SESSION_ID=$(gh issue view ISSUE_NUM --repo "$REPO" --json comments \
 ```bash
 bash "$PROJECT_DIR/scripts/dispatch-local.sh" dev-resume ISSUE_NUM SESSION_ID
 ```
+**6.** Track dispatched issue: `JUST_DISPATCHED+=(ISSUE_NUM)`
 
 ### Step 5: Stale Detection
 
 Find issues with `in-progress` or `reviewing` that may be stuck.
 
-For each such issue, check if the agent process is still alive locally. Use the correct PID file prefix based on the issue's current label:
+**Skip freshly dispatched issues:** Before checking any issue, verify it was NOT dispatched in the current cycle. Issues in `JUST_DISPATCHED` must be skipped — their PID files may not exist yet.
+
+```bash
+# Skip issues dispatched in this cycle
+if [[ " ${JUST_DISPATCHED[*]} " == *" ISSUE_NUM "* ]]; then
+  # Skip — just dispatched this cycle, PID file may not exist yet
+  continue
+fi
+```
+
+For each remaining issue, check if the agent process is still alive locally. Use the correct PID file prefix based on the issue's current label:
 
 - `in-progress` issues use PID file: `/tmp/agent-${PROJECT_ID}-issue-ISSUE_NUM.pid`
 - `reviewing` issues use PID file: `/tmp/agent-${PROJECT_ID}-review-ISSUE_NUM.pid`
@@ -229,9 +255,21 @@ kill -0 $(cat /tmp/agent-${PROJECT_ID}-issue-ISSUE_NUM.pid 2>/dev/null) 2>/dev/n
 kill -0 $(cat /tmp/agent-${PROJECT_ID}-review-ISSUE_NUM.pid 2>/dev/null) 2>/dev/null && echo ALIVE || echo DEAD
 ```
 
-If DEAD and issue still has `in-progress`:
-1. Comment: `Task appears to have crashed. Moving to pending-review for assessment.`
-2. Remove `in-progress`, add `pending-review`
+If DEAD and issue still has `in-progress`, **check whether a PR exists before deciding the transition**:
+```bash
+PR_EXISTS=$(gh pr list --repo "$REPO" --state open --json number,body \
+  -q "[.[] | select(.body | test(\"#ISSUE_NUM[^0-9]\") or test(\"#ISSUE_NUM$\"))] | length")
+
+if [ "$PR_EXISTS" -gt 0 ]; then
+  # PR exists — review agent can assess the work
+  # Comment: "Task appears to have crashed. PR found — moving to pending-review for assessment."
+  # Remove `in-progress`, add `pending-review`
+else
+  # No PR — dev agent didn't finish, retry development
+  # Comment: "Task appears to have crashed (no PR found). Moving to pending-dev for retry."
+  # Remove `in-progress`, add `pending-dev`
+fi
+```
 
 If DEAD and issue still has `reviewing`:
 1. Comment: `Review process appears to have crashed. Moving to pending-dev for retry.`

--- a/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
@@ -92,9 +92,8 @@ AGENT_RAN=false
 # Note: log file is created by nohup redirect in dispatch-local.sh.
 # Do NOT truncate it here (install -m 600 /dev/null would destroy nohup output).
 
-# Write PID for stale detection (reject symlinks to prevent redirect attacks)
-[[ -L "$PID_FILE" ]] && { echo "Error: PID file is a symlink — possible attack" >&2; exit 1; }
-echo $$ > "$PID_FILE"
+# PID guard: prevent duplicate instances for the same issue
+acquire_pid_guard "$PID_FILE" "autonomous-dev" "$ISSUE_NUMBER"
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -74,9 +74,8 @@ PID_FILE="/tmp/agent-${PROJECT_ID}-review-${ISSUE_NUMBER}.pid"
 # Note: log file is created by nohup redirect in dispatch-local.sh.
 # Do NOT truncate it here (install -m 600 /dev/null would destroy nohup output).
 
-# Write PID for stale detection (reject symlinks to prevent redirect attacks)
-[[ -L "$PID_FILE" ]] && { echo "Error: PID file is a symlink — possible attack" >&2; exit 1; }
-echo $$ > "$PID_FILE"
+# PID guard: prevent duplicate instances for the same issue
+acquire_pid_guard "$PID_FILE" "autonomous-review" "$ISSUE_NUMBER"
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/skills/autonomous-dispatcher/scripts/lib-agent.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-agent.sh
@@ -21,6 +21,23 @@ AGENT_REVIEW_MODEL="${AGENT_REVIEW_MODEL:-sonnet}"
 AGENT_PERMISSION_MODE="${AGENT_PERMISSION_MODE:-auto}"
 KIRO_AGENT_NAME="${KIRO_AGENT_NAME:-autonomous-dev}"
 
+# Acquire PID guard: prevent duplicate instances for the same issue.
+# Checks for symlink attacks, running processes, then writes current PID.
+# Args: $1=pid_file, $2=label (e.g. "autonomous-dev"), $3=issue_number
+acquire_pid_guard() {
+  local pid_file="$1" label="$2" issue_num="$3"
+  [[ -L "$pid_file" ]] && { echo "Error: PID file is a symlink — possible attack" >&2; exit 1; }
+  if [[ -f "$pid_file" ]]; then
+    local existing_pid
+    existing_pid=$(cat "$pid_file" 2>/dev/null)
+    if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" 2>/dev/null; then
+      echo "[$label] Another instance for issue #${issue_num} is already running (PID $existing_pid). Exiting." >&2
+      exit 0
+    fi
+  fi
+  echo $$ > "$pid_file"
+}
+
 # Run agent with a new session.
 # Args: $1=session_id, $2=prompt, $3=model (optional), $4=session_name (optional)
 run_agent() {

--- a/tests/unit/test-pid-guard.sh
+++ b/tests/unit/test-pid-guard.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# test-pid-guard.sh — Unit tests for PID guard logic in autonomous-dev.sh and autonomous-review.sh
+#
+# Tests the duplicate-instance prevention logic added in fix #32.
+# Run: bash tests/unit/test-pid-guard.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    ((PASS++))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected='$expected', actual='$actual')"
+    ((FAIL++))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    ((PASS++))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected to contain '$needle')"
+    ((FAIL++))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Extract PID guard logic into a testable function
+# ---------------------------------------------------------------------------
+# We test the guard logic by simulating the conditions it checks.
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo ""
+echo "=== PID Guard Tests ==="
+echo ""
+
+# TC-PID-001: First instance starts normally (no PID file)
+echo "TC-PID-001: First instance starts normally"
+PID_FILE="$TMPDIR/test-pid-001.pid"
+rm -f "$PID_FILE"
+# Simulate: no PID file exists → guard should allow start
+if [[ -f "$PID_FILE" ]]; then
+  RESULT="blocked"
+else
+  RESULT="allowed"
+fi
+assert_eq "No PID file → allowed to start" "allowed" "$RESULT"
+
+# TC-PID-002: Second instance exits when first is running
+echo "TC-PID-002: Second instance blocked when first is running"
+PID_FILE="$TMPDIR/test-pid-002.pid"
+# Start a background process to simulate a running agent
+sleep 300 &
+RUNNING_PID=$!
+echo "$RUNNING_PID" > "$PID_FILE"
+# Simulate the guard check
+EXISTING_PID=$(cat "$PID_FILE" 2>/dev/null)
+if [[ -n "$EXISTING_PID" ]] && kill -0 "$EXISTING_PID" 2>/dev/null; then
+  RESULT="blocked"
+else
+  RESULT="allowed"
+fi
+kill "$RUNNING_PID" 2>/dev/null || true
+wait "$RUNNING_PID" 2>/dev/null || true
+assert_eq "Running PID in file → blocked" "blocked" "$RESULT"
+
+# TC-PID-003: Instance starts if PID file exists but process is dead
+echo "TC-PID-003: Instance allowed if PID file has dead process"
+PID_FILE="$TMPDIR/test-pid-003.pid"
+echo "99999999" > "$PID_FILE"  # Very unlikely to be a real PID
+EXISTING_PID=$(cat "$PID_FILE" 2>/dev/null)
+if [[ -n "$EXISTING_PID" ]] && kill -0 "$EXISTING_PID" 2>/dev/null; then
+  RESULT="blocked"
+else
+  RESULT="allowed"
+fi
+assert_eq "Dead PID in file → allowed to start" "allowed" "$RESULT"
+
+# TC-PID-004: PID file with empty content → allowed
+echo "TC-PID-004: Empty PID file → allowed"
+PID_FILE="$TMPDIR/test-pid-004.pid"
+echo "" > "$PID_FILE"
+EXISTING_PID=$(cat "$PID_FILE" 2>/dev/null)
+if [[ -n "$EXISTING_PID" ]] && kill -0 "$EXISTING_PID" 2>/dev/null; then
+  RESULT="blocked"
+else
+  RESULT="allowed"
+fi
+assert_eq "Empty PID file → allowed to start" "allowed" "$RESULT"
+
+# TC-PID-005: Symlink PID file → rejected
+echo "TC-PID-005: Symlink PID file rejected"
+PID_FILE="$TMPDIR/test-pid-005.pid"
+ln -sf /etc/passwd "$PID_FILE"
+if [[ -L "$PID_FILE" ]]; then
+  RESULT="rejected"
+else
+  RESULT="allowed"
+fi
+rm -f "$PID_FILE"
+assert_eq "Symlink PID file → rejected" "rejected" "$RESULT"
+
+# ---------------------------------------------------------------------------
+# Verify PID guard exists in both scripts
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Script Content Verification ==="
+echo ""
+
+DEV_SCRIPT="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous-dev.sh"
+REVIEW_SCRIPT="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous-review.sh"
+
+LIB_AGENT="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-agent.sh"
+
+echo "TC-SCRIPT-001: lib-agent.sh has acquire_pid_guard function"
+if [[ -f "$LIB_AGENT" ]]; then
+  LIB_CONTENT=$(cat "$LIB_AGENT")
+  assert_contains "acquire_pid_guard function defined" "acquire_pid_guard()" "$LIB_CONTENT"
+  assert_contains "kill -0 check in acquire_pid_guard" 'kill -0 "$existing_pid"' "$LIB_CONTENT"
+  assert_contains "Symlink check in acquire_pid_guard" '-L "$pid_file"' "$LIB_CONTENT"
+else
+  echo -e "  ${RED}FAIL${NC}: lib-agent.sh not found at $LIB_AGENT"
+  ((FAIL++))
+fi
+
+echo "TC-SCRIPT-002: autonomous-dev.sh calls acquire_pid_guard"
+if [[ -f "$DEV_SCRIPT" ]]; then
+  DEV_CONTENT=$(cat "$DEV_SCRIPT")
+  assert_contains "PID guard call in autonomous-dev.sh" 'acquire_pid_guard "$PID_FILE" "autonomous-dev"' "$DEV_CONTENT"
+else
+  echo -e "  ${RED}FAIL${NC}: autonomous-dev.sh not found at $DEV_SCRIPT"
+  ((FAIL++))
+fi
+
+echo "TC-SCRIPT-003: autonomous-review.sh calls acquire_pid_guard"
+if [[ -f "$REVIEW_SCRIPT" ]]; then
+  REVIEW_CONTENT=$(cat "$REVIEW_SCRIPT")
+  assert_contains "PID guard call in autonomous-review.sh" 'acquire_pid_guard "$PID_FILE" "autonomous-review"' "$REVIEW_CONTENT"
+else
+  echo -e "  ${RED}FAIL${NC}: autonomous-review.sh not found at $REVIEW_SCRIPT"
+  ((FAIL++))
+fi
+
+# ---------------------------------------------------------------------------
+# Verify SKILL.md contains the fixes
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== SKILL.md Content Verification ==="
+echo ""
+
+SKILL_MD="$PROJECT_ROOT/skills/autonomous-dispatcher/SKILL.md"
+
+if [[ -f "$SKILL_MD" ]]; then
+  SKILL_CONTENT=$(cat "$SKILL_MD")
+
+  echo "TC-SKILL-001: SKILL.md has JUST_DISPATCHED tracking"
+  assert_contains "JUST_DISPATCHED initialization" "JUST_DISPATCHED=()" "$SKILL_CONTENT"
+  assert_contains "Skip freshly dispatched check" 'JUST_DISPATCHED[*]' "$SKILL_CONTENT"
+
+  echo "TC-SKILL-002: SKILL.md has PR existence check in crash transition"
+  assert_contains "PR existence check" "PR_EXISTS" "$SKILL_CONTENT"
+  assert_contains "No PR crash path" "No PR" "$SKILL_CONTENT"
+
+  echo "TC-SKILL-003: SKILL.md counts dispatcher crashes in retry count"
+  assert_contains "DISPATCHER_CRASHES variable" "DISPATCHER_CRASHES" "$SKILL_CONTENT"
+  assert_contains "Combined retry count" 'AGENT_FAILURES + DISPATCHER_CRASHES' "$SKILL_CONTENT"
+else
+  echo -e "  ${RED}FAIL${NC}: SKILL.md not found at $SKILL_MD"
+  ((FAIL++))
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results ==="
+TOTAL=$((PASS + FAIL))
+echo -e "Total: $TOTAL  ${GREEN}Passed: $PASS${NC}  ${RED}Failed: $FAIL${NC}"
+echo ""
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fixes #32 — dispatcher stale detection triggers crash loop when multiple agents run concurrently.

- **Fix 1:** Track `JUST_DISPATCHED` issues in the current cycle; Step 5 skips them to avoid false-positive DEAD detection before PID files are written
- **Fix 2:** Check PR existence before crash transition — no PR → `pending-dev` (retry dev), PR exists → `pending-review` (review can assess)
- **Fix 3:** Count dispatcher-detected crash comments (`"Task appears to have crashed"`) toward the stalled retry threshold alongside Agent Session Report failures
- **Fix 4:** Extract `acquire_pid_guard()` into `lib-agent.sh`; both wrapper scripts call it to prevent duplicate instances for the same issue

## Design
- [x] Design canvas created (`docs/designs/fix-dispatcher-stale-detection.md`)
- [x] Design approved

## Test Plan
- [x] Test cases documented (`docs/test-cases/fix-dispatcher-stale-detection.md`)
- [x] Unit tests pass (`bash tests/unit/test-pid-guard.sh` — 16/16 pass)
- [x] Code simplification review passed
- [x] PR review agent review passed

## Checklist
- [x] New unit tests written (`tests/unit/test-pid-guard.sh`)
- [x] Documentation updated (design doc, test cases)