### PR TITLE
fix(pipeline-docs): mermaid layout error on dev-agent-flow.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,8 @@ These caused 5 of 7 mermaid blocks to fail in the first commit of PR-2 ([#66](ht
 
 3. **No double quotes `"..."` inside flowchart `[]` node labels.** The inner `"` confuses the parser. Use single quotes `'...'`, or rephrase to avoid the quote entirely. Example: `[comment "exited 0 but no PR"]` → `[comment 'exited 0 but no PR']`.
 
+4. **Avoid `<br/>` inside `sequenceDiagram` message text and minimize `<br/>` count in flowchart `[]` node labels.** This is a *runtime layout error*, not a parse error: the d3-curve label-placement pass throws *"Could not find a suitable point for the given distance"* and the diagram renders as an empty box on github.com. The failure is non-deterministic across feature branches vs. main (different cache/build of GitHub's mermaid renderer), so it's possible for a PR review to show all blocks rendering fine and then break after merge — that exact regression is what surfaced this rule ([PR #66](https://github.com/zxkane/autonomous-dev-team/pull/66) post-merge). Prefer single-line message and node labels; if a label feels too long, restate the detail in the prose immediately after the diagram.
+
 Side notes: `≥`, `≠`, `⇒` (Unicode comparison/arrow chars) render fine. Parens around words are fine (`[Step 1<br/>concurrency cap?]`). The Unicode minus `−` in node labels is fine but `+` and `=` adjacent to identifiers can confuse the parser — write the words `add`/`remove` if in doubt.
 
 #### Validation procedure (mandatory for any PR that adds or edits a mermaid block)
@@ -72,6 +74,8 @@ Side notes: `≥`, `≠`, `⇒` (Unicode comparison/arrow chars) render fine. Pa
 5. If using Claude Code with the chrome-devtools MCP installed, `mcp__chrome-devtools__new_page` + `wait_for(["Parse error", "<a heading after the block>"])` automates this — see [PR #66](https://github.com/zxkane/autonomous-dev-team/pull/66) discussion for the playbook.
 
 If a block fails, fix it locally, push again, re-verify. Do NOT merge a PR with a broken mermaid block visible on github.com.
+
+**After merge, re-verify on `main`.** GitHub's mermaid renderer (`viewscreen.githubusercontent.com`) caches per ref, and feature-branch and main caches can hit different mermaid builds. A block that renders fine on the PR head can break on main (rule 4 above is the symptom this exposes). Open `https://github.com/<owner>/<repo>/blob/main/<path>.md` once the merge lands.
 
 ### Escape hatch: `pipeline-docs:none` label
 

--- a/docs/designs/mermaid-layout-dev-agent-flow.md
+++ b/docs/designs/mermaid-layout-dev-agent-flow.md
@@ -1,0 +1,59 @@
+# Fix mermaid layout error in dev-agent-flow.md
+
+## Problem
+
+After PR #66 merged, `docs/pipeline/dev-agent-flow.md` viewed on github.com (main branch) shows two empty mermaid boxes with an error message: *"Could not find a suitable point for the given distance"*. This is a runtime layout error from mermaid's d3-curve module — different from the parse errors caught and fixed during PR-66 review.
+
+The same blocks rendered fine on the PR head before merge — likely a difference in viewscreen.githubusercontent.com's mermaid build / cache behavior between feature branches and main.
+
+## Root cause hypothesis (informed but not confirmed)
+
+The error is from mermaid 10.x's edge-label-position-on-curve calculation. Two things in the current blocks are known triggers in mermaid issue trackers:
+
+1. **`<br/>` inside `sequenceDiagram` message text.** The Lifecycle block has one such case:
+   ```
+   D->>W: nohup autonomous-dev.sh --issue N --mode new<br/>(or --mode resume --session ID)
+   ```
+   Mermaid sequenceDiagram supports `<br/>` in messages, but the layout pass that places the message label on the arrow can fail to find a valid anchor when the label is multi-line on a particular arrow length.
+
+2. **Multiple `<br/>` in a single flowchart `[]` node label, especially the tall `to_dev_no_pr` node.**
+   ```
+   to_dev_no_pr[comment 'exited 0 but no PR'<br/>remove in-progress<br/>add pending-dev]
+   ```
+   Three lines of label text in one node, plus hyphenated terms, gives the layout engine a label box whose curve-anchor computation may fail to find a "suitable point" along its incoming edge.
+
+I am not 100% certain which one is the trigger — mermaid's error doesn't pinpoint the offending block. Fix is to rewrite both, since a single PR cycle on github.com is the only way to verify.
+
+## Fix
+
+**Block 1 (sequenceDiagram, "Lifecycle")**: replace the one `<br/>` in message text with a parenthetical on the same line, accepting a slightly long message. Sequence diagram horizontal width can absorb it; the layout error path is specifically about *vertical* label placement on the message arrow.
+
+**Block 2 (flowchart, "Exit trap")**: collapse multi-line node labels to single lines. Use word-spacing instead of explicit line breaks. The flowchart still reads clearly because the node ID + the surrounding edges convey the structure.
+
+Specifically:
+
+- `to_dev_no_pr[comment 'exited 0 but no PR'<br/>remove in-progress<br/>add pending-dev]` → `to_dev_no_pr[no PR exited 0 — to pending-dev]`
+- `to_review[remove in-progress<br/>remove pending-dev<br/>add pending-review]` → `to_review[to pending-review]`
+- `to_dev_fail[remove in-progress<br/>add pending-dev]` → `to_dev_fail[to pending-dev]`
+- The `enter([trap fires<br/>exit_code captured])` and `refresh[refresh GH App token<br/>just in case]` and `session_report[post Agent Session Report<br/>session_id, exit_code, mode, log path]` get similar single-line treatment.
+
+The information lost from the labels is restated in the prose immediately after the diagram (the existing "Trap contract details" section already does this), so no semantic loss.
+
+## Validation
+
+1. Push branch to GitHub.
+2. View `https://github.com/zxkane/autonomous-dev-team/blob/<sha>/docs/pipeline/dev-agent-flow.md` via chrome-devtools MCP.
+3. Confirm both mermaid blocks render as actual diagrams (no empty box, no error overlay, no parse error text).
+4. If error persists, suspect block 1 (sequenceDiagram with `<br/>` in message) and rewrite that one too.
+
+## Lesson for CONTRIBUTING.md
+
+This is a 4th mermaid landmine to add to the existing 3. It's about *layout*, not *syntax* — `bash -n`-style checks won't catch it, and even visual rendering during PR review can be cached / non-deterministic across the GitHub renderer's branch cache. **Add to CONTRIBUTING.md**:
+
+> 4. **Avoid `<br/>` inside sequenceDiagram message text and minimize `<br/>` count in flowchart node labels.** Mermaid 10.x's d3-curve label placement can intermittently fail with "Could not find a suitable point for the given distance" — the failure mode is non-deterministic and can succeed on a feature branch but fail on main. Prefer single-line message/node labels.
+
+Add this in the same fix PR.
+
+## Risk
+
+Very low — docs only. If the fix doesn't address the root cause, the symptom (empty mermaid boxes) is still no worse than the current state on main.

--- a/docs/pipeline/dev-agent-flow.md
+++ b/docs/pipeline/dev-agent-flow.md
@@ -15,7 +15,7 @@ sequenceDiagram
     participant GH as GitHub API
 
     D->>D: kill_stale_wrapper(PID_FILE)
-    D->>W: nohup autonomous-dev.sh --issue N --mode new<br/>(or --mode resume --session ID)
+    D->>W: nohup autonomous-dev.sh --issue N --mode new (or --mode resume --session ID)
     W->>L: source lib-agent.sh and lib-auth.sh
     W->>W: setup_github_auth (token or App)
     W->>W: acquire_pid_guard(PID_FILE)
@@ -106,20 +106,20 @@ The trap is the wrapper's actual contract with the dispatcher — it runs on eve
 
 ```mermaid
 flowchart TD
-    enter([trap fires<br/>exit_code captured]) --> rm_pid[rm -f PID_FILE]
+    enter([trap fires]) --> rm_pid[rm -f PID_FILE]
     rm_pid --> ran{AGENT_RAN?}
     ran -- false --> auth_done[cleanup_github_auth]
     auth_done --> done([exit])
 
-    ran -- true --> refresh[refresh GH App token<br/>just in case]
-    refresh --> session_report[post Agent Session Report<br/>session_id, exit_code, mode, log path]
+    ran -- true --> refresh[refresh App token]
+    refresh --> session_report[post Session Report]
     session_report --> exit_branch{exit_code == 0?}
 
-    exit_branch -- yes --> pr_check{PR exists for issue?}
-    pr_check -- yes --> to_review[remove in-progress<br/>remove pending-dev<br/>add pending-review]
-    pr_check -- no --> to_dev_no_pr[comment 'exited 0 but no PR'<br/>remove in-progress<br/>add pending-dev]
+    exit_branch -- yes --> pr_check{PR exists?}
+    pr_check -- yes --> to_review[set pending-review]
+    pr_check -- no --> to_dev_no_pr[set pending-dev no-PR]
 
-    exit_branch -- no --> to_dev_fail[remove in-progress<br/>add pending-dev]
+    exit_branch -- no --> to_dev_fail[set pending-dev fail]
 
     to_review --> auth_done
     to_dev_no_pr --> auth_done


### PR DESCRIPTION
## Summary

After PR #66 merged, both mermaid blocks in [`docs/pipeline/dev-agent-flow.md`](https://github.com/zxkane/autonomous-dev-team/blob/main/docs/pipeline/dev-agent-flow.md) broke on \`main\` with mermaid runtime error \`Could not find a suitable point for the given distance\` — a d3-curve label-placement failure (not a parse error). The same blocks rendered fine on the PR head before merge.

This is a hot-fix:

- Sequence diagram (Lifecycle): drop the one \`<br/>\` from message text, fold the parenthetical onto the same line.
- Flowchart (Exit trap cleanup): collapse multi-line node labels (3 \`<br/>\` per worst node) to single lines. Information is restated in the prose immediately after.
- Add a 4th landmine to CONTRIBUTING.md mermaid section: avoid \`<br/>\` in sequenceDiagram messages, minimize in flowchart node labels.
- Add a "verify on \`main\` after merge" step to the validation procedure — since this regression specifically slipped through PR-review verification (per-ref cache differences in GitHub's mermaid renderer).

## Pipeline Docs (CONTRIBUTING.md Rule 1)

- [x] Touches \`docs/pipeline/dev-agent-flow.md\` directly. Gate passes via docs-touched. Also touches no scripts paths.

## Test Plan

- [x] Visually verified both blocks render on \`https://github.com/zxkane/autonomous-dev-team/blob/47439e7/docs/pipeline/dev-agent-flow.md\` via chrome-devtools MCP — sequence diagram shows participants and arrows, flowchart shows nodes and edges. No parse error, no empty box.
- [x] Code review pass.
- [ ] Re-verify on \`main\` after merge (per the new CONTRIBUTING rule).

## Linked Issues

None — this fixes a regression introduced by #66.