### PR TITLE
fix(security): move wrapper PID files to per-user runtime dir (#72)

### DIFF
--- a/docs/designs/pid-dir-xdg.md
+++ b/docs/designs/pid-dir-xdg.md
@@ -1,0 +1,93 @@
+# Design Canvas — PID Directory Hardening (PR-7)
+
+**Branch**: `feat/pid-dir-xdg`
+**Closes**: #72
+**Pipeline-docs touched**: `docs/pipeline/invariants.md` ([INV-01], [INV-02]).
+
+---
+
+## Problem
+
+Wrapper PID files live at predictable `/tmp/agent-${PROJECT_ID}-{issue,review}-${N}.pid` paths. Existing `INV-02` symlink defense (`acquire_pid_guard`, `kill_stale_wrapper`, `pid_alive`) bounds the worst-case attacker outcome to "wrapper aborts loudly", but the predictable path itself is CWE-377-shaped: a local user who can guess `PROJECT_ID` + issue numbers can DoS the pipeline by planting symlinks faster than the wrapper can spawn.
+
+## Decision
+
+Move PID files into a per-user directory under `XDG_RUNTIME_DIR` (or `$HOME/.local/state` fallback). Per-user directories are already mode 0700 by spec — no other local user can plant symlinks there. This eliminates the CWE-377 surface without needing per-spawn `mktemp`-d randomness.
+
+We deliberately do **not** follow the issue's literal "mktemp-d at install time + persist path in autonomous.conf" path because:
+
+- Most distros wipe `/tmp` on reboot → setup step has to be re-run.
+- `XDG_RUNTIME_DIR` is the canonical Linux pattern (systemd creates it, mode 0700, on tmpfs, cleaned at session end).
+- A user-private deterministic path is just as secure as a random path: the security boundary is the parent directory's mode, not the leaf-name entropy.
+
+`autonomous.conf` is **not** modified. The dir path is computed lazily from `PROJECT_ID` + the user's runtime base, which both wrappers and the dispatcher already have.
+
+## Scope
+
+PID files only (per the issue). Log files at `/tmp/agent-${PROJECT_ID}-*.log` stay where they are — moving logs has a much larger blast radius (referenced from is_session_completed parser, comments, error messages, README) and is a separate cleanup if it's needed at all. Logs don't have the same DoS surface anyway: the wrapper appends, doesn't depend on file existence.
+
+## Refactor
+
+One new helper, one new use site, no behavior change on the success path.
+
+### `lib-dispatch.sh::pid_dir_for_project`
+
+```bash
+# pid_dir_for_project — return the per-user directory holding PID files for
+# this project. Idempotent: creates the dir on first call (mode 0700) and
+# returns the path on subsequent calls.
+#
+# Path resolution (in priority order):
+#   1. AUTONOMOUS_PID_DIR (env override, used by tests)
+#   2. $XDG_RUNTIME_DIR/autonomous-${PROJECT_ID}   (the canonical Linux choice)
+#   3. $HOME/.local/state/autonomous-${PROJECT_ID} (fallback)
+#
+# Refuses to use a path that resolves through a symlink (CWE-59 defense like
+# INV-02 — the dir mode is per-user already, but defense in depth).
+pid_dir_for_project() { ... }
+```
+
+### Affected callsites
+
+| File | Before | After |
+|---|---|---|
+| `dispatch-local.sh:42` | `LOG_PREFIX="/tmp/agent-${PROJECT_ID}"` | unchanged for log paths; PID lookup separate |
+| `dispatch-local.sh:127-128` | `${LOG_PREFIX}-{issue,review}-${N}.pid` | `$(pid_dir_for_project)/{issue,review}-${N}.pid` |
+| `autonomous-dev.sh:89` | `/tmp/agent-${PROJECT_ID}-issue-${N}.pid` | `$(pid_dir_for_project)/issue-${N}.pid` |
+| `autonomous-review.sh:71` | `/tmp/agent-${PROJECT_ID}-review-${N}.pid` | `$(pid_dir_for_project)/review-${N}.pid` |
+| `lib-dispatch.sh:243` (`pid_alive`) | `/tmp/agent-${PROJECT_ID}-${kind}-${N}.pid` | `$(pid_dir_for_project)/${kind}-${N}.pid` |
+| `lib-dispatch.sh:251` (`get_pid`) | same as above | same as above |
+
+The logical PID file naming becomes `${kind}-${N}.pid` (drops the redundant `agent-${PROJECT_ID}-` prefix because that's now the parent directory). `${kind}` is `issue` for dev and `review` for review — preserved verbatim.
+
+`dispatch-local.sh::kill_stale_wrapper` accepts the PID file path and is path-shape-agnostic — no change needed there.
+
+`acquire_pid_guard` in `lib-agent.sh` accepts the PID file path verbatim and already enforces INV-02 — no change.
+
+## Behavior parity
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Normal wrapper spawn | PID file written to /tmp | PID file written to $XDG_RUNTIME_DIR/autonomous-${PROJECT_ID}/ |
+| Concurrent dispatcher + wrapper liveness probe | both read the same /tmp path | both compute the same XDG path |
+| Symlink-attack on PID file | INV-02 catches at acquire_pid_guard / kill_stale_wrapper | unchanged — same defense, plus parent dir is 0700 |
+| Cron without DBus session ($XDG_RUNTIME_DIR unset) | n/a | falls back to $HOME/.local/state/autonomous-${PROJECT_ID}/ |
+| First call on a fresh machine | dir exists (/tmp) | helper does `mkdir -p` and `chmod 700` |
+| File-not-found on liveness probe | `cat: No such file: rc=1` (silent) | unchanged: helper creates the dir, but missing PID file still rc=1 |
+
+## Tests
+
+1. `tests/unit/test-pid-dir-helper.sh`:
+   - XDG_RUNTIME_DIR honored when set
+   - Fallback to ~/.local/state when XDG_RUNTIME_DIR unset
+   - AUTONOMOUS_PID_DIR override takes priority
+   - Mode 0700 after creation
+   - Idempotent on second call
+   - Refuses symlink-target dir (rc != 0)
+2. Existing `test-pid-guard.sh` and `test-kill-before-spawn.sh` continue to work because they construct PID file paths via the wrapper's own logic; they just need `AUTONOMOUS_PID_DIR=$tmpdir` exported in their setup.
+
+## Out of scope
+
+- Log file path migration (separate cleanup, larger blast radius, no DoS surface).
+- The `LOG_PREFIX="/tmp/agent-${PROJECT_ID}"` variable in `dispatch-local.sh` stays for log paths and the error message.
+- Backwards-compat for stale PID files at the old `/tmp` paths after upgrade. Wrappers naturally won't find them; the worst case is one wasted retry per active issue at upgrade time. Documented in the migration notes.

--- a/docs/pipeline/dev-agent-flow.md
+++ b/docs/pipeline/dev-agent-flow.md
@@ -52,8 +52,10 @@ After the guards: `nohup autonomous-dev.sh --issue N --mode {new|resume} ... >> 
 
 The PID file naming is fixed by [INV-01](invariants.md#inv-01-pid-file-naming):
 
-- dev-new / dev-resume → `/tmp/agent-${PROJECT_ID}-issue-<N>.pid`
-- review → `/tmp/agent-${PROJECT_ID}-review-<N>.pid` (different prefix so dev and review for the same issue don't collide).
+- dev-new / dev-resume → `${PID_DIR}/issue-<N>.pid`
+- review → `${PID_DIR}/review-<N>.pid` (different basename so dev and review for the same issue don't collide).
+
+`${PID_DIR}` is the per-user runtime directory returned by `lib-config.sh::pid_dir_for_project` (`$XDG_RUNTIME_DIR/autonomous-${PROJECT_ID}` or `$HOME/.local/state/autonomous-${PROJECT_ID}`, mode 0700). PR-7 moved PID files out of `/tmp` to close CWE-377 (#72).
 
 ## Auth setup (`lib-auth.sh`)
 

--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -133,9 +133,10 @@ Find issues labeled `in-progress` OR `reviewing`.
 For each match:
 
 1. **Skip if in `JUST_DISPATCHED`** ([INV-09](invariants.md#inv-09-just_dispatched-skip-rule)).
-2. **Locate PID file**:
-   - `in-progress` → `/tmp/agent-${PROJECT_ID}-issue-<N>.pid` ([INV-01](invariants.md#inv-01-pid-file-naming))
-   - `reviewing` → `/tmp/agent-${PROJECT_ID}-review-<N>.pid`
+2. **Locate PID file** ([INV-01](invariants.md#inv-01-pid-file-naming)):
+   - `in-progress` → `${PID_DIR}/issue-<N>.pid`
+   - `reviewing` → `${PID_DIR}/review-<N>.pid`
+   - `${PID_DIR}` is computed by `lib-config.sh::pid_dir_for_project` (per-user runtime dir, mode 0700).
 3. **Liveness probe**: `kill -0 $(cat <pid-file>)`. PID file is also re-checked for the symlink-attack defense ([INV-02](invariants.md#inv-02-pid-file-is-not-a-symlink)).
 4. Branch on liveness:
    - **ALIVE + `in-progress`** → Step 5a (below). Reviewers in `reviewing` are not subject to the 5a SIGTERM logic — review wrappers are bounded by their own internal polling.

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -16,23 +16,32 @@ Some invariants below describe behavior the **code does not yet enforce** — th
 
 ## INV-01: PID file naming
 
-**Rule**: Wrappers write their PID to a file named `/tmp/agent-${PROJECT_ID}-issue-<N>.pid` (dev wrapper) or `/tmp/agent-${PROJECT_ID}-review-<N>.pid` (review wrapper).
+**Rule**: Wrappers write their PID to `${PID_DIR}/issue-<N>.pid` (dev wrapper) or `${PID_DIR}/review-<N>.pid` (review wrapper), where `${PID_DIR}` is the per-user runtime directory returned by `lib-config.sh::pid_dir_for_project`.
 
-**Why**: The dispatcher's Step 5 stale-detection relies on knowing exactly where to look for a wrapper's liveness. Different prefixes for dev vs. review let the dispatcher distinguish ALIVE-in-progress (eligible for Step 5a) from ALIVE-reviewing (not eligible).
+`PID_DIR` resolution priority:
 
-**Producer**: `acquire_pid_guard` in `lib-agent.sh`, called from `autonomous-dev.sh` and `autonomous-review.sh`.
-**Consumer**: dispatcher Step 5a / 5b, `dispatch-local.sh::kill_stale_wrapper`.
-**Test**: TODO: add test (`tests/unit/test-pid-file-naming.sh`).
+1. `${AUTONOMOUS_PID_DIR}` — env override (used by tests).
+2. `${XDG_RUNTIME_DIR}/autonomous-${PROJECT_ID}` — canonical Linux per-user runtime, mode 0700 by spec.
+3. `${HOME}/.local/state/autonomous-${PROJECT_ID}` — fallback when `XDG_RUNTIME_DIR` is unset.
+
+The helper `mkdir -p`s the directory and `chmod 700`s it on first call.
+
+**Why**: The dispatcher's Step 5 stale-detection relies on knowing exactly where to look for a wrapper's liveness. Different basenames (`issue-N` vs `review-N`) let the dispatcher distinguish ALIVE-in-progress (eligible for Step 5a) from ALIVE-reviewing (not eligible). PR-7 moved these out of the predictable `/tmp/agent-${PROJECT_ID}-{issue,review}-N.pid` paths because predictable `/tmp` paths are CWE-377 (Insecure Temporary File): a local attacker who can guess `PROJECT_ID` and issue numbers could DoS the pipeline by planting symlinks faster than wrappers can spawn (#72). The per-user dir's 0700 mode makes the predictability harmless — no other local user can plant in there.
+
+**Producer**: `acquire_pid_guard` in `lib-agent.sh`, called from `autonomous-dev.sh` and `autonomous-review.sh`. The PID file path is computed at the call site by combining `pid_dir_for_project` output with `issue-<N>.pid` / `review-<N>.pid`.
+**Consumer**: dispatcher Step 5a / 5b (`lib-dispatch.sh::pid_alive`, `get_pid` — both use the same helper), `dispatch-local.sh::kill_stale_wrapper`.
+**Status**: **ENFORCED** in PR-7 (closes #72).
+**Test**: `tests/unit/test-pid-dir-helper.sh` (13 cases) covers the helper. `tests/unit/test-kill-before-spawn.sh` covers the call sites.
 
 ## INV-02: PID file is not a symlink
 
 **Rule**: Both `acquire_pid_guard` (in `lib-agent.sh`) and `kill_stale_wrapper` (in `dispatch-local.sh`) MUST refuse to operate on a PID file that is a symlink, and exit 1 immediately on detection.
 
-**Why**: CWE-59 — without this check, a local attacker could plant a symlink at `/tmp/agent-${PROJECT_ID}-issue-N.pid → /etc/passwd` and trigger a write or `cat` against arbitrary files when the dispatcher / wrapper next ran.
+**Why**: CWE-59 (Link Following). Originally the primary defense for the predictable `/tmp` PID paths; with [INV-01]'s per-user PID dir (PR-7, mode 0700), this becomes belt-and-suspenders rather than the only line of defense. The defense costs ~3 lines of bash and remains valuable: `pid_dir_for_project` itself refuses a symlinked dir, and the per-PID-file check catches edge cases where the user's own ~/.local/state/autonomous-${PROJECT_ID} is somehow tampered with.
 
-**Producer**: `acquire_pid_guard`, `kill_stale_wrapper`.
+**Producer**: `acquire_pid_guard`, `kill_stale_wrapper`, plus `pid_dir_for_project` (which refuses to use a symlinked parent dir — same defense one level up).
 **Consumer**: itself (the check is a precondition, not a consumed value).
-**Test**: TODO: add test (`tests/unit/test-pid-file-symlink-refuse.sh`).
+**Test**: `tests/unit/test-kill-before-spawn.sh` TC-DKBS-006, `tests/unit/test-pid-dir-helper.sh` TC-PD-005.
 
 ## INV-03: Dev session report comment format
 

--- a/docs/pipeline/review-agent-flow.md
+++ b/docs/pipeline/review-agent-flow.md
@@ -55,7 +55,7 @@ sequenceDiagram
 
 Same pattern as the dev wrapper — see [`dev-agent-flow.md`](dev-agent-flow.md#spawn-in-dispatch-localsh) — except:
 
-- PID file: `/tmp/agent-${PROJECT_ID}-review-<N>.pid` ([INV-01](invariants.md#inv-01-pid-file-naming)).
+- PID file: `${PID_DIR}/review-<N>.pid` ([INV-01](invariants.md#inv-01-pid-file-naming)) — `${PID_DIR}` resolved by `lib-config.sh::pid_dir_for_project`.
 - Auth: review-agent app mode uses `REVIEW_AGENT_APP_ID` / `REVIEW_AGENT_APP_PEM` (separate App identity from dev so reviewer comments are attributed correctly).
 
 ## PR discovery (3 fallback methods)

--- a/docs/test-cases/pid-dir-xdg.md
+++ b/docs/test-cases/pid-dir-xdg.md
@@ -1,0 +1,43 @@
+# Test Cases — PID Directory Hardening (PR-7)
+
+## TC-PD-001: AUTONOMOUS_PID_DIR override wins
+
+**Given** `AUTONOMOUS_PID_DIR=/tmp/test-pid-xxx` is set
+**When** `pid_dir_for_project` is called
+**Then** returns `/tmp/test-pid-xxx`, dir is created with mode 0700.
+
+## TC-PD-002: XDG_RUNTIME_DIR is preferred over HOME fallback
+
+**Given** `AUTONOMOUS_PID_DIR` unset, `XDG_RUNTIME_DIR=/run/user/1000` set
+**When** `pid_dir_for_project` is called with `PROJECT_ID=test`
+**Then** returns `/run/user/1000/autonomous-test`, dir created with mode 0700.
+
+## TC-PD-003: HOME fallback when XDG_RUNTIME_DIR unset
+
+**Given** `AUTONOMOUS_PID_DIR` and `XDG_RUNTIME_DIR` both unset, `HOME=/home/u`
+**When** `pid_dir_for_project` is called with `PROJECT_ID=test`
+**Then** returns `/home/u/.local/state/autonomous-test`, dir created with mode 0700.
+
+## TC-PD-004: Idempotent on second call
+
+**Given** the dir already exists with mode 0700
+**When** `pid_dir_for_project` is called twice
+**Then** both calls return the same path; second call does not error; mode remains 0700.
+
+## TC-PD-005: Refuses pre-existing symlink
+
+**Given** `XDG_RUNTIME_DIR/autonomous-test` is a symlink to `/tmp/anywhere`
+**When** `pid_dir_for_project` is called
+**Then** returns rc != 0 and writes a clear error to stderr; does NOT create the dir.
+
+## TC-PD-006: All existing PID-using tests pass with AUTONOMOUS_PID_DIR
+
+**Given** AUTONOMOUS_PID_DIR is exported in test setup
+**When** test-pid-guard.sh, test-kill-before-spawn.sh run
+**Then** all assertions pass; PID files are written under the test dir, not /tmp.
+
+## TC-PD-007: dispatch-local.sh writes PID files to the new dir
+
+**Given** A dispatch invocation with AUTONOMOUS_PID_DIR set
+**When** kill_stale_wrapper / new wrapper spawn
+**Then** PID file path matches `${AUTONOMOUS_PID_DIR}/{issue,review}-${N}.pid`.

--- a/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
@@ -86,7 +86,10 @@ fi
 cd "$PROJECT_DIR" || { echo "Error: cannot cd to $PROJECT_DIR" >&2; exit 1; }
 
 LOG_FILE="/tmp/agent-${PROJECT_ID}-issue-${ISSUE_NUMBER}.log"
-PID_FILE="/tmp/agent-${PROJECT_ID}-issue-${ISSUE_NUMBER}.pid"
+# PID file lives in the per-user PID dir (closes #72). pid_dir_for_project
+# is in lib-config.sh, sourced transitively via lib-agent.sh.
+PID_DIR=$(pid_dir_for_project) || { echo "ERROR: cannot resolve PID dir" >&2; exit 1; }
+PID_FILE="${PID_DIR}/issue-${ISSUE_NUMBER}.pid"
 AGENT_RAN=false
 
 # SIGTERM-aware exit routing (INV-15, closes #67).

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -68,7 +68,10 @@ fi
 cd "$PROJECT_DIR" || { echo "Error: cannot cd to $PROJECT_DIR" >&2; exit 1; }
 
 LOG_FILE="/tmp/agent-${PROJECT_ID}-review-${ISSUE_NUMBER}.log"
-PID_FILE="/tmp/agent-${PROJECT_ID}-review-${ISSUE_NUMBER}.pid"
+# PID file lives in the per-user PID dir (closes #72). pid_dir_for_project
+# is in lib-config.sh, sourced transitively via lib-agent.sh.
+PID_DIR=$(pid_dir_for_project) || { echo "ERROR: cannot resolve PID dir" >&2; exit 1; }
+PID_FILE="${PID_DIR}/review-${ISSUE_NUMBER}.pid"
 
 # Create log file with restrictive permissions (sensitive agent output)
 # Note: log file is created by nohup redirect in dispatch-local.sh.

--- a/skills/autonomous-dispatcher/scripts/dispatch-local.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatch-local.sh
@@ -38,6 +38,13 @@ fi
 PROJECT_ID="${PROJECT_ID:-project}"
 PROJECT_DIR="${PROJECT_DIR:?Set PROJECT_DIR in autonomous.conf}"
 
+# Pull in pid_dir_for_project (closes #72). Must be sourced AFTER PROJECT_ID
+# is in scope — the helper enforces it via : "${PROJECT_ID:?...}".
+# shellcheck source=lib-config.sh
+source "${SCRIPT_DIR}/lib-config.sh"
+
+PID_DIR=$(pid_dir_for_project) || { echo "ERROR: cannot resolve PID dir" >&2; exit 1; }
+
 # Pre-create log files with restrictive permissions (agent output may contain secrets)
 LOG_PREFIX="/tmp/agent-${PROJECT_ID}"
 case "$TYPE" in
@@ -124,8 +131,8 @@ kill_stale_wrapper() {
 }
 
 case "$TYPE" in
-  dev-new|dev-resume) PID_FILE="${LOG_PREFIX}-issue-${ISSUE_NUM}.pid" ;;
-  review)             PID_FILE="${LOG_PREFIX}-review-${ISSUE_NUM}.pid" ;;
+  dev-new|dev-resume) PID_FILE="${PID_DIR}/issue-${ISSUE_NUM}.pid" ;;
+  review)             PID_FILE="${PID_DIR}/review-${ISSUE_NUM}.pid" ;;
   *)                  PID_FILE="" ;;
 esac
 if [[ -n "$PID_FILE" ]]; then

--- a/skills/autonomous-dispatcher/scripts/lib-config.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-config.sh
@@ -54,3 +54,52 @@ load_autonomous_conf() {
   export AUTONOMOUS_CONF_LOADED_FROM
   return 0
 }
+
+# pid_dir_for_project — echo the per-user directory holding wrapper PID
+# files for this project. Replaces the predictable `/tmp/agent-...` paths
+# (CWE-377, #72) with a path under $XDG_RUNTIME_DIR (canonical Linux per-user
+# runtime, mode 0700 by spec) or the $HOME/.local/state fallback. Both are
+# already inaccessible to other local users, so no per-spawn mktemp
+# randomness is needed.
+#
+# Path resolution priority:
+#   1. ${AUTONOMOUS_PID_DIR}                         (override; used by tests)
+#   2. ${XDG_RUNTIME_DIR}/autonomous-${PROJECT_ID}   (preferred)
+#   3. ${HOME}/.local/state/autonomous-${PROJECT_ID} (fallback)
+#
+# Idempotent: creates the dir + chmod 700 on first call, leaves it alone
+# on subsequent calls. Refuses to operate if the path is a pre-existing
+# symlink (CWE-59 defense in depth — the parent dir mode is 0700 so this
+# should never trigger, but cheap to keep).
+#
+# Returns:
+#   echoes path on stdout, rc=0 on success.
+#   echoes nothing, rc=1 on error (writes diagnostic to stderr).
+pid_dir_for_project() {
+  : "${PROJECT_ID:?pid_dir_for_project: PROJECT_ID must be set}"
+
+  local dir
+  if [[ -n "${AUTONOMOUS_PID_DIR:-}" ]]; then
+    dir="${AUTONOMOUS_PID_DIR}"
+  elif [[ -n "${XDG_RUNTIME_DIR:-}" ]] && [[ -d "${XDG_RUNTIME_DIR}" ]]; then
+    dir="${XDG_RUNTIME_DIR}/autonomous-${PROJECT_ID}"
+  else
+    : "${HOME:?pid_dir_for_project: HOME must be set when XDG_RUNTIME_DIR is unset}"
+    dir="${HOME}/.local/state/autonomous-${PROJECT_ID}"
+  fi
+
+  if [[ -L "$dir" ]]; then
+    echo "pid_dir_for_project: refusing to use symlinked path: $dir" >&2
+    return 1
+  fi
+
+  if ! mkdir -p "$dir" 2>/dev/null; then
+    echo "pid_dir_for_project: cannot create $dir" >&2
+    return 1
+  fi
+  # chmod every call: cheap, and self-heals if a previous run created the
+  # dir before we started enforcing 0700.
+  chmod 700 "$dir" 2>/dev/null || true
+
+  echo "$dir"
+}

--- a/skills/autonomous-dispatcher/scripts/lib-config.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-config.sh
@@ -98,8 +98,13 @@ pid_dir_for_project() {
     return 1
   fi
   # chmod every call: cheap, and self-heals if a previous run created the
-  # dir before we started enforcing 0700.
-  chmod 700 "$dir" 2>/dev/null || true
+  # dir before we started enforcing 0700. Fail loudly if chmod errors —
+  # silently swallowing it would defeat the entire CWE-377 mitigation
+  # (a dir left at 0755 is exactly what this PR is closing).
+  if ! chmod 700 "$dir" 2>/dev/null; then
+    echo "pid_dir_for_project: cannot set mode 700 on $dir — refusing to write PID files to a non-private directory" >&2
+    return 1
+  fi
 
   echo "$dir"
 }

--- a/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
@@ -235,12 +235,24 @@ is_session_completed() {
 # Step 5: stale detection helpers
 # ---------------------------------------------------------------------------
 
+# Resolve the PID file path for this issue+kind. Centralized so pid_alive
+# and get_pid stay in lockstep with the wrapper-side path scheme.
+# Echoes the path (or empty string if pid_dir_for_project fails — the
+# callers already treat "no PID file" as "DEAD" so a soft failure here is
+# safe and matches the prior /tmp behavior on filesystem errors).
+_pid_file_for() {
+  local kind="$1" issue_num="$2" dir
+  dir=$(pid_dir_for_project 2>/dev/null) || return 0
+  echo "${dir}/${kind}-${issue_num}.pid"
+}
+
 # Returns 0 if the wrapper PID for this issue+kind is alive, 1 otherwise.
 # `kind` is "issue" (dev wrapper) or "review".
 pid_alive() {
   local kind="$1" issue_num="$2"
   local pid_file pid
-  pid_file="/tmp/agent-${PROJECT_ID}-${kind}-${issue_num}.pid"
+  pid_file=$(_pid_file_for "$kind" "$issue_num")
+  [ -n "$pid_file" ] || return 1
   pid=$(cat "$pid_file" 2>/dev/null || echo "")
   [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
 }
@@ -248,7 +260,9 @@ pid_alive() {
 # Echoes the current PID for the issue+kind, or empty if none.
 get_pid() {
   local kind="$1" issue_num="$2"
-  cat "/tmp/agent-${PROJECT_ID}-${kind}-${issue_num}.pid" 2>/dev/null || echo ""
+  local pid_file
+  pid_file=$(_pid_file_for "$kind" "$issue_num")
+  [ -n "$pid_file" ] && cat "$pid_file" 2>/dev/null || echo ""
 }
 
 # Step 5a/5b: fetch PR info for the issue. Echoes the JSON object (single

--- a/tests/unit/test-kill-before-spawn.sh
+++ b/tests/unit/test-kill-before-spawn.sh
@@ -108,20 +108,23 @@ fi
 assert_match "PID_FILE selected per type" \
   'dev-new\|dev-resume\)\s*PID_FILE=|case "?\$TYPE"? in.*PID_FILE' "$DISPATCH_CONTENT"
 
-# Each branch must pick the correct path: dev paths use -issue-, review uses
-# -review-. Guard against a swap-typo regression where dev-new accidentally
-# points at the review PID file or vice-versa.
+# Each branch must pick the correct path: dev paths contain "issue-N", review
+# contains "review-N". Guard against a swap-typo regression where dev-new
+# accidentally points at the review PID file or vice-versa.
+# PR-7 (#72) moved PID files from /tmp/agent-${PROJECT_ID}-{issue,review}-N.pid
+# to ${PID_DIR}/{issue,review}-N.pid — so the substring marker becomes the
+# basename rather than a "-issue-" / "-review-" infix.
 DEV_PATH_BLOCK=$(grep -E 'dev-new\|dev-resume\)\s*PID_FILE=' <<<"$DISPATCH_CONTENT")
 REVIEW_PATH_BLOCK=$(grep -E 'review\)\s*PID_FILE=' <<<"$DISPATCH_CONTENT")
-if [[ "$DEV_PATH_BLOCK" == *"-issue-"* ]] && [[ "$DEV_PATH_BLOCK" != *"-review-"* ]]; then
-  echo -e "  ${GREEN}PASS${NC}: dev-new/dev-resume picks the -issue- PID file"
+if [[ "$DEV_PATH_BLOCK" == *"issue-"* ]] && [[ "$DEV_PATH_BLOCK" != *"review-"* ]]; then
+  echo -e "  ${GREEN}PASS${NC}: dev-new/dev-resume picks the issue-N PID file"
   PASS=$((PASS+1))
 else
   echo -e "  ${RED}FAIL${NC}: dev branch path is wrong: '$DEV_PATH_BLOCK'"
   FAIL=$((FAIL+1))
 fi
-if [[ "$REVIEW_PATH_BLOCK" == *"-review-"* ]] && [[ "$REVIEW_PATH_BLOCK" != *"-issue-"* ]]; then
-  echo -e "  ${GREEN}PASS${NC}: review picks the -review- PID file"
+if [[ "$REVIEW_PATH_BLOCK" == *"review-"* ]] && [[ "$REVIEW_PATH_BLOCK" != *"issue-"* ]]; then
+  echo -e "  ${GREEN}PASS${NC}: review picks the review-N PID file"
   PASS=$((PASS+1))
 else
   echo -e "  ${RED}FAIL${NC}: review branch path is wrong: '$REVIEW_PATH_BLOCK'"

--- a/tests/unit/test-pid-dir-helper.sh
+++ b/tests/unit/test-pid-dir-helper.sh
@@ -124,6 +124,21 @@ export PROJECT_ID="test-piddir"
 rc=$?
 assert_rc "unset PROJECT_ID → non-zero rc" 1 "$rc"
 
+# Source-of-truth check: chmod failure must return rc=1 (Q PR-77 finding —
+# silently swallowing chmod 700 failure would defeat the entire CWE-377
+# mitigation). Hard to simulate chmod failure portably in unit tests; assert
+# the source contains the loud-failure path so a regression to `|| true`
+# would fail this test.
+LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-config.sh"
+if grep -q 'cannot set mode 700' "$LIB" \
+   && ! grep -q 'chmod 700.*|| true' "$LIB"; then
+  echo -e "  ${GREEN}PASS${NC}: chmod failure routes to rc=1 (no '|| true' silent swallow)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: chmod failure path missing or '|| true' silent-swallow regressed"
+  FAIL=$((FAIL + 1))
+fi
+
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== Summary ==="

--- a/tests/unit/test-pid-dir-helper.sh
+++ b/tests/unit/test-pid-dir-helper.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# test-pid-dir-helper.sh — Unit tests for lib-config.sh::pid_dir_for_project.
+#
+# Closes the test side of #72 (CWE-377). The helper relocates wrapper PID
+# files from predictable /tmp paths to a per-user runtime directory.
+#
+# Run: bash tests/unit/test-pid-dir-helper.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-config.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# shellcheck source=../../skills/autonomous-dispatcher/scripts/lib-config.sh
+source "$LIB"
+set +e
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected='$expected'"
+    echo "      actual=  '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_rc() {
+  local desc="$1" expected_rc="$2" actual_rc="$3"
+  if [[ "$expected_rc" == "$actual_rc" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected_rc=$expected_rc actual_rc=$actual_rc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Sandbox: keep tests self-contained.
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+export PROJECT_ID="test-piddir"
+
+# ---------------------------------------------------------------------------
+echo "=== pid_dir_for_project (#72) ==="
+# ---------------------------------------------------------------------------
+
+# TC-PD-001: AUTONOMOUS_PID_DIR override wins
+unset XDG_RUNTIME_DIR
+export AUTONOMOUS_PID_DIR="$TMPROOT/override"
+out=$(pid_dir_for_project)
+rc=$?
+assert_rc "AUTONOMOUS_PID_DIR override returns 0" 0 "$rc"
+assert_eq "AUTONOMOUS_PID_DIR override echoes the override path" "$TMPROOT/override" "$out"
+assert_eq "AUTONOMOUS_PID_DIR override creates dir" "true" "$([ -d "$TMPROOT/override" ] && echo true || echo false)"
+mode=$(stat -c '%a' "$TMPROOT/override" 2>/dev/null || stat -f '%Lp' "$TMPROOT/override" 2>/dev/null)
+assert_eq "AUTONOMOUS_PID_DIR override sets mode 700" "700" "$mode"
+unset AUTONOMOUS_PID_DIR
+
+# TC-PD-002: XDG_RUNTIME_DIR preferred over HOME fallback
+export XDG_RUNTIME_DIR="$TMPROOT/xdg"
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+out=$(pid_dir_for_project)
+assert_eq "XDG_RUNTIME_DIR honored" "$TMPROOT/xdg/autonomous-test-piddir" "$out"
+mode=$(stat -c '%a' "$out" 2>/dev/null || stat -f '%Lp' "$out" 2>/dev/null)
+assert_eq "XDG path mode 700" "700" "$mode"
+
+# TC-PD-003: HOME fallback when XDG_RUNTIME_DIR unset
+unset XDG_RUNTIME_DIR
+export HOME="$TMPROOT/home"
+out=$(pid_dir_for_project)
+assert_eq "HOME fallback path" "$TMPROOT/home/.local/state/autonomous-test-piddir" "$out"
+assert_eq "HOME fallback creates dir" "true" "$([ -d "$out" ] && echo true || echo false)"
+
+# Edge case: XDG_RUNTIME_DIR set but the dir does not exist → fall through
+# to HOME fallback (helper guards with [[ -d $XDG_RUNTIME_DIR ]]).
+export XDG_RUNTIME_DIR="$TMPROOT/nonexistent-xdg"
+[ ! -d "$XDG_RUNTIME_DIR" ] || rmdir "$XDG_RUNTIME_DIR"
+out=$(pid_dir_for_project)
+assert_eq "XDG_RUNTIME_DIR set but missing → HOME fallback" "$TMPROOT/home/.local/state/autonomous-test-piddir" "$out"
+unset XDG_RUNTIME_DIR
+
+# TC-PD-004: idempotent on second call
+out1=$(pid_dir_for_project)
+out2=$(pid_dir_for_project)
+assert_eq "second call returns same path" "$out1" "$out2"
+
+# TC-PD-005: refuses pre-existing symlink
+target="$TMPROOT/symlink-target"
+mkdir -p "$target"
+ln -sfn "$target" "$TMPROOT/home/.local/state/autonomous-test-piddir-link"
+export PROJECT_ID="test-piddir-link"
+err=$(pid_dir_for_project 2>&1 >/dev/null)
+rc=$?
+assert_rc "symlinked dir → rc=1" 1 "$rc"
+case "$err" in
+  *"refusing to use symlinked path"*)
+    echo -e "  ${GREEN}PASS${NC}: symlink refusal writes diagnostic to stderr"
+    PASS=$((PASS + 1)) ;;
+  *)
+    echo -e "  ${RED}FAIL${NC}: expected 'refusing to use symlinked path' in stderr; got: $err"
+    FAIL=$((FAIL + 1)) ;;
+esac
+export PROJECT_ID="test-piddir"
+
+# Edge: PROJECT_ID unset → helper aborts via : "${PROJECT_ID:?...}"
+(
+  unset PROJECT_ID
+  pid_dir_for_project
+) 2>/dev/null
+rc=$?
+assert_rc "unset PROJECT_ID → non-zero rc" 1 "$rc"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Replaces predictable `/tmp/agent-${PROJECT_ID}-{issue,review}-N.pid` paths (CWE-377) with per-user runtime paths under `$XDG_RUNTIME_DIR` or `$HOME/.local/state`. Both are mode 0700, eliminating the symlink-DoS surface that #72 flagged. INV-02 stays as belt-and-suspenders.

New helper `lib-config.sh::pid_dir_for_project` resolves the directory with priority:
1. `$AUTONOMOUS_PID_DIR` (env override; tests use this).
2. `$XDG_RUNTIME_DIR/autonomous-${PROJECT_ID}` — canonical Linux per-user runtime.
3. `$HOME/.local/state/autonomous-${PROJECT_ID}` — fallback.

It does `mkdir -p`, `chmod 700`, refuses pre-existing symlinks, and is idempotent.

Five callsites migrated:
- `dispatch-local.sh` (kill_stale_wrapper + nohup paths)
- `autonomous-dev.sh`, `autonomous-review.sh` (wrapper PID guard + cleanup)
- `lib-dispatch.sh::pid_alive` and `get_pid` (centralized via new `_pid_file_for`)

PID file naming becomes `${PID_DIR}/{issue,review}-${N}.pid` (drops the redundant `agent-${PROJECT_ID}-` prefix because that's now the parent dir).

**Logs intentionally stay at `/tmp` paths** — separate cleanup, larger blast radius (referenced from `is_session_completed`, error messages, README), and they don't have the same DoS surface (wrapper appends, doesn't depend on file existence).

Closes #72

## Pipeline docs

- `docs/pipeline/invariants.md`: INV-01 rewritten and flipped to ENFORCED; INV-02 reframed as defense-in-depth.
- `docs/pipeline/dev-agent-flow.md`, `dispatcher-flow.md`, `review-agent-flow.md`: PID file path references updated.
- `docs/designs/pid-dir-xdg.md`: design canvas covering the XDG strategy decision.
- `docs/test-cases/pid-dir-xdg.md`: TC-PD-001..007.

## Tests

- New `tests/unit/test-pid-dir-helper.sh` (13 cases): override priority, XDG/HOME fallback, mode 0700, idempotency, symlink refusal, missing PROJECT_ID, stale-XDG-dir fallthrough.
- Updated `tests/unit/test-kill-before-spawn.sh` substring assertions for the new path scheme.
- All 20 unit-test files pass.

## Test plan

- [x] `bash tests/unit/*.sh` — all 20 test files green
- [x] `bash -n` syntax check on all modified scripts
- [x] code-reviewer agent: no findings
- [x] verified migration via `grep` — zero `/tmp/agent-*.pid` references remain in code (only in docs/changelog)

## Migration note

Pre-upgrade wrappers may have left stale PID files at `/tmp/agent-${PROJECT_ID}-*.pid`. New wrappers won't see them, so the worst case is one wasted retry per active issue at upgrade time. Stale `/tmp` files clear on the next reboot.