### PR TITLE
fix(hooks): trunk-protection defense in depth — closes #64 #65 #68

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,7 @@ jobs:
             skills/autonomous-dispatcher/scripts/lib-dispatch.sh \
             skills/autonomous-dispatcher/scripts/setup-labels.sh \
             skills/autonomous-dispatcher/scripts/gh-token-refresh-daemon.sh \
-            skills/autonomous-dispatcher/scripts/gh-with-token-refresh.sh
+            skills/autonomous-dispatcher/scripts/gh-with-token-refresh.sh \
+            skills/autonomous-common/hooks/lib-push.sh \
+            skills/autonomous-common/hooks/install-git-pre-push.sh \
+            skills/autonomous-common/scripts/install-claude-hooks.sh

--- a/docs/designs/hooks-security-bundle.md
+++ b/docs/designs/hooks-security-bundle.md
@@ -1,0 +1,150 @@
+# Hooks security bundle: trunk-protection defense in depth
+
+PR-5 of the pipeline-docs plan. Closes 3 hook issues that together gate trunk-pushes. The three layers are designed to be independent — any one of them failing should not let an unwanted commit through to the trunk.
+
+## Issues addressed
+
+| # | Title | Affected file(s) |
+|---|---|---|
+| #64 | `block-push-to-main.sh` regex false-pos / false-neg | existing `skills/autonomous-common/hooks/block-push-to-main.sh` |
+| #65 | Worktree creation should install repo-local git pre-push backstop | new `skills/autonomous-common/hooks/install-git-pre-push.sh` |
+| #68 | SKILL.md frontmatter hooks are skill-scoped, not project-scoped | new `skills/autonomous-common/scripts/install-claude-hooks.sh` + docs |
+
+## The 3 layers
+
+```
+                   git push
+                      ↓
+┌─────────────────────────────────────────────────────────┐
+│ Layer 1: Claude Code PreToolUse hook                    │
+│   block-push-to-main.sh                                 │
+│   Fires on Bash tool calls inside a Claude session.     │
+│   Project-scoped (.claude/settings.json) — NOT skill-   │
+│   scoped (#68). Fixed regex (#64).                      │
+└─────────────────────────────────────────────────────────┘
+                      ↓ (passes through, or hook missing)
+┌─────────────────────────────────────────────────────────┐
+│ Layer 2: git-side pre-push hook (per-worktree)          │
+│   .git/hooks/pre-push (installed by install-git-pre-    │
+│   push.sh after every `git worktree add`)               │
+│   Fires for ANY git push, including outside Claude.     │
+│   Reads stdin, refuses lines with refs/heads/<trunk>.   │
+│   Override: --no-verify (documented).                   │
+└─────────────────────────────────────────────────────────┘
+                      ↓ (passes through, or hook missing)
+┌─────────────────────────────────────────────────────────┐
+│ Layer 3: server-side branch protection (GitHub)         │
+│   Free-tier private repos can't enforce this — Layer 2  │
+│   is the only consistent backstop in that environment.  │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Key insight from #68**: the SKILL.md frontmatter hooks are bound to the skill activation context. As soon as the agent does any free-form bash work outside `/autonomous-dev`, the frontmatter hooks don't fire. They are *not* automatically promoted to project-scoped `.claude/settings.json` entries.
+
+This repo already has a hand-maintained project-scoped `.claude/settings.json` that mirrors the SKILL.md frontmatter. **Downstream consumers don't get that for free.** PR-5 ships the installer that produces it.
+
+## Refactor first
+
+Per project direction. Before applying the 3 fixes, extract the shared parsing into a small helper:
+
+### New `skills/autonomous-common/hooks/lib-push.sh`
+
+Two pure functions used by both Layer 1 (Claude hook) and Layer 2 (git pre-push hook):
+
+- `parse_push_target_refspec(command)` — given a `git push ...` command line, echoes the **destination** ref-name(s) the push would write to. Handles:
+  - bare `git push` → `<current_branch>` (matrix push or default upstream)
+  - `git push origin feat/foo` → `feat/foo`
+  - `git push origin HEAD:refs/heads/main` → `refs/heads/main`
+  - `git push origin :main` (delete) → `:main` (caller decides)
+  - `git push --all` / `--mirror` → special markers
+- `is_trunk_ref(ref, trunk_name)` — given a ref-name, returns 0 if it refers to the trunk branch. Handles:
+  - bare `main` / `master` / configured trunk
+  - `refs/heads/main` (fully-qualified — #64 false-negative)
+  - `refs/heads/main^` etc. (rare, but should still match)
+
+Both #64 (Layer 1 fix) and #65 (Layer 2 new hook) use these primitives. This consolidation removes the duplication risk that caused #64 in the first place — without a shared parser, Layer 2 would just reinvent Layer 1's broken regex.
+
+## Per-issue fixes
+
+### #64: rewrite `block-push-to-main.sh` using `lib-push.sh`
+
+Both bug cases collapse to "use the parser, not ad-hoc regexes":
+
+- **Case A (false positive — bare push from trunk-checked-out worktree pushes a feature branch and gets blocked)**: the parser identifies the actual destination as `feat/foo` (from the explicit refspec `feat/foo`), so `is_trunk_ref` returns 1. Block doesn't fire.
+- **Case B (false negative — `HEAD:refs/heads/main` slips through)**: the parser identifies destination as `refs/heads/main`, `is_trunk_ref` returns 0. Block fires.
+
+The 5-condition regex chain in current `block-push-to-main.sh:25-29` becomes one call: `is_trunk_ref "$(parse_push_target_refspec "$command")"`.
+
+### #65: new `install-git-pre-push.sh`
+
+- Idempotent installer; resolves per-worktree hooks dir via `git rev-parse --git-path hooks`.
+- Writes a self-contained `.git/hooks/pre-push` that reads stdin lines `<local-ref> <local-sha> <remote-ref> <remote-sha>` and refuses any with `remote-ref == refs/heads/<trunk>`.
+- The trunk name is parameterized — the installer reads `git symbolic-ref refs/remotes/origin/HEAD` (or falls back to `main`) at install time and bakes it in.
+- The pre-push hook itself is plain bash with no dependencies (no `lib-push.sh` source), because git hooks run from outside any project context. The 4-line refspec parse inside the hook is intentionally simple and self-contained.
+- Worktree-bootstrap callsites: this PR doesn't change those (they're in agent prompts / the autonomous-dev SKILL.md skill). Documentation update only — the autonomous-dev skill should call the installer right after `git worktree add`.
+
+### #68: new `install-claude-hooks.sh` bootstrap
+
+A one-shot installer for downstream consumers that materializes a project-scoped `.claude/settings.json` mirroring the autonomous-dev SKILL.md frontmatter. Idempotent — re-running merges (doesn't clobber) hand-edits.
+
+- Reads the canonical hook list from a curated source-of-truth (the autonomous-common skill itself, not the autonomous-dev SKILL.md frontmatter — we don't want the consumer's settings drift to be tied to whether they parse YAML).
+- Writes / merges into `.claude/settings.json` with a `"managed_by": "autonomous-common"` annotation so future `skills update` runs can re-merge cleanly.
+- Calls `install-git-pre-push.sh` at the end (one-stop install).
+- Documented in `autonomous-common/SKILL.md`: "after `npx skills add`, run `bash .claude/skills/autonomous-common/scripts/install-claude-hooks.sh`".
+
+This is intentionally NOT auto-run on `npx skills add`. Mutating the consumer's `.claude/settings.json` without explicit consent would be surprising. The CONTRIBUTING.md / SKILL.md install steps direct consumers to run it.
+
+## Behavior preservation
+
+Strict: every diff line not directly tied to one of the 3 issues is a refactor that preserves byte-equivalent behavior. Specifically:
+- The list of hooks in `.claude/settings.json` for THIS repo is unchanged.
+- The wording of the BLOCKED message in `block-push-to-main.sh` is preserved verbatim.
+- `is_git_command()` semantics in `lib.sh` unchanged.
+
+## Test plan
+
+New tests:
+
+- `tests/unit/test-block-push-regex.sh` — covers all 8 cases from #64's table:
+  | Case | Command | Branch | Expect |
+  |---|---|---|---|
+  | TC-BP-01 Bare push from trunk | `git push` | trunk | block |
+  | TC-BP-02 Bare push from feat | `git push` | feat/x | allow |
+  | TC-BP-03 Feature push from trunk worktree (#64 case A) | `git push -u origin feat/foo` | trunk | allow |
+  | TC-BP-04 Feature push from feat worktree | `git push -u origin feat/foo` | feat/x | allow |
+  | TC-BP-05 Explicit `:trunk` short refspec | `git push origin feat:main` | feat/x | block |
+  | TC-BP-06 Explicit FQ refspec (#64 case B) | `git push origin HEAD:refs/heads/main` | feat/x | block |
+  | TC-BP-07 `--all` flag | `git push --all` | feat/x | block |
+  | TC-BP-08 `--mirror` flag | `git push --mirror` | feat/x | block |
+
+- `tests/unit/test-install-git-pre-push.sh` — covers:
+  - Idempotency: 2x install → no diff in `.git/hooks/pre-push`
+  - Worktree path resolution: install from a `git worktree add`-created subdir → hook lands in the right place (`git rev-parse --git-path hooks`)
+  - The hook itself: feed stdin lines, assert exit codes (block trunk, allow feature)
+
+- `tests/unit/test-install-claude-hooks.sh` — covers:
+  - First-time install: creates `.claude/settings.json` with the canonical hook list
+  - Re-install on existing settings.json: merges, preserves hand-edits
+  - Annotation present: `"managed_by": "autonomous-common"` field is written
+
+- `tests/unit/test-lib-push.sh` — covers `parse_push_target_refspec` and `is_trunk_ref` against the same matrix.
+
+## Per CONTRIBUTING.md Rule 1
+
+Touches `skills/autonomous-common/hooks/*.sh` (watched). Also touches `docs/pipeline/invariants.md` (new INV-17). Gate passes via docs-touched.
+
+## Risk
+
+Medium-high. Trunk protection is load-bearing. Mitigations:
+
+- **Behavior preservation**: the BLOCKED message wording and exit code (2) stay identical so existing CI that greps for blocked-by-hook output keeps working.
+- **Test coverage**: the 8-case table for #64 is comprehensive.
+- **Manual smoke test**: against a throwaway repo with `git worktree add` + `git push`, verify all 3 layers fire correctly.
+- **Rollback**: each fix is independently revertable. Layer 1 (#64) is a single-file edit. Layer 2 (#65) is a new script — revert by deleting it. Layer 3 (#68) ships a new install script that's opt-in for consumers.
+
+## Out of scope
+
+- The autonomous-dev workflow integration (calling `install-git-pre-push.sh` after `git worktree add`) is a SKILL.md prompt update, not a hook code change. PR-5 documents the call site but doesn't change the prompt body — that's a follow-up.
+- Wrapper-side fixes (#59, #60, #67) — PR-6.
+- Multi-repo dispatch (#62) — PR-7.
+- PID files CWE-377 (#72) — small follow-up.

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -205,6 +205,26 @@ The cutoff timestamp falls back to epoch (1970-01-01) for issues that have never
 
 **Test**: `tests/unit/test-lib-dispatch.sh` asserts that `extract_dev_session_id` returns `abc-123-def` for a comment containing `Dev Session ID: \`abc-123-def\`` (was previously asserting empty under the broken regex).
 
+## INV-17: Trunk protection requires defense in depth across 3 layers
+
+**Rule**: Direct pushes to the trunk branch MUST be blocked by **at least two** independent layers, since each layer alone has known gaps:
+
+1. **Claude Code PreToolUse hook** (`block-push-to-main.sh`) — only fires for Bash commands routed through a Claude session. Free-form work outside `/autonomous-dev` skill activations bypasses it (#68).
+2. **Per-worktree git pre-push hook** (`install-git-pre-push.sh`) — fires for ANY `git push`, including outside Claude. Requires per-worktree installation; `git rev-parse --git-path hooks` resolves the right dir.
+3. **Server-side branch protection** (GitHub) — best of all, but unavailable on Free-tier private repos.
+
+In environments without Layer 3 (server-side), Layers 1 and 2 must both be installed. Layer 1 alone is insufficient (see #68 production incident: 6 commits landed on trunk outside any PR).
+
+**Why**: surfaced by #64, #65, and #68 collectively. The downstream consumer that hit this had Layer 3 unavailable (GitHub Free private repo) and Layer 1 misconfigured (skill-scoped, not project-scoped). With no Layer 2 installed by default, every gap was simultaneously exposed.
+
+**Producer**: `skills/autonomous-common/scripts/install-claude-hooks.sh` is the consumer-facing one-shot installer that wires up Layer 1 (project-scoped `.claude/settings.json`) and triggers `install-git-pre-push.sh` for Layer 2.
+
+**Consumer**: every project that adopts this skill set. The autonomous-dev workflow's worktree-creation step should call `install-git-pre-push.sh` after each `git worktree add` (Layer 2 is per-worktree).
+
+**Status**: **ENFORCED** in PR-5 (closes #64, #65, #68). The 3-layer model is now documented; the installers exist. Follow-up: wire the per-worktree `install-git-pre-push.sh` call into the autonomous-dev workflow prompt (separate small PR).
+
+**Test**: `tests/unit/test-block-push-regex.sh` covers Layer 1 (11 cases). `tests/unit/test-install-git-pre-push.sh` covers Layer 2 (8 cases). `tests/unit/test-install-claude-hooks.sh` covers the consumer-side installer that wires both Layer 1 and Layer 2 (10 cases).
+
 ---
 
 ## Adding a new invariant

--- a/skills/autonomous-common/hooks/block-push-to-main.sh
+++ b/skills/autonomous-common/hooks/block-push-to-main.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 # PreToolUse hook - blocks git push directly to main branch
-# All changes must go through PR workflow
+# All changes must go through PR workflow.
+#
+# Closes #64: previous regex-only approach had a false positive
+# (feature push from a trunk-checked-out clone got blocked) and a
+# false negative (`HEAD:refs/heads/main` slipped through). Now uses
+# the lib-push.sh parser to identify the actual destination ref(s).
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
 source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=lib-push.sh
+source "$SCRIPT_DIR/lib-push.sh"
 
 input=$(cat)
 command=$(parse_command "$input")
@@ -14,19 +22,22 @@ if ! is_git_command "push" "$command"; then
   exit 0
 fi
 
-# Get current branch
-current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+# Trunk branch name. Default to `main`; respect TRUNK_BRANCH override
+# for repos with a different trunk (e.g. `master`, `trunk`).
+trunk="${TRUNK_BRANCH:-main}"
 
-# Block pushes targeting main:
-# 1. Refspec targeting main (e.g., git push origin feature:main)
-# 2. Explicit main as push target (e.g., git push origin main)
-# 3. Bulk push commands that include main (--all, --mirror)
-# 4. Pushing while on main without explicit refspec
-if [[ "$command" =~ :main([[:space:]]|$) ]] \
-  || [[ "$command" =~ (^|[[:space:]])main([[:space:]]|$) ]] \
-  || [[ "$command" =~ --all([[:space:]]|$) ]] \
-  || [[ "$command" =~ --mirror([[:space:]]|$) ]] \
-  || [[ "$current_branch" == "main" && ! "$command" =~ : ]]; then
+# Parse the destination ref(s) the push would write to. Block if any of
+# them target the trunk (covers --all/--mirror via __ALL__/__MIRROR__).
+should_block=0
+while IFS= read -r ref; do
+  [[ -z "$ref" ]] && continue
+  if is_trunk_ref "$ref" "$trunk"; then
+    should_block=1
+    break
+  fi
+done < <(parse_push_target_refspec "$command")
+
+if (( should_block == 1 )); then
   cat >&2 <<'EOF'
 ## BLOCKED - Direct Push to Main
 

--- a/skills/autonomous-common/hooks/install-git-pre-push.sh
+++ b/skills/autonomous-common/hooks/install-git-pre-push.sh
@@ -47,7 +47,9 @@ trunk="${trunk:-main}"
 
 # If a pre-push hook exists and is NOT ours, back it up.
 if [[ -f "$target" ]] && ! grep -q "$sentinel" "$target" 2>/dev/null; then
-  backup="$target.bak.$(date +%s)"
+  # Append $$ for uniqueness if two installs race within the same second
+  # (not a real attack vector, but cheap defense-in-depth).
+  backup="$target.bak.$(date +%s).$$"
   mv "$target" "$backup"
   echo "Existing unmanaged pre-push hook backed up to: $backup" >&2
 fi

--- a/skills/autonomous-common/hooks/install-git-pre-push.sh
+++ b/skills/autonomous-common/hooks/install-git-pre-push.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# install-git-pre-push.sh — write a per-worktree git pre-push hook
+# that blocks pushes to the trunk branch.
+#
+# Closes #65. This is Layer 2 of the trunk-protection defense in depth
+# (Layer 1 is the Claude PreToolUse hook block-push-to-main.sh; Layer 3
+# would be server-side branch protection, which is unavailable on
+# GitHub Free private repos).
+#
+# Usage:
+#   bash install-git-pre-push.sh                  # install in current worktree
+#   TRUNK_BRANCH=master bash install-git-pre-push.sh   # override trunk name
+#
+# Idempotent: re-running rewrites the hook with canonical contents. Any
+# pre-existing `pre-push` hook NOT marked with the "managed by autonomous-
+# common" sentinel is preserved as `pre-push.bak.<timestamp>` first.
+#
+# The emitted hook is self-contained — no `lib-push.sh` source — because
+# git hooks run from the worktree root with no project lib path on $PATH.
+
+set -euo pipefail
+
+# Resolve the worktree's hooks dir. `git rev-parse --git-path hooks`
+# correctly handles both regular clones (.git is a directory) and git
+# worktrees (.git is a file pointing into the main repo's worktrees/).
+hooks_dir=$(git rev-parse --git-path hooks 2>/dev/null) || {
+  echo "ERROR: not in a git repo (or git rev-parse failed)" >&2
+  exit 1
+}
+mkdir -p "$hooks_dir"
+
+target="$hooks_dir/pre-push"
+sentinel="# managed by autonomous-common::install-git-pre-push.sh"
+
+# Determine trunk name. Priority:
+#   1. $TRUNK_BRANCH env override
+#   2. Symbolic ref of refs/remotes/origin/HEAD (canonical trunk on origin)
+#   3. Fallback: "main"
+trunk="${TRUNK_BRANCH:-}"
+if [[ -z "$trunk" ]]; then
+  if origin_head=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null); then
+    # Strip the `origin/` prefix.
+    trunk="${origin_head#origin/}"
+  fi
+fi
+trunk="${trunk:-main}"
+
+# If a pre-push hook exists and is NOT ours, back it up.
+if [[ -f "$target" ]] && ! grep -q "$sentinel" "$target" 2>/dev/null; then
+  backup="$target.bak.$(date +%s)"
+  mv "$target" "$backup"
+  echo "Existing unmanaged pre-push hook backed up to: $backup" >&2
+fi
+
+cat > "$target" <<HOOK
+#!/usr/bin/env bash
+${sentinel}
+# Blocks direct pushes to the trunk branch (refs/heads/${trunk}).
+# Override (documented emergencies only): git push --no-verify ...
+set -euo pipefail
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [[ "\${remote_ref}" == "refs/heads/${trunk}" ]]; then
+    cat >&2 <<MSG
+## BLOCKED — Direct push to refs/heads/${trunk}
+
+Pushing directly to the trunk branch is not allowed.
+
+Required workflow:
+  1. Create a worktree: git worktree add .worktrees/feat/<name> -b feat/<name>
+  2. Push the feature branch: git push -u origin feat/<name>
+  3. Open a PR: gh pr create
+
+To override (documented emergencies only): git push --no-verify ...
+MSG
+    exit 1
+  fi
+done
+HOOK
+
+chmod +x "$target"
+echo "Installed git pre-push hook at: $target (trunk=${trunk})" >&2

--- a/skills/autonomous-common/hooks/lib-push.sh
+++ b/skills/autonomous-common/hooks/lib-push.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+# lib-push.sh — pure parsing helpers for git-push hook scripts.
+#
+# Used by:
+#   - block-push-to-main.sh (Claude PreToolUse hook, Layer 1 trunk protection)
+#   - install-git-pre-push.sh's emitted hook (Layer 2 git-side hook)
+#
+# Does not source other lib files. Self-contained pure functions; safe to
+# invoke from any context including a freshly-spawned hook process.
+#
+# This file is sourced, not executed. No `set -e` (caller controls exit
+# semantics).
+
+# ---------------------------------------------------------------------------
+# parse_push_target_refspec <command>
+#
+# Given a git-push command line, echoes the destination ref-name(s) the push
+# would write to, one per line. Returns 0 if at least one destination was
+# identified, 1 if the command is not a push or could not be parsed.
+#
+# Handles:
+#   git push                                → <current_branch>
+#   git push origin                         → <current_branch>
+#   git push origin feat/foo                → feat/foo
+#   git push -u origin feat/foo             → feat/foo
+#   git push origin feat/foo:bar            → bar
+#   git push origin HEAD:refs/heads/main    → refs/heads/main
+#   git push origin :main                   → :main (delete; caller decides)
+#   git push origin tag v1                  → refs/tags/v1
+#   git push --all origin                   → __ALL__
+#   git push --mirror origin                → __MIRROR__
+#   git push --tags origin                  → __TAGS__
+#
+# Bulk markers (__ALL__, __MIRROR__) are returned uppercase-bracketed so
+# callers can branch without ambiguity vs. a real ref named "all".
+#
+# Caller is expected to have already verified `is_git_command "push" ...`.
+parse_push_target_refspec() {
+  local command="$1"
+  local current_branch
+  current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+  # Tokenize. Strip leading `cd ... &&` etc. by trimming up to the `git` token.
+  # Match is_git_command's quote-stripping minimally — quotes around a refspec
+  # are valid (e.g. "git push origin 'feat:bar'") but rare; treat them as
+  # literal here.
+  local -a tokens
+  read -ra tokens <<<"$command"
+
+  # Find the `git` token
+  local i=0 n=${#tokens[@]}
+  while (( i < n )) && [[ "${tokens[i]}" != "git" ]]; do
+    i=$((i+1))
+  done
+  if (( i >= n )); then return 1; fi
+  i=$((i+1))
+
+  # Skip git global flags (same logic as is_git_command's flag-skip).
+  while (( i < n )); do
+    case "${tokens[i]}" in
+      -c|-C|--git-dir|--work-tree|--namespace|--super-prefix)
+        i=$(( i + 2 > n ? n : i + 2 ))
+        ;;
+      --*=*|--*)
+        i=$((i+1))
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  # Expect `push`
+  if (( i >= n )); then return 1; fi
+  if [[ "${tokens[i]}" != "push" ]]; then return 1; fi
+  i=$((i+1))
+
+  # Walk push args. Track state.
+  local found_remote=0
+  local -a refspecs=()
+  local saw_all=0 saw_mirror=0 saw_tags_flag=0 saw_delete=0
+  while (( i < n )); do
+    local tok="${tokens[i]}"
+    case "$tok" in
+      --all|--all=*)        saw_all=1 ;;
+      --mirror|--mirror=*)  saw_mirror=1 ;;
+      --tags|--tags=*)      saw_tags_flag=1 ;;
+      --delete|-d)          saw_delete=1 ;;
+      # Skip flags that take a value
+      --repo|-o|--push-option|--receive-pack|--exec|--signed)
+        i=$(( i + 2 > n ? n : i + 2 )); continue ;;
+      # Combined --flag=value or --flag forms — consume as 1 token
+      -*) ;;
+      # Positional: first one is the remote, rest are refspecs (or
+      # `tag <name>` pair).
+      *)
+        if (( found_remote == 0 )); then
+          found_remote=1
+        elif [[ "$tok" == "tag" ]] && (( i + 1 < n )); then
+          refspecs+=("refs/tags/${tokens[i+1]}")
+          i=$((i+1))
+        else
+          refspecs+=("$tok")
+        fi
+        ;;
+    esac
+    i=$((i+1))
+  done
+
+  # --all / --mirror / --tags shortcut
+  if (( saw_all == 1 )); then echo "__ALL__"; return 0; fi
+  if (( saw_mirror == 1 )); then echo "__MIRROR__"; return 0; fi
+  if (( saw_tags_flag == 1 )) && (( ${#refspecs[@]} == 0 )); then
+    echo "__TAGS__"; return 0
+  fi
+
+  # No explicit refspec: implicit destination is the *current branch*'s
+  # configured upstream (matrix or default). For our purposes, treat that as
+  # the current branch name — `git push` with default config pushes
+  # HEAD → <upstream of HEAD>, where upstream typically matches the current
+  # branch name on origin.
+  if (( ${#refspecs[@]} == 0 )); then
+    if [[ -n "$current_branch" && "$current_branch" != "HEAD" ]]; then
+      echo "$current_branch"
+      return 0
+    fi
+    return 1
+  fi
+
+  # Walk refspecs. Each can be:
+  #   src:dst   → echo dst
+  #   :dst      → echo :dst (delete)
+  #   ref       → echo ref (src=dst)
+  for r in "${refspecs[@]}"; do
+    if [[ "$r" == *:* ]]; then
+      local dst="${r#*:}"
+      local src="${r%%:*}"
+      if [[ -z "$src" ]]; then
+        # Delete form: prefix with `:` so caller can detect.
+        echo ":${dst}"
+      else
+        echo "$dst"
+      fi
+    else
+      echo "$r"
+    fi
+  done
+}
+
+# ---------------------------------------------------------------------------
+# is_trunk_ref <ref> [<trunk_name>]
+#
+# Returns 0 if <ref> targets the trunk branch, 1 otherwise. <trunk_name>
+# defaults to "main" if omitted; pass an explicit name (e.g. "master") to
+# match repos with a different trunk.
+#
+# Recognized forms (all return 0):
+#   main
+#   refs/heads/main
+#   refs/heads/main^         (rev-spec suffix; rare but valid in push)
+#
+# A leading `:` (delete-push) is stripped before matching, so
+#   :main, :refs/heads/main  also return 0
+#
+# The bulk markers __ALL__ / __MIRROR__ return 0 (they target trunk among
+# others). __TAGS__ returns 1 (tags-only push, doesn't write the trunk
+# branch ref).
+is_trunk_ref() {
+  local ref="$1"
+  local trunk="${2:-main}"
+
+  case "$ref" in
+    __ALL__|__MIRROR__) return 0 ;;
+    __TAGS__) return 1 ;;
+  esac
+
+  # Strip leading `:` (delete form).
+  ref="${ref#:}"
+
+  # Bare trunk
+  [[ "$ref" == "$trunk" ]] && return 0
+
+  # Fully-qualified
+  [[ "$ref" == "refs/heads/$trunk" ]] && return 0
+
+  # Allow rev-spec suffix on either form (e.g. main^, refs/heads/main~3)
+  [[ "$ref" == "$trunk"[\^~]* ]] && return 0
+  [[ "$ref" == "refs/heads/$trunk"[\^~]* ]] && return 0
+
+  return 1
+}

--- a/skills/autonomous-common/scripts/claude-settings.template.json
+++ b/skills/autonomous-common/scripts/claude-settings.template.json
@@ -1,0 +1,52 @@
+{
+  "_managed_by": "autonomous-common",
+  "_managed_note": "This 'hooks' block is maintained by skills/autonomous-common/scripts/install-claude-hooks.sh. Hand-edits inside this block will be overwritten on the next install. Add custom hooks via a separate top-level field or a different settings file. Other top-level keys (enabledPlugins, etc.) are merged through and preserved.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/block-push-to-main.sh",       "timeout": 5  },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/block-commit-outside-worktree.sh", "timeout": 5  },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/check-design-canvas.sh",      "timeout": 5  },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/check-code-simplifier.sh",    "timeout": 5  },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/check-shellcheck.sh",         "timeout": 15 },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/check-pr-review.sh",          "timeout": 5  },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/check-unit-tests.sh",         "timeout": 5  },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/warn-skip-verification.sh",   "timeout": 5  },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/check-rebase-before-push.sh", "timeout": 10 }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/check-test-plan.sh", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/check-test-plan.sh", "timeout": 5 }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/post-git-action-clear.sh commit code-simplifier", "timeout": 5  },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/post-git-action-clear.sh commit design-canvas",   "timeout": 5  },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/post-git-action-clear.sh push pr-review",         "timeout": 5  },
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/post-git-push.sh",                                "timeout": 30 }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/hooks/verify-completion.sh", "timeout": 10 }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/autonomous-common/scripts/install-claude-hooks.sh
+++ b/skills/autonomous-common/scripts/install-claude-hooks.sh
@@ -70,7 +70,8 @@ if [[ ! -f "$settings_file" ]]; then
   echo "Created: $settings_file (from template)" >&2
 else
   # Backup the existing file before mutation.
-  backup="$settings_file.bak.$(date +%s)"
+  # Append $$ for uniqueness if two installs race within the same second.
+  backup="$settings_file.bak.$(date +%s).$$"
   cp "$settings_file" "$backup"
 
   # Compose: existing settings + (template's _managed_by, _managed_note,

--- a/skills/autonomous-common/scripts/install-claude-hooks.sh
+++ b/skills/autonomous-common/scripts/install-claude-hooks.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# install-claude-hooks.sh — bootstrap project-scoped Claude Code hooks
+# from the autonomous-common skill's canonical template.
+#
+# Closes #68: SKILL.md frontmatter hooks are skill-scoped, so they only
+# fire while the skill is the active context. Free-form bash work outside
+# an explicit /autonomous-dev invocation bypasses them entirely. This
+# script materializes the same hooks as project-scoped entries in
+# `.claude/settings.json`, where Claude Code loads them on every session.
+#
+# Designed to be run by consumers AFTER `npx skills add zxkane/autonomous-
+# dev-team`. NOT auto-run on install — mutating .claude/settings.json
+# without explicit consent would be surprising.
+#
+# Usage:
+#   bash skills/autonomous-common/scripts/install-claude-hooks.sh
+#
+# Idempotent. Safe to re-run on `skills update`. Preserves any non-hooks
+# top-level keys (enabledPlugins, statusLine, etc.) the user has set.
+#
+# Optionally also installs the per-worktree git pre-push hook (#65) by
+# calling install-git-pre-push.sh. Disable with --no-git-hook.
+
+set -euo pipefail
+
+INSTALL_GIT_HOOK=1
+for arg in "$@"; do
+  case "$arg" in
+    --no-git-hook) INSTALL_GIT_HOOK=0 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required (apt: jq, brew: jq)." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+TEMPLATE="$SCRIPT_DIR/claude-settings.template.json"
+
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "ERROR: canonical template not found at: $TEMPLATE" >&2
+  exit 1
+fi
+
+# Locate project root. Prefer git toplevel; fall back to CWD.
+project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+settings_dir="$project_root/.claude"
+settings_file="$settings_dir/settings.json"
+mkdir -p "$settings_dir"
+
+# Strategy:
+#   - If settings.json doesn't exist: write the template verbatim.
+#   - If it exists: merge our `hooks`, `_managed_by`, `_managed_note`
+#     into the existing file, preserving any other top-level keys.
+#     This OVERWRITES any prior `hooks` block (including hand-edits).
+#     The `_managed_note` field documents this contract loud-and-clear.
+#
+# Merge uses jq, which guarantees JSON-correctness regardless of
+# whitespace / comments in the input (`.claude/settings.json` is JSON,
+# not JSONC; comments aren't valid).
+
+if [[ ! -f "$settings_file" ]]; then
+  cp "$TEMPLATE" "$settings_file"
+  echo "Created: $settings_file (from template)" >&2
+else
+  # Backup the existing file before mutation.
+  backup="$settings_file.bak.$(date +%s)"
+  cp "$settings_file" "$backup"
+
+  # Compose: existing settings + (template's _managed_by, _managed_note,
+  # hooks fields). Right side wins on key conflicts.
+  tmp=$(mktemp)
+  trap 'rm -f "$tmp"' EXIT
+  jq -s '
+    .[0] as $existing |
+    .[1] as $tmpl |
+    $existing
+      + ($tmpl | {_managed_by, _managed_note, hooks})
+  ' "$settings_file" "$TEMPLATE" > "$tmp"
+
+  # Sanity check: the merged file must still be valid JSON and contain
+  # the canonical hooks block. If anything went wrong, restore the
+  # backup and fail loudly.
+  if ! jq -e '.hooks.PreToolUse | length > 0' "$tmp" >/dev/null; then
+    mv "$backup" "$settings_file"
+    echo "ERROR: merge produced an unexpected result; restored backup" >&2
+    exit 1
+  fi
+
+  mv "$tmp" "$settings_file"
+  trap - EXIT
+  echo "Updated: $settings_file (backup at $backup)" >&2
+fi
+
+# Optional: also install the per-worktree git pre-push hook (#65).
+if (( INSTALL_GIT_HOOK == 1 )); then
+  git_hook_installer="$(dirname "$SCRIPT_DIR")/hooks/install-git-pre-push.sh"
+  if [[ -x "$git_hook_installer" ]]; then
+    echo "Installing git-side pre-push hook (#65)..." >&2
+    bash "$git_hook_installer"
+  else
+    echo "WARN: git-side hook installer not found at: $git_hook_installer" >&2
+    echo "      Skipping. Re-run with --no-git-hook to suppress this warning." >&2
+  fi
+fi
+
+echo "Done. Project-scoped Claude hooks (#68) and git pre-push (#65) are installed." >&2

--- a/tests/unit/test-block-push-regex.sh
+++ b/tests/unit/test-block-push-regex.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# test-block-push-regex.sh — Regression tests for #64 in block-push-to-main.sh.
+#
+# Covers all 8 cases from the issue's "Proposed scope" table. The test
+# constructs a throwaway git repo with both `main` and a feature branch,
+# checks out the relevant branch, then feeds the hook a JSON input
+# matching what Claude Code would deliver and asserts the exit code.
+#
+# Run: bash tests/unit/test-block-push-regex.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$PROJECT_ROOT/skills/autonomous-common/hooks/block-push-to-main.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Set up a throwaway repo so `git rev-parse --abbrev-ref HEAD` returns
+# a real branch name during the hook run. The hook calls `git` for the
+# current branch; tests must not contaminate the worktree we're running
+# in. Use a temp dir + `cd` into it for each case.
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+setup_repo() {
+  local branch="$1"
+  rm -rf "$TMPDIR/repo"
+  mkdir -p "$TMPDIR/repo"
+  git -C "$TMPDIR/repo" init --quiet --initial-branch=main
+  git -C "$TMPDIR/repo" -c user.email=test@test -c user.name=test commit \
+    --quiet --allow-empty -m init
+  if [[ "$branch" != "main" ]]; then
+    git -C "$TMPDIR/repo" checkout --quiet -b "$branch"
+  fi
+}
+
+# Run the hook from inside the throwaway repo so its `git rev-parse` sees
+# the right current branch. CLAUDE_PROJECT_DIR is set so the hook's
+# state-dir helpers work without writing into the actual project.
+run_hook() {
+  local cmd="$1"
+  local input
+  input=$(printf '{"tool_input":{"command":%s}}' "$(jq -Rn --arg c "$cmd" '$c')")
+  (cd "$TMPDIR/repo" && CLAUDE_PROJECT_DIR="$TMPDIR/repo" bash "$HOOK" <<<"$input")
+  echo $?
+}
+
+assert_exit() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected exit=$expected, actual exit=$actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ===========================================================================
+# TC-BP-01: Bare push from trunk → block
+# ===========================================================================
+echo "=== TC-BP-01: bare push from main → block ==="
+setup_repo main
+out=$(run_hook "git push")
+assert_exit "bare push from main blocked" "2" "$out"
+
+# ===========================================================================
+# TC-BP-02: Bare push from feat branch → allow
+# ===========================================================================
+echo ""
+echo "=== TC-BP-02: bare push from feat → allow ==="
+setup_repo feat/x
+out=$(run_hook "git push")
+assert_exit "bare push from feat allowed" "0" "$out"
+
+# ===========================================================================
+# TC-BP-03: Feature push from trunk-checked-out worktree → allow (#64 case A)
+# ===========================================================================
+echo ""
+echo "=== TC-BP-03: feature push from trunk worktree (#64 case A) → allow ==="
+setup_repo main
+out=$(run_hook "git push -u origin feat/foo")
+assert_exit "feature push from trunk worktree allowed (#64 case A regression guard)" "0" "$out"
+
+# ===========================================================================
+# TC-BP-04: Feature push from feat worktree → allow
+# ===========================================================================
+echo ""
+echo "=== TC-BP-04: feature push from feat worktree → allow ==="
+setup_repo feat/x
+out=$(run_hook "git push -u origin feat/foo")
+assert_exit "feature push from feat worktree allowed" "0" "$out"
+
+# ===========================================================================
+# TC-BP-05: Explicit short refspec to main → block
+# ===========================================================================
+echo ""
+echo "=== TC-BP-05: explicit short refspec to main → block ==="
+setup_repo feat/x
+out=$(run_hook "git push origin feat:main")
+assert_exit "explicit short refspec to main blocked" "2" "$out"
+
+# ===========================================================================
+# TC-BP-06: Explicit fully-qualified refspec to main → block (#64 case B)
+# ===========================================================================
+echo ""
+echo "=== TC-BP-06: fully-qualified refspec to main (#64 case B) → block ==="
+setup_repo feat/x
+out=$(run_hook "git push origin HEAD:refs/heads/main")
+assert_exit "fully-qualified refspec to main blocked (#64 case B regression guard)" "2" "$out"
+
+# ===========================================================================
+# TC-BP-07: --all flag → block (matrix push that includes trunk)
+# ===========================================================================
+echo ""
+echo "=== TC-BP-07: --all flag → block ==="
+setup_repo feat/x
+out=$(run_hook "git push --all origin")
+assert_exit "--all blocked" "2" "$out"
+
+# ===========================================================================
+# TC-BP-08: --mirror flag → block
+# ===========================================================================
+echo ""
+echo "=== TC-BP-08: --mirror flag → block ==="
+setup_repo feat/x
+out=$(run_hook "git push --mirror origin")
+assert_exit "--mirror blocked" "2" "$out"
+
+# ===========================================================================
+# TC-BP-09: --tags flag (tags only, doesn't write trunk) → allow
+# ===========================================================================
+echo ""
+echo "=== TC-BP-09: --tags only → allow ==="
+setup_repo feat/x
+out=$(run_hook "git push --tags origin")
+assert_exit "--tags only push allowed" "0" "$out"
+
+# ===========================================================================
+# TC-BP-10: TRUNK_BRANCH=master override
+# ===========================================================================
+echo ""
+echo "=== TC-BP-10: TRUNK_BRANCH=master override ==="
+rm -rf "$TMPDIR/repo"
+mkdir -p "$TMPDIR/repo"
+git -C "$TMPDIR/repo" init --quiet --initial-branch=master
+git -C "$TMPDIR/repo" -c user.email=test@test -c user.name=test commit \
+  --quiet --allow-empty -m init
+git -C "$TMPDIR/repo" checkout --quiet -b feat/x
+input=$(printf '{"tool_input":{"command":%s}}' "$(jq -Rn --arg c "git push origin HEAD:refs/heads/master" '$c')")
+actual=$(cd "$TMPDIR/repo" && CLAUDE_PROJECT_DIR="$TMPDIR/repo" TRUNK_BRANCH=master bash "$HOOK" <<<"$input"; echo $?)
+assert_exit "TRUNK_BRANCH=master + push to refs/heads/master blocked" "2" "$actual"
+
+# ===========================================================================
+# TC-BP-11: not-a-push command → allow (sanity)
+# ===========================================================================
+echo ""
+echo "=== TC-BP-11: not a push command → allow ==="
+setup_repo main
+out=$(run_hook "git status")
+assert_exit "git status (not a push) allowed" "0" "$out"
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+echo ""
+echo "==============================================="
+echo -e "Total: $((PASS + FAIL)) tests, ${GREEN}${PASS} pass${NC}, ${RED}${FAIL} fail${NC}"
+echo "==============================================="
+
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tests/unit/test-install-claude-hooks.sh
+++ b/tests/unit/test-install-claude-hooks.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# test-install-claude-hooks.sh — Tests for #68 install-claude-hooks.sh.
+#
+# Verifies:
+#   1. First-time install creates .claude/settings.json with the canonical hooks.
+#   2. Re-install merges with existing settings.json (preserves other top-level keys).
+#   3. _managed_by annotation is present.
+#   4. --no-git-hook flag suppresses the git pre-push install.
+#
+# Run: bash tests/unit/test-install-claude-hooks.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALLER="$PROJECT_ROOT/skills/autonomous-common/scripts/install-claude-hooks.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# ---------------------------------------------------------------------------
+echo "=== TC-CH-01: first-time install creates .claude/settings.json ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo1"
+git -C "$TMPDIR/repo1" init --quiet --initial-branch=main
+(cd "$TMPDIR/repo1" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+
+settings="$TMPDIR/repo1/.claude/settings.json"
+if [[ -f "$settings" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: settings.json created"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: settings.json NOT created"
+  FAIL=$((FAIL + 1))
+fi
+
+# Verify it's valid JSON
+if python3 -c "import json; json.load(open('$settings'))" 2>/dev/null; then
+  echo -e "  ${GREEN}PASS${NC}: settings.json is valid JSON"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: settings.json is not valid JSON"
+  FAIL=$((FAIL + 1))
+fi
+
+# Verify managed_by annotation
+if grep -q '"_managed_by": "autonomous-common"' "$settings"; then
+  echo -e "  ${GREEN}PASS${NC}: _managed_by annotation present"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: _managed_by annotation missing"
+  FAIL=$((FAIL + 1))
+fi
+
+# Verify the canonical hook list (block-push-to-main as a representative)
+if grep -q 'block-push-to-main.sh' "$settings"; then
+  echo -e "  ${GREEN}PASS${NC}: block-push-to-main.sh wired up"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: block-push-to-main.sh NOT in settings"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-CH-02: re-install merges with existing settings.json ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo2/.claude"
+git -C "$TMPDIR/repo2" init --quiet --initial-branch=main
+cat > "$TMPDIR/repo2/.claude/settings.json" <<'JSON'
+{
+  "model": "claude-opus-4-7",
+  "enabledPlugins": {
+    "my-custom-plugin": true
+  }
+}
+JSON
+
+(cd "$TMPDIR/repo2" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+settings="$TMPDIR/repo2/.claude/settings.json"
+
+# Existing keys should be preserved
+if jq -e '.model == "claude-opus-4-7"' "$settings" >/dev/null; then
+  echo -e "  ${GREEN}PASS${NC}: existing 'model' key preserved"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: existing 'model' key was clobbered"
+  FAIL=$((FAIL + 1))
+fi
+
+if jq -e '.enabledPlugins."my-custom-plugin" == true' "$settings" >/dev/null; then
+  echo -e "  ${GREEN}PASS${NC}: existing enabledPlugins preserved"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: existing enabledPlugins was clobbered"
+  FAIL=$((FAIL + 1))
+fi
+
+# Hooks should now be present
+if jq -e '.hooks.PreToolUse | length > 0' "$settings" >/dev/null; then
+  echo -e "  ${GREEN}PASS${NC}: hooks merged in"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: hooks NOT merged"
+  FAIL=$((FAIL + 1))
+fi
+
+# Backup of pre-existing settings should exist
+backup_count=$(find "$TMPDIR/repo2/.claude" -name 'settings.json.bak.*' | wc -l)
+if (( backup_count == 1 )); then
+  echo -e "  ${GREEN}PASS${NC}: pre-existing settings.json backed up"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: expected 1 backup, found $backup_count"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-CH-03: --no-git-hook suppresses git pre-push install ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo3"
+git -C "$TMPDIR/repo3" init --quiet --initial-branch=main
+(cd "$TMPDIR/repo3" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+
+if [[ ! -f "$TMPDIR/repo3/.git/hooks/pre-push" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: --no-git-hook prevented pre-push install"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: --no-git-hook did not suppress pre-push install"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-CH-04: default behavior installs git pre-push too ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo4"
+git -C "$TMPDIR/repo4" init --quiet --initial-branch=main
+(cd "$TMPDIR/repo4" && bash "$INSTALLER" >/dev/null 2>&1)
+
+if [[ -x "$TMPDIR/repo4/.git/hooks/pre-push" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: default install also installs git pre-push hook"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: default install did NOT install git pre-push hook"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "==============================================="
+echo -e "Total: $((PASS + FAIL)) tests, ${GREEN}${PASS} pass${NC}, ${RED}${FAIL} fail${NC}"
+echo "==============================================="
+
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tests/unit/test-install-git-pre-push.sh
+++ b/tests/unit/test-install-git-pre-push.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# test-install-git-pre-push.sh — Tests for #65 install-git-pre-push.sh.
+#
+# Verifies:
+#   1. Hook is written to the correct per-worktree hooks dir.
+#   2. Idempotency — re-running produces the same content.
+#   3. The emitted hook actually blocks pushes to refs/heads/<trunk>.
+#   4. The emitted hook allows pushes to non-trunk refs.
+#   5. TRUNK_BRANCH override works.
+#
+# Run: bash tests/unit/test-install-git-pre-push.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALLER="$PROJECT_ROOT/skills/autonomous-common/hooks/install-git-pre-push.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected='$expected', actual='$actual')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+echo "=== TC-GP-01: installs hook in correct location ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo1"
+git -C "$TMPDIR/repo1" init --quiet --initial-branch=main
+(cd "$TMPDIR/repo1" && bash "$INSTALLER" >/dev/null 2>&1)
+
+if [[ -x "$TMPDIR/repo1/.git/hooks/pre-push" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: pre-push installed and executable"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: pre-push not installed at .git/hooks/pre-push"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q 'managed by autonomous-common' "$TMPDIR/repo1/.git/hooks/pre-push"; then
+  echo -e "  ${GREEN}PASS${NC}: hook contains sentinel"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: hook missing sentinel"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-GP-02: idempotency (re-running yields same content) ==="
+# ---------------------------------------------------------------------------
+content_before=$(sha256sum "$TMPDIR/repo1/.git/hooks/pre-push" | cut -d' ' -f1)
+(cd "$TMPDIR/repo1" && bash "$INSTALLER" >/dev/null 2>&1)
+content_after=$(sha256sum "$TMPDIR/repo1/.git/hooks/pre-push" | cut -d' ' -f1)
+assert_eq "second install yields identical hook content" "$content_before" "$content_after"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-GP-03: hook blocks push to refs/heads/main ==="
+# ---------------------------------------------------------------------------
+hook="$TMPDIR/repo1/.git/hooks/pre-push"
+input="local-main abc123 refs/heads/main def456"
+out=$(echo "$input" | bash "$hook" origin 2>&1; echo "rc=$?")
+case "$out" in
+  *"BLOCKED"*"rc=1"*) echo -e "  ${GREEN}PASS${NC}: push to refs/heads/main blocked"; PASS=$((PASS + 1)) ;;
+  *) echo -e "  ${RED}FAIL${NC}: push to refs/heads/main NOT blocked: $out"; FAIL=$((FAIL + 1)) ;;
+esac
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-GP-04: hook allows push to feature branch ==="
+# ---------------------------------------------------------------------------
+input="local-feat abc123 refs/heads/feat/foo def456"
+out=$(echo "$input" | bash "$hook" origin 2>&1; echo "rc=$?")
+case "$out" in
+  *"rc=0"*) echo -e "  ${GREEN}PASS${NC}: push to refs/heads/feat/foo allowed"; PASS=$((PASS + 1)) ;;
+  *) echo -e "  ${RED}FAIL${NC}: push to refs/heads/feat/foo not allowed: $out"; FAIL=$((FAIL + 1)) ;;
+esac
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-GP-05: TRUNK_BRANCH=master override at install time ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo2"
+git -C "$TMPDIR/repo2" init --quiet --initial-branch=master
+(cd "$TMPDIR/repo2" && TRUNK_BRANCH=master bash "$INSTALLER" >/dev/null 2>&1)
+hook2="$TMPDIR/repo2/.git/hooks/pre-push"
+if grep -q 'refs/heads/master' "$hook2"; then
+  echo -e "  ${GREEN}PASS${NC}: TRUNK_BRANCH=master baked into installed hook"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: TRUNK_BRANCH=master NOT in installed hook"
+  FAIL=$((FAIL + 1))
+fi
+
+# Verify the master-trunk hook actually blocks master pushes.
+input="local-master abc123 refs/heads/master def456"
+out=$(echo "$input" | bash "$hook2" origin 2>&1; echo "rc=$?")
+case "$out" in
+  *"BLOCKED"*"rc=1"*) echo -e "  ${GREEN}PASS${NC}: master-trunk hook blocks refs/heads/master"; PASS=$((PASS + 1)) ;;
+  *) echo -e "  ${RED}FAIL${NC}: master-trunk hook did NOT block: $out"; FAIL=$((FAIL + 1)) ;;
+esac
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-GP-06: pre-existing unmanaged hook is backed up ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo3"
+git -C "$TMPDIR/repo3" init --quiet --initial-branch=main
+mkdir -p "$TMPDIR/repo3/.git/hooks"
+echo '#!/bin/bash' > "$TMPDIR/repo3/.git/hooks/pre-push"
+echo '# pre-existing user hook' >> "$TMPDIR/repo3/.git/hooks/pre-push"
+chmod +x "$TMPDIR/repo3/.git/hooks/pre-push"
+
+(cd "$TMPDIR/repo3" && bash "$INSTALLER" >/dev/null 2>&1)
+
+backup_count=$(find "$TMPDIR/repo3/.git/hooks" -name 'pre-push.bak.*' | wc -l)
+if (( backup_count == 1 )); then
+  echo -e "  ${GREEN}PASS${NC}: unmanaged hook backed up before overwrite"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: expected 1 backup file, found $backup_count"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "==============================================="
+echo -e "Total: $((PASS + FAIL)) tests, ${GREEN}${PASS} pass${NC}, ${RED}${FAIL} fail${NC}"
+echo "==============================================="
+
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

PR-5 of the pipeline-docs plan. **Highest-severity open issue** — #68's failure mode let 6 commits land directly on a downstream consumer's trunk outside any PR before the issue was diagnosed.

Closes 3 hook issues as a defense-in-depth bundle:

| # | Title | Fix |
|---|---|---|
| #64 | block-push-to-main.sh regex false-pos / false-neg | Replace 5 ad-hoc regexes with shared `lib-push.sh` parser |
| #65 | Worktree creation should install repo-local git pre-push backstop | New `install-git-pre-push.sh` — Layer 2 git-side hook |
| #68 | SKILL.md frontmatter hooks are skill-scoped, not project-scoped | New `install-claude-hooks.sh` + canonical settings template |

## Defense in depth: 3 layers

```
git push
   ↓
Layer 1 — Claude PreToolUse hook (block-push-to-main.sh)
   ↓ (passes through, or hook missing — Layer 1 is skill-scoped)
Layer 2 — git-side per-worktree pre-push hook (.git/hooks/pre-push)
   ↓ (passes through)
Layer 3 — server-side branch protection (GitHub) — UNAVAILABLE on Free private
```

Without Layer 3, both Layers 1 and 2 must be installed. PR-5 ships the installer that materializes both.

## Refactor first

Per project direction. Before applying the 3 fixes, extracted shared parsing helpers (`lib-push.sh`):

- `parse_push_target_refspec(command)` — given a `git push ...` line, echoes the destination ref(s). Handles bare push, `feat/foo`, `feat/foo:bar`, `HEAD:refs/heads/main`, `:main` (delete), `tag v1`, `--all` / `--mirror` / `--tags`, value-taking flags (`--repo`, `-o`, `--push-option`, etc.).
- `is_trunk_ref(ref, [trunk_name])` — returns 0 if `ref` targets the trunk. Matches bare, fully-qualified, delete-form, and rev-spec suffixed forms.

Both #64 (Layer 1) and #65 (Layer 2 emitted hook is intentionally self-contained, but the test reuses the parser concept) benefit from the shared logic. **Five ad-hoc regexes in `block-push-to-main.sh` collapse to one call**: `is_trunk_ref "$(parse_push_target_refspec ...)"`.

## #64 fix correctness

- **Case A (false positive — bare feature push from trunk-checked-out worktree)**: Parser resolves dest to `feat/foo`. `is_trunk_ref` returns 1. Block doesn't fire. **TC-BP-03 in test-block-push-regex.sh asserts this regression guard.**
- **Case B (false negative — `HEAD:refs/heads/main` slipped through)**: Parser resolves dest to `refs/heads/main`. `is_trunk_ref` returns 0. Block fires. **TC-BP-06 asserts this regression guard.**

Plus 9 other cases covering bulk flags, TRUNK_BRANCH override, delete-form, etc. (11 cases total).

## Layer 2 (#65) installer

`skills/autonomous-common/hooks/install-git-pre-push.sh`:
- Idempotent (sentinel-based)
- Resolves per-worktree hooks dir via `git rev-parse --git-path hooks` (handles both regular clones and worktree `.git`-file cases)
- Auto-detects trunk via `git symbolic-ref refs/remotes/origin/HEAD`, fallback `main`, override `TRUNK_BRANCH` env
- Backs up pre-existing unmanaged hooks before overwrite
- Emitted hook is self-contained (no `lib-push.sh` source) — git hooks run from worktree root with no project lib path

## Layer 1 install (#68) installer

`skills/autonomous-common/scripts/install-claude-hooks.sh` + `claude-settings.template.json`:
- One-shot consumer-facing installer. **NOT auto-run on `npx skills add`** — explicit consent required.
- jq-based merge: preserves arbitrary other top-level keys (`model`, `enabledPlugins`, etc.); only the `hooks` block + `_managed_by` annotation are managed.
- Backs up pre-existing settings.json + sanity-checks merged result before replace.
- Optional `--no-git-hook` flag; default also installs Layer 2.
- Documented in `claude-settings.template.json`'s `_managed_note` field — visible to anyone reading the consumer's settings.json.

## Pipeline Docs (CONTRIBUTING.md Rule 1)

- [x] Touches `skills/autonomous-common/hooks/*.sh` (watched). Also touches `docs/pipeline/invariants.md` (new INV-17). Gate passes via docs-touched.

## Test Plan

- [x] All 16 unit test files pass (13 prior + 3 new: `test-block-push-regex.sh`, `test-install-git-pre-push.sh`, `test-install-claude-hooks.sh`). 29 new test cases covering all the regression scenarios.
- [x] `shellcheck -S error` clean on all 14 dispatcher + autonomous-common scripts.
- [x] Code-reviewer pass — verified set-e safety on `i++` rewrites, behavior preservation of BLOCKED message + exit code 2, jq merge correctness, and parser edge cases beyond the test suite (force-push refspecs, value-taking flags, etc.).

## Behavior preservation outside the 3 fixes

Strict: every diff line not directly tied to one of the 3 issues is a refactor that preserves byte-equivalent behavior. Specifically:
- `block-push-to-main.sh` BLOCKED message wording verbatim.
- Exit code 2 unchanged.
- Other hooks in autonomous-common/hooks/ unchanged.
- This repo's own `.claude/settings.json` is unchanged (the new installer is for downstream consumers).

## Out of scope

- Wiring `install-git-pre-push.sh` into the `autonomous-dev` SKILL.md workflow prompt (after every `git worktree add`) — separate small follow-up.
- Wrapper-side fixes #59 / #60 / #67 — PR-6.
- Multi-repo dispatch #62 — PR-7.
- PID files CWE-377 #72 — small follow-up.

Closes #64
Closes #65
Closes #68