### PR TITLE
fix(scripts): prevent gh-as-user.sh from using bot token via gh wrapper

### DIFF
--- a/skills/autonomous-common/scripts/gh-as-user.sh
+++ b/skills/autonomous-common/scripts/gh-as-user.sh
@@ -19,6 +19,7 @@
 SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLEAN_PATH=$(echo "$PATH" | tr ':' '\n' \
   | while IFS= read -r dir; do
+      [[ -z "$dir" ]] && continue
       [[ -e "${dir}/gh-with-token-refresh.sh" ]] && continue
       [[ "$dir" == "$SELF_DIR" ]] && continue
       printf '%s:' "$dir"

--- a/skills/autonomous-common/scripts/gh-as-user.sh
+++ b/skills/autonomous-common/scripts/gh-as-user.sh
@@ -30,7 +30,7 @@ REAL_GH=$(PATH="$CLEAN_PATH" command -v gh 2>/dev/null) || {
 
 # Priority 1: Use explicit user PAT
 if [[ -n "${GH_USER_PAT:-}" ]]; then
-  exec env GH_TOKEN="$GH_USER_PAT" -u GH_TOKEN_FILE "$REAL_GH" "$@"
+  exec env -u GH_TOKEN_FILE GH_TOKEN="$GH_USER_PAT" "$REAL_GH" "$@"
 fi
 
 # Priority 2: Use host gh auth session.

--- a/skills/autonomous-common/scripts/gh-as-user.sh
+++ b/skills/autonomous-common/scripts/gh-as-user.sh
@@ -12,9 +12,17 @@
 # Usage:
 #   bash scripts/gh-as-user.sh pr comment 42 --body "/q review"
 
-# Find the real gh binary (skip the gh-with-token-refresh.sh wrapper)
+# Find the real gh binary — skip ALL wrapper scripts (gh-with-token-refresh.sh
+# and its symlinked `gh` alias). lib-auth.sh prepends the dispatcher's scripts/
+# dir to PATH, which is different from SELF_DIR, so stripping only our own dir
+# leaves the wrapper reachable. Strip every dir that contains the wrapper.
 SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
-CLEAN_PATH=$(echo "$PATH" | tr ':' '\n' | grep -v "^${SELF_DIR}$" | tr '\n' ':' | sed 's/:$//')
+CLEAN_PATH=$(echo "$PATH" | tr ':' '\n' \
+  | while IFS= read -r dir; do
+      [[ -e "${dir}/gh-with-token-refresh.sh" ]] && continue
+      [[ "$dir" == "$SELF_DIR" ]] && continue
+      printf '%s:' "$dir"
+    done | sed 's/:$//')
 REAL_GH=$(PATH="$CLEAN_PATH" command -v gh 2>/dev/null) || {
   echo "WARNING: Cannot find real gh binary — skipping user-auth gh call" >&2
   exit 0
@@ -22,13 +30,15 @@ REAL_GH=$(PATH="$CLEAN_PATH" command -v gh 2>/dev/null) || {
 
 # Priority 1: Use explicit user PAT
 if [[ -n "${GH_USER_PAT:-}" ]]; then
-  exec env GH_TOKEN="$GH_USER_PAT" "$REAL_GH" "$@"
+  exec env GH_TOKEN="$GH_USER_PAT" -u GH_TOKEN_FILE "$REAL_GH" "$@"
 fi
 
-# Priority 2: Use host gh auth session (unset GH_TOKEN so gh uses its own auth store)
-if env -u GH_TOKEN -u GITHUB_TOKEN -u GITHUB_PERSONAL_ACCESS_TOKEN \
+# Priority 2: Use host gh auth session.
+# Unset ALL token env vars AND GH_TOKEN_FILE — the wrapper reads the bot token
+# from GH_TOKEN_FILE even when GH_TOKEN is unset.
+if env -u GH_TOKEN -u GITHUB_TOKEN -u GITHUB_PERSONAL_ACCESS_TOKEN -u GH_TOKEN_FILE \
      "$REAL_GH" auth status >/dev/null 2>&1; then
-  exec env -u GH_TOKEN -u GITHUB_TOKEN -u GITHUB_PERSONAL_ACCESS_TOKEN "$REAL_GH" "$@"
+  exec env -u GH_TOKEN -u GITHUB_TOKEN -u GITHUB_PERSONAL_ACCESS_TOKEN -u GH_TOKEN_FILE "$REAL_GH" "$@"
 fi
 
 # Priority 3: No user auth available — exit with distinct code


### PR DESCRIPTION
## Summary

- Fixes `gh-as-user.sh` finding the `gh-with-token-refresh.sh` wrapper instead of the real `gh` binary when `GH_AUTH_MODE=app`
- Adds `GH_TOKEN_FILE` to the list of unset env vars so no wrapper can re-inject the bot token

## Root Cause

When `GH_AUTH_MODE=app`, `lib-auth.sh` prepends the dispatcher's `scripts/` directory to `PATH` and symlinks `gh` → `gh-with-token-refresh.sh` there. `gh-as-user.sh` only stripped its own directory (`SELF_DIR`) from PATH, so `REAL_GH` resolved to the wrapper — which reads the bot token from `GH_TOKEN_FILE`, bypassing the `env -u GH_TOKEN` unsets.

This caused `/q review` comments to be attributed to the bot account (`kane-review-agent[bot]`), which Amazon Q Developer silently ignores.

## Fix

1. **PATH filtering**: Strip all directories containing `gh-with-token-refresh.sh` from PATH (not just `SELF_DIR`)
2. **Env cleanup**: Unset `GH_TOKEN_FILE` alongside `GH_TOKEN`/`GITHUB_TOKEN`/`GITHUB_PERSONAL_ACCESS_TOKEN`

## Test plan

- [ ] Run `gh-as-user.sh pr comment <N> --body "/q review"` in a session with `GH_AUTH_MODE=app` — comment should be attributed to the host user, not the bot
- [ ] Verify `gh-as-user.sh` still falls back gracefully (exit 2) when no user auth is available