### PR TITLE
fix(dispatcher): kill stale wrapper before spawning a new one

### DIFF
--- a/docs/designs/dispatcher-kill-before-spawn.md
+++ b/docs/designs/dispatcher-kill-before-spawn.md
@@ -1,0 +1,88 @@
+# Dispatcher: kill stale wrapper before spawning a new one
+
+Closes #55.
+
+## Problem
+
+`dispatch-local.sh` spawns a wrapper via `nohup` without checking whether a previous wrapper for the same issue is still alive. When a stale wrapper lingers (e.g. its inner agent CLI died but the outer `bash autonomous-dev.sh` is still running), the new spawn happens anyway. Two wrappers now coexist for one issue.
+
+The `acquire_pid_guard` in `lib-agent.sh` was supposed to prevent this, but it `exit 0`s instead of taking corrective action — silently no-oping the second wrapper. The dispatcher's labels still flip (`pending-dev` → `in-progress`) but no new work happens.
+
+In production this looked like:
+
+- Issue dispatched, wrapper A starts.
+- Wrapper A's inner `claude` CLI dies but the outer bash hangs.
+- Dispatcher Step 5 marks the issue DEAD-with-no-PR → moves to `pending-dev`.
+- Next cycle dispatches resume; spawn B happens; B's `acquire_pid_guard` sees A's stale PID alive → exits 0.
+- Issue silently flips back and forth between `pending-dev` and `in-progress` with no real progress.
+
+## Goal
+
+Before any `nohup` spawn in `dispatch-local.sh`, kill any wrapper that already holds the relevant PID file for this issue+type. SIGTERM first (allow the trap to clean up), escalate to SIGKILL only if needed.
+
+## Design
+
+### Where the fix lives
+
+Single chokepoint in `dispatch-local.sh`. Other options considered:
+
+- **Modify `acquire_pid_guard` to kill instead of exit.** Rejected: spreads the kill responsibility across every wrapper, harder to reason about.
+- **Have the wrapper trap clean up before exiting.** Rejected: the bug is exactly that wrappers can hang in a way the trap doesn't cover (uninterruptible IO, deadlock).
+
+### Kill strategy
+
+```bash
+PID_FILE="<derived from $TYPE and $ISSUE_NUM>"
+if [[ -f "$PID_FILE" ]]; then
+  OLD_PID=$(cat "$PID_FILE" 2>/dev/null)
+  if [[ -n "$OLD_PID" ]] && kill -0 "$OLD_PID" 2>/dev/null; then
+    echo "Found existing wrapper for issue #${ISSUE_NUM} (PID ${OLD_PID}); sending SIGTERM..." >&2
+    kill "$OLD_PID" 2>/dev/null || true
+    # Wait up to 5s for the trap to run
+    for _ in 1 2 3 4 5; do
+      kill -0 "$OLD_PID" 2>/dev/null || break
+      sleep 1
+    done
+    # Escalate if still alive
+    if kill -0 "$OLD_PID" 2>/dev/null; then
+      echo "PID ${OLD_PID} ignored SIGTERM after 5s; escalating to SIGKILL" >&2
+      kill -9 "$OLD_PID" 2>/dev/null || true
+      sleep 1
+    fi
+  fi
+  # Remove the stale PID file regardless — the new wrapper will write its own.
+  rm -f "$PID_FILE"
+fi
+```
+
+### Why SIGTERM first, then SIGKILL after 5s
+
+- Wrappers may have a cleanup trap that flushes logs, posts a session report, removes their own PID file. SIGTERM lets that run.
+- 5 seconds is plenty for typical cleanup (gh API calls take ~1s each, traps post one-or-two comments). Longer would slow the dispatcher noticeably; shorter would too often escalate unnecessarily.
+- If the wrapper is genuinely stuck (uninterruptible IO, kernel deadlock), no signal helps anyway — SIGKILL at least ensures the kernel reaps the process so the new wrapper isn't blocked.
+
+### PID file removal
+
+After kill (or if the file existed but the PID was already dead), `rm -f "$PID_FILE"`. Otherwise the new wrapper's `acquire_pid_guard` would see a stale file and could behave inconsistently.
+
+### Cooperation with `acquire_pid_guard`
+
+We do NOT change `acquire_pid_guard`. After kill-before-spawn:
+- Old wrapper is dead, old PID file is removed.
+- New wrapper starts, calls `acquire_pid_guard`, finds no PID file (or one with a non-existent PID), writes its own PID. Normal flow.
+
+If we changed the guard too (defense in depth), the kill-before-spawn would mask any guard logic the wrapper relies on for direct invocations (someone running `bash autonomous-dev.sh` outside the dispatcher). Better to keep responsibilities separated.
+
+### Edge cases
+
+- **PID file exists, PID is already dead.** `kill -0` fails, the if-block falls through, file is removed. New spawn proceeds.
+- **PID file is empty.** `cat` returns empty, `[[ -n "" ]]` fails, file is removed. New spawn proceeds.
+- **PID file is a symlink.** Same risk as `acquire_pid_guard` warns about. Add the same `-L` check before `cat`.
+- **PID points to an unrelated process** (PID reuse on a long-running system). Kill-before-spawn would SIGTERM something that isn't ours. Mitigated by checking that the PID file's mtime is recent (heuristic) — but that adds complexity. For now we accept the small risk: the PID file is in `/tmp/` and only this dispatcher writes there with this naming pattern.
+- **SIGTERM ignored, SIGKILL also ignored.** Process is in uninterruptible kernel state. No way to recover; the new wrapper's `acquire_pid_guard` will see the empty/removed file and proceed, which is correct — there's no longer a useful wrapper to defer to.
+
+## Out of Scope
+
+- Changing `acquire_pid_guard` semantics (still exits 0 on conflict for direct invocations).
+- Killing on `dispatch-local.sh review` calls when it would interrupt a real review in progress. The review wrapper has the same PID-file shape, so the same logic applies symmetrically; this is desired.
+- Cleaning up other dispatcher-related state (worktrees, log files). Out of scope.

