### PR TITLE
docs: add post-install hook setup guide for npx skills add users

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,12 +42,21 @@ requests and bug reports.
 
 ## Hooks
 
-Workflow enforcement hooks are bundled in `skills/autonomous-common/hooks/`
-and accessible via the `hooks/` symlink at the project root. Supported by
-Claude Code and Kiro CLI. See `hooks/README.md` for per-agent setup.
+Workflow enforcement hooks are bundled in `skills/autonomous-common/hooks/`.
+Hook commands in `autonomous-dev` and `autonomous-review` SKILL.md frontmatter
+reference `$CLAUDE_PROJECT_DIR/hooks/`, so a symlink is required at the project root.
 
-For `npx skills add` users, hooks are also available via skill frontmatter
-in autonomous-dev and autonomous-review SKILL.md files.
+**Template users** already have `hooks -> skills/autonomous-common/hooks`.
+
+**`npx skills add` users** must create the symlink manually after install:
+
+```bash
+ln -sf .claude/skills/autonomous-common/hooks hooks
+ln -sf .claude/skills/autonomous-dispatcher/scripts scripts
+```
+
+Hooks are supported by Claude Code and Kiro CLI. Other IDEs follow the
+workflow steps manually. See `hooks/README.md` for the full reference.
 
 ## Scripts
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,31 @@ This installs the following skills into your agent:
 
 Supported agents include Claude Code, Cursor, Windsurf, Gemini CLI, Kiro CLI, and [many more](https://skills.sh). See the [skills.sh docs](https://skills.sh/docs) for the full list and usage guide.
 
+#### Post-Install: Enable Workflow Hooks (Claude Code / Kiro CLI)
+
+The `autonomous-dev` and `autonomous-review` skills define [Claude Code hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) in their SKILL.md frontmatter. These hooks enforce the TDD workflow (block direct pushes to main, require code review before commit, etc.). The hook commands reference `$CLAUDE_PROJECT_DIR/hooks/...`, but `npx skills add` places hook scripts inside `.claude/skills/autonomous-common/hooks/`. You need to create symlinks so the paths resolve:
+
+```bash
+# From your project root — create symlinks after npx skills add:
+ln -sf .claude/skills/autonomous-common/hooks hooks
+ln -sf .claude/skills/autonomous-dispatcher/scripts scripts
+```
+
+> **Why symlinks?** `npx skills add` copies each skill directory into `.claude/skills/`, but hook commands use `$CLAUDE_PROJECT_DIR/hooks/` (the project root). The symlinks bridge this gap. The `scripts/` symlink enables agent-callable utility scripts referenced by the skills (e.g., `scripts/gh-as-user.sh`).
+
+**Required Claude Code plugins** (add to `.claude/settings.json` under `enabledPlugins`):
+
+```json
+{
+  "enabledPlugins": {
+    "code-simplifier@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true
+  }
+}
+```
+
+> **Note:** If your IDE does not support hooks (Cursor, Windsurf, Gemini CLI), the skills still work — follow each workflow step manually. Hooks only provide automatic enforcement.
+
 ### Option B: Use as GitHub Template (Full Pipeline)
 
 For the complete autonomous pipeline — including hooks, wrapper scripts, dispatcher cron, and GitHub App auth:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Supported agents include Claude Code, Cursor, Windsurf, Gemini CLI, Kiro CLI, an
 
 #### Post-Install: Enable Workflow Hooks (Claude Code / Kiro CLI)
 
-The `autonomous-dev` and `autonomous-review` skills define [Claude Code hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) in their SKILL.md frontmatter. These hooks enforce the TDD workflow (block direct pushes to main, require code review before commit, etc.). The hook commands reference `$CLAUDE_PROJECT_DIR/hooks/...`, but `npx skills add` places hook scripts inside `.claude/skills/autonomous-common/hooks/`. You need to create symlinks so the paths resolve:
+The `autonomous-dev` and `autonomous-review` skills define Claude Code hooks in their SKILL.md frontmatter. These hooks enforce the TDD workflow (block direct pushes to main, require code review before commit, etc.). The hook commands reference `$CLAUDE_PROJECT_DIR/hooks/...`, but `npx skills add` places hook scripts inside `.claude/skills/autonomous-common/hooks/`. You need to create symlinks so the paths resolve:
 
 ```bash
 # From your project root — create symlinks after npx skills add:

--- a/skills/autonomous-common/SKILL.md
+++ b/skills/autonomous-common/SKILL.md
@@ -16,7 +16,7 @@ Shared hooks and scripts used by the autonomous-dev, autonomous-review, and auto
 
 ## Setup for `npx skills add` Users
 
-If you installed these skills via `npx skills add`, create symlinks at your project root so that path references in the other skills resolve correctly:
+If you installed these skills via `npx skills add`, hook commands in the `autonomous-dev` and `autonomous-review` SKILL.md frontmatter reference `$CLAUDE_PROJECT_DIR/hooks/` and `$CLAUDE_PROJECT_DIR/scripts/`, but `npx skills add` places these files inside `.claude/skills/`. Create symlinks at your project root so the paths resolve:
 
 ```bash
 # From your project root:
@@ -24,7 +24,18 @@ ln -sf .claude/skills/autonomous-common/hooks hooks
 ln -sf .claude/skills/autonomous-dispatcher/scripts scripts
 ```
 
-Then copy and configure `.claude/settings.json` from the autonomous-dev-team template repository to enable workflow enforcement hooks.
+Required Claude Code plugins (add to `.claude/settings.json` under `enabledPlugins`):
+
+```json
+{
+  "enabledPlugins": {
+    "code-simplifier@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true
+  }
+}
+```
+
+> IDEs without hook support (Cursor, Windsurf, Gemini CLI) don't need symlinks — the skills work without hooks, but workflow steps must be followed manually.
 
 ## Hooks
 


### PR DESCRIPTION
## Summary

- Add "Post-Install: Enable Workflow Hooks" section to README under Option A, explaining why symlinks are needed and the exact commands to create them
- Update AGENTS.md to distinguish template users (symlinks pre-existing) from `npx skills add` users (must create symlinks manually)
- Update autonomous-common SKILL.md with specific `enabledPlugins` JSON instead of vague "copy settings.json" instruction

## Context

The `autonomous-dev` and `autonomous-review` skills define hooks in their SKILL.md frontmatter that reference `$CLAUDE_PROJECT_DIR/hooks/...`. After `npx skills add`, hook scripts land in `.claude/skills/autonomous-common/hooks/`, but those paths don't resolve without a symlink at the project root. This setup step was previously buried in `autonomous-common/SKILL.md` (a non-user-invocable skill), so users wouldn't discover it.

## Test Plan

- [x] Documentation changes only — no code changes
- [x] Verified symlink paths are correct
- [x] No private repo references included