### PR TITLE
feat(dispatcher): config-driven multi-project outer loop (#62)

### DIFF
--- a/docs/designs/multi-project-dispatcher.md
+++ b/docs/designs/multi-project-dispatcher.md
@@ -1,0 +1,129 @@
+# Design Canvas — Config-driven Multi-project Dispatcher (PR-8)
+
+**Branch**: `feat/multi-project-dispatcher`
+**Closes**: #62 (axes 1 + 3 only — pluggable execution backend deferred to a follow-up).
+**Pipeline-docs touched**: `docs/pipeline/dispatcher-flow.md` (new outer-loop section).
+
+---
+
+## Why
+
+Today the dispatcher tick is single-project: `dispatcher-tick.sh` sources one `autonomous.conf` at startup and runs one tick. To dispatch across multiple repositories, an operator forks the skill and edits its hardcoded `PROJECTS=()` array — losing upstream updates and turning every repo onboarding into a code change.
+
+This PR keeps `dispatcher-tick.sh` unchanged and wraps it in a tiny outer loop driven by a separate `dispatcher.conf` file. The schema is intentionally minimal so the change is reviewable and reversible.
+
+## Scope
+
+In scope:
+- New `dispatcher.conf.example` declaring a `PROJECTS=()` array of paths to per-project `autonomous.conf` files.
+- New `dispatcher-multi-tick.sh` outer loop.
+- Updated SKILL.md / dispatcher-flow.md documenting the new entry point and its backwards-compat fallback.
+- Tests covering iteration, env-override propagation, and per-project failure isolation.
+
+Out of scope (deferred):
+- Pluggable execution backend (`EXECUTION_BACKEND=local|ssm`). Will be a follow-up PR (PR-9 if pursued) once the multi-project plumbing is verified.
+- `dispatch-ssm.sh` brand-new SSM driver. Larger surface, would need its own design canvas.
+
+## Schema
+
+```bash
+# dispatcher.conf
+# Lookup priority: $DISPATCHER_CONF env, $HOME/.autonomous/dispatcher.conf,
+# $XDG_CONFIG_HOME/autonomous/dispatcher.conf.
+
+# Required: list of per-project autonomous.conf paths.
+# Each path must point to a project's existing autonomous.conf; the dispatcher
+# sources it (in a subshell) before running one tick.
+PROJECTS=(
+  "/data/git/myrepo-a/scripts/autonomous.conf"
+  "/data/git/myrepo-b/scripts/autonomous.conf"
+)
+```
+
+Per-project values (REPO, PROJECT_ID, MAX_CONCURRENT, DISPATCHER_APP_ID, DISPATCHER_APP_PEM, ...) all stay in each project's `autonomous.conf`. The outer loop just iterates.
+
+## Per-tick semantics
+
+```text
+dispatcher-multi-tick.sh tick:
+  load dispatcher.conf  (sets PROJECTS array)
+  for each conf_path in PROJECTS:
+    in a subshell with AUTONOMOUS_CONF=$conf_path:
+      bash dispatcher-tick.sh
+      capture exit code, log it
+    on exit: subshell teardown (env restored automatically)
+  exit 0  # outer loop never fails the tick — one bad project must not block others
+```
+
+Key isolation property: each project gets its own subshell. Variables set by one project's `autonomous.conf` (REPO, PROJECT_ID, MAX_CONCURRENT, etc.) cannot leak into the next project's tick. This matches the `lib-config.sh::load_autonomous_conf` priority-1 path (`AUTONOMOUS_CONF` env override) introduced in PR-4 — no new mechanism needed.
+
+## Concurrency model — per-project, not global
+
+Each per-project tick checks its own `MAX_CONCURRENT` against issues with its own `REPO`'s active labels. There is **no** global cross-project concurrency cap. Rationale:
+
+- Different projects often run on different cloud-station instances or with different agent quotas.
+- Adding global concurrency would require shared state across ticks (a file lock or a count file under the PID dir).
+- Operators who need a global cap can compose: set per-project `MAX_CONCURRENT=2` and have at most N projects.
+
+## Backwards compatibility
+
+The dispatcher's existing single-project behavior is preserved exactly:
+
+- `DISPATCHER_CONF` unset → SKILL.md continues to advise `bash dispatcher-tick.sh` directly. No wrapper involved. Existing single-repo deployments do not need to migrate.
+- `DISPATCHER_CONF` set but file missing → `dispatcher-multi-tick.sh` writes a clear error to stderr and exits non-zero, so cron logs surface the misconfiguration instead of silently skipping ticks.
+- `DISPATCHER_CONF` set, `PROJECTS=()` empty → loop runs zero iterations, exits 0 with a single log line.
+
+## GitHub App auth (issue #62 axis 3)
+
+The wrappers (`autonomous-dev.sh`, `autonomous-review.sh`) already read `DISPATCHER_APP_ID` / `DISPATCHER_APP_PEM` from each project's own `autonomous.conf` via `lib-auth.sh::setup_github_auth`. This already works — the multi-project wrapper inherits it for free because each project's `autonomous.conf` is sourced fresh in the subshell.
+
+The cron prompt in SKILL.md updates from "set REPO, source autonomous.conf, run dispatcher-tick.sh" to just "run dispatcher-multi-tick.sh" — the per-project auth happens inside each iteration.
+
+## Failure isolation
+
+The outer loop must continue past per-project failures (one project's misconfiguration must not stall others). Use:
+
+```bash
+for conf in "${PROJECTS[@]}"; do
+  if ! ( AUTONOMOUS_CONF="$conf" bash "$SCRIPT_DIR/dispatcher-tick.sh" ); then
+    log "  WARN: tick failed for $conf (rc=$?)"
+  fi
+done
+```
+
+The inner subshell's exit code is captured but does NOT short-circuit the loop. Each project gets one tick attempt per cron cycle.
+
+## Tests
+
+`tests/unit/test-dispatcher-multi-tick.sh`:
+
+1. PROJECTS=() is honored — iterates the right number of times.
+2. Each iteration runs `dispatcher-tick.sh` with `AUTONOMOUS_CONF` set to the right path (verified via a stub `dispatcher-tick.sh` that records its env).
+3. Per-project failure does not break the loop — second project still runs after first one fails.
+4. DISPATCHER_CONF unset → wrapper aborts with a clear message (it is opt-in, not a silent no-op).
+5. DISPATCHER_CONF set but file missing → non-zero exit + diagnostic.
+6. PROJECTS unset (or empty array) inside dispatcher.conf → exit 0 with a single log line.
+
+The existing test suite continues to pass unchanged because `dispatcher-tick.sh` itself is not modified.
+
+## SKILL.md cron contract
+
+Old cron command (single-project, still supported):
+```bash
+bash "$PROJECT_DIR/scripts/dispatcher-tick.sh"
+```
+
+New cron command (multi-project):
+```bash
+DISPATCHER_CONF="$HOME/.autonomous/dispatcher.conf" \
+  bash "$PROJECT_DIR/scripts/dispatcher-multi-tick.sh"
+```
+
+Both are documented in SKILL.md; the multi-project form is recommended when more than one repo is in scope.
+
+## What we're explicitly not doing
+
+- **Not** changing dispatcher-tick.sh's interface or any of its 5 steps.
+- **Not** adding cross-project state (shared counters, locks, JUST_DISPATCHED across projects).
+- **Not** adding `EXECUTION_BACKEND` routing — that's a separate axis with a much larger surface (a brand new `dispatch-ssm.sh` driver).
+- **Not** changing how individual wrappers read auth — they already pull from per-project `autonomous.conf`.

--- a/docs/designs/multi-project-dispatcher.md
+++ b/docs/designs/multi-project-dispatcher.md
@@ -121,6 +121,20 @@ DISPATCHER_CONF="$HOME/.autonomous/dispatcher.conf" \
 
 Both are documented in SKILL.md; the multi-project form is recommended when more than one repo is in scope.
 
+## Trust gate on dispatcher.conf source (CWE-94)
+
+`source` of an operator-controlled file means arbitrary code execution as the dispatcher user. The wrapper enforces a trust gate before sourcing `dispatcher.conf`:
+
+- File must be owned by the current uid (or root).
+- File must NOT be group- or other-writable.
+- Parent directory must NOT be group- or other-writable.
+
+These are the same trust checks `sudo` and `ssh` apply to their config files. `/tmp` (mode 1777) is rejected by the parent-dir check, so operators are nudged toward `$HOME/.autonomous/dispatcher.conf` (mode 0700 home dir).
+
+Escape hatch: `AUTONOMOUS_TRUST_CONF=1` disables the gate. Documented in `dispatcher.conf.example` for shared-VM cases where the conf is owned by a different uid by design.
+
+The gate applies only to `dispatcher.conf` in this PR — per-project `autonomous.conf` files are sourced inside the subshell via `lib-config.sh::load_autonomous_conf` (existing pattern, not modified here). A follow-up PR could extend the trust gate to that path; out of scope for this change.
+
 ## What we're explicitly not doing
 
 - **Not** changing dispatcher-tick.sh's interface or any of its 5 steps.

--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -2,7 +2,15 @@
 
 The dispatcher runs as a cron job (default every 5 minutes) and is **stateless across ticks**. Each tick reads the current label set on every `autonomous` issue, reads PID files for any wrappers it might be tracking, makes decisions, dispatches subprocesses, and updates labels. There is no in-memory carry-over from the previous tick.
 
-The behavior described here is implemented by `skills/autonomous-dispatcher/scripts/dispatcher-tick.sh` (the single entry point) backed by `skills/autonomous-dispatcher/scripts/lib-dispatch.sh` (composable helpers — one function per gh/jq query). The dispatcher agent reads `SKILL.md` and runs `bash "$PROJECT_DIR/scripts/dispatcher-tick.sh"`; that script does everything described below in one process. Function names cited below (e.g. `count_active`, `check_deps_resolved`) are defined in `lib-dispatch.sh`.
+The behavior described here is implemented by `skills/autonomous-dispatcher/scripts/dispatcher-tick.sh` (the per-project entry point) backed by `skills/autonomous-dispatcher/scripts/lib-dispatch.sh` (composable helpers — one function per gh/jq query). The dispatcher agent reads `SKILL.md` and runs `bash "$PROJECT_DIR/scripts/dispatcher-tick.sh"`; that script does everything described below in one process. Function names cited below (e.g. `count_active`, `check_deps_resolved`) are defined in `lib-dispatch.sh`.
+
+## Multi-project outer loop (PR-8, #62)
+
+For deployments that scan more than one repository per cron, `dispatcher-multi-tick.sh` wraps `dispatcher-tick.sh` in an outer iteration over a `PROJECTS=()` array declared in a separate `dispatcher.conf` file. Each iteration sets `AUTONOMOUS_CONF` to a per-project path and runs `dispatcher-tick.sh` in a subshell, so per-project state cannot leak between iterations.
+
+The outer loop intentionally does NOT carry shared state (no global concurrency cap, no cross-project JUST_DISPATCHED). Each project's tick is independent — concurrency is enforced per-project against that project's `MAX_CONCURRENT`. This keeps the multi-project layer minimal: just a `for` loop over `bash -c '... dispatcher-tick.sh'`. Per-project failures are logged but do not abort sibling projects.
+
+The rest of this document describes the per-project tick in isolation; everything below applies whether `dispatcher-tick.sh` is invoked directly (single-project) or by the multi-tick wrapper (one of N projects).
 
 ## Tick lifecycle
 

--- a/docs/test-cases/multi-project-dispatcher.md
+++ b/docs/test-cases/multi-project-dispatcher.md
@@ -1,0 +1,53 @@
+# Test Cases — Multi-project Dispatcher (PR-8)
+
+## TC-MP-001: PROJECTS=() iterates the right number of times
+
+**Given** dispatcher.conf with PROJECTS=("/tmp/conf-a" "/tmp/conf-b" "/tmp/conf-c")
+**When** dispatcher-multi-tick.sh runs (with stub dispatcher-tick.sh)
+**Then** the stub is invoked 3 times.
+
+## TC-MP-002: AUTONOMOUS_CONF env propagated per iteration
+
+**Given** PROJECTS=("/tmp/conf-a" "/tmp/conf-b")
+**When** dispatcher-multi-tick.sh runs (with a stub that records `$AUTONOMOUS_CONF`)
+**Then** the stub recorded "/tmp/conf-a" once and "/tmp/conf-b" once, in PROJECTS order.
+
+## TC-MP-003: Per-project failure does not break the loop
+
+**Given** PROJECTS=("/tmp/conf-a" "/tmp/conf-b") and stub returns rc=1 for conf-a, rc=0 for conf-b
+**When** dispatcher-multi-tick.sh runs
+**Then** both projects are attempted, the wrapper exits 0, and stderr contains a "tick failed for /tmp/conf-a" warning.
+
+## TC-MP-004: DISPATCHER_CONF unset → wrapper aborts
+
+**Given** DISPATCHER_CONF env unset (and no $HOME/.autonomous/dispatcher.conf, no $XDG_CONFIG_HOME/.../dispatcher.conf)
+**When** dispatcher-multi-tick.sh runs
+**Then** rc != 0 and stderr explains "DISPATCHER_CONF not set".
+
+## TC-MP-005: DISPATCHER_CONF set but file missing → diagnostic
+
+**Given** DISPATCHER_CONF=/nonexistent/path
+**When** dispatcher-multi-tick.sh runs
+**Then** rc != 0 and stderr names the missing path.
+
+## TC-MP-006: Empty PROJECTS=() → exit 0 with one log line
+
+**Given** dispatcher.conf with `PROJECTS=()`
+**When** dispatcher-multi-tick.sh runs
+**Then** rc == 0 and exactly one "no projects configured" log line.
+
+## TC-MP-007: PROJECTS unset → diagnostic
+
+**Given** dispatcher.conf that does NOT define PROJECTS
+**When** dispatcher-multi-tick.sh runs
+**Then** rc != 0 and stderr explains PROJECTS array missing.
+
+## TC-MP-008: Source-of-truth check on outer loop subshell
+
+**Given** dispatcher-multi-tick.sh source
+**When** grepped for the iteration logic
+**Then** the loop body runs `dispatcher-tick.sh` inside parentheses (subshell isolation), passes AUTONOMOUS_CONF as a per-iteration env, and does NOT exit on per-project failure.
+
+## TC-MP-009: Backwards compat (single-project path)
+
+The existing `dispatcher-tick.sh` continues to work standalone. Verified by the existing 20 unit-test files passing unchanged — no test in this PR modifies anything those tests probe.

--- a/skills/autonomous-dispatcher/SKILL.md
+++ b/skills/autonomous-dispatcher/SKILL.md
@@ -18,13 +18,24 @@ Scan GitHub issues and dispatch dev/review tasks locally. One cron tick is one i
 
 ## What to do
 
-When the cron fires (default: every 5 min), run:
+When the cron fires (default: every 5 min), run **one** of:
+
+**Single-project deployment** (one repo per dispatcher):
 
 ```bash
 bash "$PROJECT_DIR/scripts/dispatcher-tick.sh"
 ```
 
-That's it. The script handles all 5 steps of one tick:
+**Multi-project deployment** (one cron, many repos — closes #62):
+
+```bash
+DISPATCHER_CONF="$HOME/.autonomous/dispatcher.conf" \
+  bash "$PROJECT_DIR/scripts/dispatcher-multi-tick.sh"
+```
+
+The multi-tick wrapper iterates `PROJECTS=()` from `dispatcher.conf` and runs one `dispatcher-tick.sh` per project, with each project's `autonomous.conf` sourced in a subshell via the `AUTONOMOUS_CONF` env override. Per-project failures are logged to stderr but do not stall other projects. See `scripts/dispatcher.conf.example` for the schema.
+
+Either form runs the same 5-step tick:
 
 1. **Concurrency gate** — abort if `count(in-progress + reviewing) >= MAX_CONCURRENT`.
 2. **scan-new** — find `autonomous`-only issues, check dependencies, dispatch dev-new.

--- a/skills/autonomous-dispatcher/scripts/dispatcher-multi-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-multi-tick.sh
@@ -58,6 +58,44 @@ if [[ ! -r "$CONF" ]]; then
   exit 1
 fi
 
+# Trust gate before sourcing (CWE-94 mitigation, Q PR-78 finding):
+# `source` of an attacker-writable file executes arbitrary code as the
+# dispatcher user. Refuse to source if the file is owned by someone else
+# or is group/other-writable. Same trust model sudo/ssh-config use.
+#
+# Refuses also if the parent dir is g+w / o+w, since an attacker who can
+# rename a sibling file into the parent could swap the sentinel.
+#
+# Disabled when AUTONOMOUS_TRUST_CONF=1 (escape hatch for shared-dev
+# scenarios like dev VMs where the operator owns the conf via a different
+# uid; documented in dispatcher.conf.example).
+trust_check() {
+  local path="$1" label="$2"
+  if [[ -n "${AUTONOMOUS_TRUST_CONF:-}" ]]; then
+    return 0
+  fi
+  local owner perms parent_perms
+  owner=$(stat -c '%u' "$path" 2>/dev/null || stat -f '%u' "$path" 2>/dev/null)
+  perms=$(stat -c '%a' "$path" 2>/dev/null || stat -f '%Lp' "$path" 2>/dev/null)
+  if [[ "$owner" != "$(id -u)" && "$owner" != "0" ]]; then
+    echo "ERROR: $label at '$path' is not owned by current user or root (uid=$owner). Refusing to source. Set AUTONOMOUS_TRUST_CONF=1 to override." >&2
+    return 1
+  fi
+  # Group or other write bit set — anyone in the group (or anyone, period)
+  # can edit the file and inject code that we'd execute on the next tick.
+  if [[ -n "$perms" ]] && (( (10#$perms & 0022) != 0 )); then
+    echo "ERROR: $label at '$path' has insecure permissions ($perms). Refusing to source — chmod go-w. Set AUTONOMOUS_TRUST_CONF=1 to override." >&2
+    return 1
+  fi
+  parent_perms=$(stat -c '%a' "$(dirname "$path")" 2>/dev/null || stat -f '%Lp' "$(dirname "$path")" 2>/dev/null)
+  if [[ -n "$parent_perms" ]] && (( (10#$parent_perms & 0022) != 0 )); then
+    echo "ERROR: parent directory of '$path' is g+w or o+w ($parent_perms). Refusing to source — chmod go-w on the parent." >&2
+    return 1
+  fi
+}
+
+trust_check "$CONF" "dispatcher.conf" || exit 1
+
 # ---------------------------------------------------------------------------
 # Load PROJECTS array
 # ---------------------------------------------------------------------------

--- a/skills/autonomous-dispatcher/scripts/dispatcher-multi-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-multi-tick.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# dispatcher-multi-tick.sh — outer loop for multi-project dispatching (#62).
+#
+# One cron invocation runs one tick per project listed in dispatcher.conf.
+# Each project's `autonomous.conf` is sourced in a subshell via the
+# AUTONOMOUS_CONF env override (lib-config.sh priority 1) so settings
+# cannot leak between projects.
+#
+# Backwards compat: `dispatcher-tick.sh` itself is unchanged. Single-project
+# deployments continue to work by invoking `dispatcher-tick.sh` directly.
+#
+# Usage:
+#   DISPATCHER_CONF=/path/to/dispatcher.conf bash dispatcher-multi-tick.sh
+# or with default lookup:
+#   bash dispatcher-multi-tick.sh   # tries $HOME/.autonomous/dispatcher.conf
+#                                   #  then $XDG_CONFIG_HOME/autonomous/dispatcher.conf
+#
+# Exit codes:
+#   0 — at least one project ticked (per-project failures logged but tolerated)
+#   1 — dispatcher.conf cannot be located, is unreadable, or PROJECTS unset
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+log() { echo "[dispatcher-multi-tick] $(date -u +%H:%M:%S) $*"; }
+warn() { echo "[dispatcher-multi-tick] $(date -u +%H:%M:%S) $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Locate dispatcher.conf
+# ---------------------------------------------------------------------------
+resolve_dispatcher_conf() {
+  if [[ -n "${DISPATCHER_CONF:-}" ]]; then
+    echo "$DISPATCHER_CONF"
+    return 0
+  fi
+  if [[ -n "${HOME:-}" ]] && [[ -f "${HOME}/.autonomous/dispatcher.conf" ]]; then
+    echo "${HOME}/.autonomous/dispatcher.conf"
+    return 0
+  fi
+  if [[ -n "${XDG_CONFIG_HOME:-}" ]] && [[ -f "${XDG_CONFIG_HOME}/autonomous/dispatcher.conf" ]]; then
+    echo "${XDG_CONFIG_HOME}/autonomous/dispatcher.conf"
+    return 0
+  fi
+  return 1
+}
+
+CONF=$(resolve_dispatcher_conf) || {
+  echo "ERROR: dispatcher.conf not found. Set DISPATCHER_CONF or place the file at:" >&2
+  echo "  \$HOME/.autonomous/dispatcher.conf" >&2
+  echo "  \$XDG_CONFIG_HOME/autonomous/dispatcher.conf" >&2
+  echo "See dispatcher.conf.example for the schema." >&2
+  exit 1
+}
+
+if [[ ! -r "$CONF" ]]; then
+  echo "ERROR: dispatcher.conf at '$CONF' is missing or unreadable" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Load PROJECTS array
+# ---------------------------------------------------------------------------
+# Source in the current shell (we need the array to drive the loop).
+# Any leftover env from this source is fine because each per-project tick
+# runs in its own subshell with AUTONOMOUS_CONF set, which lib-config.sh
+# treats as priority-1 and re-sources the chosen autonomous.conf fresh.
+# shellcheck disable=SC1090
+source "$CONF"
+
+if ! declare -p PROJECTS &>/dev/null; then
+  echo "ERROR: dispatcher.conf at '$CONF' does not define PROJECTS array" >&2
+  echo "See dispatcher.conf.example for the schema." >&2
+  exit 1
+fi
+
+if [[ "${#PROJECTS[@]}" -eq 0 ]]; then
+  log "no projects configured in $CONF — exiting 0"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Per-project tick loop
+# ---------------------------------------------------------------------------
+# Each iteration runs dispatcher-tick.sh in a subshell (parentheses) with
+# AUTONOMOUS_CONF set to the project's conf path. The subshell's exit code
+# is captured but does NOT short-circuit the loop — one bad project must
+# not block ticks for the others.
+log "scanning ${#PROJECTS[@]} project(s) from $CONF"
+
+OK=0
+FAIL=0
+for proj_conf in "${PROJECTS[@]}"; do
+  if [[ ! -r "$proj_conf" ]]; then
+    warn "  WARN: skipping unreadable project conf: $proj_conf"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  log "  ticking project: $proj_conf"
+  if ( AUTONOMOUS_CONF="$proj_conf" bash "$SCRIPT_DIR/dispatcher-tick.sh" ); then
+    OK=$((OK + 1))
+  else
+    rc=$?
+    warn "  WARN: tick failed for $proj_conf (rc=$rc)"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+log "tick complete: $OK ok, $FAIL failed (out of ${#PROJECTS[@]} projects)"
+exit 0

--- a/skills/autonomous-dispatcher/scripts/dispatcher.conf.example
+++ b/skills/autonomous-dispatcher/scripts/dispatcher.conf.example
@@ -14,6 +14,17 @@
 # Per-project values are sourced fresh in a subshell each iteration so
 # settings cannot leak between projects.
 
+# Trust gate: dispatcher-multi-tick.sh refuses to source a `dispatcher.conf`
+# (or its parent dir) that is group/other-writable, or owned by a different
+# user, because `source` of an attacker-writable file means arbitrary code
+# execution as the dispatcher user (CWE-94). Recommended file mode: 0644
+# owned by the dispatcher user, or 0600 if the conf has secrets. Recommended
+# parent dir mode: 0755 (or 0700).
+#
+# Set AUTONOMOUS_TRUST_CONF=1 to disable the trust gate (e.g. shared dev
+# VMs where the conf is owned by a tooling uid distinct from the runtime
+# uid). Off by default — opt in only when you understand the risk.
+
 # Required: paths to per-project `autonomous.conf` files.
 # Each path is sourced in a subshell before running one tick for that
 # project. Missing paths cause that project's tick to be skipped with a

--- a/skills/autonomous-dispatcher/scripts/dispatcher.conf.example
+++ b/skills/autonomous-dispatcher/scripts/dispatcher.conf.example
@@ -1,0 +1,24 @@
+# dispatcher.conf — multi-project dispatcher configuration
+#
+# Copied to:
+#   $DISPATCHER_CONF                              (env override; takes priority)
+#   $HOME/.autonomous/dispatcher.conf             (default)
+#   $XDG_CONFIG_HOME/autonomous/dispatcher.conf   (XDG fallback)
+#
+# Read by `dispatcher-multi-tick.sh`. Each cron tick iterates PROJECTS[]
+# and runs one `dispatcher-tick.sh` per project, sourcing the project's
+# own `autonomous.conf` via the AUTONOMOUS_CONF env override (#62).
+#
+# This file does NOT replace per-project `autonomous.conf` — REPO,
+# PROJECT_ID, DISPATCHER_APP_ID, MAX_CONCURRENT, etc. all stay there.
+# Per-project values are sourced fresh in a subshell each iteration so
+# settings cannot leak between projects.
+
+# Required: paths to per-project `autonomous.conf` files.
+# Each path is sourced in a subshell before running one tick for that
+# project. Missing paths cause that project's tick to be skipped with a
+# warning — they do NOT block other projects.
+PROJECTS=(
+  "/data/git/myrepo-a/scripts/autonomous.conf"
+  "/data/git/myrepo-b/scripts/autonomous.conf"
+)

--- a/tests/unit/test-dispatcher-multi-tick.sh
+++ b/tests/unit/test-dispatcher-multi-tick.sh
@@ -50,6 +50,12 @@ assert_rc() {
 # Sandbox: copy wrapper + stub tick into a temp dir to control its lookup.
 TMPROOT=$(mktemp -d)
 trap 'rm -rf "$TMPROOT"' EXIT
+
+# /tmp is 1777 (world-writable, sticky) on every Linux distro, so the
+# wrapper's trust gate (CWE-94 mitigation) refuses to source confs under
+# it without the explicit opt-out. Tests run on /tmp because mktemp -d
+# defaults there; AUTONOMOUS_TRUST_CONF=1 disables the gate.
+export AUTONOMOUS_TRUST_CONF=1
 SANDBOX="$TMPROOT/scripts"
 mkdir -p "$SANDBOX"
 cp "$WRAPPER_SRC" "$SANDBOX/dispatcher-multi-tick.sh"
@@ -234,6 +240,35 @@ case "$(cat "$stderr_log")" in
     PASS=$((PASS + 1)) ;;
   *)
     echo -e "  ${RED}FAIL${NC}: expected 'PROJECTS array' in stderr"
+    FAIL=$((FAIL + 1)) ;;
+esac
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-MP-009: Trust gate refuses world-writable conf parent (CWE-94) ==="
+# ---------------------------------------------------------------------------
+# Q PR-78 finding: source of an attacker-writable file = arbitrary code
+# execution. Verify the trust gate fires when AUTONOMOUS_TRUST_CONF is unset
+# (default-secure). /tmp is mode 1777 → trust gate refuses → wrapper exits 1
+# with a clear stderr message.
+stderr_log="$TMPROOT/stderr-009"
+DISPATCHER_CONF="$CONF" \
+  env -u AUTONOMOUS_TRUST_CONF \
+  bash "$SANDBOX/dispatcher-multi-tick.sh" >/dev/null 2>"$stderr_log"
+rc=$?
+[ "$rc" -ne 0 ] && {
+  echo -e "  ${GREEN}PASS${NC}: trust gate rejects world-writable parent (rc=$rc)"
+  PASS=$((PASS + 1))
+} || {
+  echo -e "  ${RED}FAIL${NC}: expected non-zero rc when AUTONOMOUS_TRUST_CONF unset"
+  FAIL=$((FAIL + 1))
+}
+case "$(cat "$stderr_log")" in
+  *"insecure permissions"*|*"parent directory"*|*"not owned"*)
+    echo -e "  ${GREEN}PASS${NC}: trust-gate diagnostic in stderr"
+    PASS=$((PASS + 1)) ;;
+  *)
+    echo -e "  ${RED}FAIL${NC}: expected trust-gate diagnostic in stderr; got: $(cat "$stderr_log")"
     FAIL=$((FAIL + 1)) ;;
 esac
 

--- a/tests/unit/test-dispatcher-multi-tick.sh
+++ b/tests/unit/test-dispatcher-multi-tick.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+# test-dispatcher-multi-tick.sh — Unit tests for dispatcher-multi-tick.sh.
+#
+# Closes the test side of #62 (config-driven multi-project dispatch).
+#
+# Strategy: stub `dispatcher-tick.sh` with a recording shim that captures
+# its $AUTONOMOUS_CONF env on each invocation. The wrapper sees the stub
+# via $SCRIPT_DIR/dispatcher-tick.sh resolution, since the test runs the
+# wrapper from a sandbox copy of skills/autonomous-dispatcher/scripts/.
+#
+# Run: bash tests/unit/test-dispatcher-multi-tick.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WRAPPER_SRC="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/dispatcher-multi-tick.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected='$expected'"
+    echo "      actual=  '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_rc() {
+  local desc="$1" expected_rc="$2" actual_rc="$3"
+  if [[ "$expected_rc" == "$actual_rc" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected_rc=$expected_rc actual_rc=$actual_rc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Sandbox: copy wrapper + stub tick into a temp dir to control its lookup.
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+SANDBOX="$TMPROOT/scripts"
+mkdir -p "$SANDBOX"
+cp "$WRAPPER_SRC" "$SANDBOX/dispatcher-multi-tick.sh"
+
+# Stub dispatcher-tick.sh: appends "$AUTONOMOUS_CONF\n" to a sentinel file
+# and exits with the rc encoded in $TICK_RC_FOR_<basename of conf>.
+# Defaults to 0 if no override env is set.
+cat > "$SANDBOX/dispatcher-tick.sh" <<'EOF'
+#!/bin/bash
+echo "$AUTONOMOUS_CONF" >> "$TICK_RECORD_FILE"
+override_var="TICK_RC_FOR_$(basename "$AUTONOMOUS_CONF" | tr -c 'A-Za-z0-9' '_')"
+rc=${!override_var:-0}
+exit "$rc"
+EOF
+chmod +x "$SANDBOX/dispatcher-tick.sh"
+
+# Helper: write a dispatcher.conf with given project paths.
+write_conf() {
+  local conf="$1"; shift
+  {
+    echo 'PROJECTS=('
+    for p in "$@"; do
+      printf '  %q\n' "$p"
+    done
+    echo ')'
+  } > "$conf"
+}
+
+# ---------------------------------------------------------------------------
+echo "=== TC-MP-001: PROJECTS=() iterates the right number of times ==="
+# ---------------------------------------------------------------------------
+CONF="$TMPROOT/disp-001.conf"
+RECORD="$TMPROOT/record-001"
+: > "$RECORD"
+# Touch fake project confs so the readability check passes.
+for p in "$TMPROOT/proj-a.conf" "$TMPROOT/proj-b.conf" "$TMPROOT/proj-c.conf"; do
+  touch "$p"
+done
+write_conf "$CONF" "$TMPROOT/proj-a.conf" "$TMPROOT/proj-b.conf" "$TMPROOT/proj-c.conf"
+
+DISPATCHER_CONF="$CONF" TICK_RECORD_FILE="$RECORD" \
+  bash "$SANDBOX/dispatcher-multi-tick.sh" >/dev/null 2>&1
+rc=$?
+assert_rc "rc=0 when all projects tick cleanly" 0 "$rc"
+assert_eq "stub invoked 3 times" "3" "$(wc -l <"$RECORD" | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-MP-002: AUTONOMOUS_CONF env propagated per iteration ==="
+# ---------------------------------------------------------------------------
+expected="$TMPROOT/proj-a.conf
+$TMPROOT/proj-b.conf
+$TMPROOT/proj-c.conf"
+assert_eq "AUTONOMOUS_CONF recorded in PROJECTS order" "$expected" "$(cat "$RECORD")"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-MP-003: Per-project failure does not break the loop ==="
+# ---------------------------------------------------------------------------
+RECORD="$TMPROOT/record-003"
+: > "$RECORD"
+# Force conf-a's tick to return rc=2. Build the override env name from the
+# filename, then export it so the subshell sees it. (Inline `VAR=value cmd`
+# would require a literal var name, which we can't write here because the
+# name depends on $TMPROOT.)
+override_var="TICK_RC_FOR_$(basename "$TMPROOT/proj-a.conf" | tr -c 'A-Za-z0-9' '_')"
+export "$override_var=2"
+
+stderr_log="$TMPROOT/stderr-003"
+DISPATCHER_CONF="$CONF" TICK_RECORD_FILE="$RECORD" \
+  bash "$SANDBOX/dispatcher-multi-tick.sh" >/dev/null 2>"$stderr_log"
+unset "$override_var"
+rc=$?
+# Wrapper exits 0 even though one project failed.
+assert_rc "wrapper exits 0 despite per-project failure" 0 "$rc"
+assert_eq "all 3 projects still attempted" "3" "$(wc -l <"$RECORD" | tr -d ' ')"
+case "$(cat "$stderr_log")" in
+  *"tick failed for $TMPROOT/proj-a.conf"*)
+    echo -e "  ${GREEN}PASS${NC}: stderr names the failed project"
+    PASS=$((PASS + 1)) ;;
+  *)
+    echo -e "  ${RED}FAIL${NC}: expected 'tick failed for ${TMPROOT}/proj-a.conf' in stderr"
+    FAIL=$((FAIL + 1)) ;;
+esac
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-MP-004: DISPATCHER_CONF unset → wrapper aborts ==="
+# ---------------------------------------------------------------------------
+# Point HOME and XDG away from anything that exists.
+RECORD="$TMPROOT/record-004"
+: > "$RECORD"
+stderr_log="$TMPROOT/stderr-004"
+HOME="$TMPROOT/no-home" XDG_CONFIG_HOME="$TMPROOT/no-xdg" \
+  TICK_RECORD_FILE="$RECORD" \
+  bash "$SANDBOX/dispatcher-multi-tick.sh" >/dev/null 2>"$stderr_log"
+rc=$?
+[ "$rc" -ne 0 ] && {
+  echo -e "  ${GREEN}PASS${NC}: rc != 0 (got $rc)"
+  PASS=$((PASS + 1))
+} || {
+  echo -e "  ${RED}FAIL${NC}: expected non-zero rc"
+  FAIL=$((FAIL + 1))
+}
+case "$(cat "$stderr_log")" in
+  *"dispatcher.conf not found"*)
+    echo -e "  ${GREEN}PASS${NC}: stderr explains missing dispatcher.conf"
+    PASS=$((PASS + 1)) ;;
+  *)
+    echo -e "  ${RED}FAIL${NC}: expected 'dispatcher.conf not found' in stderr"
+    FAIL=$((FAIL + 1)) ;;
+esac
+assert_eq "no projects ticked when conf is missing" "0" "$(wc -l <"$RECORD" | tr -d ' ')"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-MP-005: DISPATCHER_CONF set but file missing → diagnostic ==="
+# ---------------------------------------------------------------------------
+stderr_log="$TMPROOT/stderr-005"
+DISPATCHER_CONF="$TMPROOT/nonexistent-conf" \
+  bash "$SANDBOX/dispatcher-multi-tick.sh" >/dev/null 2>"$stderr_log"
+rc=$?
+[ "$rc" -ne 0 ] && {
+  echo -e "  ${GREEN}PASS${NC}: rc != 0 (got $rc)"
+  PASS=$((PASS + 1))
+} || {
+  echo -e "  ${RED}FAIL${NC}: expected non-zero rc"
+  FAIL=$((FAIL + 1))
+}
+case "$(cat "$stderr_log")" in
+  *"missing or unreadable"*)
+    echo -e "  ${GREEN}PASS${NC}: stderr explains missing path"
+    PASS=$((PASS + 1)) ;;
+  *)
+    echo -e "  ${RED}FAIL${NC}: expected 'missing or unreadable' in stderr"
+    FAIL=$((FAIL + 1)) ;;
+esac
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-MP-006: Empty PROJECTS=() → exit 0 with one log line ==="
+# ---------------------------------------------------------------------------
+EMPTY_CONF="$TMPROOT/disp-empty.conf"
+echo 'PROJECTS=()' > "$EMPTY_CONF"
+RECORD="$TMPROOT/record-006"
+: > "$RECORD"
+stdout_log="$TMPROOT/stdout-006"
+DISPATCHER_CONF="$EMPTY_CONF" TICK_RECORD_FILE="$RECORD" \
+  bash "$SANDBOX/dispatcher-multi-tick.sh" >"$stdout_log" 2>&1
+rc=$?
+assert_rc "empty PROJECTS → rc=0" 0 "$rc"
+assert_eq "no projects ticked" "0" "$(wc -l <"$RECORD" | tr -d ' ')"
+case "$(cat "$stdout_log")" in
+  *"no projects configured"*)
+    echo -e "  ${GREEN}PASS${NC}: stdout has 'no projects configured' log line"
+    PASS=$((PASS + 1)) ;;
+  *)
+    echo -e "  ${RED}FAIL${NC}: expected 'no projects configured' in stdout"
+    FAIL=$((FAIL + 1)) ;;
+esac
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-MP-007: PROJECTS unset → diagnostic ==="
+# ---------------------------------------------------------------------------
+NO_ARRAY_CONF="$TMPROOT/disp-no-array.conf"
+echo 'OTHER_VAR=42' > "$NO_ARRAY_CONF"
+stderr_log="$TMPROOT/stderr-007"
+DISPATCHER_CONF="$NO_ARRAY_CONF" \
+  bash "$SANDBOX/dispatcher-multi-tick.sh" >/dev/null 2>"$stderr_log"
+rc=$?
+[ "$rc" -ne 0 ] && {
+  echo -e "  ${GREEN}PASS${NC}: rc != 0 (got $rc)"
+  PASS=$((PASS + 1))
+} || {
+  echo -e "  ${RED}FAIL${NC}: expected non-zero rc"
+  FAIL=$((FAIL + 1))
+}
+case "$(cat "$stderr_log")" in
+  *"PROJECTS array"*)
+    echo -e "  ${GREEN}PASS${NC}: stderr names PROJECTS"
+    PASS=$((PASS + 1)) ;;
+  *)
+    echo -e "  ${RED}FAIL${NC}: expected 'PROJECTS array' in stderr"
+    FAIL=$((FAIL + 1)) ;;
+esac
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-MP-008: Source-of-truth check on outer loop subshell ==="
+# ---------------------------------------------------------------------------
+# The loop body must run dispatcher-tick.sh in a subshell (parentheses),
+# pass AUTONOMOUS_CONF as a per-iteration env, and not exit on per-project
+# failure. Detect drift via grep.
+if grep -q '^\s*if ( AUTONOMOUS_CONF=' "$WRAPPER_SRC" \
+   && grep -q 'bash "\$SCRIPT_DIR/dispatcher-tick.sh"' "$WRAPPER_SRC"; then
+  echo -e "  ${GREEN}PASS${NC}: loop runs dispatcher-tick.sh in subshell with AUTONOMOUS_CONF env"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: outer loop subshell pattern missing or changed shape"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Addresses axes 1 and 3 of issue #62 (config-driven project registry + per-project GitHub App auth). The pluggable execution backend axis (axis 2 — `EXECUTION_BACKEND=local|ssm`) is deferred to a follow-up PR; this issue stays open until that lands.