--- a/docs/test-cases/dispatcher-kill-before-spawn.md
+++ b/docs/test-cases/dispatcher-kill-before-spawn.md
@@ -1,0 +1,51 @@
+# Test Cases: dispatcher-kill-before-spawn
+
+Closes #55.
+
+## TC-DKBS-001: Static — `dispatch-local.sh` checks PID file before nohup
+
+**Verify** `dispatch-local.sh` contains a kill-before-spawn block that:
+- Reads the PID file matching `$TYPE` (issue or review)
+- Calls `kill -0` to test liveness
+- Sends SIGTERM (plain `kill`) before any `nohup`
+- Waits up to 5 seconds for the process to exit
+- Escalates to `kill -9` only if still alive
+- Removes the PID file after kill (or if the PID was already dead)
+
+## TC-DKBS-002: Behavioral — alive PID gets SIGTERM'd
+
+**Setup:** Start a `sleep 60` background process. Write its PID to a temp PID file. Invoke just the kill-before-spawn function (extracted as a sourceable function or inline-replicated).
+
+**Verify:** the sleep process is no longer running after the function returns. PID file is gone.
+
+## TC-DKBS-003: Behavioral — dead PID is handled cleanly
+
+**Setup:** Write a clearly-not-running PID (e.g. 99999999) to a temp PID file. Invoke the kill-before-spawn function.
+
+**Verify:** no error, function returns 0, PID file is gone.
+
+## TC-DKBS-004: Behavioral — SIGTERM-ignoring process is escalated to SIGKILL
+
+**Setup:** Start a process that traps SIGTERM and sleeps. Write its PID. Invoke kill-before-spawn.
+
+**Verify:** the process is dead within ~6 seconds (5s SIGTERM grace + 1s SIGKILL settle). PID file is gone.
+
+## TC-DKBS-005: Behavioral — empty PID file is tolerated
+
+**Setup:** Touch an empty PID file. Invoke kill-before-spawn.
+
+**Verify:** no error, function returns 0, file is gone afterward.
+
+## TC-DKBS-006: Behavioral — symlink PID file is rejected
+
+**Setup:** Create a symlink at the PID file path pointing to `/etc/passwd`. Invoke kill-before-spawn.
+
+**Verify:** function refuses (does not follow the symlink, does not delete `/etc/passwd`).
+
+## TC-DKBS-007: Static — both spawn paths (dev-new/resume + review) are guarded
+
+**Verify:** every `nohup` invocation in `dispatch-local.sh` is preceded by the kill-before-spawn check (i.e. dev-new, dev-resume, review all benefit).
+
+## TC-DKBS-008: Static — log message is emitted on kill
+
+**Verify:** the kill-before-spawn block writes a stderr message identifying the killed PID, so operators reading dispatcher logs can correlate "agent disappeared" with "dispatcher killed it".

--- a/skills/autonomous-dispatcher/scripts/dispatch-local.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatch-local.sh
@@ -55,31 +55,71 @@ esac
 # new wrapper starts from a clean state.
 #
 # Refuses to follow symlinks (CWE-59) — same defense as acquire_pid_guard.
+#
+# Return codes:
+#   0 — safe to spawn (PID file gone, no live holder)
+#   1 — refuse to spawn: symlink, unreadable PID file, or process still alive
+#       after SIGKILL+grace
+#
+# `kill ... || true` on success paths is intentional. ESRCH (process gone
+# between checks) is the only "expected benign" failure of `kill`; we capture
+# stderr to distinguish it from EPERM/EINVAL/etc and surface real errors.
 kill_stale_wrapper() {
   local pid_file="$1"
   if [[ -L "$pid_file" ]]; then
     echo "ERROR: PID file is a symlink, refusing to operate on it: $pid_file" >&2
     return 1
   fi
-  if [[ -f "$pid_file" ]]; then
-    local old_pid
-    old_pid=$(cat "$pid_file" 2>/dev/null)
-    if [[ -n "$old_pid" ]] && kill -0 "$old_pid" 2>/dev/null; then
-      echo "Found existing wrapper for issue #${ISSUE_NUM} (PID ${old_pid}); sending SIGTERM..." >&2
-      kill "$old_pid" 2>/dev/null || true
-      local _i
-      for _i in 1 2 3 4 5; do
-        kill -0 "$old_pid" 2>/dev/null || break
-        sleep 1
-      done
+  if [[ ! -f "$pid_file" ]]; then
+    return 0
+  fi
+
+  # Distinguish empty content from "could not read". Deleting an unreadable
+  # PID file would leave a possibly-still-running wrapper untracked.
+  # Test readability first; only then capture content.
+  if ! [[ -r "$pid_file" ]]; then
+    echo "ERROR: cannot read PID file $pid_file (permission denied or removed)" >&2
+    return 1
+  fi
+  local old_pid
+  old_pid=$(cat "$pid_file" 2>/dev/null)
+
+  if [[ -n "$old_pid" ]] && kill -0 "$old_pid" 2>/dev/null; then
+    echo "Found existing wrapper for issue #${ISSUE_NUM} (PID ${old_pid}); sending SIGTERM..." >&2
+    local term_err
+    term_err=$(kill "$old_pid" 2>&1) || {
+      # ESRCH (no such process) is benign — the process exited between the
+      # liveness check and the kill. Anything else is a real problem.
+      if [[ "$term_err" != *"No such process"* && -n "$term_err" ]]; then
+        echo "WARNING: SIGTERM to PID ${old_pid} failed: ${term_err}" >&2
+      fi
+    }
+    local _i
+    for _i in 1 2 3 4 5; do
+      kill -0 "$old_pid" 2>/dev/null || break
+      sleep 1
+    done
+    if kill -0 "$old_pid" 2>/dev/null; then
+      echo "WARNING: PID ${old_pid} ignored SIGTERM after 5s; escalating to SIGKILL" >&2
+      local kill_err
+      kill_err=$(kill -9 "$old_pid" 2>&1) || {
+        if [[ "$kill_err" != *"No such process"* && -n "$kill_err" ]]; then
+          echo "WARNING: SIGKILL to PID ${old_pid} failed: ${kill_err}" >&2
+        fi
+      }
+      sleep 1
+      # Final liveness check — if still alive, we cannot safely spawn.
       if kill -0 "$old_pid" 2>/dev/null; then
-        echo "PID ${old_pid} ignored SIGTERM after 5s; escalating to SIGKILL" >&2
-        kill -9 "$old_pid" 2>/dev/null || true
-        sleep 1
+        echo "ERROR: PID ${old_pid} survived SIGKILL+1s grace; refusing to spawn alongside it" >&2
+        return 1
       fi
     fi
-    rm -f "$pid_file"
   fi
+
+  # Remove PID file regardless. If `rm -f` fails (read-only mount, perm),
+  # acquire_pid_guard in the new wrapper re-validates liveness on whatever
+  # PID is in the file — and we just verified that PID is no longer alive.
+  rm -f "$pid_file"
   return 0
 }
 

