### PR TITLE
docs(pipeline): scaffold pipeline docs and workflow-first CI gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ## Pipeline Docs (CONTRIBUTING.md Rule 1)
 
-- [ ] If this PR touches a watched path (any `skills/autonomous-*/scripts/*.sh`, `skills/autonomous-common/hooks/*.sh`, or `skills/autonomous-*/SKILL.md` — see [CONTRIBUTING.md](../CONTRIBUTING.md#what-pipeline-behavior-means) for the full list), I have updated `docs/pipeline/` to match the new behavior — OR I have applied the `pipeline-docs:none` label with rationale below.
+- [ ] If this PR touches a watched path (any `skills/autonomous-*/scripts/*.sh`, `skills/autonomous-common/hooks/*.sh`, or `skills/autonomous-*/SKILL.md` — see [CONTRIBUTING.md](CONTRIBUTING.md#what-pipeline-behavior-means) for the full list), I have updated `docs/pipeline/` to match the new behavior — OR I have applied the `pipeline-docs:none` label with rationale below.
 
 <!-- If pipeline-docs:none is applied, briefly explain why the change has no observable pipeline behavior. -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- 1-3 bullets describing what changed and why. -->
+
+## Pipeline Docs (CONTRIBUTING.md Rule 1)
+
+- [ ] If this PR touches a watched path (`skills/autonomous-{dispatcher,dev,review,common}/scripts|hooks|SKILL.md`), I have updated `docs/pipeline/` to match the new behavior — OR I have applied the `pipeline-docs:none` label with rationale below.
+
+<!-- If pipeline-docs:none is applied, briefly explain why the change has no observable pipeline behavior. -->
+
+## Test Plan
+
+<!-- How was this verified? -->
+
+- [ ] Local checks pass (shellcheck if scripts changed, `bash -n` minimum)
+- [ ] CI checks pass
+
+## Linked Issues
+
+<!-- Closes #N / Fixes #N -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ## Pipeline Docs (CONTRIBUTING.md Rule 1)
 
-- [ ] If this PR touches a watched path (`skills/autonomous-{dispatcher,dev,review,common}/scripts|hooks|SKILL.md`), I have updated `docs/pipeline/` to match the new behavior — OR I have applied the `pipeline-docs:none` label with rationale below.
+- [ ] If this PR touches a watched path (any `skills/autonomous-*/scripts/*.sh`, `skills/autonomous-common/hooks/*.sh`, or `skills/autonomous-*/SKILL.md` — see [CONTRIBUTING.md](../CONTRIBUTING.md#what-pipeline-behavior-means) for the full list), I have updated `docs/pipeline/` to match the new behavior — OR I have applied the `pipeline-docs:none` label with rationale below.
 
 <!-- If pipeline-docs:none is applied, briefly explain why the change has no observable pipeline behavior. -->
 

--- a/.github/workflows/pipeline-docs-gate.yml
+++ b/.github/workflows/pipeline-docs-gate.yml
@@ -41,15 +41,20 @@ jobs:
             exit 1
           fi
           MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
-          git diff --name-only "$MERGE_BASE" "$HEAD_SHA" > /tmp/changed.txt
+          # Use mktemp instead of a fixed /tmp path to avoid CWE-377 symlink races.
+          CHANGED_FILE=$(mktemp)
+          git diff --name-only "$MERGE_BASE" "$HEAD_SHA" > "$CHANGED_FILE"
           echo "Changed files in PR:"
-          cat /tmp/changed.txt
+          cat "$CHANGED_FILE"
+          echo "changed_file=$CHANGED_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Classify changes
         id: classify
+        env:
+          CHANGED_FILE: ${{ steps.diff.outputs.changed_file }}
         run: |
           set -euo pipefail
-          changed_file=/tmp/changed.txt
+          changed_file="$CHANGED_FILE"
 
           # Watched paths — touching any of these requires a docs/pipeline/
           # update (or the override label). Keep in sync with CONTRIBUTING.md.

--- a/.github/workflows/pipeline-docs-gate.yml
+++ b/.github/workflows/pipeline-docs-gate.yml
@@ -1,0 +1,142 @@
+name: Pipeline Docs Gate
+
+# Enforces CONTRIBUTING.md Rule 1: any PR that touches pipeline behavior MUST
+# also touch docs/pipeline/. Override with the `pipeline-docs:none` label.
+#
+# See docs/pipeline/README.md for what lives in pipeline docs.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gate:
+    name: Require pipeline docs update
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Need merge-base with the PR's base branch to diff PR-only changes.
+          fetch-depth: 0
+
+      - name: Compute changed files
+        id: diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Validate inputs are 40-char SHAs to defend against unexpected refs.
+          if ! [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::BASE_SHA does not look like a SHA: $BASE_SHA"
+            exit 1
+          fi
+          if ! [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::HEAD_SHA does not look like a SHA: $HEAD_SHA"
+            exit 1
+          fi
+          MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+          git diff --name-only "$MERGE_BASE" "$HEAD_SHA" > /tmp/changed.txt
+          echo "Changed files in PR:"
+          cat /tmp/changed.txt
+
+      - name: Classify changes
+        id: classify
+        run: |
+          set -euo pipefail
+          changed_file=/tmp/changed.txt
+
+          # Watched paths — touching any of these requires a docs/pipeline/
+          # update (or the override label). Keep in sync with CONTRIBUTING.md.
+          watched_regex='^(skills/autonomous-(dispatcher|dev|review)/scripts/.*\.sh$|skills/autonomous-common/(hooks|scripts)/.*\.sh$|skills/autonomous-(dispatcher|dev|review|common)/SKILL\.md$)'
+
+          docs_regex='^docs/pipeline/.*\.md$'
+
+          touches_pipeline=0
+          touches_docs=0
+          if grep -E -q "$watched_regex" "$changed_file"; then
+            touches_pipeline=1
+          fi
+          if grep -E -q "$docs_regex" "$changed_file"; then
+            touches_docs=1
+          fi
+
+          echo "touches_pipeline=$touches_pipeline" >> "$GITHUB_OUTPUT"
+          echo "touches_docs=$touches_docs" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Pipeline Docs Gate"
+            echo ""
+            echo "- Touches pipeline behavior: \`$touches_pipeline\`"
+            echo "- Touches \`docs/pipeline/\`: \`$touches_docs\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Check for override label
+        id: override
+        env:
+          # toJson returns a JSON array of label-name strings. We feed it
+          # to jq via stdin, never via shell interpolation, so attacker-
+          # controlled label names cannot inject shell.
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+          has_override=0
+          if printf '%s' "$LABELS_JSON" | jq -e 'any(. == "pipeline-docs:none")' >/dev/null; then
+            has_override=1
+          fi
+          echo "has_override=$has_override" >> "$GITHUB_OUTPUT"
+          echo "- Override label \`pipeline-docs:none\` applied: \`$has_override\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Enforce gate
+        env:
+          TOUCHES_PIPELINE: ${{ steps.classify.outputs.touches_pipeline }}
+          TOUCHES_DOCS: ${{ steps.classify.outputs.touches_docs }}
+          HAS_OVERRIDE: ${{ steps.override.outputs.has_override }}
+        run: |
+          set -euo pipefail
+          if [ "$TOUCHES_PIPELINE" = "0" ]; then
+            echo "PR does not touch watched pipeline paths — gate not applicable."
+            {
+              echo ""
+              echo "**Result: PASS** (no watched paths in diff)"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ "$HAS_OVERRIDE" = "1" ]; then
+            echo "Override label 'pipeline-docs:none' is applied — gate bypassed."
+            {
+              echo ""
+              echo "**Result: PASS** (override label applied)"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ "$TOUCHES_DOCS" = "1" ]; then
+            echo "Pipeline behavior changed AND docs/pipeline/ updated — gate satisfied."
+            {
+              echo ""
+              echo "**Result: PASS** (docs synced)"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "::error::Pipeline behavior changed but docs/pipeline/ was not updated."
+          {
+            echo ""
+            echo "**Result: FAIL**"
+            echo ""
+            echo "This PR modifies files that influence pipeline behavior, but does not"
+            echo "update any file under \`docs/pipeline/\`. Per CONTRIBUTING.md Rule 1:"
+            echo ""
+            echo "1. Update the relevant file(s) in \`docs/pipeline/\` describing the new behavior, **or**"
+            echo "2. Apply the \`pipeline-docs:none\` label to attest this PR has no observable pipeline change."
+            echo ""
+            echo "See \`docs/pipeline/README.md\` for which file to update."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,8 @@ To stop that pattern: **any change to pipeline behavior MUST update [`docs/pipel
 A change is a pipeline-behavior change if it touches any of:
 
 - `skills/autonomous-dispatcher/scripts/**/*.sh`
-- `skills/autonomous-dev/scripts/**/*.sh` (when added)
-- `skills/autonomous-review/scripts/**/*.sh` (when added)
+- `skills/autonomous-dev/scripts/**/*.sh`
+- `skills/autonomous-review/scripts/**/*.sh`
 - `skills/autonomous-common/hooks/**/*.sh`
 - `skills/autonomous-common/scripts/**/*.sh`
 - `skills/autonomous-{dispatcher,dev,review,common}/SKILL.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,12 +12,14 @@ To stop that pattern: **any change to pipeline behavior MUST update [`docs/pipel
 
 A change is a pipeline-behavior change if it touches any of:
 
-- `skills/autonomous-dispatcher/scripts/**/*.sh`
-- `skills/autonomous-dev/scripts/**/*.sh`
-- `skills/autonomous-review/scripts/**/*.sh`
-- `skills/autonomous-common/hooks/**/*.sh`
-- `skills/autonomous-common/scripts/**/*.sh`
+- `skills/autonomous-dispatcher/scripts/**/*.sh` (recursive — any depth)
+- `skills/autonomous-dev/scripts/**/*.sh` (recursive)
+- `skills/autonomous-review/scripts/**/*.sh` (recursive)
+- `skills/autonomous-common/hooks/**/*.sh` (recursive)
+- `skills/autonomous-common/scripts/**/*.sh` (recursive)
 - `skills/autonomous-{dispatcher,dev,review,common}/SKILL.md`
+
+(The `**` glob notation is for human readability — the CI gate uses an equivalent ERE regex with `.*` which matches across directory separators, so subdirectories of `scripts/` and `hooks/` are correctly covered.)
 
 If your PR diff touches any of those paths, it MUST also touch one or more files under `docs/pipeline/`. CI enforces this — see [`.github/workflows/pipeline-docs-gate.yml`](.github/workflows/pipeline-docs-gate.yml).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing
+
+Thanks for working on `autonomous-dev-team`. Two rules drive how we ship changes here.
+
+## Rule 1: Flow first, code second
+
+This project's job is to coordinate three autonomous agents (dispatcher, dev, review) through a shared GitHub-issue label state machine. Bugs in this kind of system come from the seams between components, not from any one component in isolation. Every bug we have shipped a fix for in the dispatcher / wrappers traced back to a state-machine corner that was implicit in code but undocumented.
+
+To stop that pattern: **any change to pipeline behavior MUST update [`docs/pipeline/`](docs/pipeline/) before — or in the same PR as — the code change.**
+
+### What "pipeline behavior" means
+
+A change is a pipeline-behavior change if it touches any of:
+
+- `skills/autonomous-dispatcher/scripts/**/*.sh`
+- `skills/autonomous-dev/scripts/**/*.sh` (when added)
+- `skills/autonomous-review/scripts/**/*.sh` (when added)
+- `skills/autonomous-common/hooks/**/*.sh`
+- `skills/autonomous-common/scripts/**/*.sh`
+- `skills/autonomous-{dispatcher,dev,review,common}/SKILL.md`
+
+If your PR diff touches any of those paths, it MUST also touch one or more files under `docs/pipeline/`. CI enforces this — see [`.github/workflows/pipeline-docs-gate.yml`](.github/workflows/pipeline-docs-gate.yml).
+
+### What to write in `docs/pipeline/`
+
+Pick the right file:
+
+| If your change is about… | Update… |
+|---|---|
+| A label transition or a new state | `state-machine.md` |
+| A dispatcher cron-tick step | `dispatcher-flow.md` |
+| The dev wrapper lifecycle, prompt, or trap | `dev-agent-flow.md` |
+| The review wrapper lifecycle, decision gate, or trailer | `review-agent-flow.md` |
+| A handoff between two actors (e.g. dev → review) | `handoffs.md` |
+| A new cross-cutting rule discovered while debugging | `invariants.md` (add a new `INV-NN`) |
+
+If your change spans more than one of the above, update each.
+
+### Discovered a new invariant? Write it down.
+
+Most pipeline bugs surface a previously-implicit invariant. After fixing the bug, add the rule to [`docs/pipeline/invariants.md`](docs/pipeline/invariants.md) under a new `INV-NN` ID, with:
+
+- One-sentence rule
+- The bug that motivated it (link the issue / PR)
+- Producer (which actor must uphold it) and consumer (which actor relies on it)
+- Where it's tested (or "TODO: add test")
+
+### Escape hatch: `pipeline-docs:none` label
+
+Some PRs legitimately don't change pipeline behavior even though they touch a watched path:
+
+- Typo / formatting fix in a comment
+- Dependency bump
+- CI workflow tweak that happens to live under a watched path
+- Pure refactor with no observable behavior change (rare — usually still a `state-machine.md` line)
+
+For those, apply the `pipeline-docs:none` label to the PR. The CI gate will skip the docs-required check. The label is auditable in PR list views, so a reviewer can ask "are you sure?".
+
+If `pipeline-docs:none` doesn't yet exist in the repo, a maintainer can create it once with:
+
+```bash
+gh label create pipeline-docs:none \
+  --description "Explicitly attests this PR has no pipeline behavior change" \
+  --color d4c5f9
+```
+
+### Worked example
+
+Fixing the "MERGED PRs treated as open dependencies" bug (#61):
+
+1. **First**: edit [`docs/pipeline/dispatcher-flow.md`](docs/pipeline/dispatcher-flow.md) Step 2 to clarify dep-check accepts both `CLOSED` and `MERGED`.
+2. Add a new invariant `INV-11: Dependency state includes MERGED` to [`docs/pipeline/invariants.md`](docs/pipeline/invariants.md).
+3. **Then**: change the script to match the documented behavior.
+4. Open the PR. CI gate sees both `skills/.../scripts/*.sh` and `docs/pipeline/*.md` in the diff → passes.
+
+If you change the script first and the docs after, that's fine too — they just have to land in the same PR. CI checks the PR diff, not the per-commit ordering.
+
+## Rule 2: Use the `autonomous-dev` workflow on yourself
+
+This repo's TDD + worktree + review-bot discipline is documented in [`CLAUDE.md`](CLAUDE.md) and the [`autonomous-dev`](skills/autonomous-dev/SKILL.md) skill. Use them when contributing here. The hooks in `.claude/settings.json` will block:
+
+- Commits outside `.worktrees/`
+- Pushes directly to `main`
+- Pushes when behind `origin/main`
+
+Don't bypass with `--no-verify`. If a hook fires, fix the underlying issue.
+
+## PR checklist
+
+Before opening a PR, confirm:
+
+- [ ] Worktree under `.worktrees/<branch>/` (not the main checkout)
+- [ ] Design canvas at `docs/designs/<feature>.md` (for non-trivial changes)
+- [ ] Pipeline docs synced (Rule 1) OR `pipeline-docs:none` label applied
+- [ ] Local tests pass (`bash -n` on changed shell scripts at minimum; shellcheck if installed)
+- [ ] `Closes #N` in the PR body if it fixes an open issue
+- [ ] Conventional-commit-style PR title (`fix(dispatcher): ...`, `docs(pipeline): ...`, etc.)
+
+Reviewers will check Rule 1 first. Save yourself the round-trip.

--- a/docs/designs/pipeline-docs-scaffold.md
+++ b/docs/designs/pipeline-docs-scaffold.md
@@ -1,0 +1,101 @@
+# Pipeline docs scaffold + workflow-first CI gate
+
+Closes nothing on its own — sets up the structure for future bug-fix and feature PRs to follow a "update flow doc, then change code" discipline.
+
+## Problem
+
+Recent dispatcher / dev / review bug fixes (#41, #44, #50, #53, #54, #55, #56, #57, plus open #58–#62) share a common pattern: each fix had to re-derive the full state machine from `SKILL.md` + scattered `### Step 5b` comments + wrapper trap code, and several fixes only patched the symptom on one branch of the state machine without updating the others.
+
+There is no single authoritative document that describes:
+
+- The label state machine for an `autonomous` issue
+- The dispatcher's per-tick algorithm
+- The dev-agent / review-agent wrapper lifecycle (trap, cleanup, retries)
+- The five handoff points between the three agents (and their invariants)
+
+Result: regression-prone fixes, hard onboarding, and a 438-line dispatcher SKILL.md where >50% of the body is bash code blocks the agent re-types verbatim.
+
+## Goal
+
+Set up structure for a flow-first contribution discipline — without changing any pipeline code yet. Two follow-up PRs (PR-2 fills in the docs, PR-3 slims the dispatcher SKILL.md by extracting bash to scripts) build on this scaffold.
+
+## What this PR ships
+
+1. **`docs/pipeline/` skeleton** — README index + 6 stub files (state-machine, dispatcher-flow, dev-agent-flow, review-agent-flow, handoffs, invariants). Stubs only; PR-2 fills them.
+
+2. **`CONTRIBUTING.md`** — explicit "update pipeline docs before / alongside scripts" rule. Defines:
+   - Trigger paths (which paths in a PR force the rule)
+   - Exemptions (typo / formatting only)
+   - Escape hatch (`pipeline-docs:none` PR label for explicit no-flow-change PRs, e.g. CI tweaks)
+
+3. **`.github/workflows/pipeline-docs-gate.yml`** — CI hard gate. Fails the PR check if it touches any of:
+   - `skills/autonomous-dispatcher/scripts/`
+   - `skills/autonomous-dev/scripts/` (if/when added)
+   - `skills/autonomous-review/scripts/` (if/when added)
+   - `skills/autonomous-common/hooks/`
+   - `skills/autonomous-common/scripts/`
+   - `skills/autonomous-{dispatcher,dev,review,common}/SKILL.md`
+
+   …without also touching `docs/pipeline/` OR carrying the `pipeline-docs:none` label.
+
+4. **`.github/pull_request_template.md`** — adds a checkbox surfacing the rule to PR authors.
+
+## Non-goals
+
+- Filling in the actual pipeline docs (PR-2)
+- Refactoring SKILL.md or scripts (PR-3+)
+- Changing any current pipeline behavior
+
+## Design decisions
+
+### Why a separate `docs/pipeline/` directory and not extending `docs/autonomous-pipeline.md`?
+
+The existing `autonomous-pipeline.md` is an overview / quick-start. The new docs are normative state-machine references that will grow as bugs surface invariants. Separate dir keeps overview vs. spec-grade docs distinct, and lets the CI gate watch a focused path glob.
+
+The existing `docs/autonomous-pipeline.md` stays — PR-2 will add a "see `docs/pipeline/` for the authoritative state machine" pointer at its top.
+
+### Why a hard CI gate and not a soft hook?
+
+The user picked **hard** (CI block) over soft (PR template only) and medium (pre-push warning) explicitly. Rationale: the bug stream this is meant to prevent has shipped via PRs whose authors clearly *did* understand the state machine they were touching but had no incentive to write it down. A blocking gate forces the writeup.
+
+### Escape hatch design
+
+`pipeline-docs:none` label, applied by PR author. Rationale:
+
+- Some PRs legitimately don't touch flow (e.g. typo in a comment, dependency bumps, CI-only changes that happen to be under a watched path).
+- Keeping the override visible (a label, not a magic commit-message tag) makes the bypass auditable in PR list views.
+- A reviewer who sees the label has explicit context to ask "are you sure?".
+
+Alternative considered: skip-via-commit-message (e.g. `[skip pipeline-docs]`). Rejected — invisible in the PR card, and the workflow would still need to parse commits.
+
+### Why include SKILL.md in the watched paths?
+
+The whole point of PR-3 is to move logic *out of* SKILL.md into scripts. But until then, SKILL.md still contains the state machine. Touching it without updating `docs/pipeline/` is exactly the failure mode this gate prevents.
+
+Once PR-3 lands and SKILL.md is thin prose only, the gate can drop SKILL.md from the watched glob — but that's a future tweak.
+
+### Watched paths — rationale for each
+
+| Path | Why watched |
+|---|---|
+| `skills/autonomous-dispatcher/scripts/*.sh` | All the wrapper / dispatch / lib-* scripts. Any change here is a state-machine change. |
+| `skills/autonomous-common/hooks/*.sh` | Workflow-enforcement hooks. Changes affect dev-agent flow. |
+| `skills/autonomous-common/scripts/*.sh` | mark-issue-checkbox / reply-to-comments / resolve-threads — all participate in the dev-agent's PR lifecycle. |
+| `skills/autonomous-{dispatcher,dev,review,common}/SKILL.md` | Until PR-3, SKILL.md *is* the state machine. |
+
+Not watched (intentionally):
+
+- `skills/create-issue/` — issue-authoring helper, not part of the dispatch loop.
+- `skills/autonomous-*/references/` — long-form prose only, no behavior.
+- `docs/` (anywhere) — these are the docs themselves.
+- `.github/`, `*.example`, `package.json`, etc.
+
+## Validation plan
+
+- `markdownlint` on the new files (project doesn't use it today, so just visual check).
+- Open this PR and confirm the `pipeline-docs-gate` job *passes* (this PR adds docs and modifies no scripts → no gate trigger needed; but if the gate runs at all it should be green).
+- Open a quick test PR with a no-op edit to `skills/autonomous-dispatcher/scripts/setup-labels.sh` and no docs change → confirm the gate fails. Then add the `pipeline-docs:none` label → confirm it passes. (Done in a throwaway branch, not landed.)
+
+## Risk
+
+Low. No code change, no behavior change. Only risk is a too-strict gate that annoys future authors — mitigated by the `pipeline-docs:none` label.

--- a/docs/pipeline/README.md
+++ b/docs/pipeline/README.md
@@ -1,0 +1,45 @@
+# Autonomous Pipeline — Authoritative Flow Reference
+
+This directory is the **single source of truth** for how the autonomous pipeline behaves end-to-end. The dispatcher, dev-agent wrapper, and review-agent wrapper are all required to match what is documented here. Bug fixes and features MUST update the relevant doc(s) before (or in the same PR as) the code change. See [`CONTRIBUTING.md`](../../CONTRIBUTING.md) for the rule.
+
+For the high-level overview and quick start, see [`docs/autonomous-pipeline.md`](../autonomous-pipeline.md). This directory is the spec; that file is the orientation.
+
+## Files
+
+| File | Scope |
+|---|---|
+| [`state-machine.md`](state-machine.md) | The label state machine for an `autonomous`-tagged GitHub issue. The entire pipeline is a function of label transitions. |
+| [`dispatcher-flow.md`](dispatcher-flow.md) | What the dispatcher does on each cron tick. The five steps, dependency check, retry counter, stale detection (5a + 5b). |
+| [`dev-agent-flow.md`](dev-agent-flow.md) | The dev-agent wrapper lifecycle: PID guard, prompt construction, agent invocation, exit-trap label transitions. |
+| [`review-agent-flow.md`](review-agent-flow.md) | The review-agent wrapper lifecycle: PID guard, requirement-drift detection, decision gate, reviewed-HEAD trailer. |
+| [`handoffs.md`](handoffs.md) | The five handoff points between dispatcher / dev / review and the invariants each side is required to uphold. |
+| [`invariants.md`](invariants.md) | Cross-cutting invariants (PID file naming, retry-counter cutoff rule, SHA trailer format, "crashed"-keyword regex contract, etc.). |
+
+## Reading order
+
+First time:
+
+1. `state-machine.md` — get the labels and transitions in your head.
+2. `handoffs.md` — see where the three agents meet.
+3. `dispatcher-flow.md`, `dev-agent-flow.md`, `review-agent-flow.md` — the per-agent details.
+4. `invariants.md` — the rules that keep them coherent.
+
+Fixing a bug:
+
+1. Find the misbehavior on the state-machine diagram.
+2. Read the relevant flow doc.
+3. Read the invariant the bug violated (or, if none exists, write one as part of your fix).
+4. Update the flow doc to describe the new behavior.
+5. Then change the code.
+
+## Status
+
+| Doc | Status |
+|---|---|
+| `README.md` | Done (this file) |
+| `state-machine.md` | Stub — filled in PR-2 |
+| `dispatcher-flow.md` | Stub — filled in PR-2 |
+| `dev-agent-flow.md` | Stub — filled in PR-2 |
+| `review-agent-flow.md` | Stub — filled in PR-2 |
+| `handoffs.md` | Stub — filled in PR-2 |
+| `invariants.md` | Stub — filled in PR-2 |

--- a/docs/pipeline/dev-agent-flow.md
+++ b/docs/pipeline/dev-agent-flow.md
@@ -1,0 +1,28 @@
+# Dev-Agent Wrapper Flow
+
+> **Status: scaffold.** This file is filled in by PR-2.
+
+## Purpose
+
+Describes the lifecycle of a single dev-agent invocation: from `dispatch-local.sh` spawning `autonomous-dev.sh`, through prompt construction and agent invocation, through the exit trap that updates issue labels.
+
+## Outline (filled by PR-2)
+
+1. **Spawn** — `dispatch-local.sh` kills any stale wrapper for this issue+type, then `nohup autonomous-dev.sh ...`. Why `kill_stale_wrapper` is at the dispatcher level, not in `acquire_pid_guard`.
+2. **PID guard** — `acquire_pid_guard` writes `$$` to `/tmp/agent-${PROJECT_ID}-issue-${ISSUE_NUM}.pid`. Symlink-attack defense.
+3. **Auth setup** — `setup_github_auth` (token vs app mode), `gh-token-refresh-daemon` lifecycle.
+4. **Mode = new** — uuidgen session-id, build prompt with `<user-issue-content>` injection-defense tags, `run_agent`.
+5. **Mode = resume** — fetch review feedback + PR inline comments, build resume prompt, `resume_agent`. Fallback to new-session on resume failure.
+6. **Exit trap (`cleanup`)** — the contract:
+   - PID file always cleaned up.
+   - Skip label update if `AGENT_RAN=false`.
+   - On exit 0: verify a PR exists. If yes → `pending-review`. If no → `pending-dev` (#40).
+   - On exit ≠ 0: → `pending-dev`.
+   - Post Agent Session Report comment with session-id, exit code, mode, log path.
+7. **Path resolution** — `readlink -f` vs `BASH_SOURCE`, the symlink-vendor pattern (#58).
+
+## Cross-references
+
+- [`dispatcher-flow.md`](dispatcher-flow.md) — Step 4 dispatches dev-resume.
+- [`handoffs.md`](handoffs.md) — wrapper-trap-vs-dispatcher race on label transitions.
+- [`invariants.md`](invariants.md) — "crashed"-keyword contract; PID file naming; session report format.

--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -1,0 +1,28 @@
+# Dispatcher Flow (per cron tick)
+
+> **Status: scaffold.** This file is filled in by PR-2.
+
+## Purpose
+
+Describes exactly what the dispatcher does on each cron tick (default: every 5 minutes). The dispatcher is stateless — it reads issue labels and PID files, makes decisions, dispatches subprocesses, and updates labels.
+
+## Outline (filled by PR-2)
+
+1. **Tick lifecycle** — initialize `JUST_DISPATCHED`, run Steps 1–5, exit. No persistent state across ticks.
+2. **Step 1: concurrency gate** — count `in-progress` + `reviewing` issues, abort tick if at `MAX_CONCURRENT`.
+3. **Step 2: scan-new** — find `autonomous`-only issues, dependency-check, label `in-progress`, dispatch `dev-new`.
+4. **Step 3: scan-pending-review** — label `reviewing`, dispatch `review`.
+5. **Step 4: scan-pending-dev** — retry-counter check (with stalled-cutoff rule), session-id extraction, label `in-progress`, dispatch `dev-resume`.
+6. **Step 5: stale detection**
+   - 5a: ALIVE-with-PR-ready-for-review (idle gate, CI-green gate, SIGTERM, transition to `pending-review`).
+   - 5b: DEAD-with-PR (HEAD SHA comparison, transition to `pending-review` or `pending-dev`).
+   - 5b: DEAD-without-PR (transition to `pending-dev`).
+   - 5b: DEAD-while-`reviewing` (transition to `pending-dev`).
+7. **`JUST_DISPATCHED` rationale** — why freshly dispatched issues are skipped from stale detection.
+8. **Failure modes** — token expiry, malformed jq output, fail-closed defaults.
+
+## Cross-references
+
+- [`state-machine.md`](state-machine.md) — the label transitions caused by each step.
+- [`handoffs.md`](handoffs.md) — Step 5 is the most race-prone handoff.
+- [`invariants.md`](invariants.md) — retry-counter cutoff rule, "crashed"-keyword regex contract.

--- a/docs/pipeline/handoffs.md
+++ b/docs/pipeline/handoffs.md
@@ -1,0 +1,37 @@
+# Handoff Points and Their Invariants
+
+> **Status: scaffold.** This file is filled in by PR-2.
+
+## Purpose
+
+The pipeline has three actors (dispatcher, dev wrapper, review wrapper) but five places where work is handed off. This file enumerates each handoff, the data carrier (label, comment, PID file, PR), the producing-side and consuming-side invariants, and the failure modes when an invariant is violated.
+
+## The five handoffs
+
+1. **Dispatcher → dev (new)** — `autonomous` (no other label) → `in-progress`. Carrier: label + dispatched subprocess.
+2. **Dispatcher → dev (resume)** — `pending-dev` → `in-progress`. Carrier: label + session-id extracted from prior dev session report comment.
+3. **Dev → review** — `in-progress` → `pending-review`. Carrier: label + open PR referencing the issue.
+4. **Dispatcher → review** — `pending-review` → `reviewing`. Carrier: label.
+5. **Review → dev (send-back)** — `reviewing` → `pending-dev`. Carrier: label + "Review findings:" comment + PR inline comments + Reviewed-HEAD trailer.
+
+## Outline (filled by PR-2)
+
+For each of the five handoffs, document:
+
+- **Trigger** — what makes the handoff happen.
+- **Producer-side invariants** — what the upstream actor MUST guarantee (e.g. dev MUST post Dev Session ID before exiting; review MUST post Reviewed HEAD trailer before exiting).
+- **Consumer-side invariants** — what the downstream actor MUST tolerate (e.g. dispatcher MUST handle a missing trailer as "review never ran successfully" not as failure).
+- **Race window** — what happens when both sides act simultaneously.
+- **Failure mode** — what the next cron tick does if the handoff partially completed.
+
+## Cross-cutting concerns
+
+- **Dispatcher-vs-wrapper-trap race**: covered by Step 5a's `JUST_DISPATCHED` skip and the wrapper trap's idempotent label edits. See #57.
+- **Reviewed-HEAD trailer empty-fallthrough**: empty value routes to `pending-review` (safe first-review case OR transient post-failure). Documented in [`invariants.md`](invariants.md).
+- **Resume-on-completed-session hang** (#59): dispatcher MUST check session terminal state before issuing resume. Invariant added in PR-5.
+
+## Cross-references
+
+- [`state-machine.md`](state-machine.md) — the label edges this file describes.
+- [`dispatcher-flow.md`](dispatcher-flow.md), [`dev-agent-flow.md`](dev-agent-flow.md), [`review-agent-flow.md`](review-agent-flow.md) — the per-actor steps.
+- [`invariants.md`](invariants.md) — the rules each side must uphold.

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -1,0 +1,42 @@
+# Cross-cutting Invariants
+
+> **Status: scaffold.** This file is filled in by PR-2.
+
+## Purpose
+
+Catalog of rules that span the dispatcher / dev / review boundaries. When a bug fix discovers a new invariant, add it here and reference it from the relevant flow doc.
+
+Each invariant has a fixed shape:
+
+```
+INV-<NN>: <one-sentence rule>
+
+Why: <the historical bug this exists to prevent — link the issue / PR>
+Producer: <which actor must uphold it>
+Consumer: <which actor relies on it>
+Test: <where this is verified, or "TODO: add test">
+```
+
+## Outline (filled by PR-2)
+
+Initial invariant set, derived from the bug stream that motivated this scaffold:
+
+- **INV-01: PID file naming** — `/tmp/agent-${PROJECT_ID}-issue-${N}.pid` for dev, `-review-${N}.pid` for review. Producer: wrappers. Consumer: dispatcher Step 5.
+- **INV-02: PID file is not a symlink** — wrappers and `kill_stale_wrapper` refuse to operate on symlinked PID files (CWE-59).
+- **INV-03: Dev session report comment format** — Producer: dev wrapper exit trap. Consumer: dispatcher Step 4 retry counter + dispatcher Step 4 session-id extraction.
+- **INV-04: Reviewed-HEAD trailer format** — `` `Reviewed HEAD: \`<sha>\`` ``. Producer: review wrapper. Consumer: dispatcher Step 5b SHA comparison (#53).
+- **INV-05: Retry-counter cutoff rule** — only count failures *after* the most recent "Marking as stalled" comment. Removing `stalled` resets the counter (#41).
+- **INV-06: "crashed" / "process not found" keyword contract** — Step 5b dispatcher comments containing these phrases are counted by Step 4 retry regex. Comments for forward-progress paths (PR found, no new commits since last review) MUST NOT contain these phrases (#50).
+- **INV-07: Empty Reviewed-HEAD trailer routes to `pending-review`** — covers both first-review and trailer-post-failure cases (#53).
+- **INV-08: Wrapper exit trap is idempotent against label state** — wrapper trap can race with dispatcher Step 5; both must converge to the same final label within one tick.
+- **INV-09: `JUST_DISPATCHED` skip rule** — Step 5 MUST skip issues dispatched in the current tick (their PID file may not be written yet).
+- **INV-10: 5-minute idle gate before SIGTERM** — Step 5a MUST require ≥300s since `PR.updatedAt` before killing an alive wrapper (#56).
+- **INV-11: Dependency state includes `MERGED`** — Step 2 dep-check treats both `CLOSED` and `MERGED` as resolved. PRs return `MERGED` not `CLOSED` (#61).
+- **INV-12: Resume only against unfinished sessions** — dispatcher MUST NOT issue resume against a session whose terminal state is `completed` (#59). [Added in PR-5.]
+- **INV-13: Wall-clock cap on agent invocations** — `run_agent` / `resume_agent` MUST be wrapped in `timeout` (default 4h, override via `AGENT_TIMEOUT`) to bound hung calls (#60). [Added in PR-5.]
+- **INV-14: `lib-agent.sh` config lookup honors symlink-vendor pattern** — script-local paths MUST resolve to the invocation path, not the `readlink -f` target (#58). [Added in PR-4.]
+
+## Cross-references
+
+- All flow docs cite these invariants by ID (e.g. "[INV-04]") rather than restating them.
+- [`state-machine.md`](state-machine.md) — invariants that constrain transitions are flagged inline there.

--- a/docs/pipeline/review-agent-flow.md
+++ b/docs/pipeline/review-agent-flow.md
@@ -1,0 +1,27 @@
+# Review-Agent Wrapper Flow
+
+> **Status: scaffold.** This file is filled in by PR-2.
+
+## Purpose
+
+Describes the lifecycle of a single review-agent invocation: from `dispatch-local.sh` spawning `autonomous-review.sh`, through review checklist execution, through merge / send-back decision and the exit trap.
+
+## Outline (filled by PR-2)
+
+1. **Spawn** — same `kill_stale_wrapper` discipline as dev. PID file: `/tmp/agent-${PROJECT_ID}-review-${ISSUE_NUM}.pid`.
+2. **PID guard** — same defense as dev wrapper.
+3. **Auth setup** — review-agent typically uses Sonnet (vs dev Opus) and a separate App identity.
+4. **Mergeability check** — `gh pr view ... --json mergeable` (`MERGEABLE` / `CONFLICTING` / `UNKNOWN`). Rebase procedure on `CONFLICTING`. Wait+retry on `UNKNOWN`.
+5. **Requirement drift detection (mandatory pre-diff step)** — read all issue comments for scope changes after the issue was first opened.
+6. **Review checklist** — process compliance, code quality, testing, infra, optional bot reviewer verification.
+7. **E2E verification** — Chrome DevTools MCP procedure (only if a preview URL is configured).
+8. **Acceptance criteria marking** — `mark-issue-checkbox.sh` per criterion, only after verification.
+9. **Findings → Decision gate** — `BLOCKING ⇒ FAIL` rule, no middle ground.
+10. **Reviewed-HEAD trailer** — wrapper posts `Reviewed HEAD: ` after each verdict so the dispatcher's Step 5b can skip redundant reviews when the PR HEAD didn't change (#53).
+11. **Exit trap** — labels: PASS → `approved` (+ auto-merge unless `no-auto-close`); FAIL → `pending-dev`.
+
+## Cross-references
+
+- [`dispatcher-flow.md`](dispatcher-flow.md) — Step 5b's HEAD-SHA comparison depends on the trailer this wrapper posts.
+- [`handoffs.md`](handoffs.md) — review-→-dev send-back is one of the five handoff points.
+- [`invariants.md`](invariants.md) — Reviewed-HEAD trailer format; decision-gate hard rule.

--- a/docs/pipeline/state-machine.md
+++ b/docs/pipeline/state-machine.md
@@ -1,0 +1,21 @@
+# Issue Label State Machine
+
+> **Status: scaffold.** This file is filled in by PR-2. The structure below is the contract; the content is a placeholder until the next PR lands.
+
+## Purpose
+
+The autonomous pipeline is driven entirely by GitHub issue labels. This document is the authoritative description of the legal label states, the transitions between them, and which actor performs each transition.
+
+## Outline (filled by PR-2)
+
+1. **Labels** — table of every label, owner, meaning.
+2. **State diagram** — mermaid `stateDiagram-v2` covering the five active states (`autonomous`, `in-progress`, `pending-review`, `reviewing`, `pending-dev`) and the two terminal states (`approved`, `stalled`).
+3. **Transition table** — for each transition: trigger, actor (dispatcher / dev wrapper / review wrapper / dispatcher cleanup trap), preconditions, postconditions, comment-on-issue side effect.
+4. **Forbidden transitions** — explicit list of "this must never happen" combinations (e.g. `in-progress` + `reviewing` simultaneously).
+5. **Concurrent-modification semantics** — what happens when the wrapper trap and the dispatcher both edit labels in the same window (see #57 race).
+
+## Cross-references
+
+- [`dispatcher-flow.md`](dispatcher-flow.md) — the steps that *cause* most transitions.
+- [`handoffs.md`](handoffs.md) — the transitions that span actors.
+- [`invariants.md`](invariants.md) — invariants that constrain valid transitions.


### PR DESCRIPTION
## Summary

PR-1 of a multi-PR plan to introduce a "flow first, code second" discipline for the autonomous pipeline. **Docs-only — no scripts, no behavior change.**

- `docs/pipeline/` skeleton (README + 6 stubs filled in PR-2): state-machine, dispatcher-flow, dev-agent-flow, review-agent-flow, handoffs, invariants.
- `CONTRIBUTING.md`: explicit Rule 1 with watched paths, escape hatch (`pipeline-docs:none` label), worked example.
- `.github/workflows/pipeline-docs-gate.yml`: hard CI gate that fails PRs touching watched paths without `docs/pipeline/` updates; honors the override label.
- `.github/pull_request_template.md`: surfaces Rule 1 to PR authors.
- `docs/designs/pipeline-docs-scaffold.md`: design canvas.

## Motivation

Recent dispatcher / wrapper bug stream (#41-#57 plus open #58-#62) consistently traced back to state-machine corners that were implicit in code but undocumented. The 438-line `autonomous-dispatcher/SKILL.md` is >50% bash code blocks the agent re-types verbatim. Future PRs will:

- **PR-2**: fill `docs/pipeline/` from current SKILL.md + scripts (still no behavior change).
- **PR-3**: extract bash from `autonomous-dispatcher/SKILL.md` into `lib-dispatch.sh` + small entrypoint scripts.
- **PR-4**: fix #58 (readlink-vendor) + #61 (MERGED-not-CLOSED) — small low-risk bugs that validate the new flow.
- **PR-5**: fix #59 (resume-on-completed) + #60 (wall-clock timeout).
- **PR-6**: feat #62 (multi-repo dispatch + pluggable backend).
- **PR-7**: `/skill-creator` polish on the slimmed skills.

## Pipeline Docs (CONTRIBUTING.md Rule 1)

- [x] PR touches `docs/pipeline/` directly — gate passes by docs-touched path. Also touches no watched scripts paths, so the gate would PASS even without the docs.

## Test Plan

- [x] `bash -n` clean on all referenced scripts (this PR adds none).
- [x] `python3 -c "yaml.safe_load(...)"` — workflow YAML parses.
- [x] Manual regex validation: ran the gate's watched_regex against this PR's diff → no matches → gate inert (correct).
- [x] Code review pass via `pr-review-toolkit:code-reviewer` (two rounds: initial + fix).
- [ ] Will spot-check on a real bug-fix PR (PR-4) that the gate fails when scripts change without docs/pipeline.

## Linked Issues

Sets up structure for the open bug stream: #58, #59, #60, #61, #62. None closed by this PR.