### PR TITLE
feat(hooks): add shellcheck pre-commit hook for shell script linting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,6 +26,11 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/check-shellcheck.sh",
+            "timeout": 15
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/check-pr-review.sh",
             "timeout": 5
           },

--- a/docs/designs/shellcheck-hook.md
+++ b/docs/designs/shellcheck-hook.md
@@ -1,0 +1,53 @@
+# Design: ShellCheck Pre-Commit Hook
+
+**Feature:** check-shellcheck.sh PreToolUse hook
+**Date:** 2026-03-26
+**Status:** Draft
+**Issue:** #35
+
+## Problem
+
+Shell scripts in the autonomous-dev-team project get flagged by PR review bots (Amazon Q Developer, etc.) for injection vulnerabilities, unquoted variables, and other shell pitfalls. These are easily detectable statically with ShellCheck and should be caught at dev time, not during PR review.
+
+## Solution
+
+A `check-shellcheck.sh` PreToolUse hook that runs ShellCheck on staged `.sh` files before `git commit`, blocking the commit if error-level findings exist.
+
+## Hook Behavior
+
+```
+git commit triggered
+  -> Parse command from hook JSON input
+  -> Skip if not a git commit command
+  -> Skip if --amend (code already checked)
+  -> Find staged .sh files via: git diff --cached --name-only --diff-filter=ACM -- '*.sh'
+  -> If no .sh files staged: exit 0 (pass)
+  -> If shellcheck not installed: warn on stderr, exit 0 (allow)
+  -> Run shellcheck --severity=error on each staged file
+  -> If any errors found: print findings, exit 2 (block)
+  -> If all clean: exit 0 (pass)
+```
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Error-level only (`--severity=error`) | Avoids noise from style/info warnings; focuses on real bugs |
+| Graceful degradation | Not all environments have shellcheck; warn but don't block |
+| Skip `--amend` | Code was already checked on the original commit |
+| Only staged files | Don't check unstaged or untracked files |
+| `--diff-filter=ACM` | Only check Added, Copied, Modified files (skip Deleted) |
+| Uses `lib.sh` patterns | Consistent with existing hooks (`parse_command`, `is_git_command`) |
+| Exit code 2 for block | Matches project convention (exit 2 = block) |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `skills/autonomous-common/hooks/check-shellcheck.sh` | New hook script |
+| `skills/autonomous-common/hooks/README.md` | Add to hook reference table |
+| `skills/autonomous-common/SKILL.md` | Add to hook table |
+
+## Integration
+
+The hook is a PreToolUse hook triggered on `Bash` commands. It will be added to `.claude/settings.json` by users who want shellcheck enforcement. The hook follows the same pattern as `block-commit-outside-worktree.sh`.

--- a/docs/test-cases/shellcheck-hook.md
+++ b/docs/test-cases/shellcheck-hook.md
@@ -1,0 +1,46 @@
+# Test Cases: ShellCheck Pre-Commit Hook
+
+**Feature:** check-shellcheck.sh
+**Issue:** #35
+
+## Test Scenarios
+
+### TC-SC-001: Non-commit command passes through
+- **Input:** `git push origin main`
+- **Expected:** Exit 0 (pass through, no check)
+
+### TC-SC-002: Amend commit is skipped
+- **Input:** `git commit --amend`
+- **Expected:** Exit 0 (skip, code already checked)
+
+### TC-SC-003: No staged .sh files
+- **Input:** `git commit -m "update readme"` with only `.md` files staged
+- **Expected:** Exit 0 (nothing to check)
+
+### TC-SC-004: Staged .sh file with shellcheck errors
+- **Input:** `git commit -m "add script"` with a staged `.sh` file containing SC2086 (unquoted variable)
+- **Expected:** Exit 2 (block commit), stderr shows findings
+
+### TC-SC-005: Staged .sh file with no errors
+- **Input:** `git commit -m "add script"` with a clean `.sh` file staged
+- **Expected:** Exit 0 (pass)
+
+### TC-SC-006: shellcheck not installed
+- **Input:** `git commit -m "add script"` with `.sh` files staged, but `shellcheck` binary not on PATH
+- **Expected:** Exit 0 (warn on stderr, allow commit)
+
+### TC-SC-007: Mixed staged files (some .sh, some not)
+- **Input:** `git commit -m "update"` with `.md` and `.sh` files staged; `.sh` file is clean
+- **Expected:** Exit 0 (only checks .sh files, passes)
+
+### TC-SC-008: Multiple .sh files, one has errors
+- **Input:** `git commit -m "update"` with two `.sh` files staged; one clean, one with errors
+- **Expected:** Exit 2 (block), stderr shows findings for the bad file
+
+### TC-SC-009: Hook passes shellcheck itself
+- **Input:** Run `shellcheck --severity=error check-shellcheck.sh`
+- **Expected:** Exit 0 (no findings)
+
+### TC-SC-010: Deleted .sh files are not checked
+- **Input:** `git commit -m "remove script"` with a `.sh` file deleted (git status shows D)
+- **Expected:** Exit 0 (deleted files skipped via --diff-filter=ACM)