--- a/skills/autonomous-dispatcher/scripts/dispatch-local.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatch-local.sh
@@ -45,6 +45,53 @@ case "$TYPE" in
   review)             install -m 600 /dev/null "${LOG_PREFIX}-review-${ISSUE_NUM}.log" 2>/dev/null || true ;;
 esac
 
+# Kill any stale wrapper that still holds the PID file for this issue+type.
+# Closes #55: previously a lingering wrapper (inner CLI dead, outer bash hung)
+# would block `acquire_pid_guard` in the new wrapper, which silently exit 0'd
+# and left the issue oscillating between labels with no real progress.
+#
+# Strategy: SIGTERM, give the trap up to 5 seconds to clean up, escalate to
+# SIGKILL only if the process is still alive. Then remove the PID file so the
+# new wrapper starts from a clean state.
+#
+# Refuses to follow symlinks (CWE-59) — same defense as acquire_pid_guard.
+kill_stale_wrapper() {
+  local pid_file="$1"
+  if [[ -L "$pid_file" ]]; then
+    echo "ERROR: PID file is a symlink, refusing to operate on it: $pid_file" >&2
+    return 1
+  fi
+  if [[ -f "$pid_file" ]]; then
+    local old_pid
+    old_pid=$(cat "$pid_file" 2>/dev/null)
+    if [[ -n "$old_pid" ]] && kill -0 "$old_pid" 2>/dev/null; then
+      echo "Found existing wrapper for issue #${ISSUE_NUM} (PID ${old_pid}); sending SIGTERM..." >&2
+      kill "$old_pid" 2>/dev/null || true
+      local _i
+      for _i in 1 2 3 4 5; do
+        kill -0 "$old_pid" 2>/dev/null || break
+        sleep 1
+      done
+      if kill -0 "$old_pid" 2>/dev/null; then
+        echo "PID ${old_pid} ignored SIGTERM after 5s; escalating to SIGKILL" >&2
+        kill -9 "$old_pid" 2>/dev/null || true
+        sleep 1
+      fi
+    fi
+    rm -f "$pid_file"
+  fi
+  return 0
+}
+
+case "$TYPE" in
+  dev-new|dev-resume) PID_FILE="${LOG_PREFIX}-issue-${ISSUE_NUM}.pid" ;;
+  review)             PID_FILE="${LOG_PREFIX}-review-${ISSUE_NUM}.pid" ;;
+  *)                  PID_FILE="" ;;
+esac
+if [[ -n "$PID_FILE" ]]; then
+  kill_stale_wrapper "$PID_FILE" || exit 1
+fi
+
 case "$TYPE" in
   dev-new)
     nohup "${PROJECT_DIR}/scripts/autonomous-dev.sh" \

--- a/tests/unit/test-kill-before-spawn.sh
+++ b/tests/unit/test-kill-before-spawn.sh
@@ -191,23 +191,36 @@ echo "$ALIVE_PID" > "$PID_FILE"
 
 # Confirm the process is alive before killing
 if kill -0 "$ALIVE_PID" 2>/dev/null; then
-  kill_stale_wrapper "$PID_FILE"
+  # Note: this script runs with `set -uo pipefail` (no errexit), so
+  # `kill_stale_wrapper` returning non-zero won't abort the test — that's
+  # exactly the assertion path we want to exercise.
+  kill_stale_wrapper "$PID_FILE" >/dev/null 2>&1
   RC=$?
-  if wait_for_pid_gone "$ALIVE_PID"; then
-    echo -e "  ${GREEN}PASS${NC}: alive PID $ALIVE_PID was killed"
-    PASS=$((PASS+1))
-  else
-    echo -e "  ${RED}FAIL${NC}: alive sleep PID $ALIVE_PID still running after kill_stale"
-    kill -9 "$ALIVE_PID" 2>/dev/null || true
-    FAIL=$((FAIL+1))
-  fi
+  # Assert function-level success FIRST. If the function reports an error,
+  # don't let an incidental external-cause death of the sleep process mask it.
+  # (Q PR #57: race-condition risk where wait_for_pid_gone could pass while
+  # kill_stale_wrapper actually returned non-zero.)
   assert_eq "Function returned 0" "0" "$RC"
-  if [[ -e "$PID_FILE" ]]; then
-    echo -e "  ${RED}FAIL${NC}: PID file still exists"
-    FAIL=$((FAIL+1))
+  if [[ "$RC" == "0" ]]; then
+    if wait_for_pid_gone "$ALIVE_PID"; then
+      echo -e "  ${GREEN}PASS${NC}: alive PID $ALIVE_PID was killed"
+      PASS=$((PASS+1))
+    else
+      echo -e "  ${RED}FAIL${NC}: alive sleep PID $ALIVE_PID still running after kill_stale"
+      kill -9 "$ALIVE_PID" 2>/dev/null || true
+      FAIL=$((FAIL+1))
+    fi
+    if [[ -e "$PID_FILE" ]]; then
+      echo -e "  ${RED}FAIL${NC}: PID file still exists"
+      FAIL=$((FAIL+1))
+    else
+      echo -e "  ${GREEN}PASS${NC}: PID file removed"
+      PASS=$((PASS+1))
+    fi
   else