New `dispatcher-multi-tick.sh` is a thin outer wrapper around the unmodified `dispatcher-tick.sh`. Each cron tick iterates a `PROJECTS=()` array from a separate `dispatcher.conf` file and runs one tick per project, with each project's `autonomous.conf` sourced fresh in a subshell via the `AUTONOMOUS_CONF` priority-1 path that `lib-config.sh::load_autonomous_conf` already supports (introduced in PR-4).

Refs #62 (axes 1 + 3 only — issue stays open for axis 2)

## Behavior

- **Backwards compat**: `dispatcher-tick.sh` is unmodified. Single-project deployments continue to invoke it directly. Multi-project is opt-in via `DISPATCHER_CONF` env or default lookups (`$HOME/.autonomous/dispatcher.conf`, `$XDG_CONFIG_HOME/autonomous/dispatcher.conf`).
- **Per-project failure isolation**: one bad `autonomous.conf` cannot stall other projects. Each iteration runs in a subshell; failures are logged to stderr but the loop continues.
- **No global concurrency**: each project's tick checks its own `MAX_CONCURRENT` against its own `REPO`'s active labels. Operators wanting a global cap can compose with per-project limits.
- **No state leakage**: subshell isolation guarantees `REPO`, `PROJECT_ID`, `MAX_CONCURRENT`, `GH_TOKEN`, etc. cannot bleed between projects.
- **Trust gate** (added after Q review): refuses to source `dispatcher.conf` if file or parent dir is group/other-writable, or if the file is not owned by current uid (CWE-94 mitigation, sudo/ssh-style). Override via `AUTONOMOUS_TRUST_CONF=1`.

