### PR TITLE
fix(dispatcher): skip redundant review when PR HEAD unchanged

### DIFF
--- a/docs/designs/dispatcher-skip-redundant-review.md
+++ b/docs/designs/dispatcher-skip-redundant-review.md
@@ -1,0 +1,88 @@
+# Dispatcher: skip redundant review when PR HEAD unchanged since last review
+
+## Problem
+
+When `Step 5: Stale Detection` finds an `in-progress` issue whose dev process is dead and a PR exists, the dispatcher unconditionally moves the issue to `pending-review`. If the PR HEAD SHA has not advanced since the last `Review findings` comment, this re-runs the review agent on identical code and produces the same findings — wasted compute and wasted review-agent quota. The dev agent never gets another chance to act on the prior findings.
+
+Observed on issue #115 in the consumer repo: dev exited without pushing new commits, dispatcher routed back to review, review re-emitted the same blocking finding (bench gate not completed), loop repeated.
+
+## Goal
+
+Branch the dead-with-PR transition on whether the PR HEAD has advanced since the last review:
+
+- **HEAD advanced** (or no review comment exists yet) → `pending-review` (current behavior).
+- **HEAD unchanged** → `pending-dev` so the dev agent retries against the existing review feedback.
+
+## Design
+
+### 1. Review agent records the reviewed HEAD SHA
+
+`autonomous-review.sh` already captures `PR_BRANCH` near line 203. Add `PR_HEAD_SHA=$(gh pr view ... --json headRefOid -q .headRefOid)` alongside it.
+
+After the agent posts its `Review findings:` / `Review PASSED` comment and the wrapper finishes parsing the verdict, post a short trailer comment from the wrapper itself:
+
+```
+Reviewed HEAD: `<sha>` (issue #N, session `<session-id>`)
+```
+
+The trailer is posted in **both** branches (PASSED and findings) so any future tooling can rely on the marker. The session ID is included to make the trailer searchable per-review without leaking the verdict text.
+
+Why a separate comment instead of asking the agent to embed it: the agent's prompt is already long; relying on the agent to include a precise SHA is brittle (it would have to call `gh pr view` itself). The wrapper has the SHA in hand and can post the trailer reliably.
+
+If the trailer fails to post (network/permission error), the dispatcher falls back to the existing behavior (no SHA found → assume new code, route to review). This is safe degradation.
+
+### 2. Dispatcher Step 5 compares SHAs
+
+Update `skills/autonomous-dispatcher/SKILL.md` Step 5 dead-with-PR branch:
+
+```bash
+PR_INFO=$(gh pr list --repo "$REPO" --state open --json number,body,headRefOid \
+  -q "[.[] | select(.body | test(\"#${ISSUE_NUM}[^0-9]\") or test(\"#${ISSUE_NUM}$\"))] | .[0]")
+PR_EXISTS=$(jq -e 'length > 0' <<<"$PR_INFO" >/dev/null 2>&1 && echo 1 || echo 0)
+
+if [ "$PR_EXISTS" = "1" ]; then
+  CURRENT_HEAD=$(jq -r '.headRefOid // empty' <<<"$PR_INFO")
+  LAST_REVIEWED_HEAD=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json comments \
+    -q '[.comments[].body | capture("Reviewed HEAD: `(?P<sha>[0-9a-f]{7,40})`"; "g") | .sha] | last // empty')
+
+  if [[ -n "$LAST_REVIEWED_HEAD" && -n "$CURRENT_HEAD" ]] \
+       && [[ "$CURRENT_HEAD" == "$LAST_REVIEWED_HEAD"* || "$LAST_REVIEWED_HEAD" == "$CURRENT_HEAD"* ]]; then
+    # No new commits since last review — retry dev so it can act on existing findings.
+    # (Wording avoids "crashed" so retry-counter regex from Step 4 does not match.)
+    gh issue comment "$ISSUE_NUM" --repo "$REPO" \
+      --body "Dev process exited (no new commits since last review at \`${CURRENT_HEAD:0:7}\`). Moving to pending-dev for retry."
+    gh issue edit "$ISSUE_NUM" --repo "$REPO" \
+      --remove-label "in-progress" --add-label "pending-dev"
+  else
+    # New commits OR no prior review trailer — let the review agent assess.
+    gh issue comment "$ISSUE_NUM" --repo "$REPO" \
+      --body "Dev process exited (PR found). Moving to pending-review for assessment."
+    gh issue edit "$ISSUE_NUM" --repo "$REPO" \
+      --remove-label "in-progress" --add-label "pending-review"
+  fi
+fi
+```
+
+### 3. Retry-counter interaction
+
+The new `pending-dev` route comment ("Dev process exited (no new commits since last review at `<sha>`)") MUST NOT match the existing crash regex in Step 4:
+
+```
+"Task appears to have crashed \\(no PR found\\)|process not found"
+```
+
+The chosen wording avoids "crashed" and "process not found", so this finding does not increment the retry counter on its own. The dev agent's eventual `Agent Session Report` (with non-zero exit) will still count if it fails. This matches the precedent set by PR #50 (`fix(dispatcher): exclude "PR found" handoff from retry counter`).
+
+### 4. Edge cases
+
+- **No prior review yet**: `LAST_REVIEWED_HEAD` is empty → falls through to `pending-review`. Correct: review hasn't seen the PR yet.
+- **Review trailer post failed**: `LAST_REVIEWED_HEAD` is empty → `pending-review`. Same fallback as above; review will run again, but no worse than today's behavior.
+- **SHA prefix vs full**: GitHub `headRefOid` returns the full 40-char SHA. The trailer also stores the full SHA. Use `==` for an exact match; the prefix-match safety net handles legacy data only.
+- **Dev pushed and then crashed**: `CURRENT_HEAD` differs from `LAST_REVIEWED_HEAD` → `pending-review`. Correct: new code needs review.
+- **Multiple PRs on same issue** (rare): the existing `gh pr list` query already takes the first match. No change.
+
+## Out of Scope
+
+- Changing the cleanup-trap behavior in `autonomous-dev.sh` (which sets `pending-review` after agent exits with code 0 and PR exists). The cleanup-trap path is the *successful* dev exit; new commits are guaranteed there because the agent reached its terminal step. The bug only happens on Step 5's stale-detection path, which fires when dev exited *without* the cleanup trap running (true crash, OOM, kill, etc.).
+- Tracking review-passed-on-SHA for caching merge decisions. The current scope is just the dead-with-PR transition.
+- Embedding the SHA inside the agent's `Review findings:` body (would require prompt changes and is more brittle).