-    echo -e "  ${GREEN}PASS${NC}: PID file removed"
-    PASS=$((PASS+1))
+    # Skip downstream assertions; cleanup the leaked sleep before continuing.
+    kill -9 "$ALIVE_PID" 2>/dev/null || true
+    rm -f "$PID_FILE"
   fi
 else
   echo -e "  ${RED}FAIL${NC}: setup error — sleep didn't start"

--- a/tests/unit/test-kill-before-spawn.sh
+++ b/tests/unit/test-kill-before-spawn.sh
@@ -108,6 +108,26 @@ fi
 assert_match "PID_FILE selected per type" \
   'dev-new\|dev-resume\)\s*PID_FILE=|case "?\$TYPE"? in.*PID_FILE' "$DISPATCH_CONTENT"
 
+# Each branch must pick the correct path: dev paths use -issue-, review uses
+# -review-. Guard against a swap-typo regression where dev-new accidentally
+# points at the review PID file or vice-versa.
+DEV_PATH_BLOCK=$(grep -E 'dev-new\|dev-resume\)\s*PID_FILE=' <<<"$DISPATCH_CONTENT")
+REVIEW_PATH_BLOCK=$(grep -E 'review\)\s*PID_FILE=' <<<"$DISPATCH_CONTENT")
+if [[ "$DEV_PATH_BLOCK" == *"-issue-"* ]] && [[ "$DEV_PATH_BLOCK" != *"-review-"* ]]; then
+  echo -e "  ${GREEN}PASS${NC}: dev-new/dev-resume picks the -issue- PID file"
+  PASS=$((PASS+1))
+else
+  echo -e "  ${RED}FAIL${NC}: dev branch path is wrong: '$DEV_PATH_BLOCK'"
+  FAIL=$((FAIL+1))
+fi
+if [[ "$REVIEW_PATH_BLOCK" == *"-review-"* ]] && [[ "$REVIEW_PATH_BLOCK" != *"-issue-"* ]]; then
+  echo -e "  ${GREEN}PASS${NC}: review picks the -review- PID file"
+  PASS=$((PASS+1))
+else
+  echo -e "  ${RED}FAIL${NC}: review branch path is wrong: '$REVIEW_PATH_BLOCK'"
+  FAIL=$((FAIL+1))
+fi
+
 # ============================================================================
 # TC-DKBS-008: Log message emitted on kill
 # ============================================================================
@@ -123,41 +143,39 @@ assert_match "Stderr log on found wrapper" \
 # against synthetic processes.
 # ============================================================================
 
-# Extract the kill block as a sourceable function. Strategy: read the file,
-# wrap the kill-before-spawn block in a function, source it. If the project
-# uses a helper function, just source the file's relevant section.
-#
-# To avoid coupling to the exact function signature, we replicate the
-# documented behavior in this test file. The static checks above ensure
-# the actual implementation matches the same semantics.
-#
-# This local replica is what the implementation is required to behave like.
+# Source the actual implementation so behavioral tests verify the real
+# function — no replica drift. Strategy: extract the function definition from
+# dispatch-local.sh into a temp file and source it. ISSUE_NUM is required by
+# the function's log messages, so set a placeholder.
+EXTRACT_FILE=$(mktemp)
+awk '
+  /^kill_stale_wrapper\(\) \{$/ { in_fn=1 }
+  in_fn { print }
+  in_fn && /^\}$/ { in_fn=0 }
+' "$DISPATCH_SCRIPT" > "$EXTRACT_FILE"
+if [[ ! -s "$EXTRACT_FILE" ]]; then
+  echo -e "${RED}FATAL${NC}: failed to extract kill_stale_wrapper from $DISPATCH_SCRIPT"
+  rm -f "$EXTRACT_FILE"
+  exit 1
+fi
+ISSUE_NUM="test"  # for log messages inside the function
+# shellcheck source=/dev/null
+source "$EXTRACT_FILE"
+rm -f "$EXTRACT_FILE"
 
