### PR TITLE
fix(dispatcher): reset retry counter after stalled→unstalled transition (#41)

### DIFF
--- a/docs/designs/fix-retry-counter-reset.md
+++ b/docs/designs/fix-retry-counter-reset.md
@@ -1,0 +1,24 @@
+# Fix: Retry counter resets after stalled→unstalled transition
+
+**Date:** 2026-03-29
+**Issue:** #41
+**Status:** Approved
+
+## Problem
+
+Dispatcher retry counting in SKILL.md Step 4 counts ALL crash comments ever
+posted on an issue. After removing `stalled` label, old crashes still count,
+causing immediate re-stalling.
+
+## Fix
+
+Use the timestamp of the last "Marking as stalled" comment as a cutoff.
+Only count crashes that occurred AFTER that timestamp. If no stalled comment
+exists, count all crashes (backward compatible).
+
+The jq filter finds the last stalled comment's `createdAt`, then filters
+crash/failure comments to only those created after that timestamp.
+
+## Files changed
+
+- `skills/autonomous-dispatcher/SKILL.md` — Step 4 retry counting logic

--- a/docs/test-cases/fix-retry-counter-reset.md
+++ b/docs/test-cases/fix-retry-counter-reset.md
@@ -1,0 +1,16 @@
+# Test Cases: Fix retry counter reset (#41)
+
+## TC-RCR-001: SKILL.md has stalled cutoff logic
+
+**Steps:** Verify SKILL.md Step 4 references "Marking as stalled" for cutoff
+**Expected:** Content check passes
+
+## TC-RCR-002: SKILL.md filters crashes by timestamp
+
+**Steps:** Verify SKILL.md uses createdAt comparison to filter comments
+**Expected:** Content check passes
+
+## TC-RCR-003: Backward compatible when no stalled history
+
+**Steps:** Verify the logic handles the case where no stalled comment exists
+**Expected:** Content check passes (fallback to count all)

--- a/skills/autonomous-dispatcher/SKILL.md
+++ b/skills/autonomous-dispatcher/SKILL.md
@@ -188,15 +188,20 @@ gh issue list --repo "$REPO" --state open --limit 100 \
 
 For each found issue (respecting concurrency limit):
 
-**1. Check retry count** — before dispatching, count BOTH **failed** `Agent Session Report (Dev)` comments (exit code ≠ 0) AND **dispatcher-detected crash** comments. Successful dev completions (exit code 0) that were sent back by review do NOT count as retries:
+**1. Check retry count** — before dispatching, count BOTH **failed** `Agent Session Report (Dev)` comments (exit code ≠ 0) AND **dispatcher-detected crash** comments. Only count failures that occurred **after the last stalled→unstalled transition** (i.e., after the most recent "Marking as stalled" comment). This ensures that removing the `stalled` label resets the retry counter. Successful dev completions (exit code 0) that were sent back by review do NOT count as retries:
 ```bash
-# Count failed agent session reports
-AGENT_FAILURES=$(gh issue view ISSUE_NUM --repo "$REPO" --json comments \
-  -q '[.comments[] | select((.body | test("Agent Session Report \\(Dev\\)")) and (.body | test("Exit code: 0") | not))] | length')
+# Find the timestamp of the last "Marking as stalled" comment (retry counter cutoff).
+# If the issue was never stalled, use epoch (1970-01-01T00:00:00Z) to count all comments.
+LAST_STALLED_AT=$(gh issue view ISSUE_NUM --repo "$REPO" --json comments \
+  -q '[.comments[] | select(.body | test("Marking as stalled"))] | last | .createdAt // "1970-01-01T00:00:00Z"')
 
-# Count dispatcher-detected crashes (stale detection or review crash comments)
+# Count failed agent session reports (only after last stalled cutoff)
+AGENT_FAILURES=$(gh issue view ISSUE_NUM --repo "$REPO" --json comments \
+  -q "[.comments[] | select((.createdAt > \"${LAST_STALLED_AT}\") and (.body | test(\"Agent Session Report \\\\(Dev\\\\)\")) and (.body | test(\"Exit code: 0\") | not))] | length")
+
+# Count dispatcher-detected crashes (only after last stalled cutoff)
 DISPATCHER_CRASHES=$(gh issue view ISSUE_NUM --repo "$REPO" --json comments \
-  -q '[.comments[] | select(.body | test("Task appears to have crashed|process not found|crashed \\(no PR found\\)|crashed\\. PR found"))] | length')
+  -q "[.comments[] | select((.createdAt > \"${LAST_STALLED_AT}\") and (.body | test(\"Task appears to have crashed|process not found|crashed \\\\(no PR found\\\\)|crashed\\\\. PR found\")))] | length")
 
 RETRY_COUNT=$((AGENT_FAILURES + DISPATCHER_CRASHES))
 MAX_RETRIES="${MAX_RETRIES:-3}"
@@ -212,7 +217,7 @@ if [ "$RETRY_COUNT" -ge "$MAX_RETRIES" ]; then
 fi
 ```
 
-If combined retry count exceeds `MAX_RETRIES` (default 3), add `stalled` label, remove `pending-dev`, post a comment, and **skip this issue**.
+If combined retry count exceeds `MAX_RETRIES` (default 3), add `stalled` label, remove `pending-dev`, post a comment, and **skip this issue**. When a user removes the `stalled` label to re-dispatch, the retry counter automatically resets because only crashes after the latest "Marking as stalled" comment are counted.
 
 **2.** Extract latest dev session ID from issue comments (search for `Dev Session ID:` — do NOT match `Review Session ID:`):
 ```bash

--- a/tests/unit/test-retry-counter-reset.sh
+++ b/tests/unit/test-retry-counter-reset.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# test-retry-counter-reset.sh — Unit tests for retry counter reset logic
+#
+# Verifies that SKILL.md Step 4 retry counting resets after stalled→unstalled.
+# Verifies fix for issue #41.
+# Run: bash tests/unit/test-retry-counter-reset.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    ((PASS++))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected to contain '$needle')"
+    ((FAIL++))
+  fi
+}
+
+SKILL_MD="$PROJECT_ROOT/skills/autonomous-dispatcher/SKILL.md"
+
+if [[ ! -f "$SKILL_MD" ]]; then
+  echo -e "${RED}FATAL${NC}: SKILL.md not found at $SKILL_MD"
+  exit 1
+fi
+
+CONTENT=$(cat "$SKILL_MD")
+
+# ===========================================================================
+# TC-RCR-001: SKILL.md has stalled cutoff logic
+# ===========================================================================
+echo ""
+echo "=== TC-RCR-001: Stalled cutoff logic exists ==="
+echo ""
+
+assert_contains "References stalled marker comment" 'Marking as stalled' "$CONTENT"
+assert_contains "Has LAST_STALLED_AT variable" 'LAST_STALLED_AT' "$CONTENT"
+
+# ===========================================================================
+# TC-RCR-002: SKILL.md filters crashes by timestamp
+# ===========================================================================
+echo ""
+echo "=== TC-RCR-002: Filters crashes after stalled cutoff ==="
+echo ""
+
+assert_contains "Filters by createdAt" 'createdAt' "$CONTENT"
+assert_contains "Compares timestamps for crash filtering" 'LAST_STALLED_AT' "$CONTENT"
+
+# ===========================================================================
+# TC-RCR-003: Backward compatible fallback
+# ===========================================================================
+echo ""
+echo "=== TC-RCR-003: Backward compatible when no stalled history ==="
+echo ""
+
+assert_contains "Fallback epoch for no stalled history" '1970' "$CONTENT"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results ==="
+TOTAL=$((PASS + FAIL))
+echo -e "Total: $TOTAL  ${GREEN}Passed: $PASS${NC}  ${RED}Failed: $FAIL${NC}"
+echo ""
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Use the timestamp of the last "Marking as stalled" comment as a cutoff for retry counting in SKILL.md Step 4
- Only crashes/failures after that timestamp count toward `MAX_RETRIES`
- Issues never stalled use epoch (`1970-01-01T00:00:00Z`) as fallback — backward compatible
- Removing `stalled` label now effectively resets the retry counter

Fixes #41

## Design
- [x] Design canvas created (`docs/designs/fix-retry-counter-reset.md`)
- [x] Design approved

## Test Plan
- [x] Test cases documented (`docs/test-cases/fix-retry-counter-reset.md`)
- [x] Unit tests pass (5 new + 48 existing = 53 total)
- [ ] CI checks pass
- [x] Code simplification review passed
- [x] PR review agent review passed
- [ ] Reviewer bot findings addressed
- [ ] E2E tests pass

## Checklist
- [x] New unit tests written (`tests/unit/test-retry-counter-reset.sh`)
- [x] Documentation updated