--- a/docs/designs/dispatcher-skip-redundant-review.md
+++ b/docs/designs/dispatcher-skip-redundant-review.md
@@ -45,8 +45,7 @@ if [ "$PR_EXISTS" = "1" ]; then
   LAST_REVIEWED_HEAD=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json comments \
     -q '[.comments[].body | capture("Reviewed HEAD: `(?P<sha>[0-9a-f]{7,40})`"; "g") | .sha] | last // empty')
 
-  if [[ -n "$LAST_REVIEWED_HEAD" && -n "$CURRENT_HEAD" ]] \
-       && [[ "$CURRENT_HEAD" == "$LAST_REVIEWED_HEAD"* || "$LAST_REVIEWED_HEAD" == "$CURRENT_HEAD"* ]]; then
+  if [[ -n "$LAST_REVIEWED_HEAD" && -n "$CURRENT_HEAD" && "$CURRENT_HEAD" == "$LAST_REVIEWED_HEAD" ]]; then
     # No new commits since last review — retry dev so it can act on existing findings.
     # (Wording avoids "crashed" so retry-counter regex from Step 4 does not match.)
     gh issue comment "$ISSUE_NUM" --repo "$REPO" \
@@ -77,7 +76,7 @@ The chosen wording avoids "crashed" and "process not found", so this finding doe
 
 - **No prior review yet**: `LAST_REVIEWED_HEAD` is empty → falls through to `pending-review`. Correct: review hasn't seen the PR yet.
 - **Review trailer post failed**: `LAST_REVIEWED_HEAD` is empty → `pending-review`. Same fallback as above; review will run again, but no worse than today's behavior.
-- **SHA prefix vs full**: GitHub `headRefOid` returns the full 40-char SHA. The trailer also stores the full SHA. Use `==` for an exact match; the prefix-match safety net handles legacy data only.
+- **SHA prefix vs full**: GitHub `headRefOid` returns the full 40-char SHA, and the wrapper writes the full SHA into the trailer. Exact `==` is sufficient; no prefix-match safety net needed because there is no legacy non-full-SHA trailer format to support.
 - **Dev pushed and then crashed**: `CURRENT_HEAD` differs from `LAST_REVIEWED_HEAD` → `pending-review`. Correct: new code needs review.
 - **Multiple PRs on same issue** (rare): the existing `gh pr list` query already takes the first match. No change.
 