-kill_stale_wrapper_test_replica() {
-  local pid_file="$1"
-  [[ -L "$pid_file" ]] && return 1
-  if [[ -f "$pid_file" ]]; then
-    local old_pid
-    old_pid=$(cat "$pid_file" 2>/dev/null)
-    if [[ -n "$old_pid" ]] && kill -0 "$old_pid" 2>/dev/null; then
-      kill "$old_pid" 2>/dev/null || true
-      local i
-      for i in 1 2 3 4 5; do
-        kill -0 "$old_pid" 2>/dev/null || break
-        sleep 1
-      done
-      if kill -0 "$old_pid" 2>/dev/null; then
-        kill -9 "$old_pid" 2>/dev/null || true
-        sleep 1
-      fi
-    fi
-    rm -f "$pid_file"
-  fi
-  return 0
+# Bounded reap-poll: kill returns before the OS reaps. Wait up to ~2s,
+# breaking as soon as the PID is gone. Avoids fixed-sleep flakes on slow CI.
+wait_for_pid_gone() {
+  local pid="$1" timeout="${2:-20}" i
+  for ((i = 0; i < timeout; i++)); do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 0.1
+  done
+  return 1
 }
 
 TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
+trap 'rm -rf "$TMPDIR"; rm -f "$EXTRACT_FILE"' EXIT
 
 # ============================================================================
 # TC-DKBS-002: Alive PID gets killed
@@ -173,17 +191,15 @@ echo "$ALIVE_PID" > "$PID_FILE"
 
 # Confirm the process is alive before killing
 if kill -0 "$ALIVE_PID" 2>/dev/null; then
-  kill_stale_wrapper_test_replica "$PID_FILE"
+  kill_stale_wrapper "$PID_FILE"
   RC=$?
-  # Give the OS a moment to reap
-  sleep 0.2
-  if kill -0 "$ALIVE_PID" 2>/dev/null; then
+  if wait_for_pid_gone "$ALIVE_PID"; then
+    echo -e "  ${GREEN}PASS${NC}: alive PID $ALIVE_PID was killed"
+    PASS=$((PASS+1))
+  else
     echo -e "  ${RED}FAIL${NC}: alive sleep PID $ALIVE_PID still running after kill_stale"
     kill -9 "$ALIVE_PID" 2>/dev/null || true
     FAIL=$((FAIL+1))
-  else
-    echo -e "  ${GREEN}PASS${NC}: alive PID $ALIVE_PID was killed"
-    PASS=$((PASS+1))
   fi
   assert_eq "Function returned 0" "0" "$RC"
   if [[ -e "$PID_FILE" ]]; then
@@ -208,7 +224,7 @@ echo
 PID_FILE="$TMPDIR/test-003.pid"
 echo "99999999" > "$PID_FILE"  # very unlikely to exist
 START_TIME=$SECONDS
-kill_stale_wrapper_test_replica "$PID_FILE"
+kill_stale_wrapper "$PID_FILE"
 RC=$?
 ELAPSED=$(( SECONDS - START_TIME ))
 assert_eq "Function returned 0 for dead PID" "0" "$RC"
@@ -241,23 +257,23 @@ RESISTANT_PID=$!
 echo "$RESISTANT_PID" > "$PID_FILE"
 
 START_TIME=$SECONDS
-kill_stale_wrapper_test_replica "$PID_FILE"
+kill_stale_wrapper "$PID_FILE"
 ELAPSED=$(( SECONDS - START_TIME ))
-sleep 0.2
-if kill -0 "$RESISTANT_PID" 2>/dev/null; then
+if wait_for_pid_gone "$RESISTANT_PID"; then
+  echo -e "  ${GREEN}PASS${NC}: SIGTERM-resistant PID was eventually killed (took ${ELAPSED}s)"
+  PASS=$((PASS+1))
+else
   echo -e "  ${RED}FAIL${NC}: SIGTERM-resistant PID $RESISTANT_PID still running"
   kill -9 "$RESISTANT_PID" 2>/dev/null || true
   FAIL=$((FAIL+1))
-else
-  echo -e "  ${GREEN}PASS${NC}: SIGTERM-resistant PID was eventually killed (took ${ELAPSED}s)"
-  PASS=$((PASS+1))
 fi
-# Should take 5s grace + 1s escalation settle ≈ 6s, but allow up to 8s slack
-if [[ "$ELAPSED" -ge 5 && "$ELAPSED" -le 8 ]]; then
-  echo -e "  ${GREEN}PASS${NC}: escalation timing within expected 5-8s window (${ELAPSED}s)"
+# Should take 5s grace + 1s escalation settle ≈ 6s. Generous bounds to absorb
+# slow CI runners: at least 5s (the grace MUST elapse) and no more than 12s.
+if [[ "$ELAPSED" -ge 5 && "$ELAPSED" -le 12 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: escalation timing within expected 5-12s window (${ELAPSED}s)"
   PASS=$((PASS+1))
 else
-  echo -e "  ${RED}FAIL${NC}: escalation took ${ELAPSED}s — outside expected 5-8s window"
+  echo -e "  ${RED}FAIL${NC}: escalation took ${ELAPSED}s — outside expected 5-12s window"
   FAIL=$((FAIL+1))
 fi
 
@@ -270,7 +286,7 @@ echo
 
 PID_FILE="$TMPDIR/test-005.pid"
 : > "$PID_FILE"  # touch empty
-kill_stale_wrapper_test_replica "$PID_FILE"
+kill_stale_wrapper "$PID_FILE"
 RC=$?
 assert_eq "Function returned 0 for empty file" "0" "$RC"
 if [[ -e "$PID_FILE" ]]; then
@@ -292,7 +308,7 @@ PID_FILE="$TMPDIR/test-006.pid"
 TARGET="$TMPDIR/symlink-target"
 echo "should-not-be-deleted" > "$TARGET"
 ln -sf "$TARGET" "$PID_FILE"
-kill_stale_wrapper_test_replica "$PID_FILE"
+kill_stale_wrapper "$PID_FILE"
 RC=$?
 # Function should refuse (return non-zero) and NOT remove the target.
 if [[ -f "$TARGET" ]]; then
@@ -302,6 +318,44 @@ else
   echo -e "  ${RED}FAIL${NC}: symlink target was deleted — security regression"
   FAIL=$((FAIL+1))
 fi
+
+# ============================================================================
+# TC-DKBS-009: Unreadable PID file returns 1 (does NOT delete it)
+# ============================================================================
+echo
+echo "=== TC-DKBS-009: unreadable PID file is refused, not silently deleted ==="
+echo
+
+PID_FILE="$TMPDIR/test-009.pid"
+echo "12345" > "$PID_FILE"
+chmod 000 "$PID_FILE"
+# Skip if running as root (chmod 000 is bypassed)
+if [[ "$(id -u)" == "0" ]]; then
+  echo -e "  ${RED}SKIP${NC}: running as root, chmod 000 is bypassed"
+  chmod 644 "$PID_FILE"
+else
+  set +e
+  kill_stale_wrapper "$PID_FILE" >/tmp/test-009.stderr 2>&1
+  RC=$?
+  set -e
+  chmod 644 "$PID_FILE"  # restore so trap can clean up
+  if [[ "$RC" != "0" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: unreadable PID file → return code $RC (not 0)"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: unreadable PID file silently returned 0"
+    FAIL=$((FAIL+1))
+  fi
+  # File must still exist — we refused to operate on it, didn't delete it
+  if [[ -e "$PID_FILE" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: unreadable PID file preserved (not deleted)"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: unreadable PID file was deleted — silent-failure regression"
+    FAIL=$((FAIL+1))
+  fi
+fi
+rm -f /tmp/test-009.stderr
 
 # ----------------------------------------------------------------------------
 # Summary

--- a/tests/unit/test-kill-before-spawn.sh
+++ b/tests/unit/test-kill-before-spawn.sh
@@ -347,10 +347,11 @@ if [[ "$(id -u)" == "0" ]]; then
   echo -e "  ${RED}SKIP${NC}: running as root, chmod 000 is bypassed"
   chmod 644 "$PID_FILE"
 else
-  set +e
-  kill_stale_wrapper "$PID_FILE" >/tmp/test-009.stderr 2>&1
+  # Capture function output into the per-run TMPDIR (not /tmp) so concurrent
+  # test runs don't collide on a fixed path (Q PR #57 review, CWE-377).
+  STDERR_FILE="$TMPDIR/test-009.stderr"
+  kill_stale_wrapper "$PID_FILE" >"$STDERR_FILE" 2>&1
   RC=$?
-  set -e
   chmod 644 "$PID_FILE"  # restore so trap can clean up
   if [[ "$RC" != "0" ]]; then
     echo -e "  ${GREEN}PASS${NC}: unreadable PID file → return code $RC (not 0)"
@@ -368,7 +369,7 @@ else
     FAIL=$((FAIL+1))
   fi
 fi
-rm -f /tmp/test-009.stderr
+# STDERR_FILE is inside TMPDIR which the EXIT trap removes — no separate cleanup needed.
 
 # ----------------------------------------------------------------------------
 # Summary

--- a/tests/unit/test-kill-before-spawn.sh
+++ b/tests/unit/test-kill-before-spawn.sh
@@ -1,0 +1,316 @@
+#!/bin/bash
+# test-kill-before-spawn.sh — Regression tests for issue #55.
+#
+# Verifies that dispatch-local.sh kills any stale wrapper for an issue
+# before spawning a new one (SIGTERM, 5s grace, SIGKILL escalation).
+#
+# Run: bash tests/unit/test-kill-before-spawn.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Avoid `grep -q` here — combined with `set -o pipefail` and a large haystack
+# it can produce SIGPIPE flakes (rc=141). Use full grep + non-empty check.
+assert_match() {
+  local desc="$1" pattern="$2" haystack="$3"
+  if [[ -n "$(grep -E "$pattern" <<<"$haystack")" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected to match '$pattern')"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected to contain '$needle')"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_eq() {
+  local desc="$1" expected="$2" got="$3"
+  if [[ "$expected" == "$got" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected '$expected', got '$got')"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+DISPATCH_SCRIPT="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/dispatch-local.sh"
+[[ -f "$DISPATCH_SCRIPT" ]] || { echo -e "${RED}FATAL${NC}: $DISPATCH_SCRIPT not found"; exit 1; }
+DISPATCH_CONTENT=$(cat "$DISPATCH_SCRIPT")
+
+# ============================================================================
+# TC-DKBS-001: Static — kill-before-spawn block is present
+# ============================================================================
+echo
+echo "=== TC-DKBS-001: kill-before-spawn block is present ==="
+echo
+
+# Patterns accept either uppercase ($PID_FILE / $OLD_PID — inline form) or
+# lowercase ($pid_file / $old_pid — function-local form).
+assert_match "Reads existing PID via cat"               'cat "?\$\{?(PID_FILE|pid_file)'      "$DISPATCH_CONTENT"
+assert_match "Liveness check via kill -0"               'kill -0 "?\$\{?(OLD_PID|old_pid)'    "$DISPATCH_CONTENT"
+assert_match "SIGTERM (plain kill)"                     'kill "?\$\{?(OLD_PID|old_pid)'       "$DISPATCH_CONTENT"
+assert_match "5-second grace loop"                      'for [_a-z]+ in 1 2 3 4 5'            "$DISPATCH_CONTENT"
+assert_match "SIGKILL escalation"                       'kill -9 "?\$\{?(OLD_PID|old_pid)'    "$DISPATCH_CONTENT"
+assert_match "PID file removed after kill"              'rm -f "?\$\{?(PID_FILE|pid_file)'    "$DISPATCH_CONTENT"
+
+# ============================================================================
+# TC-DKBS-007: Both spawn paths guarded
+# ============================================================================
+echo
+echo "=== TC-DKBS-007: All nohup invocations are preceded by kill-before-spawn ==="
+echo
+
+# Two acceptable factorings:
+# (A) Inline check per nohup: `kill -0` block appears ≥ 3 times (one per type).
+# (B) Factored function: a kill_stale_wrapper-style function exists and is
+#     called BEFORE the first nohup. The PID_FILE used at the call site is
+#     derived from $TYPE so all three spawn types are covered by the single
+#     call. This is the cleaner factoring.
+NOHUP_LINE=$(grep -nE '^\s*nohup ' <<<"$DISPATCH_CONTENT" | head -1 | cut -d: -f1)
+KILL_FN_DEF_LINE=$(grep -nE '^kill_stale_wrapper *\(\)' <<<"$DISPATCH_CONTENT" | head -1 | cut -d: -f1)
+KILL_FN_CALL_LINE=$(grep -nE 'kill_stale_wrapper "\$' <<<"$DISPATCH_CONTENT" | head -1 | cut -d: -f1)
+INLINE_KILL0_COUNT=$(grep -c 'kill -0 "\?\$\{\?\(OLD_PID\|old_pid\)' <<<"$DISPATCH_CONTENT" || true)
+
+if [[ -n "$KILL_FN_DEF_LINE" && -n "$KILL_FN_CALL_LINE" && -n "$NOHUP_LINE" ]] \
+     && [[ "$KILL_FN_DEF_LINE" -lt "$NOHUP_LINE" ]] \
+     && [[ "$KILL_FN_CALL_LINE" -lt "$NOHUP_LINE" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: kill_stale_wrapper defined (line $KILL_FN_DEF_LINE) and called (line $KILL_FN_CALL_LINE) before first nohup (line $NOHUP_LINE)"
+  PASS=$((PASS+1))
+elif [[ "$INLINE_KILL0_COUNT" -ge 3 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: inline kill -0 checks ($INLINE_KILL0_COUNT) cover each spawn path"
+  PASS=$((PASS+1))
+else
+  echo -e "  ${RED}FAIL${NC}: no kill_stale_wrapper call before nohup (def=$KILL_FN_DEF_LINE call=$KILL_FN_CALL_LINE nohup=$NOHUP_LINE), and inline kill -0 count is $INLINE_KILL0_COUNT (need ≥3)"
+  FAIL=$((FAIL+1))
+fi
+
+# Also assert there's a way to derive PID_FILE per type — the call site must
+# match on $TYPE and select the right PID file path.
+assert_match "PID_FILE selected per type" \
+  'dev-new\|dev-resume\)\s*PID_FILE=|case "?\$TYPE"? in.*PID_FILE' "$DISPATCH_CONTENT"
+
+# ============================================================================
+# TC-DKBS-008: Log message emitted on kill
+# ============================================================================
+echo
+echo "=== TC-DKBS-008: Log message on kill ==="
+echo
+
+assert_match "Stderr log on found wrapper" \
+  'Found existing wrapper|sending SIGTERM|killing stale' "$DISPATCH_CONTENT"
+
+# ============================================================================
+# Behavioral tests — extract the kill function (or inline replica) and run it
+# against synthetic processes.
+# ============================================================================
+
+# Extract the kill block as a sourceable function. Strategy: read the file,
+# wrap the kill-before-spawn block in a function, source it. If the project
+# uses a helper function, just source the file's relevant section.
+#
+# To avoid coupling to the exact function signature, we replicate the
+# documented behavior in this test file. The static checks above ensure
+# the actual implementation matches the same semantics.
+#
+# This local replica is what the implementation is required to behave like.
+
+kill_stale_wrapper_test_replica() {
+  local pid_file="$1"
+  [[ -L "$pid_file" ]] && return 1
+  if [[ -f "$pid_file" ]]; then
+    local old_pid
+    old_pid=$(cat "$pid_file" 2>/dev/null)
+    if [[ -n "$old_pid" ]] && kill -0 "$old_pid" 2>/dev/null; then
+      kill "$old_pid" 2>/dev/null || true
+      local i
+      for i in 1 2 3 4 5; do
+        kill -0 "$old_pid" 2>/dev/null || break
+        sleep 1
+      done
+      if kill -0 "$old_pid" 2>/dev/null; then
+        kill -9 "$old_pid" 2>/dev/null || true
+        sleep 1
+      fi
+    fi
+    rm -f "$pid_file"
+  fi
+  return 0
+}
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# ============================================================================
+# TC-DKBS-002: Alive PID gets killed
+# ============================================================================
+echo
+echo "=== TC-DKBS-002: alive PID is SIGTERM'd ==="
+echo
+
+PID_FILE="$TMPDIR/test-002.pid"
+sleep 60 &
+ALIVE_PID=$!
+echo "$ALIVE_PID" > "$PID_FILE"
+
+# Confirm the process is alive before killing
+if kill -0 "$ALIVE_PID" 2>/dev/null; then
+  kill_stale_wrapper_test_replica "$PID_FILE"
+  RC=$?
+  # Give the OS a moment to reap
+  sleep 0.2
+  if kill -0 "$ALIVE_PID" 2>/dev/null; then
+    echo -e "  ${RED}FAIL${NC}: alive sleep PID $ALIVE_PID still running after kill_stale"
+    kill -9 "$ALIVE_PID" 2>/dev/null || true
+    FAIL=$((FAIL+1))
+  else
+    echo -e "  ${GREEN}PASS${NC}: alive PID $ALIVE_PID was killed"
+    PASS=$((PASS+1))
+  fi
+  assert_eq "Function returned 0" "0" "$RC"
+  if [[ -e "$PID_FILE" ]]; then
+    echo -e "  ${RED}FAIL${NC}: PID file still exists"
+    FAIL=$((FAIL+1))
+  else
+    echo -e "  ${GREEN}PASS${NC}: PID file removed"
+    PASS=$((PASS+1))
+  fi
+else
+  echo -e "  ${RED}FAIL${NC}: setup error — sleep didn't start"
+  FAIL=$((FAIL+1))
+fi
+
+# ============================================================================
+# TC-DKBS-003: Dead PID is handled cleanly
+# ============================================================================
+echo
+echo "=== TC-DKBS-003: dead PID handled cleanly ==="
+echo
+
+PID_FILE="$TMPDIR/test-003.pid"
+echo "99999999" > "$PID_FILE"  # very unlikely to exist
+START_TIME=$SECONDS
+kill_stale_wrapper_test_replica "$PID_FILE"
+RC=$?
+ELAPSED=$(( SECONDS - START_TIME ))
+assert_eq "Function returned 0 for dead PID" "0" "$RC"
+if [[ "$ELAPSED" -le 1 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: dead-PID path completed quickly (${ELAPSED}s, no needless sleep)"
+  PASS=$((PASS+1))
+else
+  echo -e "  ${RED}FAIL${NC}: dead-PID path took ${ELAPSED}s — should be <=1s"
+  FAIL=$((FAIL+1))
+fi
+if [[ -e "$PID_FILE" ]]; then
+  echo -e "  ${RED}FAIL${NC}: PID file still exists after dead-PID handling"
+  FAIL=$((FAIL+1))
+else
+  echo -e "  ${GREEN}PASS${NC}: PID file removed"
+  PASS=$((PASS+1))
+fi
+
+# ============================================================================
+# TC-DKBS-004: SIGTERM-ignoring process is escalated to SIGKILL
+# ============================================================================
+echo
+echo "=== TC-DKBS-004: SIGTERM-resistant process gets SIGKILL ==="
+echo
+
+PID_FILE="$TMPDIR/test-004.pid"
+# Spawn a bash that traps SIGTERM and keeps sleeping
+bash -c 'trap "" TERM; sleep 60' &
+RESISTANT_PID=$!
+echo "$RESISTANT_PID" > "$PID_FILE"
+
+START_TIME=$SECONDS
+kill_stale_wrapper_test_replica "$PID_FILE"
+ELAPSED=$(( SECONDS - START_TIME ))
+sleep 0.2
+if kill -0 "$RESISTANT_PID" 2>/dev/null; then
+  echo -e "  ${RED}FAIL${NC}: SIGTERM-resistant PID $RESISTANT_PID still running"
+  kill -9 "$RESISTANT_PID" 2>/dev/null || true
+  FAIL=$((FAIL+1))
+else
+  echo -e "  ${GREEN}PASS${NC}: SIGTERM-resistant PID was eventually killed (took ${ELAPSED}s)"
+  PASS=$((PASS+1))
+fi
+# Should take 5s grace + 1s escalation settle ≈ 6s, but allow up to 8s slack
+if [[ "$ELAPSED" -ge 5 && "$ELAPSED" -le 8 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: escalation timing within expected 5-8s window (${ELAPSED}s)"
+  PASS=$((PASS+1))
+else
+  echo -e "  ${RED}FAIL${NC}: escalation took ${ELAPSED}s — outside expected 5-8s window"
+  FAIL=$((FAIL+1))
+fi
+
+# ============================================================================
+# TC-DKBS-005: Empty PID file is tolerated
+# ============================================================================
+echo
+echo "=== TC-DKBS-005: empty PID file tolerated ==="
+echo
+
+PID_FILE="$TMPDIR/test-005.pid"
+: > "$PID_FILE"  # touch empty
+kill_stale_wrapper_test_replica "$PID_FILE"
+RC=$?
+assert_eq "Function returned 0 for empty file" "0" "$RC"
+if [[ -e "$PID_FILE" ]]; then
+  echo -e "  ${RED}FAIL${NC}: empty PID file still exists"
+  FAIL=$((FAIL+1))
+else
+  echo -e "  ${GREEN}PASS${NC}: empty PID file removed"
+  PASS=$((PASS+1))
+fi
+
+# ============================================================================
+# TC-DKBS-006: Symlink PID file is rejected
+# ============================================================================
+echo
+echo "=== TC-DKBS-006: symlink PID file rejected ==="
+echo
+
+PID_FILE="$TMPDIR/test-006.pid"
+TARGET="$TMPDIR/symlink-target"
+echo "should-not-be-deleted" > "$TARGET"
+ln -sf "$TARGET" "$PID_FILE"
+kill_stale_wrapper_test_replica "$PID_FILE"
+RC=$?
+# Function should refuse (return non-zero) and NOT remove the target.
+if [[ -f "$TARGET" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: symlink target preserved"
+  PASS=$((PASS+1))
+else
+  echo -e "  ${RED}FAIL${NC}: symlink target was deleted — security regression"
+  FAIL=$((FAIL+1))
+fi
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+echo
+echo "=== Results ==="
+TOTAL=$((PASS + FAIL))
+echo -e "Total: $TOTAL  ${GREEN}Passed: $PASS${NC}  ${RED}Failed: $FAIL${NC}"
+echo
+
+[[ $FAIL -gt 0 ]] && exit 1
+exit 0


### PR DESCRIPTION
## Summary

Closes #55.

`dispatch-local.sh` previously spawned wrappers via `nohup` without killing any stale wrapper that still held the PID file. When a wrapper hung — e.g. its inner agent CLI died but the outer bash was stuck in uninterruptible IO — the new wrapper's `acquire_pid_guard` saw the live PID and silently `exit 0`'d. The dispatcher's labels flipped (`pending-dev` → `in-progress`) but no real work happened. Issue oscillated forever.

## Fix

Add `kill_stale_wrapper()` to `dispatch-local.sh`, called once before any `nohup`. The PID_FILE path is derived per `$TYPE` so a single function call covers all three spawn types (dev-new, dev-resume, review).

**Strategy:** SIGTERM → 5-second grace (so the wrapper's cleanup trap can flush logs and post a session report) → SIGKILL only if the process ignores SIGTERM. Then remove the PID file so the new wrapper starts clean.

**Safety guards:**
- Refuses to follow symlinks (CWE-59) — same defense as `acquire_pid_guard`.
- Distinguishes "unreadable PID file" from "empty PID file" — refuses (returns 1) on the former so we don't silently delete state we couldn't read.
- Captures stderr from SIGTERM and SIGKILL; benign ESRCH ("no such process") is silent, anything else is logged.
- Final liveness check after SIGKILL+1s. If the process survived, returns 1 — `dispatch-local.sh` exits rather than spawning a second wrapper alongside a zombie.

## Changes

- `skills/autonomous-dispatcher/scripts/dispatch-local.sh` — added `kill_stale_wrapper()` function and one call site before the spawn case statement.
- `tests/unit/test-kill-before-spawn.sh` (new, 24 assertions across TC-DKBS-001..009). Static checks confirm the function shape; behavioral tests source the actual function from the script (via awk extraction — no replica drift) and run it against synthetic processes.
- `docs/designs/dispatcher-kill-before-spawn.md` — design rationale.
- `docs/test-cases/dispatcher-kill-before-spawn.md` — test cases doc.

## Test plan

- [x] `bash tests/unit/test-kill-before-spawn.sh` (24/24)
- [x] All 11 unit suites pass
- [x] `shellcheck` reports no new warnings
- [x] Behavioral tests cover: alive PID killed, dead PID handled cleanly (no needless sleep), empty PID file tolerated, symlink rejected (target preserved), SIGTERM-resistant process escalated within 5-12s window, unreadable file refused without deletion
- [ ] Real-world: next dispatcher cycle on a downstream consumer issue with a hung wrapper. Expected: clean handoff to the new wrapper, log line "Found existing wrapper for issue #N (PID X); sending SIGTERM..."

## PR review findings (already addressed in 2nd commit)

- **Critical/Important**: cat error silently swallowed; kill stderr discarded; no post-SIGKILL liveness check; asymmetric return-code contract; test replica drift; timing flakiness.
- **Suggestions deferred**: PID-reuse recheck (design doc accepts the small risk), concurrent-dispatch test (predates this change), EPERM test (single-user pipeline).