### PR TITLE
fix(hooks): fix verify-completion Stop hook infinite loop and output format

### DIFF
--- a/skills/autonomous-common/hooks/verify-completion.sh
+++ b/skills/autonomous-common/hooks/verify-completion.sh
@@ -30,11 +30,6 @@ fi
 
 # Check if gh CLI is available
 if ! command -v gh &> /dev/null; then
-  cat <<EOF
-{
-  "systemMessage": "## ⚠️ Warning - GitHub CLI Not Available\\n\\nThe \`gh\` CLI is not installed. Cannot verify CI status automatically.\\n\\nPlease verify manually:\\n1. Check GitHub Actions status in browser\\n2. Ensure all CI checks pass\\n3. Run E2E tests on preview environment\\n\\n**Task completion allowed - but verify manually.**"
-}
-EOF
   exit 0
 fi
 
@@ -47,25 +42,11 @@ status=$(echo "$ci_status" | jq -r '.[0].status // "unknown"')
 conclusion=$(echo "$ci_status" | jq -r '.[0].conclusion // "unknown"')
 
 # Helper function to output BLOCKING hook response
-# Exit code 2 blocks the action
+# Stop hooks: block message goes to stderr, exit code 2
 output_block_response() {
   local message="$1"
-  cat <<EOF
-{
-  "systemMessage": "$message"
-}
-EOF
+  echo "$message" >&2
   exit 2
-}
-
-# Helper function to output warning (non-blocking)
-output_warn_response() {
-  local message="$1"
-  cat <<EOF
-{
-  "systemMessage": "$message"
-}
-EOF
 }
 
 # Function to check unresolved review threads
@@ -126,17 +107,35 @@ get_unresolved_review_details() {
   fi
 
   # Get details of unresolved threads (first 5)
-  echo "$result" | jq -r '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == false) | "- \(.path // "general"): \(.comments.nodes[0].author.login) - \(.comments.nodes[0].body | split("\n")[0] | .[0:80])..."] | .[0:5] | join("\\n")'
+  echo "$result" | jq -r '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and .isOutdated == false) | "- \(.path // "general"): \(.comments.nodes[0].author.login) - \(.comments.nodes[0].body | split("\n")[0] | .[0:80])..."] | .[0:5] | join("\n")'
 }
 
 # Case 1: CI is still running - BLOCK
 if [[ "$status" == "in_progress" || "$status" == "queued" ]]; then