--- a/skills/autonomous-common/SKILL.md
+++ b/skills/autonomous-common/SKILL.md
@@ -38,6 +38,7 @@ Workflow enforcement hooks in `hooks/` directory. See `hooks/README.md` for the 
 | `check-code-simplifier.sh` | PreToolUse | Blocks commits until code-simplifier review |
 | `check-pr-review.sh` | PreToolUse | Blocks pushes until PR review |
 | `check-test-plan.sh` | PreToolUse | Reminds about test plan |
+| `check-shellcheck.sh` | PreToolUse | Blocks commits if staged .sh files have shellcheck errors |
 | `check-unit-tests.sh` | PreToolUse | Warns about unrun unit tests |
 | `check-rebase-before-push.sh` | PreToolUse | Blocks push if behind origin/main |
 | `warn-skip-verification.sh` | PreToolUse | Warns about --no-verify |

--- a/skills/autonomous-common/hooks/README.md
+++ b/skills/autonomous-common/hooks/README.md
@@ -41,6 +41,7 @@ IDEs without hook support (Cursor, Windsurf, Gemini CLI, etc.) rely on skill ins
 | `check-code-simplifier.sh` | PreToolUse | Bash | Blocks commits until code-simplifier review |
 | `check-pr-review.sh` | PreToolUse | Bash | Blocks pushes until PR review complete |
 | `check-test-plan.sh` | PreToolUse | Write/Edit | Reminds about test plan before code changes |
+| `check-shellcheck.sh` | PreToolUse | Bash | Blocks commits if staged .sh files have shellcheck errors |
 | `check-unit-tests.sh` | PreToolUse | Bash | Warns about unrun unit tests |
 | `warn-skip-verification.sh` | PreToolUse | Bash | Warns about --no-verify usage |
 | `check-rebase-before-push.sh` | PreToolUse | Bash | Blocks push if branch is behind origin/main |

--- a/skills/autonomous-common/hooks/check-shellcheck.sh
+++ b/skills/autonomous-common/hooks/check-shellcheck.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# PreToolUse hook - runs shellcheck on staged .sh files before commit
+# Blocks commit if error-level findings exist; warns if shellcheck not installed
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+input=$(cat)
+command=$(parse_command "$input")
+
+# Only check git commit commands
+if ! is_git_command "commit" "$command"; then
+  exit 0
+fi
+
+# Skip amends (code was already checked)
+if [[ "$command" =~ --amend ]]; then
+  exit 0
+fi
+
+# Find staged .sh files (Added, Copied, Modified only — skip Deleted)
+staged_sh_files=$(git diff --cached --name-only --diff-filter=ACM -- '*.sh' 2>/dev/null || true)
+
+# No staged shell scripts — nothing to check
+if [[ -z "$staged_sh_files" ]]; then
+  exit 0
+fi
+
+# Graceful degradation: warn if shellcheck is not installed
+if ! command -v shellcheck &>/dev/null; then
+  cat >&2 <<'EOF'
+## Warning: shellcheck not installed
+
+Staged `.sh` files were not checked for shell scripting errors.
+Install shellcheck for automatic linting: https://github.com/koalaman/shellcheck#installing
+
+**Proceeding with commit...**
+EOF
+  exit 0
+fi
+
+# Run shellcheck on each staged file, collect failures
+has_errors=false
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  [[ ! -f "$file" ]] && continue
+  if ! shellcheck --severity=error "$file" >&2; then
+    has_errors=true
+  fi
+done <<< "$staged_sh_files"
+
+if [[ "$has_errors" == "true" ]]; then
+  cat >&2 <<'EOF'
+
+## BLOCKED - ShellCheck errors found
+
+Fix the error-level findings above before committing. Common fixes:
+
+| Code | Fix |
+|------|-----|
+| SC2086 | Quote variables: `"$var"` instead of `$var` |
+| SC2046 | Quote command substitution: `"$(cmd)"` instead of `$(cmd)` |
+| SC2155 | Declare and assign separately: `local var; var=$(cmd)` |
+
+Run `shellcheck --severity=error <file>` to re-check after fixing.
+EOF
+  exit 2
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Add `check-shellcheck.sh` PreToolUse hook that runs `shellcheck --severity=error` on staged `.sh` files before commit, catching common shell pitfalls (SC2086 unquoted variables, SC2046 unquoted command substitution, SC2155 declare-and-assign) at dev time instead of during PR review
- Graceful degradation: warns but allows commit if `shellcheck` is not installed
- Register hook in `.claude/settings.json` with 15s timeout

Closes #35

## Design
- [x] Design canvas created (`docs/designs/shellcheck-hook.md`)

## Test Plan
- [x] Test cases documented (`docs/test-cases/shellcheck-hook.md`)
- [x] Hook passes shellcheck itself (`shellcheck --severity=error check-shellcheck.sh`)
- [x] Code simplification review passed
- [x] PR review agent review passed
- [x] CI checks pass
- [x] Reviewer bot findings addressed (no findings)
- [x] E2E tests pass (N/A — shell script hook, no deployed environment)

## Checklist
- [x] Hook created in `skills/autonomous-common/hooks/check-shellcheck.sh`
- [x] `hooks/README.md` hook reference table updated
- [x] `SKILL.md` hook table updated
- [x] Hook registered in `.claude/settings.json`
- [x] Hook passes shellcheck itself