## Tests

`tests/unit/test-dispatcher-multi-tick.sh` (19 cases) — uses a stub `dispatcher-tick.sh` that records `$AUTONOMOUS_CONF` per invocation:

- TC-MP-001/002: PROJECTS array iterated in order, env propagated correctly
- TC-MP-003: per-project failure → wrapper still exits 0, stderr names the failed project
- TC-MP-004: `DISPATCHER_CONF` unset (and no default-location file) → wrapper aborts non-zero
- TC-MP-005: `DISPATCHER_CONF` set but file missing → diagnostic
- TC-MP-006: empty `PROJECTS=()` → exit 0 with single log line
- TC-MP-007: `dispatcher.conf` missing the `PROJECTS` array entirely → diagnostic
- TC-MP-008: source-of-truth grep against the wrapper to detect drift in the subshell pattern
- TC-MP-009: trust gate refuses world-writable conf parent (CWE-94)

All 21 unit-test files pass.

## Pipeline docs

- `docs/pipeline/dispatcher-flow.md`: new "Multi-project outer loop" section before the per-project step descriptions; explicitly notes the no-shared-state design.
- `skills/autonomous-dispatcher/SKILL.md`: documents both single-project and multi-project cron commands side-by-side.
- `docs/designs/multi-project-dispatcher.md`: design canvas covering the schema decision, the trust gate, and what's deferred.

## Test plan

- [x] `bash tests/unit/*.sh` — all 21 test files green
- [x] `bash -n` syntax check on `dispatcher-multi-tick.sh`
- [x] `shellcheck` clean on the new wrapper
- [x] code-reviewer agent: ship it (no findings >= 80 confidence)
- [x] Q review: addressed CWE-94 source-of-conf finding with real trust gate
- [x] backwards-compat verified — `dispatcher-tick.sh` byte-identical to main

## Follow-up (separate PR)

Axis 2 of #62: pluggable `EXECUTION_BACKEND=local|ssm` routing in `dispatch-local.sh` (rename to `dispatch.sh`?) plus a brand-new `dispatch-ssm.sh` driver for AWS Systems Manager. Larger surface; needs its own design canvas. **Issue #62 stays open after this PR merges**, to be closed by the follow-up.