-  output_block_response "## ⛔ BLOCKED - CI Still Running\\n\\nGitHub Actions is still running on branch '$current_branch'.\\n\\n### Required Steps:\\n1. Wait for CI to complete:\\n   \`\`\`bash\\n   gh run watch\\n   \`\`\`\\n2. Once CI passes, run E2E tests\\n3. Mark E2E complete and retry\\n\\n**Cannot complete task while CI is running.**"
+  output_block_response "## ⛔ BLOCKED - CI Still Running
+
+GitHub Actions is still running on branch '$current_branch'.
+
+### Required Steps:
+1. Wait for CI to complete: \`gh run watch\`
+2. Once CI passes, run E2E tests
+3. Mark E2E complete and retry
+
+**Cannot complete task while CI is running.**"
 fi
 
 # Case 2: CI failed - BLOCK
 if [[ "$status" == "completed" && "$conclusion" == "failure" ]]; then
-  output_block_response "## ⛔ BLOCKED - CI Failed\\n\\nThe latest GitHub Actions run on branch '$current_branch' failed.\\n\\n### Required Steps:\\n1. Check failure logs:\\n   \`\`\`bash\\n   gh run view --log-failed\\n   \`\`\`\\n2. Fix the issues\\n3. Run code-simplifier and commit\\n4. Run pr-review and push\\n5. Wait for CI to pass\\n6. Run E2E tests\\n\\n**Cannot complete task with failing CI.**"
+  output_block_response "## ⛔ BLOCKED - CI Failed
+
+The latest GitHub Actions run on branch '$current_branch' failed.
+
+### Required Steps:
+1. Check failure logs: \`gh run view --log-failed\`
+2. Fix the issues
+3. Push and wait for CI to pass
+
+**Cannot complete task with failing CI.**"
 fi
 
 # Case 3: CI passed - check E2E and review comments
@@ -146,23 +145,59 @@ if [[ "$status" == "completed" && "$conclusion" == "success" ]]; then
 
   if [[ "$unresolved_count" -gt 0 ]]; then
     review_details=$(get_unresolved_review_details)
-    output_block_response "## ⛔ BLOCKED - Unresolved Review Comments\\n\\nThere are $unresolved_count unresolved review thread(s) on PR #$pr_number.\\n\\n### Unresolved Comments:\\n$review_details\\n\\n### Required Steps:\\n1. Review each comment and address the feedback\\n2. Resolve the conversations on GitHub:\\n   \`\`\`bash\\n   gh pr view $pr_number --web\\n   \`\`\`\\n3. Or mark threads as resolved if addressed\\n4. Retry task completion\\n\\n**Cannot complete task with unresolved review comments.**"
+    output_block_response "## ⛔ BLOCKED - Unresolved Review Comments
+
+There are $unresolved_count unresolved review thread(s) on PR #$pr_number.
+
+### Unresolved Comments:
+$review_details
+
+### Required Steps:
+1. Review each comment and address the feedback
+2. Resolve conversations: \`gh pr view $pr_number --web\`
+3. Retry task completion
+
+**Cannot complete task with unresolved review comments.**"
   fi
 
-  # Check if e2e-tests state exists
+  # Check E2E: local state OR CI e2e job passed OR no e2e job exists
+  e2e_done=false
+  e2e_job_exists=false
+
+  # Check local state first (set by state-manager.sh mark e2e-tests)
   if "$STATE_MANAGER" check e2e-tests 2>/dev/null; then
-    # All checks passed
-    output_warn_response "## ✅ Verification Complete\\n\\n- CI passed ✓\\n- E2E tests verified ✓\\n- All review comments resolved ✓\\n\\nBranch: '$current_branch'\\n\\n**Task completion allowed. Ready for peer review.**"
+    e2e_done=true
+  fi
+
+  # Check CI for E2E job status
+  if [[ -n "$pr_number" ]] && ! $e2e_done; then
+    e2e_ci=$(gh pr checks "$pr_number" --json name,state 2>/dev/null || echo "[]")
+    if echo "$e2e_ci" | jq -e '[.[] | select(.name | test("e2e|E2E"; "i"))] | length > 0' &>/dev/null; then
+      e2e_job_exists=true
+      if echo "$e2e_ci" | jq -e '[.[] | select(.name | test("e2e|E2E"; "i")) | select(.state == "SUCCESS")] | length > 0' &>/dev/null; then
+        e2e_done=true
+      fi
+    fi
+  fi
+
+  if $e2e_done || ! $e2e_job_exists; then
+    # All checks passed, or no E2E job in CI (skip requirement).
+    # Exit silently — no stdout output to avoid Stop hook re-trigger loop.
     exit 0
   else
-    # E2E tests not run yet - BLOCK
-    output_block_response "## ⛔ BLOCKED - E2E Tests Required\\n\\nCI passed on branch '$current_branch', but E2E tests have not been run.\\n\\n### Required Steps (Step 8):\\n1. Get the PR preview URL:\\n   \`\`\`bash\\n   gh pr view --json url\\n   \`\`\`\\n\\n2. Run E2E tests using Chrome DevTools MCP:\\n   - Navigate to the preview URL\\n   - Test authentication flows (if applicable)\\n   - Test the specific functionality changed\\n   - Verify no console errors\\n   - Capture screenshots if needed\\n\\n3. After E2E verification, mark as complete:\\n   \`\`\`bash\\n   hooks/state-manager.sh mark e2e-tests\\n   \`\`\`\\n\\n4. Retry task completion\\n\\n**Cannot complete task without E2E verification.**"
+    # E2E job exists in CI but hasn't passed
+    output_block_response "## ⛔ BLOCKED - E2E Tests Required
+
+CI passed on branch '$current_branch', but E2E tests have not passed.
+
+### Required Steps:
+1. Check E2E test status: \`gh pr checks $pr_number\`
+2. If E2E failed, check logs and fix
+3. Or mark E2E as complete manually: \`hooks/state-manager.sh mark e2e-tests\`
+
+**Cannot complete task without E2E verification.**"
   fi
 fi
 
-# Case 4: No CI runs found (possibly no push yet) - warn only
-if [[ "$status" == "unknown" ]]; then
-  output_warn_response "## ⚠️ Warning - No CI Runs Found\\n\\nNo GitHub Actions runs found for branch '$current_branch'.\\n\\nIf you haven't pushed yet, please:\\n1. Run code-simplifier and commit\\n2. Run pr-review and push\\n3. Wait for CI to pass\\n4. Run E2E tests\\n\\nIf this is expected (e.g., research task), you may proceed."
-fi
-
+# Case 4: No CI runs found — exit silently (no stdout to avoid hook loop)
 exit 0


### PR DESCRIPTION
## Summary

Fix three issues with `verify-completion.sh` Stop hook that cause an infinite loop in Claude Code:

1. **Block responses go to stdout instead of stderr** — Claude Code Stop hooks should write blocking errors to stderr with exit 2. The `output_block_response` function was writing JSON to stdout.

2. **Success paths cause infinite loop** — When verification passes, the hook wrote a `systemMessage` JSON to stdout. Claude Code relays Stop hook stdout back to the assistant, which triggers a new response, which fires the Stop hook again → infinite loop. Fix: exit 0 silently on all success paths (no stdout output).

3. **E2E check relies solely on ephemeral local state** — `state-manager.sh check e2e-tests` state resets across conversations, so the hook perpetually blocks even after E2E tests have passed in CI. Fix: also check `gh pr checks` for an E2E job that passed, and skip the E2E requirement entirely when no E2E job exists in CI.

## Changes

- `output_block_response()`: write to stderr instead of stdout
- Remove `output_warn_response()` (unused after fix)
- All success/approve paths: silent `exit 0` (no stdout)
- E2E check: local state → CI e2e job → no e2e job exists (fallthrough)
- Block messages: plain text instead of escaped JSON (stderr is shown directly)

## Test plan

- [ ] On a branch with passing CI and no E2E job: hook exits silently (no loop)
- [ ] On a branch with passing CI and passing E2E job: hook exits silently
- [ ] On a branch with failing CI: hook blocks with stderr message
- [ ] On a branch with unresolved review comments: hook blocks
- [ ] On main/master branch: hook skips entirely