--- a/docs/test-cases/dispatcher-skip-redundant-review.md
+++ b/docs/test-cases/dispatcher-skip-redundant-review.md
@@ -1,0 +1,53 @@
+# Test Cases: dispatcher-skip-redundant-review
+
+## TC-DSRR-001: Review wrapper records reviewed HEAD SHA
+
+**Setup:** static analysis of `skills/autonomous-dispatcher/scripts/autonomous-review.sh`
+
+**Verify:**
+- Script captures `PR_HEAD_SHA` via `gh pr view ... --json headRefOid -q .headRefOid`.
+- Script posts a trailer comment containing the literal string `Reviewed HEAD:` followed by a backtick-wrapped SHA on both the PASSED and findings branches.
+- Trailer is posted from the wrapper, not produced by the agent prompt.
+
+## TC-DSRR-002: Trailer post failure does not abort review
+
+**Verify:** the trailer post call is wrapped with `|| true` (or equivalent) so a network/permission failure doesn't break the existing PASS/merge or send-back flow.
+
+## TC-DSRR-003: Dispatcher SKILL.md describes SHA comparison
+
+**Setup:** static analysis of `skills/autonomous-dispatcher/SKILL.md` Step 5.
+
+**Verify:**
+- Step 5 dead-with-PR branch reads the current PR `headRefOid`.
+- It extracts `Reviewed HEAD:` from issue comments using a regex that captures a 7+ hex SHA.
+- It branches on the comparison:
+  - SHA matches → comment that avoids the words "crashed" and "process not found", and adds `pending-dev`.
+  - SHA differs or empty → existing `pending-review` flow with the existing wording.
+
+## TC-DSRR-004: New comment wording does not match retry-counter regex
+
+**Setup:** unit test that pulls the new "no new commits since last review" wording and checks it against the regex from Step 4:
+
+```
+Task appears to have crashed \(no PR found\)|process not found
+```
+
+**Verify:** the new comment string fails the regex (so the retry counter is not incremented for this transition).
+
+## TC-DSRR-005: Existing "Dev process exited (PR found)" wording also fails the regex
+
+**Setup:** regression check — make sure the existing PR-found handoff wording still does not match the retry regex (PR #50 precedent).
+
+## TC-DSRR-006: Dispatcher Step 5 keeps `pending-review` when no review trailer is found
+
+**Verify:** SKILL.md explicitly states that empty `LAST_REVIEWED_HEAD` falls through to `pending-review` (no first-review starvation).
+
+## TC-DSRR-007: Trailer marker is grep-able with the documented regex
+
+**Setup:** synthesize a trailer comment body matching what the wrapper posts. Run the SKILL.md jq capture against it and assert it returns the expected SHA.
+
+```
+Reviewed HEAD: `abcdef1234567890abcdef1234567890abcdef12` (issue #115, session `f95638fe-...`)
+```
+
+Expected jq output: `abcdef1234567890abcdef1234567890abcdef12`.

--- a/skills/autonomous-dispatcher/SKILL.md
+++ b/skills/autonomous-dispatcher/SKILL.md
@@ -301,7 +301,12 @@ else
 fi
 ```
 
-> **Note on the empty-trailer fallthrough:** an empty `LAST_REVIEWED_HEAD` (no prior review trailer found) routes to `pending-review`, not `pending-dev`. This protects the first-review path: review must see the PR at least once before any "no new commits" gate can apply.
+> **Note on the empty-trailer fallthrough:** an empty `LAST_REVIEWED_HEAD` (no prior review trailer found) routes to `pending-review`, not `pending-dev`. Two distinct causes can produce an empty value, both routed identically but with different operational meaning:
+>
+> 1. **Review never ran successfully against this PR yet** — the safe first-review case. `pending-review` correctly hands the PR to the review agent.
+> 2. **Trailer post failed** (token expiry, 403, rate limit) — the wrapper logs `WARNING: Failed to post Reviewed HEAD trailer` to its review log. Operationally this means SHA-match detection is broken; if you observe `pending-review` cycling without new commits across multiple dispatch ticks, grep the review log at `/tmp/agent-${PROJECT_ID}-review-*.log` for that warning.
+>
+> The trailer marker is wrapper-managed: only `autonomous-review.sh` should write `Reviewed HEAD: \`<sha>\``. A maintainer comment containing the literal phrase would be picked up too — acceptable trade-off given the 40-char hex match is unlikely in casual prose.
 
 If DEAD and issue still has `reviewing`:
 1. Comment: `Review process appears to have crashed. Moving to pending-dev for retry.`

--- a/skills/autonomous-dispatcher/SKILL.md
+++ b/skills/autonomous-dispatcher/SKILL.md
@@ -264,22 +264,44 @@ kill -0 $(cat /tmp/agent-${PROJECT_ID}-issue-ISSUE_NUM.pid 2>/dev/null) 2>/dev/n
 kill -0 $(cat /tmp/agent-${PROJECT_ID}-review-ISSUE_NUM.pid 2>/dev/null) 2>/dev/null && echo ALIVE || echo DEAD
 ```
 
-If DEAD and issue still has `in-progress`, **check whether a PR exists before deciding the transition**:
+If DEAD and issue still has `in-progress`, **check whether a PR exists before deciding the transition**, and if it does, **compare the PR HEAD SHA against the last reviewed SHA** so a redundant review is skipped when no new commits were pushed:
 ```bash
-PR_EXISTS=$(gh pr list --repo "$REPO" --state open --json number,body \
-  -q "[.[] | select(.body | test(\"#ISSUE_NUM[^0-9]\") or test(\"#ISSUE_NUM$\"))] | length")
+# Fetch current PR (number + HEAD SHA + body) in a single call.
+PR_INFO=$(gh pr list --repo "$REPO" --state open --json number,body,headRefOid \
+  -q "[.[] | select(.body | test(\"#ISSUE_NUM[^0-9]\") or test(\"#ISSUE_NUM$\"))] | .[0] // empty")
 
-if [ "$PR_EXISTS" -gt 0 ]; then
-  # PR exists — forward progress. Review agent can assess the work.
-  # Comment: "Dev process exited (PR found). Moving to pending-review for assessment."
-  # Remove `in-progress`, add `pending-review`
-  # (Wording avoids "crashed" so the Step 4 retry-counter regex does not match it.)
+if [ -n "$PR_INFO" ]; then
+  CURRENT_HEAD=$(jq -r '.headRefOid // empty' <<<"$PR_INFO")
+
+  # Find the most recent "Reviewed HEAD: `<sha>`" trailer the review wrapper
+  # posted after the previous verdict comment. Empty means review never ran
+  # successfully against the current PR (or trailer post failed).
+  LAST_REVIEWED_HEAD=$(gh issue view ISSUE_NUM --repo "$REPO" --json comments \
+    -q '[.comments[].body | capture("Reviewed HEAD: `(?<sha>[0-9a-f]{7,40})`"; "g") | .sha] | last // empty')
+
+  if [ -n "$LAST_REVIEWED_HEAD" ] && [ -n "$CURRENT_HEAD" ] && [ "$CURRENT_HEAD" = "$LAST_REVIEWED_HEAD" ]; then
+    # No new commits since last review. Re-running review would re-emit the
+    # same findings against identical code. Retry dev so it can act on the
+    # existing review feedback instead.
+    # (Wording avoids "crashed" / "process not found" so the Step 4 retry
+    #  counter regex does not match it.)
+    # Comment: "Dev process exited (no new commits since last review at `<sha>`). Moving to pending-dev for retry."
+    # Remove `in-progress`, add `pending-dev`
+  else
+    # PR has new commits OR no prior review trailer was found — let the
+    # review agent assess the work.
+    # Comment: "Dev process exited (PR found). Moving to pending-review for assessment."
+    # Remove `in-progress`, add `pending-review`
+    # (Wording avoids "crashed" so the Step 4 retry-counter regex does not match it.)
+  fi
 else
-  # No PR — dev agent didn't finish, retry development
+  # No PR — dev agent didn't finish, retry development.
   # Comment: "Task appears to have crashed (no PR found). Moving to pending-dev for retry."
   # Remove `in-progress`, add `pending-dev`
 fi
 ```
+
+> **Note on the empty-trailer fallthrough:** an empty `LAST_REVIEWED_HEAD` (no prior review trailer found) routes to `pending-review`, not `pending-dev`. This protects the first-review path: review must see the PR at least once before any "no new commits" gate can apply.
 
 If DEAD and issue still has `reviewing`:
 1. Comment: `Review process appears to have crashed. Moving to pending-dev for retry.`

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -201,7 +201,8 @@ fi
 # Build review prompt
 # ---------------------------------------------------------------------------
 PR_BRANCH=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefName -q '.headRefName' 2>/dev/null || true)
-log "PR branch: ${PR_BRANCH:-UNKNOWN}"
+PR_HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid -q '.headRefOid' 2>/dev/null || true)
+log "PR branch: ${PR_BRANCH:-UNKNOWN} (HEAD: ${PR_HEAD_SHA:0:7})"
 
 SESSION_ID=$(uuidgen)
 
@@ -482,6 +483,19 @@ for _poll_attempt in $(seq 1 6); do
   fi
   log "Waiting for review comment to appear (attempt ${_poll_attempt}/6)..."
 done
+
+# Post a "Reviewed HEAD" trailer comment so the dispatcher can detect whether
+# new commits have landed since the last review. The dispatcher uses this to
+# decide between routing a dead-with-PR transition to pending-review (new code
+# to review) vs. pending-dev (no new code, retry dev).
+# Only emitted when the agent produced a verdict comment — a missing verdict
+# already routes to pending-dev via the FAILED branch below.
+if [[ -n "$LATEST_COMMENT" && -n "$PR_HEAD_SHA" ]]; then
+  gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+    --body "Reviewed HEAD: \`${PR_HEAD_SHA}\` (issue #${ISSUE_NUMBER}, session \`${SESSION_ID}\`)" \
+    >/dev/null 2>&1 \
+    || log "WARNING: Failed to post Reviewed HEAD trailer (non-fatal — dispatcher will route to pending-review)"
+fi
 
 if echo "$LATEST_COMMENT" | head -1 | grep -qi "^Review PASSED"; then
   log "Review PASSED for PR #${PR_NUMBER}."

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -491,10 +491,14 @@ done
 # Only emitted when the agent produced a verdict comment — a missing verdict
 # already routes to pending-dev via the FAILED branch below.
 if [[ -n "$LATEST_COMMENT" && -n "$PR_HEAD_SHA" ]]; then
-  gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+  # Capture stderr so token/permission/rate-limit failures are diagnosable.
+  # If this post fails persistently the dispatcher cannot detect SHA-match,
+  # so the WARNING is the only operator-visible breadcrumb (see SKILL.md
+  # Step 5 empty-trailer fallthrough).
+  _trailer_err=$(gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
     --body "Reviewed HEAD: \`${PR_HEAD_SHA}\` (issue #${ISSUE_NUMBER}, session \`${SESSION_ID}\`)" \
-    >/dev/null 2>&1 \
-    || log "WARNING: Failed to post Reviewed HEAD trailer (non-fatal — dispatcher will route to pending-review)"
+    2>&1 >/dev/null) \
+    || log "WARNING: Failed to post Reviewed HEAD trailer (non-fatal): ${_trailer_err}"
 fi
 
 if echo "$LATEST_COMMENT" | head -1 | grep -qi "^Review PASSED"; then

--- a/tests/unit/test-pid-guard.sh
+++ b/tests/unit/test-pid-guard.sh
@@ -174,15 +174,16 @@ if [[ -f "$SKILL_MD" ]]; then
   assert_contains "Skip freshly dispatched check" 'JUST_DISPATCHED[*]' "$SKILL_CONTENT"
 
   echo "TC-SKILL-002: SKILL.md has PR existence check in crash transition"
-  # Step 5 fetches the PR (number + body + headRefOid) and gates on whether
-  # the result is non-empty. The variable name evolved from PR_EXISTS to
-  # PR_INFO when the SHA-comparison logic landed; either form satisfies the
-  # "existence check" intent of this assertion.
-  if [[ "$SKILL_CONTENT" == *"PR_EXISTS"* ]] || [[ "$SKILL_CONTENT" == *"PR_INFO"* ]]; then
+  # Step 5 must gate the dead-with-PR transition on a non-empty test of the
+  # fetched PR object. The variable name evolved from PR_EXISTS to PR_INFO
+  # when the SHA-comparison logic landed (#54), so accept either — but only
+  # if it appears in a real conditional (-gt 0 for the count form, or -n for
+  # the object form), not just any mention.
+  if echo "$SKILL_CONTENT" | grep -qE '\[ "?\$PR_EXISTS"? -gt 0 \]|\[ -n "?\$PR_INFO"? \]'; then
     echo -e "  ${GREEN}PASS${NC}: PR existence check"
     PASS=$((PASS+1))
   else
-    echo -e "  ${RED}FAIL${NC}: PR existence check (expected PR_EXISTS or PR_INFO)"
+    echo -e "  ${RED}FAIL${NC}: PR existence check (expected '[ \$PR_EXISTS -gt 0 ]' or '[ -n \$PR_INFO ]')"
     FAIL=$((FAIL+1))
   fi
   assert_contains "No PR crash path" "No PR" "$SKILL_CONTENT"

--- a/tests/unit/test-pid-guard.sh
+++ b/tests/unit/test-pid-guard.sh
@@ -174,7 +174,17 @@ if [[ -f "$SKILL_MD" ]]; then
   assert_contains "Skip freshly dispatched check" 'JUST_DISPATCHED[*]' "$SKILL_CONTENT"
 
   echo "TC-SKILL-002: SKILL.md has PR existence check in crash transition"
-  assert_contains "PR existence check" "PR_EXISTS" "$SKILL_CONTENT"
+  # Step 5 fetches the PR (number + body + headRefOid) and gates on whether
+  # the result is non-empty. The variable name evolved from PR_EXISTS to
+  # PR_INFO when the SHA-comparison logic landed; either form satisfies the
+  # "existence check" intent of this assertion.
+  if [[ "$SKILL_CONTENT" == *"PR_EXISTS"* ]] || [[ "$SKILL_CONTENT" == *"PR_INFO"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: PR existence check"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: PR existence check (expected PR_EXISTS or PR_INFO)"
+    FAIL=$((FAIL+1))
+  fi
   assert_contains "No PR crash path" "No PR" "$SKILL_CONTENT"
 
   echo "TC-SKILL-003: SKILL.md counts dispatcher crashes in retry count"

--- a/tests/unit/test-skip-redundant-review.sh
+++ b/tests/unit/test-skip-redundant-review.sh
@@ -89,8 +89,15 @@ TRAILER_BLOCK=$(awk '
   }
 ' "$REVIEW_SCRIPT")
 
-assert_match "Trailer post tolerates failure (|| true or || log fallback)" \
-  '\|\| (true|log )' "$TRAILER_BLOCK"
+# Guard against silent vacuous-pass if the trailer layout changes and the
+# block extractor produces an empty match — fail loudly instead.
+if [[ -z "$TRAILER_BLOCK" ]]; then
+  echo -e "  ${RED}FAIL${NC}: trailer block extraction empty — script layout changed, update awk pattern"
+  FAIL=$((FAIL+1))
+else
+  assert_match "Trailer post tolerates failure (|| true or || log fallback)" \
+    '\|\| (true|log )' "$TRAILER_BLOCK"
+fi
 
 # ============================================================================
 # TC-DSRR-003: Dispatcher SKILL.md describes SHA comparison
@@ -158,6 +165,7 @@ echo
 if ! command -v jq >/dev/null 2>&1; then
   echo -e "  ${RED}SKIP${NC}: jq not installed"
 else
+  # Single-trailer fixture
   SAMPLE=$(cat <<'EOF'
 {
   "comments": [
@@ -178,6 +186,29 @@ EOF
     PASS=$((PASS+1))
   else
     echo -e "  ${RED}FAIL${NC}: jq capture did not return SHA, got: '$EXTRACTED'"
+    FAIL=$((FAIL+1))
+  fi
+
+  # Multi-trailer fixture — assert `last` returns the newest SHA, not the oldest.
+  # Guards against a regression that swaps `last` for `first`.
+  MULTI_SAMPLE=$(cat <<'EOF'
+{
+  "comments": [
+    {"body": "Reviewed HEAD: `1111111111111111111111111111111111111111` (issue #1, session `aaa`)"},
+    {"body": "Resuming development..."},
+    {"body": "Reviewed HEAD: `2222222222222222222222222222222222222222` (issue #1, session `bbb`)"}
+  ]
+}
+EOF
+  )
+  MULTI_EXTRACTED=$(echo "$MULTI_SAMPLE" | jq -r '
+    [.comments[].body | capture("Reviewed HEAD: `(?<sha>[0-9a-f]{7,40})`"; "g") | .sha] | last // empty
+  ')
+  if [[ "$MULTI_EXTRACTED" == "2222222222222222222222222222222222222222" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: jq capture returns newest SHA across multiple trailers"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: expected newest SHA from multi-trailer fixture, got: '$MULTI_EXTRACTED'"
     FAIL=$((FAIL+1))
   fi
 fi

--- a/tests/unit/test-skip-redundant-review.sh
+++ b/tests/unit/test-skip-redundant-review.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# test-skip-redundant-review.sh — Unit tests for dispatcher skipping redundant review
+# when the PR HEAD SHA has not advanced since the last review.
+#
+# See docs/designs/dispatcher-skip-redundant-review.md
+# Run: bash tests/unit/test-skip-redundant-review.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected to contain '$needle')"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (should NOT contain '$needle')"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_match() {
+  local desc="$1" pattern="$2" haystack="$3"
+  if echo "$haystack" | grep -Eq "$pattern"; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected to match '$pattern')"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+REVIEW_SCRIPT="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous-review.sh"
+SKILL_FILE="$PROJECT_ROOT/skills/autonomous-dispatcher/SKILL.md"
+
+[[ -f "$REVIEW_SCRIPT" ]] || { echo -e "${RED}FATAL${NC}: $REVIEW_SCRIPT not found"; exit 1; }
+[[ -f "$SKILL_FILE"   ]] || { echo -e "${RED}FATAL${NC}: $SKILL_FILE not found";   exit 1; }
+
+REVIEW_CONTENT=$(cat "$REVIEW_SCRIPT")
+SKILL_CONTENT=$(cat "$SKILL_FILE")
+
+# ============================================================================
+# TC-DSRR-001: Review wrapper records reviewed HEAD SHA
+# ============================================================================
+echo
+echo "=== TC-DSRR-001: Review wrapper records reviewed HEAD SHA ==="
+echo
+
+assert_contains "PR_HEAD_SHA captured via headRefOid" "headRefOid" "$REVIEW_CONTENT"
+assert_contains "PR_HEAD_SHA variable defined"        "PR_HEAD_SHA=" "$REVIEW_CONTENT"
+assert_contains "Trailer string present"              "Reviewed HEAD:" "$REVIEW_CONTENT"
+
+# ============================================================================
+# TC-DSRR-002: Trailer post failure does not abort review
+# ============================================================================
+echo
+echo "=== TC-DSRR-002: Trailer post is non-fatal ==="
+echo
+
+# Extract just the trailer command — from "gh issue comment ... Reviewed HEAD"
+# up to the next blank line or `fi`. The post must either:
+#   - be wrapped in `|| true`, OR
+#   - chain to a `log` warning with `||` (which under set -e still suppresses
+#     the failure because log returns 0, ending the chain successfully).
+TRAILER_BLOCK=$(awk '
+  /gh issue comment.*Reviewed HEAD|--body "Reviewed HEAD/ { found=1 }
+  found {
+    print
+    if (/^[[:space:]]*$/ || /^fi[[:space:]]*$/) { found=0 }
+  }
+' "$REVIEW_SCRIPT")
+
+assert_match "Trailer post tolerates failure (|| true or || log fallback)" \
+  '\|\| (true|log )' "$TRAILER_BLOCK"
+
+# ============================================================================
+# TC-DSRR-003: Dispatcher SKILL.md describes SHA comparison
+# ============================================================================
+echo
+echo "=== TC-DSRR-003: SKILL.md Step 5 compares SHAs ==="
+echo
+
+assert_contains "SKILL.md mentions headRefOid"           "headRefOid"      "$SKILL_CONTENT"
+assert_contains "SKILL.md extracts Reviewed HEAD SHA"    "Reviewed HEAD:"  "$SKILL_CONTENT"
+assert_contains "SKILL.md branches on SHA equality"      "no new commits since last review" "$SKILL_CONTENT"
+assert_contains "SKILL.md keeps PR-found handoff path"   "Dev process exited (PR found)"    "$SKILL_CONTENT"
+
+# ============================================================================
+# TC-DSRR-004: New "no new commits" wording does not match retry regex
+# ============================================================================
+echo
+echo "=== TC-DSRR-004: New wording is excluded from retry counter ==="
+echo
+
+NEW_WORDING="Dev process exited (no new commits since last review at \`abc1234\`). Moving to pending-dev for retry."
+RETRY_REGEX='Task appears to have crashed \(no PR found\)|process not found'
+
+if echo "$NEW_WORDING" | grep -Eq "$RETRY_REGEX"; then
+  echo -e "  ${RED}FAIL${NC}: new wording incorrectly matches retry regex"
+  FAIL=$((FAIL+1))
+else
+  echo -e "  ${GREEN}PASS${NC}: new wording does not match retry regex"
+  PASS=$((PASS+1))
+fi
+
+# ============================================================================
+# TC-DSRR-005: Existing PR-found wording still excluded from retry regex
+# ============================================================================
+echo
+echo "=== TC-DSRR-005: PR-found handoff wording is excluded from retry counter ==="
+echo
+
+OLD_WORDING="Dev process exited (PR found). Moving to pending-review for assessment."
+
+if echo "$OLD_WORDING" | grep -Eq "$RETRY_REGEX"; then
+  echo -e "  ${RED}FAIL${NC}: PR-found wording incorrectly matches retry regex"
+  FAIL=$((FAIL+1))
+else
+  echo -e "  ${GREEN}PASS${NC}: PR-found wording does not match retry regex"
+  PASS=$((PASS+1))
+fi
+
+# ============================================================================
+# TC-DSRR-006: SKILL.md falls through to pending-review when no trailer found
+# ============================================================================
+echo
+echo "=== TC-DSRR-006: Empty LAST_REVIEWED_HEAD → pending-review ==="
+echo
+
+assert_contains "SKILL.md notes empty-trailer fallback" "no prior review trailer" "$SKILL_CONTENT"
+
+# ============================================================================
+# TC-DSRR-007: Trailer marker is jq/regex-greppable as documented
+# ============================================================================
+echo
+echo "=== TC-DSRR-007: Trailer is parseable by documented regex ==="
+echo
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo -e "  ${RED}SKIP${NC}: jq not installed"
+else
+  SAMPLE=$(cat <<'EOF'
+{
+  "comments": [
+    {"body": "Dispatching autonomous review..."},
+    {"body": "Review findings:\n\n1. **[BLOCKING]** ...\n\nReview Session: `f95638fe-e8d1-4e5d-87b6-d505b79961dc`"},
+    {"body": "Reviewed HEAD: `abcdef1234567890abcdef1234567890abcdef12` (issue #115, session `f95638fe-e8d1-4e5d-87b6-d505b79961dc`)"}
+  ]
+}
+EOF
+  )
+
+  EXTRACTED=$(echo "$SAMPLE" | jq -r '
+    [.comments[].body | capture("Reviewed HEAD: `(?<sha>[0-9a-f]{7,40})`"; "g") | .sha] | last // empty
+  ')
+
+  if [[ "$EXTRACTED" == "abcdef1234567890abcdef1234567890abcdef12" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: jq capture extracts the SHA"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: jq capture did not return SHA, got: '$EXTRACTED'"
+    FAIL=$((FAIL+1))
+  fi
+fi
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+echo
+echo "=== Results ==="
+TOTAL=$((PASS + FAIL))
+echo -e "Total: $TOTAL  ${GREEN}Passed: $PASS${NC}  ${RED}Failed: $FAIL${NC}"
+echo
+
+[[ $FAIL -gt 0 ]] && exit 1
+exit 0


### PR DESCRIPTION
## Summary

Step 5 stale detection used to route any dead-with-PR transition to `pending-review`, even when the PR HEAD hadn't advanced since the last review. That re-ran the review agent on identical code and re-emitted the same findings — a loop the dev agent never got to break.

This PR adds a `Reviewed HEAD: \`<sha>\`` trailer comment posted by the review wrapper after each verdict. Step 5 now compares the current PR HEAD against the most recent trailer:

- HEAD matches last reviewed SHA → `pending-dev` (retry dev so it can act on existing findings)
- HEAD differs **or** no trailer found → `pending-review` (existing behavior, protects first-review path)

The new "no new commits since last review" wording is crafted to avoid the Step 4 retry-counter regex, matching #50's precedent for the "PR found" handoff.

## Changes

- `skills/autonomous-dispatcher/scripts/autonomous-review.sh` — capture `PR_HEAD_SHA` via `gh pr view --json headRefOid`; post trailer comment after verdict polling. Stderr is captured into the WARNING log so chronic post failures are diagnosable.
- `skills/autonomous-dispatcher/SKILL.md` — Step 5 dead-with-PR branch now extracts last reviewed SHA, compares against current PR HEAD, branches between `pending-dev` and `pending-review`. Empty-trailer fallthrough explicitly documents the two distinct causes and points operators at the review log.
- `tests/unit/test-skip-redundant-review.sh` (new) — 13 static-analysis cases covering wrapper trailer emission, SKILL.md SHA-comparison logic, retry-regex exclusion, jq capture syntax (incl. multi-trailer "last wins").
- `tests/unit/test-pid-guard.sh` — TC-SKILL-002 widened to accept either `PR_EXISTS` or `PR_INFO`, with a strict conditional pattern check.
- `docs/designs/dispatcher-skip-redundant-review.md` and `docs/test-cases/dispatcher-skip-redundant-review.md` — design canvas + test-case document.

## Test plan

- [x] `bash tests/unit/test-skip-redundant-review.sh` (13/13)
- [x] All 9 unit suites pass (`for t in tests/unit/test-*.sh; do bash "$t"; done`)
- [x] `shellcheck` reports no new warnings on the modified script
- [x] Verified `set -e` survival of trailer-post failure path with synthetic 401-stderr fixture
- [x] Verified `last` vs `first` regression sensitivity with multi-trailer jq fixture
- [ ] Real-world: next dispatcher cycle on a downstream consumer issue where dev exits without new commits — should now route back to `pending-dev` instead of redundant `pending-review`.