### PR TITLE
fix(scripts): verify PR exists before setting pending-review (#40)

### DIFF
--- a/docs/designs/fix-cleanup-pr-check.md
+++ b/docs/designs/fix-cleanup-pr-check.md
@@ -1,0 +1,33 @@
+# Fix: Cleanup trap verifies PR exists before setting pending-review
+
+**Date:** 2026-03-29
+**Issue:** #40
+**Status:** Approved
+
+## Problem
+
+`autonomous-dev.sh` cleanup trap sets `pending-review` whenever exit code is 0,
+without checking if a PR was actually created. This wastes a review dispatch cycle
+and confuses retry counting.
+
+## Fix
+
+In the cleanup trap's success branch (exit code 0), check for an open PR whose
+body references the issue number. If no PR exists, set `pending-dev` instead
+and post a distinguishing comment.
+
+```bash
+if [[ $exit_code -eq 0 ]]; then
+    PR_EXISTS=$(gh pr list --repo "$REPO" --state open --json body \
+      -q "[.[] | select(.body | test(\"#${ISSUE_NUMBER}[^0-9]\") or test(\"#${ISSUE_NUMBER}$\"))] | length" 2>/dev/null || echo "0")
+    if [[ "$PR_EXISTS" -gt 0 ]]; then
+        # PR found → pending-review
+    else
+        # No PR → pending-dev with warning
+    fi
+fi
+```
+
+## Files changed
+
+- `skills/autonomous-dispatcher/scripts/autonomous-dev.sh` — cleanup function

--- a/docs/test-cases/fix-cleanup-pr-check.md
+++ b/docs/test-cases/fix-cleanup-pr-check.md
@@ -1,0 +1,21 @@
+# Test Cases: Fix cleanup PR check (#40)
+
+## TC-CPC-001: Script contains PR existence check in success branch
+
+**Steps:** Verify autonomous-dev.sh has `PR_EXISTS` check inside the exit_code==0 branch
+**Expected:** Content check passes
+
+## TC-CPC-002: Script posts warning when exit 0 but no PR
+
+**Steps:** Verify autonomous-dev.sh has "no PR was created" warning message
+**Expected:** Content check passes
+
+## TC-CPC-003: Script still sets pending-review when PR exists
+
+**Steps:** Verify the pending-review label transition is still present
+**Expected:** Content check passes
+
+## TC-CPC-004: Non-zero exit still goes to pending-dev
+
+**Steps:** Verify the failure branch (exit != 0) is unchanged
+**Expected:** Content check passes

--- a/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
@@ -140,10 +140,23 @@ EOF
 
   # Transition labels based on whether agent succeeded or failed
   if [[ $exit_code -eq 0 ]]; then
-    # Success: move to pending-review for the review agent
-    gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
-      --remove-label "in-progress" --remove-label "pending-dev" \
-      --add-label "pending-review" || log "WARNING: Failed to update issue labels"
+    # Verify a PR was actually created before declaring success
+    PR_EXISTS=$(gh pr list --repo "$REPO" --state open --json body \
+      -q "[.[] | select(.body | test(\"#${ISSUE_NUMBER}[^0-9]\") or test(\"#${ISSUE_NUMBER}$\"))] | length" 2>/dev/null || echo "0")
+    if [[ "$PR_EXISTS" -gt 0 ]]; then
+      # PR found: move to pending-review for the review agent
+      gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+        --remove-label "in-progress" --remove-label "pending-dev" \
+        --add-label "pending-review" || log "WARNING: Failed to update issue labels"
+    else
+      # Agent exited 0 but no PR was created — retry development
+      log "WARNING: Agent exited 0 but no PR was created for issue #${ISSUE_NUMBER}"
+      gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+        --body "Agent exited successfully but no PR was created. Moving to pending-dev for retry." 2>/dev/null || true
+      gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
+        --remove-label "in-progress" \
+        --add-label "pending-dev" || log "WARNING: Failed to update issue labels"
+    fi
   else
     # Failure: move back to pending-dev so dispatcher can retry
     gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \

--- a/tests/unit/test-cleanup-pr-check.sh
+++ b/tests/unit/test-cleanup-pr-check.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# test-cleanup-pr-check.sh — Unit tests for cleanup trap PR existence check
+#
+# Verifies that autonomous-dev.sh checks for PR existence before setting
+# pending-review on exit code 0.
+# Verifies fix for issue #40.
+# Run: bash tests/unit/test-cleanup-pr-check.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    ((PASS++))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected to contain '$needle')"
+    ((FAIL++))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    ((PASS++))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (should NOT contain '$needle')"
+    ((FAIL++))
+  fi
+}
+
+DEV_SCRIPT="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous-dev.sh"
+
+if [[ ! -f "$DEV_SCRIPT" ]]; then
+  echo -e "${RED}FATAL${NC}: autonomous-dev.sh not found at $DEV_SCRIPT"
+  exit 1
+fi
+
+CONTENT=$(cat "$DEV_SCRIPT")
+
+# ===========================================================================
+# TC-CPC-001: Script contains PR existence check in cleanup
+# ===========================================================================
+echo ""
+echo "=== TC-CPC-001: Cleanup has PR existence check ==="
+echo ""
+
+assert_contains "PR_EXISTS variable in script" 'PR_EXISTS' "$CONTENT"
+assert_contains "gh pr list check for issue number" 'gh pr list' "$CONTENT"
+
+# ===========================================================================
+# TC-CPC-002: Script posts warning when exit 0 but no PR
+# ===========================================================================
+echo ""
+echo "=== TC-CPC-002: Warning message for exit 0 without PR ==="
+echo ""
+
+assert_contains "Warning about no PR created" 'no PR was created' "$CONTENT"
+assert_contains "Sets pending-dev on no PR" 'pending-dev' "$CONTENT"
+
+# ===========================================================================
+# TC-CPC-003: Script still sets pending-review when PR exists
+# ===========================================================================
+echo ""
+echo "=== TC-CPC-003: pending-review still set when PR exists ==="
+echo ""
+
+assert_contains "pending-review label transition" 'pending-review' "$CONTENT"
+
+# ===========================================================================
+# TC-CPC-004: Non-zero exit still goes to pending-dev (unchanged)
+# ===========================================================================
+echo ""
+echo "=== TC-CPC-004: Non-zero exit → pending-dev (unchanged) ==="
+echo ""
+
+assert_contains "Failure branch exists" 'Agent failed' "$CONTENT"
+
+# ===========================================================================
+# TC-CPC-005: The PR check uses the ISSUE_NUMBER variable
+# ===========================================================================
+echo ""
+echo "=== TC-CPC-005: PR check references ISSUE_NUMBER ==="
+echo ""
+
+assert_contains "PR check uses ISSUE_NUMBER" 'ISSUE_NUMBER' "$CONTENT"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results ==="
+TOTAL=$((PASS + FAIL))
+echo -e "Total: $TOTAL  ${GREEN}Passed: $PASS${NC}  ${RED}Failed: $FAIL${NC}"
+echo ""
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Add PR existence check in `autonomous-dev.sh` cleanup trap before setting `pending-review`
- When agent exits 0 but no PR was created, fall back to `pending-dev` with a warning comment
- Prevents wasted review dispatch cycles and confusing retry counting

Fixes #40

## Design
- [x] Design canvas created (`docs/designs/fix-cleanup-pr-check.md`)
- [x] Design approved

## Test Plan
- [x] Test cases documented (`docs/test-cases/fix-cleanup-pr-check.md`)
- [x] Unit tests pass (7 new + 41 existing = 48 total)
- [ ] CI checks pass
- [x] Code simplification review passed
- [x] PR review agent review passed
- [ ] Reviewer bot findings addressed
- [ ] E2E tests pass

## Checklist
- [x] New unit tests written (`tests/unit/test-cleanup-pr-check.sh`)
- [x] Documentation updated