### PR TITLE
fix(dispatcher): exclude "PR found" handoff from retry counter

### DIFF
--- a/docs/designs/fix-retry-counter-pr-found.md
+++ b/docs/designs/fix-retry-counter-pr-found.md
@@ -2,9 +2,8 @@
 
 ## Problem
 
-Issue zxkane/quant-scorer#192 was marked `stalled` right after the review agent
-completed its first review and posted blocking findings. See the 06:41 comment:
-https://github.com/zxkane/quant-scorer/issues/192#issuecomment-4350233257
+An autonomous issue was marked `stalled` right after the review agent completed
+its first review and posted blocking findings.
 
 ### Observed timeline
 1. 06:08 — dispatcher: "Task appears to have crashed (no PR found)" (real crash #1)

--- a/docs/designs/fix-retry-counter-pr-found.md
+++ b/docs/designs/fix-retry-counter-pr-found.md
@@ -34,13 +34,18 @@ path. This keeps counting accurate without adding new state.
 ### Changes
 
 1. `skills/autonomous-dispatcher/SKILL.md` Step 4:
-   - Drop `|crashed\\. PR found` from the `DISPATCHER_CRASHES` regex.
+   - Tighten the `DISPATCHER_CRASHES` regex from three loose alternatives
+     (`Task appears to have crashed|process not found|crashed \(no PR found\)|crashed\. PR found`)
+     down to two explicit Step 5 preambles
+     (`Task appears to have crashed \(no PR found\)|process not found`).
+   - Add an inline rationale comment warning future editors not to re-introduce
+     a broad `crashed` or `exited` alternative.
 2. `skills/autonomous-dispatcher/SKILL.md` Step 5:
    - Change the "PR found" comment from `"Task appears to have crashed. PR found — moving to pending-review for assessment."` to `"Dev process exited (PR found). Moving to pending-review for assessment."`
-   - This avoids future regex collisions and reads accurately: a PR is not a crash.
+   - Reads accurately: a PR is not a crash.
 3. `tests/unit/test-retry-counter-reset.sh`:
-   - Add TC-RCR-004 asserting `crashed. PR found` is no longer in the counting regex.
-   - Add TC-RCR-005 asserting the "Dev process exited; PR found" wording is used.
+   - Add TC-RCR-004 guarding the new Step 5 wording.
+   - Add TC-RCR-005 guarding the tightened Step 4 regex (regression guard).
 
 ### Non-goals
 

--- a/docs/designs/fix-retry-counter-pr-found.md
+++ b/docs/designs/fix-retry-counter-pr-found.md
@@ -1,0 +1,57 @@
+# Design: Exclude "crashed. PR found" from Retry Counter
+
+## Problem
+
+Issue zxkane/quant-scorer#192 was marked `stalled` right after the review agent
+completed its first review and posted blocking findings. See the 06:41 comment:
+https://github.com/zxkane/quant-scorer/issues/192#issuecomment-4350233257
+
+### Observed timeline
+1. 06:08 — dispatcher: "Task appears to have crashed (no PR found)" (real crash #1)
+2. 06:16 — dispatcher: "Task appears to have crashed (no PR found)" (real crash #2)
+3. 06:31 — dispatcher: "Task appears to have crashed. **PR found** — moving to pending-review"
+4. 06:35 — review dispatched
+5. 06:38 — review agent posts findings, moves label `reviewing` → `pending-dev`
+6. 06:41 — next cycle counts 3 crash comments, marks `stalled`
+
+### Root cause
+
+`skills/autonomous-dispatcher/SKILL.md` Step 4 retry-count regex matches
+`"crashed\\. PR found"` as a dispatcher-detected crash. But that event actually
+indicates **forward progress**: the dev process produced a PR before exiting, so
+the work is successfully handed to review. Counting it as a retry punishes
+progress and causes premature `stalled`.
+
+Prior fix #41/#44 only reset the counter on `stalled → unstalled`. It does not
+handle the legitimate `review → pending-dev` handoff for blocking findings.
+
+## Fix
+
+Scope: minimal. Remove `crashed. PR found` from the crash-counting regex, and
+rename the Step 5 comment so the word "crashed" never appears in a forward-progress
+path. This keeps counting accurate without adding new state.
+
+### Changes
+
+1. `skills/autonomous-dispatcher/SKILL.md` Step 4:
+   - Drop `|crashed\\. PR found` from the `DISPATCHER_CRASHES` regex.
+2. `skills/autonomous-dispatcher/SKILL.md` Step 5:
+   - Change the "PR found" comment from `"Task appears to have crashed. PR found — moving to pending-review for assessment."` to `"Dev process exited (PR found). Moving to pending-review for assessment."`
+   - This avoids future regex collisions and reads accurately: a PR is not a crash.
+3. `tests/unit/test-retry-counter-reset.sh`:
+   - Add TC-RCR-004 asserting `crashed. PR found` is no longer in the counting regex.
+   - Add TC-RCR-005 asserting the "Dev process exited; PR found" wording is used.
+
+### Non-goals
+
+- Do not change the "no PR found" retry path — that is a real dev failure.
+- Do not add a new label or state.
+- Do not touch review-side logic.
+
+## Risk
+
+- Historical comments on existing issues still contain the old "crashed. PR found"
+  wording. After this change, the new regex will not count them, so any running
+  issue's retry counter effectively drops by ≤1. That is the intended effect (those
+  instances were never real failures).
+- Step 5 comment wording change is cosmetic for humans; no script greps for it.

--- a/docs/test-cases/fix-retry-counter-pr-found.md
+++ b/docs/test-cases/fix-retry-counter-pr-found.md
@@ -16,16 +16,19 @@ Unit tests guarding the SKILL.md contract. Extends
 
 ### TC-RCR-005 — Step 4 retry-counter regex is anchored on explicit preambles
 - **Given** the Step 4 `DISPATCHER_CRASHES` jq regex in SKILL.md
-- **Extract** the full `test(...)` argument from the `DISPATCHER_CRASHES=` line only
-  (so other file occurrences of the phrase don't leak into the assertion)
+- **Extract** every `test(...)` argument from the `DISPATCHER_CRASHES=` statement
+  (the assignment line and the next 3 lines, to tolerate benign reformatting)
+- **Expect** exactly ONE `test(...)` argument is extracted — extraction returning
+  zero means SKILL.md layout changed and the guard is blind; more than one means
+  an additional test() alternative was injected into the retry counter
 - **Expect** the extracted regex is exactly `test("Task appears to have crashed \(no PR found\)|process not found")`
 - **Expect** the extracted regex does NOT contain the `crashed\. PR found` alternative
 - **Why** Guards against future edits broadening the regex — a bare `crashed`
-  alternative, a `crashed[^(]` alternative, or re-adding `crashed. PR found`
-  would all substring-match the forward-progress `Dev process exited (PR found)`
-  comment and reintroduce this bug. Extracting the exact regex argument (rather
-  than scanning the whole file) avoids false positives from prose references to
-  the same phrase elsewhere in SKILL.md.
+  alternative, a `crashed[^(]` alternative, a chained second `test(...)` call,
+  or re-adding `crashed. PR found` would all substring-match the forward-progress
+  `Dev process exited (PR found)` comment and reintroduce this bug. Extracting
+  the exact regex argument (rather than scanning the whole file) avoids false
+  positives from prose references to the same phrase elsewhere in SKILL.md.
 
 ## Out of scope
 

--- a/docs/test-cases/fix-retry-counter-pr-found.md
+++ b/docs/test-cases/fix-retry-counter-pr-found.md
@@ -11,11 +11,17 @@ Unit tests guarding the SKILL.md contract. Extends
 - **Given** Step 5 stale-detection guidance for the `in-progress` + PR-exists branch
 - **Expect** SKILL.md documents the comment `Dev process exited (PR found). Moving to pending-review for assessment.`
 - **Expect** SKILL.md does NOT contain the old `Task appears to have crashed. PR found` phrasing
-- **Why** The Step 4 retry-counter regex treats `Task appears to have crashed` as a
-  crash marker. Removing the phrase from the forward-progress branch is the single
-  behavioral guarantee that prevents premature `stalled` — guarding the comment
-  wording also guards the regex indirectly (since the regex alternative literal
-  was already dropped in the matching change).
+- **Why** Removing the "crashed" wording from the forward-progress branch is the
+  behavioral guarantee that prevents premature `stalled` after review returns work.
+
+### TC-RCR-005 — Step 4 retry-counter regex is anchored on explicit preambles
+- **Given** the Step 4 `DISPATCHER_CRASHES` jq regex in SKILL.md
+- **Expect** the regex contains the explicit `Task appears to have crashed \(no PR found\)` alternative
+- **Expect** the regex does NOT contain the bare `Task appears to have crashed` alternative
+- **Expect** the regex does NOT contain the `crashed\. PR found` alternative
+- **Why** Guards against future edits re-introducing a broad `crashed` alternative
+  that would substring-match the forward-progress `Dev process exited (PR found)`
+  comment and reintroduce this bug.
 
 ## Out of scope
 

--- a/docs/test-cases/fix-retry-counter-pr-found.md
+++ b/docs/test-cases/fix-retry-counter-pr-found.md
@@ -1,0 +1,24 @@
+# Test Cases: Exclude "crashed. PR found" from Retry Counter
+
+## Scope
+
+Unit tests guarding the SKILL.md contract. Extends
+`tests/unit/test-retry-counter-reset.sh` with two new cases.
+
+## Cases
+
+### TC-RCR-004 — Step 5 comment for PR-found path uses non-crash wording
+- **Given** Step 5 stale-detection guidance for the `in-progress` + PR-exists branch
+- **Expect** SKILL.md documents the comment `Dev process exited (PR found). Moving to pending-review for assessment.`
+- **Expect** SKILL.md does NOT contain the old `Task appears to have crashed. PR found` phrasing
+- **Why** The Step 4 retry-counter regex treats `Task appears to have crashed` as a
+  crash marker. Removing the phrase from the forward-progress branch is the single
+  behavioral guarantee that prevents premature `stalled` — guarding the comment
+  wording also guards the regex indirectly (since the regex alternative literal
+  was already dropped in the matching change).
+
+## Out of scope
+
+- E2E: exercising the full dispatcher cron cycle. Unit-level assertions on SKILL.md
+  cover the contract; E2E is covered by observing pipeline behavior on subsequent
+  issues.

--- a/docs/test-cases/fix-retry-counter-pr-found.md
+++ b/docs/test-cases/fix-retry-counter-pr-found.md
@@ -16,12 +16,16 @@ Unit tests guarding the SKILL.md contract. Extends
 
 ### TC-RCR-005 — Step 4 retry-counter regex is anchored on explicit preambles
 - **Given** the Step 4 `DISPATCHER_CRASHES` jq regex in SKILL.md
-- **Expect** the regex contains the explicit `Task appears to have crashed \(no PR found\)` alternative
-- **Expect** the regex does NOT contain the bare `Task appears to have crashed` alternative
-- **Expect** the regex does NOT contain the `crashed\. PR found` alternative
-- **Why** Guards against future edits re-introducing a broad `crashed` alternative
-  that would substring-match the forward-progress `Dev process exited (PR found)`
-  comment and reintroduce this bug.
+- **Extract** the full `test(...)` argument from the `DISPATCHER_CRASHES=` line only
+  (so other file occurrences of the phrase don't leak into the assertion)
+- **Expect** the extracted regex is exactly `test("Task appears to have crashed \(no PR found\)|process not found")`
+- **Expect** the extracted regex does NOT contain the `crashed\. PR found` alternative
+- **Why** Guards against future edits broadening the regex — a bare `crashed`
+  alternative, a `crashed[^(]` alternative, or re-adding `crashed. PR found`
+  would all substring-match the forward-progress `Dev process exited (PR found)`
+  comment and reintroduce this bug. Extracting the exact regex argument (rather
+  than scanning the whole file) avoids false positives from prose references to
+  the same phrase elsewhere in SKILL.md.
 
 ## Out of scope
 

--- a/skills/autonomous-dispatcher/SKILL.md
+++ b/skills/autonomous-dispatcher/SKILL.md
@@ -200,11 +200,12 @@ AGENT_FAILURES=$(gh issue view ISSUE_NUM --repo "$REPO" --json comments \
   -q "[.comments[] | select((.createdAt > \"${LAST_STALLED_AT}\") and (.body | test(\"Agent Session Report \\\\(Dev\\\\)\")) and (.body | test(\"Exit code: 0\") | not))] | length")
 
 # Count dispatcher-detected crashes (only after last stalled cutoff).
-# Note: a dev process that exits after producing a PR is forward progress
-# (the PR is handed to review via "Dev process exited (PR found)" in Step 5),
-# so that transition is NOT counted toward retries.
+# The regex is anchored on explicit Step 5 crash preambles. A dev process that
+# exits after producing a PR is forward progress (handed to review as
+# "Dev process exited (PR found)") and MUST NOT match this regex — do not add
+# a broad `crashed` or `exited` alternative here.
 DISPATCHER_CRASHES=$(gh issue view ISSUE_NUM --repo "$REPO" --json comments \
-  -q "[.comments[] | select((.createdAt > \"${LAST_STALLED_AT}\") and (.body | test(\"Task appears to have crashed|process not found|crashed \\\\(no PR found\\\\)\")))] | length")
+  -q "[.comments[] | select((.createdAt > \"${LAST_STALLED_AT}\") and (.body | test(\"Task appears to have crashed \\\\(no PR found\\\\)|process not found\")))] | length")
 
 RETRY_COUNT=$((AGENT_FAILURES + DISPATCHER_CRASHES))
 MAX_RETRIES="${MAX_RETRIES:-3}"

--- a/skills/autonomous-dispatcher/SKILL.md
+++ b/skills/autonomous-dispatcher/SKILL.md
@@ -199,9 +199,12 @@ LAST_STALLED_AT=$(gh issue view ISSUE_NUM --repo "$REPO" --json comments \
 AGENT_FAILURES=$(gh issue view ISSUE_NUM --repo "$REPO" --json comments \
   -q "[.comments[] | select((.createdAt > \"${LAST_STALLED_AT}\") and (.body | test(\"Agent Session Report \\\\(Dev\\\\)\")) and (.body | test(\"Exit code: 0\") | not))] | length")
 
-# Count dispatcher-detected crashes (only after last stalled cutoff)
+# Count dispatcher-detected crashes (only after last stalled cutoff).
+# Note: a dev process that exits after producing a PR is forward progress
+# (the PR is handed to review via "Dev process exited (PR found)" in Step 5),
+# so that transition is NOT counted toward retries.
 DISPATCHER_CRASHES=$(gh issue view ISSUE_NUM --repo "$REPO" --json comments \
-  -q "[.comments[] | select((.createdAt > \"${LAST_STALLED_AT}\") and (.body | test(\"Task appears to have crashed|process not found|crashed \\\\(no PR found\\\\)|crashed\\\\. PR found\")))] | length")
+  -q "[.comments[] | select((.createdAt > \"${LAST_STALLED_AT}\") and (.body | test(\"Task appears to have crashed|process not found|crashed \\\\(no PR found\\\\)\")))] | length")
 
 RETRY_COUNT=$((AGENT_FAILURES + DISPATCHER_CRASHES))
 MAX_RETRIES="${MAX_RETRIES:-3}"
@@ -266,9 +269,10 @@ PR_EXISTS=$(gh pr list --repo "$REPO" --state open --json number,body \
   -q "[.[] | select(.body | test(\"#ISSUE_NUM[^0-9]\") or test(\"#ISSUE_NUM$\"))] | length")
 
 if [ "$PR_EXISTS" -gt 0 ]; then
-  # PR exists — review agent can assess the work
-  # Comment: "Task appears to have crashed. PR found — moving to pending-review for assessment."
+  # PR exists — forward progress. Review agent can assess the work.
+  # Comment: "Dev process exited (PR found). Moving to pending-review for assessment."
   # Remove `in-progress`, add `pending-review`
+  # (Wording avoids "crashed" so the Step 4 retry-counter regex does not match it.)
 else
   # No PR — dev agent didn't finish, retry development
   # Comment: "Task appears to have crashed (no PR found). Moving to pending-dev for retry."

--- a/tests/unit/test-retry-counter-reset.sh
+++ b/tests/unit/test-retry-counter-reset.sh
@@ -118,6 +118,9 @@ else
   if [[ "$TEST_CALL_COUNT" != "1" ]]; then
     echo -e "  ${RED}FAIL${NC}: DISPATCHER_CRASHES statement has $TEST_CALL_COUNT test() calls, expected 1 (a chained test() may have broadened the retry counter)"
     ((FAIL++))
+  else
+    echo -e "  ${GREEN}PASS${NC}: Statement has exactly one test() call"
+    ((PASS++))
   fi
 
   # Required: the two explicit Step 5 crash preambles

--- a/tests/unit/test-retry-counter-reset.sh
+++ b/tests/unit/test-retry-counter-reset.sh
@@ -101,12 +101,17 @@ echo ""
 echo "=== TC-RCR-005: Retry-counter regex anchored on explicit preambles ==="
 echo ""
 
-assert_contains "Regex anchors on explicit '(no PR found)' variant" \
-  'Task appears to have crashed \\\\(no PR found\\\\)' "$CONTENT"
-assert_not_contains "Regex drops bare 'Task appears to have crashed' alternative" \
-  'test(\"Task appears to have crashed|' "$CONTENT"
+# Extract the exact jq test(...) regex argument on the DISPATCHER_CRASHES line
+# and assert its full content. This catches ANY broadening — bare `crashed`,
+# `crashed. PR found`, `crashed[^(]`, etc. — regardless of shape.
+DISPATCHER_CRASH_REGEX=$(grep -A1 '^DISPATCHER_CRASHES=' "$SKILL_MD" \
+  | grep -oE 'test\(\\"[^"]*\\"\)' | head -1)
+
+assert_contains "Regex is exactly the two explicit Step 5 preambles" \
+  'test(\"Task appears to have crashed \\\\(no PR found\\\\)|process not found\")' \
+  "$DISPATCHER_CRASH_REGEX"
 assert_not_contains "Regex does not re-add 'crashed. PR found' alternative" \
-  'crashed\\\\. PR found' "$CONTENT"
+  'crashed\\\\. PR found' "$DISPATCHER_CRASH_REGEX"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/unit/test-retry-counter-reset.sh
+++ b/tests/unit/test-retry-counter-reset.sh
@@ -28,6 +28,17 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    ((PASS++))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected NOT to contain '$needle')"
+    ((FAIL++))
+  fi
+}
+
 SKILL_MD="$PROJECT_ROOT/skills/autonomous-dispatcher/SKILL.md"
 
 if [[ ! -f "$SKILL_MD" ]]; then
@@ -65,6 +76,20 @@ echo "=== TC-RCR-003: Backward compatible when no stalled history ==="
 echo ""
 
 assert_contains "Fallback epoch for no stalled history" '1970' "$CONTENT"
+
+# ===========================================================================
+# TC-RCR-004: PR-found handoff uses non-crash wording
+# ===========================================================================
+# Rationale: when the dev process exits after producing a PR, that is forward
+# progress (handed to review), not a retry. The Step 5 comment must not contain
+# the word "crashed", so the Step 4 retry-counter regex cannot substring-match
+# it and trigger a premature `stalled` label.
+echo ""
+echo "=== TC-RCR-004: Step 5 'PR found' comment uses non-crash wording ==="
+echo ""
+
+assert_contains "Uses 'Dev process exited (PR found)' wording" 'Dev process exited (PR found)' "$CONTENT"
+assert_not_contains "Drops old 'crashed. PR found' wording" 'Task appears to have crashed. PR found' "$CONTENT"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/unit/test-retry-counter-reset.sh
+++ b/tests/unit/test-retry-counter-reset.sh
@@ -101,17 +101,30 @@ echo ""
 echo "=== TC-RCR-005: Retry-counter regex anchored on explicit preambles ==="
 echo ""
 
-# Extract the exact jq test(...) regex argument on the DISPATCHER_CRASHES line
-# and assert its full content. This catches ANY broadening — bare `crashed`,
-# `crashed. PR found`, `crashed[^(]`, etc. — regardless of shape.
-DISPATCHER_CRASH_REGEX=$(grep -A1 '^DISPATCHER_CRASHES=' "$SKILL_MD" \
-  | grep -oE 'test\(\\"[^"]*\\"\)' | head -1)
+# Extract the jq test(...) regex argument(s) from the DISPATCHER_CRASHES
+# statement and assert there is EXACTLY one, with EXACTLY the intended content.
+# Catches any broadening — bare `crashed`, `crashed. PR found`, `crashed[^(]`,
+# an injected second test(...) alternative, etc.
+#
+# Uses -A3 to tolerate benign reformatting (line breaks within the statement);
+# the statement is the only one in SKILL.md starting with `DISPATCHER_CRASHES=`.
+mapfile -t DISPATCHER_CRASH_REGEXES < <(
+  grep -A3 '^DISPATCHER_CRASHES=' "$SKILL_MD" | grep -oE 'test\(\\"[^"]*\\"\)'
+)
 
-assert_contains "Regex is exactly the two explicit Step 5 preambles" \
-  'test(\"Task appears to have crashed \\\\(no PR found\\\\)|process not found\")' \
-  "$DISPATCHER_CRASH_REGEX"
-assert_not_contains "Regex does not re-add 'crashed. PR found' alternative" \
-  'crashed\\\\. PR found' "$DISPATCHER_CRASH_REGEX"
+if [[ ${#DISPATCHER_CRASH_REGEXES[@]} -eq 0 ]]; then
+  echo -e "  ${RED}FAIL${NC}: Could not extract any test(...) from DISPATCHER_CRASHES statement — SKILL.md layout changed"
+  ((FAIL++))
+elif [[ ${#DISPATCHER_CRASH_REGEXES[@]} -gt 1 ]]; then
+  echo -e "  ${RED}FAIL${NC}: Extracted ${#DISPATCHER_CRASH_REGEXES[@]} test(...) calls, expected exactly 1 (a second test() may have broadened the retry counter)"
+  ((FAIL++))
+else
+  assert_contains "Regex is exactly the two explicit Step 5 preambles" \
+    'test(\"Task appears to have crashed \\\\(no PR found\\\\)|process not found\")' \
+    "${DISPATCHER_CRASH_REGEXES[0]}"
+  assert_not_contains "Regex does not re-add 'crashed. PR found' alternative" \
+    'crashed\\\\. PR found' "${DISPATCHER_CRASH_REGEXES[0]}"
+fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/unit/test-retry-counter-reset.sh
+++ b/tests/unit/test-retry-counter-reset.sh
@@ -82,14 +82,31 @@ assert_contains "Fallback epoch for no stalled history" '1970' "$CONTENT"
 # ===========================================================================
 # Rationale: when the dev process exits after producing a PR, that is forward
 # progress (handed to review), not a retry. The Step 5 comment must not contain
-# the word "crashed", so the Step 4 retry-counter regex cannot substring-match
-# it and trigger a premature `stalled` label.
+# "crashed", so the Step 4 retry-counter regex cannot match it and trigger a
+# premature `stalled` label.
 echo ""
 echo "=== TC-RCR-004: Step 5 'PR found' comment uses non-crash wording ==="
 echo ""
 
 assert_contains "Uses 'Dev process exited (PR found)' wording" 'Dev process exited (PR found)' "$CONTENT"
 assert_not_contains "Drops old 'crashed. PR found' wording" 'Task appears to have crashed. PR found' "$CONTENT"
+
+# ===========================================================================
+# TC-RCR-005: Retry-counter regex is anchored on explicit Step 5 preambles
+# ===========================================================================
+# Guards against future edits re-adding a broad `crashed` alternative that
+# would substring-match the forward-progress "Dev process exited (PR found)"
+# comment and reintroduce the premature-stalled bug.
+echo ""
+echo "=== TC-RCR-005: Retry-counter regex anchored on explicit preambles ==="
+echo ""
+
+assert_contains "Regex anchors on explicit '(no PR found)' variant" \
+  'Task appears to have crashed \\\\(no PR found\\\\)' "$CONTENT"
+assert_not_contains "Regex drops bare 'Task appears to have crashed' alternative" \
+  'test(\"Task appears to have crashed|' "$CONTENT"
+assert_not_contains "Regex does not re-add 'crashed. PR found' alternative" \
+  'crashed\\\\. PR found' "$CONTENT"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/unit/test-retry-counter-reset.sh
+++ b/tests/unit/test-retry-counter-reset.sh
@@ -101,29 +101,36 @@ echo ""
 echo "=== TC-RCR-005: Retry-counter regex anchored on explicit preambles ==="
 echo ""
 
-# Extract the jq test(...) regex argument(s) from the DISPATCHER_CRASHES
-# statement and assert there is EXACTLY one, with EXACTLY the intended content.
-# Catches any broadening — bare `crashed`, `crashed. PR found`, `crashed[^(]`,
-# an injected second test(...) alternative, etc.
-#
-# Uses -A3 to tolerate benign reformatting (line breaks within the statement);
-# the statement is the only one in SKILL.md starting with `DISPATCHER_CRASHES=`.
-mapfile -t DISPATCHER_CRASH_REGEXES < <(
-  grep -A3 '^DISPATCHER_CRASHES=' "$SKILL_MD" | grep -oE 'test\(\\"[^"]*\\"\)'
-)
+# Grab the multi-line DISPATCHER_CRASHES=... statement as a blob and run
+# semantic checks against it directly. This approach does NOT depend on a
+# specific quoting style (\", '"', heredoc) — any future reformat that keeps
+# the statement textually present will still be guarded. Uses -A3 to tolerate
+# line breaks within the statement (the real block is 2 lines today).
+DISPATCHER_CRASH_STMT=$(grep -A3 '^DISPATCHER_CRASHES=' "$SKILL_MD")
 
-if [[ ${#DISPATCHER_CRASH_REGEXES[@]} -eq 0 ]]; then
-  echo -e "  ${RED}FAIL${NC}: Could not extract any test(...) from DISPATCHER_CRASHES statement — SKILL.md layout changed"
-  ((FAIL++))
-elif [[ ${#DISPATCHER_CRASH_REGEXES[@]} -gt 1 ]]; then
-  echo -e "  ${RED}FAIL${NC}: Extracted ${#DISPATCHER_CRASH_REGEXES[@]} test(...) calls, expected exactly 1 (a second test() may have broadened the retry counter)"
+if [[ -z "$DISPATCHER_CRASH_STMT" ]]; then
+  echo -e "  ${RED}FAIL${NC}: DISPATCHER_CRASHES= statement not found in SKILL.md — layout changed, guard is blind"
   ((FAIL++))
 else
-  assert_contains "Regex is exactly the two explicit Step 5 preambles" \
-    'test(\"Task appears to have crashed \\\\(no PR found\\\\)|process not found\")' \
-    "${DISPATCHER_CRASH_REGEXES[0]}"
-  assert_not_contains "Regex does not re-add 'crashed. PR found' alternative" \
-    'crashed\\\\. PR found' "${DISPATCHER_CRASH_REGEXES[0]}"
+  # Expect exactly one test() call in the statement. More than one means a
+  # second alternative was chained in and the retry counter was broadened.
+  TEST_CALL_COUNT=$(grep -oE 'test\(' <<<"$DISPATCHER_CRASH_STMT" | wc -l | tr -d ' ')
+  if [[ "$TEST_CALL_COUNT" != "1" ]]; then
+    echo -e "  ${RED}FAIL${NC}: DISPATCHER_CRASHES statement has $TEST_CALL_COUNT test() calls, expected 1 (a chained test() may have broadened the retry counter)"
+    ((FAIL++))
+  fi
+
+  # Required: the two explicit Step 5 crash preambles
+  assert_contains "Statement includes '(no PR found)' alternative" \
+    'Task appears to have crashed \\\\(no PR found\\\\)' "$DISPATCHER_CRASH_STMT"
+  assert_contains "Statement includes 'process not found' alternative" \
+    'process not found' "$DISPATCHER_CRASH_STMT"
+
+  # Forbidden: the old over-broad alternatives
+  assert_not_contains "Statement does not re-add 'crashed. PR found' alternative" \
+    'crashed\\\\. PR found' "$DISPATCHER_CRASH_STMT"
+  assert_not_contains "Statement does not re-add bare 'Task appears to have crashed|' alternative" \
+    'Task appears to have crashed|' "$DISPATCHER_CRASH_STMT"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Dispatcher was counting the `"Task appears to have crashed. PR found …"` handoff comment as a retry, causing issues to be marked `stalled` the moment the review agent legitimately sent work back to `pending-dev` with blocking findings.
- Drop `crashed\. PR found` from the Step 4 `DISPATCHER_CRASHES` regex and rename the Step 5 PR-found comment to `"Dev process exited (PR found). …"` so the forward-progress path can't substring-match the crash regex.
- Tighten the Step 4 regex to the two explicit Step 5 preambles (`Task appears to have crashed (no PR found)`, `process not found`) as a belt-and-braces regression guard.

Reproduced downstream: 2 real `(no PR found)` crashes + 1 `PR found` handoff pushed `RETRY_COUNT` to `MAX_RETRIES=3`, so the next dispatcher cycle after a successful review marked the issue `stalled`.

## Design
- [x] Design canvas created (`docs/designs/fix-retry-counter-pr-found.md`)
- [x] Design approved

## Test Plan
- [x] Test cases documented (`docs/test-cases/fix-retry-counter-pr-found.md`)
- [x] Unit tests pass (all 7 files, 10 assertions in `test-retry-counter-reset.sh`)
- [ ] CI checks pass
- [x] Code simplification review passed
- [x] PR review agent review passed
- [ ] Reviewer bot findings addressed (no new findings)
- [ ] E2E tests pass

## Checklist
- [x] New unit tests written (TC-RCR-004 wording guard, TC-RCR-005 regex regression guard)
- [x] SKILL.md rationale comment added warning future editors not to broaden the regex
- [x] Documentation updated