### PR TITLE
fix(dispatcher): handle ALIVE process with ready-for-review PR

### DIFF
--- a/docs/designs/dispatcher-stale-alive-with-pr.md
+++ b/docs/designs/dispatcher-stale-alive-with-pr.md
@@ -1,0 +1,103 @@
+# Dispatcher: handle ALIVE process + ready-for-review PR
+
+Closes #54.
+
+## Problem
+
+`Step 5: Stale Detection` only acts on DEAD processes. When a dev agent finishes its work (PR opened, CI green) but the wrapper process does not exit cleanly — for example because the underlying agent CLI is hung in a polling loop or waiting on a tool result — the issue stays in `in-progress` forever:
+
+- ALIVE branch: skip silently
+- DEAD branch: existing PR/no-PR handling
+
+Downstream issues that depend on this one also never dispatch, because dispatch gates on the dependency being CLOSED. Production cron has been observed stalling whole dependency chains this way.
+
+## Goal
+
+When the dev wrapper is ALIVE but its real work is done (PR up, CI green, no recent activity), the dispatcher must:
+
+1. Send `SIGTERM` to the wrapper so the PID file clears,
+2. Transition the issue from `in-progress` to `pending-review` so the review agent picks it up.
+
+## Design
+
+### Where the new branch fits
+
+Step 5 currently runs `kill -0 $(cat $PID_FILE) && echo ALIVE || echo DEAD` and only branches on DEAD. Add a new branch **before** the ALIVE-skip:
+
+```
+For each in-progress issue (not in JUST_DISPATCHED):
+  PID_ALIVE=$(kill -0 ... && echo 1 || echo 0)
+  if PID_ALIVE == 1:
+    PR_INFO=$(gh pr list ... | first match)
+    if PR_INFO is non-empty:
+      CI_GREEN=$(every check SUCCESS, at least one check)
+      if CI_GREEN:
+        IDLE_SECONDS = now - PR.updatedAt
+        if IDLE_SECONDS > 300:
+          SIGTERM the wrapper PID
+          comment "Dev process still alive but PR ready (CI green, idle Xs). Moving to pending-review."
+          remove `in-progress`, add `pending-review`
+          continue
+    # Otherwise: leave alone (no PR yet, or CI not green, or PR recently updated — agent may still be pushing)
+    continue
+  # PID_ALIVE == 0: existing DEAD path (unchanged)
+```
+
+### Why the 5-minute idle gate
+
+Without an idle gate, we'd kill an agent that *just* pushed a passing CI check and is about to do its own cleanup (close worktree, post status comment, etc). The risk of premature kill — leaking a half-written comment, or worse, a half-pushed branch — outweighs the cost of waiting one more dispatcher cycle (5 min by default).
+
+`PR.updatedAt` is the timestamp of the most recent PR-state mutation (commit pushed, comment, label change). It's the right signal: as long as the agent is actively driving the PR, this stays fresh; once the agent goes quiet, it ages.
+
+5 minutes also matches the dispatcher cron interval — so the next cycle will be the one to act, not the cycle that detects the green-CI state.
+
+### Why kill at all (vs. just transitioning the label)
+
+If we only transition the label, the wrapper stays alive holding `/tmp/agent-${PROJECT_ID}-issue-${ISSUE_NUM}.pid`. Two follow-on problems:
+
+1. The `acquire_pid_guard` in `lib-agent.sh` will refuse to start a new dev session for the same issue (e.g. if review sends it back to `pending-dev`), because the existing PID is still alive. The user's #55 bug is exactly this surface: zombie wrappers blocking re-dispatch.
+2. Resource leak. Production has been seen with multiple such zombies per issue.
+
+`SIGTERM` is the right signal — agent shells trap it and clean up. We do NOT escalate to `SIGKILL` here; a stuck-on-SIGTERM wrapper is rare enough and a separate failure mode best handled by an operator.
+
+### Why "all checks SUCCESS + non-empty"
+
+Three failure shapes ruled out by the non-empty check:
+
+- A PR with **no checks configured at all** ([] on `gh pr checks`): could happen on a brand-new repo or a misconfigured branch. Treating empty as green means we'd transition immediately on PR-open, defeating the purpose of waiting for CI.
+- **Required checks not yet started** (everything `QUEUED` / `PENDING`): empty SUCCESS-only filter would pass `all SUCCESS` vacuously on the empty-after-filter set. Need both "every check is SUCCESS" AND "the check list is non-empty".
+- **Skipped checks** (`SKIPPED`, `NEUTRAL`): conservatively NOT counted as success. If a repo has a routinely-skipped check, the agent's normal workflow will exit cleanly when CI finishes; we only need this stale path for the hung-agent case, where being conservative is fine.
+
+Concretely:
+
+```bash
+CI_STATES=$(gh pr checks "$PR_NUM" --repo "$REPO" --json state -q '[.[].state]')
+CI_GREEN=$(jq -e 'length > 0 and all(. == "SUCCESS")' <<<"$CI_STATES" >/dev/null && echo 1 || echo 0)
+```
+
+### Idempotence under repeated cron ticks
+
+If the dispatcher transitions an issue to `pending-review` but the wrapper survives the SIGTERM (rare, but possible if the agent is in uninterruptible IO), the next dispatcher tick will:
+
+- Find the issue in `pending-review` (label already moved), so this Step 5 in-progress branch doesn't re-fire.
+- Step 3 (review dispatch) will pick it up with no new transition needed.
+
+If by then the agent has *also* moved the issue back to `in-progress` somehow (it shouldn't — it's mid-shutdown), the same branch will SIGTERM again. That's safe.
+
+### Operator-visibility
+
+Comment posted on transition:
+
+```
+Dev process still alive but PR #<N> is ready (all CI checks passed, idle 312s).
+Sent SIGTERM to PID <pid>. Moving to pending-review.
+```
+
+The "still alive" wording deliberately differs from both DEAD-with-PR ("Dev process exited (PR found)") and the new "no new commits" wording from #53 — three distinct operator signals. None of them match the Step 4 retry-counter regex (`Task appears to have crashed \(no PR found\)|process not found`).
+
+## Out of Scope
+
+- The companion problem of zombie wrappers blocking *re-dispatch* (issue #55) is a separate fix. This PR handles only the ALIVE+ready-PR transition. After this lands, PIDs from such zombies will be cleared by SIGTERM, which incidentally helps #55 in the most common shape.
+- A `SIGKILL` escalation after SIGTERM grace period — out of scope. If we observe SIGTERM-resistant agents in production, we'll add a follow-up.
+- Detecting "agent is in a tight loop with no PR-side activity" (e.g. spinning on internal state). The PR-updatedAt heuristic works for the common shape; pathological loops are out of scope.
+- Reviewing-state ALIVE handling (review agent stuck). Same shape, but the review agent does its own labels (PASS/find) so the failure mode is different. Out of scope here.

--- a/docs/test-cases/dispatcher-stale-alive-with-pr.md
+++ b/docs/test-cases/dispatcher-stale-alive-with-pr.md
@@ -1,0 +1,66 @@
+# Test Cases: dispatcher-stale-alive-with-pr
+
+Closes #54.
+
+## TC-DSAP-001: SKILL.md describes the new ALIVE-with-PR branch
+
+**Verify** SKILL.md Step 5 contains:
+- `gh pr checks` invocation
+- `updatedAt` reference for PR idle-time computation
+- A SIGTERM (`kill -TERM` or `kill ` without `-9`) call
+- A 300-second (5-minute) idle threshold
+- Transition to `pending-review` on the new path
+
+## TC-DSAP-002: Comment wording does not match the retry-counter regex
+
+The new "still alive but PR is ready" comment must NOT match the Step 4 regex:
+```
+Task appears to have crashed \(no PR found\)|process not found
+```
+
+**Verify** by running the documented regex against the new comment string.
+
+## TC-DSAP-003: Comment wording is distinct from existing handoff phrases
+
+**Verify** the new comment string differs from both:
+- `Dev process exited (PR found)` (existing DEAD-with-PR-and-new-commits)
+- `Dev process exited (no new commits since last review at` (PR #53)
+
+so that operators can distinguish the three transition causes from issue history alone.
+
+## TC-DSAP-004: jq CI-green predicate works as documented
+
+**Setup:** synthesize fixtures and run the SKILL.md jq predicate:
+```jq
+length > 0 and all(. == "SUCCESS")
+```
+
+**Cases:**
+- Empty array `[]` → false (predicate must reject "no checks at all")
+- `["SUCCESS"]` → true
+- `["SUCCESS","SUCCESS","SUCCESS"]` → true
+- `["SUCCESS","PENDING"]` → false
+- `["SUCCESS","FAILURE"]` → false
+- `["SKIPPED","SUCCESS"]` → false (conservative — skip not counted as green)
+
+## TC-DSAP-005: Idle-time math works on a known timestamp
+
+**Setup:** given a fixed `PR.updatedAt = 2026-05-08T00:00:00Z` and a current time of `2026-05-08T00:06:00Z`, the documented idle-seconds expression yields ≥ 300.
+
+This locks in that the SKILL.md expression isn't off by 1000× (ms vs s), reading the wrong field, or using the wrong baseline timestamp.
+
+## TC-DSAP-006: ALIVE branch does NOT fire when no PR exists
+
+**Verify** SKILL.md explicitly says: if `PR_INFO` is empty, the ALIVE branch does not transition; the agent is left alone (still doing development work). This is a documentation assertion — if SKILL.md ever loses this guard, the dispatcher would prematurely transition issues with no PR yet.
+
+## TC-DSAP-007: ALIVE branch does NOT fire when CI is not green
+
+**Verify** SKILL.md says: when `CI_GREEN == 0`, the ALIVE branch does not transition. Same documentation-assertion shape as TC-DSAP-006.
+
+## TC-DSAP-008: ALIVE branch does NOT fire when PR was updated within 5 minutes
+
+**Verify** SKILL.md gates the SIGTERM+transition on idle-seconds > 300. This protects the case where the agent just pushed a green CI build and is about to do its own cleanup (close worktree, post final status).
+
+## TC-DSAP-009: SIGTERM is preferred over SIGKILL
+
+**Verify** the SKILL.md kill invocation uses `kill <pid>` or `kill -TERM <pid>`, NOT `kill -9` or `kill -KILL`. SIGTERM allows agent shells to trap and clean up.

--- a/skills/autonomous-dispatcher/SKILL.md
+++ b/skills/autonomous-dispatcher/SKILL.md
@@ -258,11 +258,64 @@ For each remaining issue, check if the agent process is still alive locally. Use
 
 ```bash
 # For in-progress issues:
-kill -0 $(cat /tmp/agent-${PROJECT_ID}-issue-ISSUE_NUM.pid 2>/dev/null) 2>/dev/null && echo ALIVE || echo DEAD
+PID=$(cat /tmp/agent-${PROJECT_ID}-issue-ISSUE_NUM.pid 2>/dev/null)
+kill -0 "$PID" 2>/dev/null && echo ALIVE || echo DEAD
 
 # For reviewing issues:
 kill -0 $(cat /tmp/agent-${PROJECT_ID}-review-ISSUE_NUM.pid 2>/dev/null) 2>/dev/null && echo ALIVE || echo DEAD
 ```
+
+#### Step 5a (NEW): ALIVE + PR ready for review (issue #54)
+
+If ALIVE and issue still has `in-progress`, the agent process is running but its real work may already be done — PR opened, CI green, and no recent activity for several minutes. In that case the wrapper is hung (polling loop, stuck IO) and is blocking the issue from progressing. Send `SIGTERM` and transition to `pending-review`:
+
+```bash
+PR_INFO=$(gh pr list --repo "$REPO" --state open --json number,body,updatedAt \
+  -q "[.[] | select(.body | test(\"#ISSUE_NUM[^0-9]\") or test(\"#ISSUE_NUM$\"))] | .[0] // empty")
+
+if [ -n "$PR_INFO" ]; then
+  PR_NUM=$(jq -r '.number' <<<"$PR_INFO")
+  PR_UPDATED_AT=$(jq -r '.updatedAt' <<<"$PR_INFO")
+
+  # CI green = at least one check, all SUCCESS. Empty / pending / failed / skipped → not green.
+  CI_STATES=$(gh pr checks "$PR_NUM" --repo "$REPO" --json state -q '[.[].state]' 2>/dev/null || echo '[]')
+  CI_GREEN=$(jq -e 'length > 0 and all(. == "SUCCESS")' <<<"$CI_STATES" >/dev/null 2>&1 && echo 1 || echo 0)
+
+  if [ "$CI_GREEN" = "1" ]; then
+    # Idle = seconds since the PR was last updated. Uses GNU `date -d` to parse
+    # the GitHub ISO-8601 timestamp; `date +%s` for the current epoch.
+    PR_UPDATED_EPOCH=$(date -u -d "$PR_UPDATED_AT" +%s 2>/dev/null || echo 0)
+    NOW_EPOCH=$(date -u +%s)
+    IDLE_SECONDS=$(( NOW_EPOCH - PR_UPDATED_EPOCH ))
+
+    if [ "$IDLE_SECONDS" -gt 300 ]; then
+      # Agent hasn't touched the PR in 5+ minutes and CI is green.
+      # SIGTERM the wrapper so its PID file clears, then hand off to review.
+      kill "$PID" 2>/dev/null || true
+      gh issue comment ISSUE_NUM --repo "$REPO" \
+        --body "Dev process still alive but PR #${PR_NUM} is ready (all CI checks passed, idle ${IDLE_SECONDS}s). Sent SIGTERM to PID ${PID}. Moving to pending-review."
+      gh issue edit ISSUE_NUM --repo "$REPO" \
+        --remove-label "in-progress" --add-label "pending-review"
+      continue   # done with this issue this cycle
+    fi
+    # Else: PR moved within the last 5 min — agent may still be doing cleanup
+    #       (closing worktree, posting status, etc). Leave alone for now.
+  fi
+  # Else: CI not green (pending or failing) — leave alone, agent is presumably
+  #       still working on it.
+fi
+# Else: no PR yet — agent is still developing, leave alone.
+
+# Fall through to the existing ALIVE-skip below (no transition).
+```
+
+**Why a 5-minute idle gate (idle > 300s):** without it, the dispatcher might SIGTERM an agent that just pushed its passing CI build and is about to do its own cleanup. 5 min matches the dispatcher cron interval — the next cycle will be the one to act, not the cycle that detected green CI.
+
+**Why SIGTERM, not SIGKILL:** agent shells trap SIGTERM and clean up (close worktree handles, flush logs). Plain `kill` defaults to SIGTERM. We do NOT escalate to SIGKILL here — a SIGTERM-resistant agent is rare and best handled by an operator.
+
+**Guard rails:** the new branch fires only when ALL of these hold — alive PID, **PR exists for the issue** (no PR yet → leave alone), **CI green** (CI not green → leave alone), **idle > 300s** (recent activity → leave alone). Each guard is enforced by the conditional structure above.
+
+#### Step 5b: DEAD branch (existing)
 
 If DEAD and issue still has `in-progress`, **check whether a PR exists before deciding the transition**, and if it does, **compare the PR HEAD SHA against the last reviewed SHA** so a redundant review is skipped when no new commits were pushed:
 ```bash

--- a/skills/autonomous-dispatcher/SKILL.md
+++ b/skills/autonomous-dispatcher/SKILL.md
@@ -285,10 +285,13 @@ if [ -n "$PR_INFO" ]; then
     # CI green = at least one check, all SUCCESS. Empty / pending / failed / skipped → not green.
     # Capture stderr so a transport error (token expiry, rate limit) is diagnosable
     # rather than silently equivalent to "no checks".
+    # Use mktemp (not a fixed /tmp path) — concurrent dispatcher instances would
+    # otherwise collide on the same file (CWE-377: insecure temporary file).
     CI_STATES_ERR=""
-    CI_STATES=$(gh pr checks "$PR_NUM" --repo "$REPO" --json state -q '[.[].state]' 2>/tmp/_gh-checks-err) \
-      || { CI_STATES_ERR=$(cat /tmp/_gh-checks-err); CI_STATES='[]'; }
-    rm -f /tmp/_gh-checks-err
+    CI_ERR_FILE=$(mktemp)
+    CI_STATES=$(gh pr checks "$PR_NUM" --repo "$REPO" --json state -q '[.[].state]' 2>"$CI_ERR_FILE") \
+      || { CI_STATES_ERR=$(cat "$CI_ERR_FILE"); CI_STATES='[]'; }
+    rm -f "$CI_ERR_FILE"
     if [ -n "$CI_STATES_ERR" ]; then
       echo "WARN: gh pr checks failed for PR #${PR_NUM}: ${CI_STATES_ERR}" >&2
     fi

--- a/skills/autonomous-dispatcher/SKILL.md
+++ b/skills/autonomous-dispatcher/SKILL.md
@@ -274,40 +274,78 @@ PR_INFO=$(gh pr list --repo "$REPO" --state open --json number,body,updatedAt \
   -q "[.[] | select(.body | test(\"#ISSUE_NUM[^0-9]\") or test(\"#ISSUE_NUM$\"))] | .[0] // empty")
 
 if [ -n "$PR_INFO" ]; then
-  PR_NUM=$(jq -r '.number' <<<"$PR_INFO")
-  PR_UPDATED_AT=$(jq -r '.updatedAt' <<<"$PR_INFO")
+  PR_NUM=$(jq -r '.number // empty' <<<"$PR_INFO")
+  PR_UPDATED_AT=$(jq -r '.updatedAt // empty' <<<"$PR_INFO")
 
-  # CI green = at least one check, all SUCCESS. Empty / pending / failed / skipped → not green.
-  CI_STATES=$(gh pr checks "$PR_NUM" --repo "$REPO" --json state -q '[.[].state]' 2>/dev/null || echo '[]')
-  CI_GREEN=$(jq -e 'length > 0 and all(. == "SUCCESS")' <<<"$CI_STATES" >/dev/null 2>&1 && echo 1 || echo 0)
-
-  if [ "$CI_GREEN" = "1" ]; then
-    # Idle = seconds since the PR was last updated. Uses GNU `date -d` to parse
-    # the GitHub ISO-8601 timestamp; `date +%s` for the current epoch.
-    PR_UPDATED_EPOCH=$(date -u -d "$PR_UPDATED_AT" +%s 2>/dev/null || echo 0)
-    NOW_EPOCH=$(date -u +%s)
-    IDLE_SECONDS=$(( NOW_EPOCH - PR_UPDATED_EPOCH ))
-
-    if [ "$IDLE_SECONDS" -gt 300 ]; then
-      # Agent hasn't touched the PR in 5+ minutes and CI is green.
-      # SIGTERM the wrapper so its PID file clears, then hand off to review.
-      kill "$PID" 2>/dev/null || true
-      gh issue comment ISSUE_NUM --repo "$REPO" \
-        --body "Dev process still alive but PR #${PR_NUM} is ready (all CI checks passed, idle ${IDLE_SECONDS}s). Sent SIGTERM to PID ${PID}. Moving to pending-review."
-      gh issue edit ISSUE_NUM --repo "$REPO" \
-        --remove-label "in-progress" --add-label "pending-review"
-      continue   # done with this issue this cycle
+  # Validate jq outputs — schema drift or partial JSON would otherwise let
+  # `null` propagate into `gh pr checks "null"` (silent 404 loop).
+  if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]] || [ -z "$PR_UPDATED_AT" ]; then
+    echo "WARN: malformed PR info for issue ISSUE_NUM (PR_NUM='$PR_NUM', PR_UPDATED_AT='$PR_UPDATED_AT'); leaving as-is" >&2
+  else
+    # CI green = at least one check, all SUCCESS. Empty / pending / failed / skipped → not green.
+    # Capture stderr so a transport error (token expiry, rate limit) is diagnosable
+    # rather than silently equivalent to "no checks".
+    CI_STATES_ERR=""
+    CI_STATES=$(gh pr checks "$PR_NUM" --repo "$REPO" --json state -q '[.[].state]' 2>/tmp/_gh-checks-err) \
+      || { CI_STATES_ERR=$(cat /tmp/_gh-checks-err); CI_STATES='[]'; }
+    rm -f /tmp/_gh-checks-err
+    if [ -n "$CI_STATES_ERR" ]; then
+      echo "WARN: gh pr checks failed for PR #${PR_NUM}: ${CI_STATES_ERR}" >&2
     fi
-    # Else: PR moved within the last 5 min — agent may still be doing cleanup
-    #       (closing worktree, posting status, etc). Leave alone for now.
+    CI_GREEN=$(jq -e 'length > 0 and all(. == "SUCCESS")' <<<"$CI_STATES" >/dev/null 2>&1 && echo 1 || echo 0)
+
+    if [ "$CI_GREEN" = "1" ]; then
+      # Idle = seconds since the PR was last updated.
+      # `date -d` is GNU-only; macOS/BSD uses `date -j -f`. Fall back across
+      # the two so the dispatcher works on both. On parse failure, fail-CLOSED:
+      # leave the PR alone instead of treating it as 1.7e9-seconds idle (which
+      # would unconditionally fire SIGTERM).
+      PR_UPDATED_EPOCH=$(date -u -d "$PR_UPDATED_AT" +%s 2>/dev/null \
+        || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$PR_UPDATED_AT" +%s 2>/dev/null \
+        || echo "")
+      if [ -z "$PR_UPDATED_EPOCH" ]; then
+        echo "WARN: cannot parse PR.updatedAt='${PR_UPDATED_AT}' for issue ISSUE_NUM; leaving as-is" >&2
+      else
+        NOW_EPOCH=$(date -u +%s)
+        IDLE_SECONDS=$(( NOW_EPOCH - PR_UPDATED_EPOCH ))
+
+        if [ "$IDLE_SECONDS" -gt 300 ]; then
+          # Re-verify the PID is still alive AND still ours. Between the
+          # earlier kill -0 check and this point, the wrapper could have
+          # exited and the PID could have been reassigned to an unrelated
+          # process. If recheck fails, treat as DEAD and fall through to
+          # the existing DEAD-with-PR path on the next cron tick.
+          if ! kill -0 "$PID" 2>/dev/null; then
+            echo "INFO: wrapper PID ${PID} for issue ISSUE_NUM exited between checks; deferring to next cycle" >&2
+          else
+            # Agent hasn't touched the PR in 5+ minutes and CI is green.
+            # SIGTERM the wrapper so its PID file clears, then hand off to review.
+            if kill "$PID" 2>/dev/null; then
+              KILL_NOTE="Sent SIGTERM to PID ${PID}"
+            else
+              KILL_NOTE="PID ${PID} already gone"
+            fi
+            gh issue comment ISSUE_NUM --repo "$REPO" \
+              --body "Dev process still alive but PR #${PR_NUM} is ready (all CI checks passed, idle ${IDLE_SECONDS}s). ${KILL_NOTE}. Moving to pending-review."
+            gh issue edit ISSUE_NUM --repo "$REPO" \
+              --remove-label "in-progress" --add-label "pending-review"
+            continue   # done with this issue this cycle
+          fi
+        fi
+        # Else: PR moved within the last 5 min — agent may still be doing cleanup
+        #       (closing worktree, posting status, etc). Leave alone for now.
+      fi
+    fi
+    # Else: CI not green (pending or failing) — leave alone, agent is presumably
+    #       still working on it.
   fi
-  # Else: CI not green (pending or failing) — leave alone, agent is presumably
-  #       still working on it.
 fi
 # Else: no PR yet — agent is still developing, leave alone.
 
 # Fall through to the existing ALIVE-skip below (no transition).
 ```
+
+> **Concurrent-shutdown race:** between `kill "$PID"` and `gh issue edit ... pending-review`, the wrapper's own SIGTERM trap may also call `gh issue edit` (its `cleanup()` trap posts a session report and may set labels). Outcomes are bounded — the wrapper trap targets `pending-review` (PR exists, exit 0 path) or `pending-dev` (failure path); in the worst case the labels flip back and forth for one cron tick, but the next cycle stabilizes (Step 3 picks up `pending-review`, Step 4 picks up `pending-dev`). No data loss, just one extra comment per ~1% of transitions.
 
 **Why a 5-minute idle gate (idle > 300s):** without it, the dispatcher might SIGTERM an agent that just pushed its passing CI build and is about to do its own cleanup. 5 min matches the dispatcher cron interval — the next cycle will be the one to act, not the cycle that detected green CI.
 

--- a/tests/unit/test-stale-alive-with-pr.sh
+++ b/tests/unit/test-stale-alive-with-pr.sh
@@ -297,6 +297,24 @@ echo
 assert_contains "gh pr checks failure logged" \
   "gh pr checks failed" "$SKILL_CONTENT"
 
+# ============================================================================
+# TC-DSAP-015: Stderr capture uses mktemp, not a fixed /tmp path
+# ============================================================================
+echo
+echo "=== TC-DSAP-015: stderr capture uses mktemp (CWE-377) ==="
+echo
+# Concurrent dispatcher instances would race on a fixed /tmp/_gh-checks-err
+# path. Q flagged this as a security vulnerability; the regression guard
+# checks both that mktemp is used and that no fixed path appears.
+assert_contains "mktemp used for stderr capture" "mktemp" "$SKILL_CONTENT"
+if [[ -n "$(grep -E '/tmp/_gh-checks-err' <<<"$SKILL_CONTENT")" ]]; then
+  echo -e "  ${RED}FAIL${NC}: SKILL.md still references the fixed /tmp/_gh-checks-err path"
+  FAIL=$((FAIL+1))
+else
+  echo -e "  ${GREEN}PASS${NC}: no fixed /tmp/_gh-checks-err reference"
+  PASS=$((PASS+1))
+fi
+
 # ----------------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------------

--- a/tests/unit/test-stale-alive-with-pr.sh
+++ b/tests/unit/test-stale-alive-with-pr.sh
@@ -217,6 +217,86 @@ else
   FAIL=$((FAIL+1))
 fi
 
+# ============================================================================
+# TC-DSAP-010: Date-parse failure must NOT fall back to epoch 0
+# ============================================================================
+echo
+echo "=== TC-DSAP-010: Date-parse fail-CLOSED ==="
+echo
+# Regression guard for the fail-OPEN bug surfaced in PR review:
+# `PR_UPDATED_EPOCH=$(date -u -d ... || echo 0)` would make IDLE_SECONDS huge
+# and unconditionally fire SIGTERM. The fix must NOT use `|| echo 0` *as the
+# fallback specifically for PR_UPDATED_EPOCH*; it must either fail-closed
+# (skip the issue this cycle) or use `$NOW_EPOCH` as the safe default.
+#
+# (Note: an unrelated `|| echo 0` is fine for CI_GREEN, where 0 means
+#  "not green" — that is the safe direction.)
+PR_EPOCH_BLOCK=$(awk '/PR_UPDATED_EPOCH=/{found=1} found{print; if (/\)$|fi$/) found=0}' \
+  <<<"$SKILL_CONTENT")
+if [[ -n "$(grep -E '\|\| *echo *0\b' <<<"$PR_EPOCH_BLOCK")" ]]; then
+  echo -e "  ${RED}FAIL${NC}: SKILL.md still uses '|| echo 0' for PR_UPDATED_EPOCH (fail-OPEN regression)"
+  FAIL=$((FAIL+1))
+else
+  echo -e "  ${GREEN}PASS${NC}: PR_UPDATED_EPOCH does not fall back to 0 (fail-CLOSED)"
+  PASS=$((PASS+1))
+fi
+# Also assert that the parse-failure path is documented as leaving the issue
+# alone (fail-CLOSED).
+assert_contains "Date-parse failure documented as leave-alone" \
+  "cannot parse PR.updatedAt" "$SKILL_CONTENT"
+
+# ============================================================================
+# TC-DSAP-011: BSD/macOS date fallback present
+# ============================================================================
+echo
+echo "=== TC-DSAP-011: BSD/macOS date fallback ==="
+echo
+# `date -d` is GNU-only. Without a BSD fallback the dispatcher would
+# misbehave on macOS even after the fail-CLOSED fix.
+assert_match "macOS date -j -f fallback present" \
+  'date -[uU]? *-j -f' "$SKILL_CONTENT"
+
+# ============================================================================
+# TC-DSAP-012: Null-guard on jq-extracted PR_NUM
+# ============================================================================
+echo
+echo "=== TC-DSAP-012: PR_NUM null-guard ==="
+echo
+# Without a guard, malformed PR_INFO → PR_NUM='null' → `gh pr checks "null"`
+# 404 forever.
+assert_match "PR_NUM validated as positive integer" \
+  'PR_NUM.*=~.*\^\[0-9\]\+\$|\[\[.*PR_NUM.*\[0-9\]' "$SKILL_CONTENT"
+
+# ============================================================================
+# TC-DSAP-013: PID re-verified before SIGTERM
+# ============================================================================
+echo
+echo "=== TC-DSAP-013: PID re-verified before SIGTERM ==="
+echo
+# Mitigates PID-reuse hazard between the earlier kill -0 check and the actual
+# kill. SKILL.md must show a recheck (kill -0) inside the new branch, not just
+# at the top.
+RECHECK_COUNT=$(grep -c 'kill -0 "\$PID"' <<<"$SKILL_CONTENT" || true)
+if [[ "$RECHECK_COUNT" -ge 2 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: PID is rechecked with kill -0 inside Step 5a (count=${RECHECK_COUNT})"
+  PASS=$((PASS+1))
+else
+  echo -e "  ${RED}FAIL${NC}: only ${RECHECK_COUNT} 'kill -0 \"\$PID\"' calls found (expected at least 2: liveness + pre-SIGTERM recheck)"
+  FAIL=$((FAIL+1))
+fi
+
+# ============================================================================
+# TC-DSAP-014: gh pr checks failure produces a diagnostic
+# ============================================================================
+echo
+echo "=== TC-DSAP-014: gh pr checks failure is observable ==="
+echo
+# The original `2>/dev/null || echo '[]'` discarded stderr. The fix must
+# capture it and surface it (via WARN log or stderr) so a chronic gh failure
+# is diagnosable instead of silently skipping issues forever.
+assert_contains "gh pr checks failure logged" \
+  "gh pr checks failed" "$SKILL_CONTENT"
+
 # ----------------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------------

--- a/tests/unit/test-stale-alive-with-pr.sh
+++ b/tests/unit/test-stale-alive-with-pr.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+# test-stale-alive-with-pr.sh — Regression tests for issue #54.
+#
+# Verifies that the dispatcher's Step 5 has an ALIVE+PR-ready branch that
+# kills the lingering wrapper process and transitions to pending-review when:
+#   - PID is alive
+#   - PR exists for the issue
+#   - All CI checks pass (and are non-empty)
+#   - PR has been idle (no updates) for >300s
+#
+# See docs/designs/dispatcher-stale-alive-with-pr.md
+# Run: bash tests/unit/test-stale-alive-with-pr.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected to contain '$needle')"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# NOTE: avoid `grep -q` here — it exits early on first match, which combined
+# with `set -o pipefail` and a large haystack (full SKILL.md) makes `echo` exit
+# with SIGPIPE (rc=141). That gets propagated through the pipeline and the
+# match is reported as a miss. Use full-output grep + stdout-emptiness instead.
+assert_match() {
+  local desc="$1" pattern="$2" haystack="$3"
+  if [[ -n "$(grep -E "$pattern" <<<"$haystack")" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected to match '$pattern')"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_no_match() {
+  local desc="$1" pattern="$2" haystack="$3"
+  if [[ -z "$(grep -E "$pattern" <<<"$haystack")" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (should NOT match '$pattern')"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+SKILL_FILE="$PROJECT_ROOT/skills/autonomous-dispatcher/SKILL.md"
+[[ -f "$SKILL_FILE" ]] || { echo -e "${RED}FATAL${NC}: $SKILL_FILE not found"; exit 1; }
+SKILL_CONTENT=$(cat "$SKILL_FILE")
+
+# ============================================================================
+# TC-DSAP-001: SKILL.md describes the new ALIVE-with-PR branch
+# ============================================================================
+echo
+echo "=== TC-DSAP-001: SKILL.md ALIVE+PR branch ==="
+echo
+
+assert_contains "gh pr checks invocation"          "gh pr checks"  "$SKILL_CONTENT"
+assert_contains "PR.updatedAt referenced"          "updatedAt"     "$SKILL_CONTENT"
+assert_match    "SIGTERM mentioned (not -9/-KILL)" 'kill[^-9]'     "$SKILL_CONTENT"
+assert_no_match "No SIGKILL on this path"          'kill -9|kill -KILL' "$SKILL_CONTENT"
+assert_contains "5-minute idle threshold (300s)"   "300"           "$SKILL_CONTENT"
+assert_contains "Transitions to pending-review"    "pending-review" "$SKILL_CONTENT"
+
+# ============================================================================
+# TC-DSAP-002: New wording is excluded from retry-counter regex
+# ============================================================================
+echo
+echo "=== TC-DSAP-002: New wording is excluded from retry counter ==="
+echo
+
+NEW_WORDING="Dev process still alive but PR #117 is ready (all CI checks passed, idle 312s). Sent SIGTERM to PID 12345. Moving to pending-review."
+RETRY_REGEX='Task appears to have crashed \(no PR found\)|process not found'
+
+if echo "$NEW_WORDING" | grep -Eq "$RETRY_REGEX"; then
+  echo -e "  ${RED}FAIL${NC}: new wording incorrectly matches retry regex"
+  FAIL=$((FAIL+1))
+else
+  echo -e "  ${GREEN}PASS${NC}: new wording does not match retry regex"
+  PASS=$((PASS+1))
+fi
+
+# ============================================================================
+# TC-DSAP-003: Wording is distinct from other handoff phrases
+# ============================================================================
+echo
+echo "=== TC-DSAP-003: Wording is distinct from prior handoffs ==="
+echo
+
+# The new comment must contain a phrase unique to this transition path
+# ("still alive" or similar) so that historical comments can be classified.
+assert_match "New comment carries 'still alive' marker phrase" \
+  'still alive' "$NEW_WORDING"
+
+# And the full distinguishing phrase ("still alive but PR") must appear in
+# SKILL.md so the dispatcher implements it. (Plain "still alive" is too weak —
+# it occurs in unrelated prose elsewhere.)
+assert_contains "SKILL.md uses 'still alive but PR' marker" \
+  "still alive but PR" "$SKILL_CONTENT"
+
+# Negative checks — confirm the new wording is NOT a substring match of either
+# of the other transition comments (would confuse downstream parsers).
+OLD_DEAD_PR_FOUND="Dev process exited (PR found). Moving to pending-review for assessment."
+OLD_NO_NEW_COMMITS='Dev process exited (no new commits since last review at `abc1234`). Moving to pending-dev for retry.'
+if [[ "$NEW_WORDING" == *"Dev process exited"* ]]; then
+  echo -e "  ${RED}FAIL${NC}: new wording overlaps with 'Dev process exited' phrase"
+  FAIL=$((FAIL+1))
+else
+  echo -e "  ${GREEN}PASS${NC}: new wording does not collide with 'exited' transitions"
+  PASS=$((PASS+1))
+fi
+
+# ============================================================================
+# TC-DSAP-004: jq CI-green predicate works as documented
+# ============================================================================
+echo
+echo "=== TC-DSAP-004: jq CI-green predicate ==="
+echo
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo -e "  ${RED}SKIP${NC}: jq not installed"
+else
+  predicate='length > 0 and all(. == "SUCCESS")'
+  declare -A FIXTURES=(
+    ["[]"]="false"
+    ['["SUCCESS"]']="true"
+    ['["SUCCESS","SUCCESS","SUCCESS"]']="true"
+    ['["SUCCESS","PENDING"]']="false"
+    ['["SUCCESS","FAILURE"]']="false"
+    ['["SKIPPED","SUCCESS"]']="false"
+  )
+  for input in "${!FIXTURES[@]}"; do
+    expected="${FIXTURES[$input]}"
+    got=$(jq "$predicate" <<<"$input")
+    if [[ "$got" == "$expected" ]]; then
+      echo -e "  ${GREEN}PASS${NC}: predicate($input) = $expected"
+      PASS=$((PASS+1))
+    else
+      echo -e "  ${RED}FAIL${NC}: predicate($input) expected $expected, got $got"
+      FAIL=$((FAIL+1))
+    fi
+  done
+fi
+
+# ============================================================================
+# TC-DSAP-005: Idle-time math is correct
+# ============================================================================
+echo
+echo "=== TC-DSAP-005: Idle-time math ==="
+echo
+
+# Reference computation that SKILL.md should match: epoch-second delta.
+PAST="2026-05-08T00:00:00Z"
+NOW="2026-05-08T00:06:00Z"
+PAST_EPOCH=$(date -u -d "$PAST" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$PAST" +%s 2>/dev/null)
+NOW_EPOCH=$(date -u -d "$NOW" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$NOW" +%s 2>/dev/null)
+IDLE=$(( NOW_EPOCH - PAST_EPOCH ))
+if [[ "$IDLE" -ge 300 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: idle math (6 min) yields $IDLE seconds (>= 300)"
+  PASS=$((PASS+1))
+else
+  echo -e "  ${RED}FAIL${NC}: idle math broken — got $IDLE seconds, expected >= 300"
+  FAIL=$((FAIL+1))
+fi
+
+# Also assert SKILL.md uses the +%s / `date -d` pattern (or jq fromdateiso8601).
+if [[ -n "$(grep -E 'date -[uU]? *-d|fromdateiso8601|date \+%s' <<<"$SKILL_CONTENT")" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: SKILL.md computes idle via known timestamp method"
+  PASS=$((PASS+1))
+else
+  echo -e "  ${RED}FAIL${NC}: SKILL.md doesn't use date -d / fromdateiso8601 / date +%s"
+  FAIL=$((FAIL+1))
+fi
+
+# ============================================================================
+# TC-DSAP-006/7/8/9: Documentation assertions on the guard rails
+# ============================================================================
+echo
+echo "=== TC-DSAP-006: Empty PR_INFO does NOT transition ==="
+echo
+assert_contains "Skip when no PR" "no PR yet" "$SKILL_CONTENT"
+
+echo
+echo "=== TC-DSAP-007: Non-green CI does NOT transition ==="
+echo
+assert_contains "Skip when CI not green" "CI not green" "$SKILL_CONTENT"
+
+echo
+echo "=== TC-DSAP-008: Recent activity (idle ≤ 300s) does NOT transition ==="
+echo
+assert_match "Idle gate documented" 'idle (>|>=|greater than) *300|> *300' "$SKILL_CONTENT"
+
+echo
+echo "=== TC-DSAP-009: SIGTERM not SIGKILL ==="
+echo
+# Already covered in TC-DSAP-001 (no -9/-KILL) — assert positively too.
+if [[ -n "$(grep -E 'SIGTERM|kill -TERM|kill "?\$\{?[A-Z_]*PID' <<<"$SKILL_CONTENT")" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: SKILL.md uses SIGTERM (default kill signal)"
+  PASS=$((PASS+1))
+else
+  echo -e "  ${RED}FAIL${NC}: SKILL.md does not use plain kill / SIGTERM"
+  FAIL=$((FAIL+1))
+fi
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+echo
+echo "=== Results ==="
+TOTAL=$((PASS + FAIL))
+echo -e "Total: $TOTAL  ${GREEN}Passed: $PASS${NC}  ${RED}Failed: $FAIL${NC}"
+echo
+
+[[ $FAIL -gt 0 ]] && exit 1
+exit 0


### PR DESCRIPTION
## Summary

Closes #54.

`Step 5: Stale Detection` previously only acted on DEAD processes. When a dev wrapper finished its work (PR opened, CI green) but did not exit cleanly — e.g. because the agent CLI was hung in a polling loop — the issue stayed in `in-progress` forever, and downstream issues that depended on it stalled silently.

This PR adds **Step 5a**: when the dev wrapper is ALIVE but the PR is clearly ready for review (CI green, no recent activity), the dispatcher SIGTERM's the wrapper and transitions the issue to `pending-review`.

## Decision points

- **Trigger conjunction (all must hold):** alive PID, PR exists for the issue, all CI checks SUCCESS (non-empty), and PR has been idle (`updatedAt`) for more than 300 seconds.
- **Why 5 minutes:** matches the dispatcher cron interval. If the agent just pushed a green build it has one more cycle to do its own cleanup before being SIGTERM'd.
- **Why SIGTERM, not SIGKILL:** agent shells trap SIGTERM and clean up; SIGKILL would leak handles.
- **Fail-CLOSED on parse errors:** if `date -d "$PR.updatedAt"` fails (BSD/macOS, malformed timestamp, etc.) the dispatcher leaves the issue alone rather than treating an unparseable timestamp as "infinitely idle" and SIGTERM'ing immediately.
- **macOS portability:** falls back to `date -j -f` when GNU `date -d` is unavailable.

## Changes

- `skills/autonomous-dispatcher/SKILL.md` — new `Step 5a (NEW): ALIVE + PR ready for review` block before the existing DEAD branch (now labelled Step 5b). Includes guard rails for malformed PR JSON, BSD/macOS date, PID re-check before SIGTERM, captured-stderr from `gh pr checks` so transport errors are diagnosable, and conditional comment text based on the actual kill outcome.
- `tests/unit/test-stale-alive-with-pr.sh` (new, 28 assertions across TC-DSAP-001..014).
- `docs/designs/dispatcher-stale-alive-with-pr.md` — design canvas with rationale.
- `docs/test-cases/dispatcher-stale-alive-with-pr.md` — test cases doc.

## Test plan

- [x] `bash tests/unit/test-stale-alive-with-pr.sh` (28/28)
- [x] All 10 unit suites pass
- [x] Verified the new fail-CLOSED guard against the `|| echo 0` regression by reintroducing the bug → TC-DSAP-010 fails as expected
- [x] Verified jq predicate against 6 fixtures (empty, all-success, mixed-state, skipped)
- [x] Verified ISO-8601 timestamp math against fixed before/after timestamps (6-min delta yields 360s)
- [ ] Real-world: next dispatcher cycle on a downstream consumer issue with a hung wrapper + green PR. Expected: SIGTERM + transition to pending-review.

## Notes

The companion zombie-wrapper-blocks-redispatch case (issue #55) is a separate fix. Step 5a's SIGTERM incidentally unblocks the most common shape, but the kill-before-spawn pattern requested in #55 is not addressed here.