### PR TITLE
feat(dispatcher): pluggable execution backend (local | remote-aws-ssm)

### DIFF
--- a/docs/designs/exec-backend-routing.md
+++ b/docs/designs/exec-backend-routing.md
@@ -1,0 +1,305 @@
+# Design Canvas — Pluggable Execution Backend (PR-9)
+
+**Branch**: `feat/exec-backend-routing`
+**Closes**: #62 (axis 2 — final axis after PR-8 covered axes 1+3).
+**Pipeline-docs touched**: `docs/pipeline/dispatcher-flow.md` (routing layer + remote-DEAD-branch caveat).
+
+---
+
+## Deployment topology
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│  dispatcher box (one machine, one cron)                                  │
+│                                                                          │
+│  $HOME/.autonomous/dispatcher.conf  declares all projects:               │
+│    - some are LOCAL  (autonomous.conf path on disk here)                 │
+│    - some are REMOTE (inline metadata + SSM_INSTANCE_ID)                 │
+│                                                                          │
+│  cron tick → dispatcher-multi-tick.sh                                    │
+│    │                                                                     │
+│    ├─→ tick(local-project)   sources autonomous.conf, calls              │
+│    │                          dispatch-local.sh on this box              │
+│    │                                                                     │
+│    ├─→ tick(remote-project)  loads inline metadata, calls                │
+│    │                          dispatch-remote-aws-ssm.sh ───────┐        │
+│    │                                                            │        │
+│    └─→ tick(another-remote)  loads inline metadata, calls       │        │
+│                               dispatch-remote-aws-ssm.sh ──┐    │        │
+└────────────────────────────────────────────────────────────┼────┼────────┘
+                                                             │    │
+              aws ssm send-command (fire-and-forget per task)│    │
+                                                             ▼    ▼
+                                              ┌──────────────────────┐
+                                              │ remote dev box       │
+                                              │ (per-project EC2)    │
+                                              │                      │
+                                              │ has its own copy of  │
+                                              │ PROJECT_DIR/scripts/ │
+                                              │   autonomous.conf    │
+                                              │                      │
+                                              │ runs dispatch-       │
+                                              │   local.sh + the     │
+                                              │   wrapper + the      │
+                                              │   agent CLI          │
+                                              └──────────────────────┘
+```
+
+Critical fact: **the dispatcher box does NOT have any per-project `autonomous.conf` for remote projects.** It only knows what `dispatcher.conf` tells it (REPO, SSM_INSTANCE_ID, etc). The remote dev box has its own `autonomous.conf` that's used by the wrapper after SSM kicks off `dispatch-local.sh`.
+
+This is why PR-8's "every project has an autonomous.conf path" pattern doesn't fit — that pattern assumes co-location of dispatcher and project source. Real deployment is mixed.
+
+## What dispatcher needs to know per project
+
+The dispatcher's per-project tick uses `lib-dispatch.sh` to:
+
+- list issues with the right labels (`gh issue list --repo "$REPO"`)
+- fetch PR state (`gh pr list --repo "$REPO"`)
+- update labels (`gh issue edit --repo "$REPO"`)
+- comment on issues (`gh issue comment --repo "$REPO"`)
+- check process liveness (PID file at known path, `kill -0`)
+- spawn dev/review wrappers (via the dispatch backend)
+
+The variables `lib-dispatch.sh` reads via `: "${VAR:?...}"`:
+
+- `REPO`, `REPO_OWNER`, `PROJECT_ID`
+- `MAX_RETRIES` (default 3), `MAX_CONCURRENT` (default 5)
+
+Plus the GitHub App auth (read by the cron prompt before sourcing lib-dispatch):
+
+- `DISPATCHER_APP_ID`, `DISPATCHER_APP_PEM` (when GH_AUTH_MODE=app)
+
+Everything else (`PROJECT_DIR`, `AGENT_CMD`, `AGENT_TIMEOUT`, etc.) is consumed by the wrapper, which reads its OWN local `autonomous.conf` after SSM puts it on the right box.
+
+## Schema: dispatcher.conf
+
+Two flavors of project entry coexist in the same `PROJECTS` array:
+
+```bash
+# dispatcher.conf
+
+# Mix and match:
+PROJECTS=()
+
+# === LOCAL project: traditional path (PR-8 backwards compat) ===
+# Format: a string ending in "autonomous.conf" — multi-tick treats as a
+# file path and sources it. The autonomous.conf provides REPO etc.
+PROJECTS+=( "/data/git/myrepo-local/scripts/autonomous.conf" )
+
+# === REMOTE project: inline metadata block ===
+# Format: a multi-line string of bash assignments. Multi-tick detects the
+# newline + bash-statement shape and eval's it inside a subshell.
+# REPO and PROJECT_ID are required; everything else has defaults.
+PROJECTS+=( '
+PROJECT_ID=projB
+REPO=myorg/projB                 # REPO_OWNER + REPO_NAME auto-derived
+EXECUTION_BACKEND=remote-aws-ssm
+SSM_INSTANCE_ID=i-0abc1234567890def
+SSM_REGION=ap-southeast-1
+SSM_REMOTE_USER=ubuntu
+SSM_REMOTE_SHELL=bash
+SSM_REMOTE_PROFILE=
+SSM_REMOTE_PROJECT_DIR=/data/git/projB
+SSM_REMOTE_PROJECT_ID=projB
+DISPATCHER_APP_ID=3013418
+DISPATCHER_APP_PEM=/data/auth/projB.pem
+GH_AUTH_MODE=app
+' )
+
+PROJECTS+=( '
+PROJECT_ID=projC
+REPO=myorg/projC                 # REPO_OWNER + REPO_NAME auto-derived
+EXECUTION_BACKEND=remote-aws-ssm
+SSM_INSTANCE_ID=i-0def4567890abc123
+SSM_REMOTE_PROJECT_DIR=/data/git/projC
+SSM_REMOTE_PROJECT_ID=projC
+DISPATCHER_APP_ID=3013418
+DISPATCHER_APP_PEM=/data/auth/projC.pem
+' )
+```
+
+### Why a multi-line string and not a sub-array
+
+Bash arrays don't nest. A multi-line string is the closest readable approximation. The conf file remains a single bash file (no separate sidecar conf files to track) — operators add a new project by appending one block.
+
+### Detection rule
+
+`dispatcher-multi-tick.sh` decides per element:
+
+- contains a `/` and exists as a regular file → **local**: `source "$entry"`
+- otherwise → **remote**: treat as inline bash, validate, then `eval` inside the per-project subshell
+
+### REPO_OWNER / REPO_NAME auto-derivation
+
+`lib-dispatch.sh` requires `REPO`, `REPO_OWNER`, and `REPO_NAME` separately (App-token scoping reads owner+name independently). In the local-project case, the operator's own `autonomous.conf` declares all three (matches PR-8 / `autonomous.conf.example`).
+
+In the remote-project inline-metadata case, the operator only writes `REPO=owner/name` — the multi-tick wrapper auto-derives the missing two before invoking `dispatcher-tick.sh`:
+
+```bash
+: "${REPO_OWNER:=${REPO%%/*}}"
+: "${REPO_NAME:=${REPO##*/}}"
+```
+
+This trims one common copy-paste error (rename in only one of three places). Local entries keep the historical "write all three" pattern unchanged for backwards compat.
+
+## Routing in dispatcher-tick.sh
+
+After `load_autonomous_conf` returns (or after the multi-tick wrapper has sourced/eval'd the project's metadata into the subshell env), `dispatcher-tick.sh` defines a thin `dispatch()` helper:
+
+```bash
+dispatch() {
+  case "${EXECUTION_BACKEND:-local}" in
+    local)
+      bash "$PROJECT_DIR/scripts/dispatch-local.sh" "$@"
+      ;;
+    remote-aws-ssm)
+      bash "$SCRIPT_DIR/dispatch-remote-aws-ssm.sh" "$@"
+      ;;
+    *)
+      log "  ERROR: unknown EXECUTION_BACKEND='$EXECUTION_BACKEND' — skipping"
+      return 1
+      ;;
+  esac
+}
+```
+
+Steps 2/3/4 each replace their inline `bash "$PROJECT_DIR/scripts/dispatch-local.sh" ...` with `dispatch ...`. **`dispatch-local.sh` location and behavior unchanged** — backwards compat.
+
+## dispatcher-multi-tick.sh changes
+
+Two changes to the existing PR-8 multi-tick wrapper:
+
+1. **Iteration shape**: each `PROJECTS[i]` is now either a path or an inline bash block. The loop body decides per element:
+
+   ```bash
+   for entry in "${PROJECTS[@]}"; do
+     if [[ "$entry" == *"/"* && -f "$entry" ]]; then
+       # local project: PR-8 behavior, set AUTONOMOUS_CONF env override
+       ( AUTONOMOUS_CONF="$entry" bash "$SCRIPT_DIR/dispatcher-tick.sh" )
+     else
+       # remote project: validate and eval inline metadata in subshell
+       _dispatch_remote_project "$entry"
+     fi
+   done
+   ```
+
+2. **Inline-block validator**: before `eval`, check the block contains only `KEY=VALUE` lines (allow comments, allow blank lines). Reject anything that looks like a command. This isn't sandbox-grade — `dispatcher.conf` is already trusted by PR-8's trust gate — but it catches accidental injection of shell commands by an operator who copy-pasted poorly.
+
+3. **Required-field check**: after eval, assert `REPO` and `PROJECT_ID` are set; warn-and-skip otherwise (don't blow up the whole loop for one bad entry).
+
+The trust gate from PR-8 (refuses g+w / o+w `dispatcher.conf` parent dir) extends naturally — the same source of truth. No new trust check needed.
+
+## dispatch-remote-aws-ssm.sh
+
+Derived from the user's existing private implementation. Generalizations for upstream:
+
+| Original | Upstream | Why |
+|---|---|---|
+| `PROJECT_DIR="${DISPATCH_PROJECT_DIR:-/data/git/VidSyllabus}"` | required (no default) | Don't bake private repo path |
+| `PROJECT_ID="${DISPATCH_PROJECT_ID:-vidsyllabus}"` | required (no default) | Same |
+| `sudo -u ubuntu zsh -li -c '<cmd>'` | `sudo -u ${SSM_REMOTE_USER:-ubuntu} ${SSM_REMOTE_SHELL:-bash} -l -c '<cmd>'` | Per-project shell choice |
+| `source /home/ubuntu/.bash_aliases; <cmd>` | If `SSM_REMOTE_PROFILE` non-empty: prepend `source $SSM_REMOTE_PROFILE; ` | Optional |
+
+The `dispatch-remote-aws-ssm.sh` reads its inputs from the env exported by the dispatcher tick:
+
+- `SSM_REMOTE_PROJECT_DIR` — absolute path on the remote box where the project lives
+- `SSM_REMOTE_PROJECT_ID` — project id used in the remote PID/log path
+- `SSM_INSTANCE_ID` — EC2 instance ID
+- `SSM_REGION` — default `ap-southeast-1`
+- `SSM_REMOTE_USER` (default `ubuntu`)
+- `SSM_REMOTE_SHELL` (default `bash`)
+- `SSM_REMOTE_PROFILE` (default empty, no profile load)
+
+It builds the remote command:
+
+```bash
+INNER_CMD="${SSM_REMOTE_PROFILE:+source $SSM_REMOTE_PROFILE;} \
+  PROJECT_DIR=$SSM_REMOTE_PROJECT_DIR PROJECT_ID=$SSM_REMOTE_PROJECT_ID \
+  bash $SSM_REMOTE_PROJECT_DIR/scripts/dispatch-local.sh dev-new $ISSUE_NUM"
+
+FULL_CMD="sudo -u $SSM_REMOTE_USER $SSM_REMOTE_SHELL -l -c '$INNER_CMD'"
+
+# JSON-safe via jq --arg (no shell-injection regression)
+COMMANDS_JSON=$(jq -n --arg cmd "$FULL_CMD" '[$cmd]')
+
+aws ssm send-command \
+  --instance-ids "$SSM_INSTANCE_ID" \
+  --document-name "AWS-RunShellScript" \
+  --region "${SSM_REGION:-ap-southeast-1}" \
+  --parameters "{\"commands\": $COMMANDS_JSON}"
+```
+
+`set -euo pipefail` + dependency check (`aws`, `jq`) + input validation (issue/session/project ids) preserved verbatim from the seed.
+
+## PID file: dispatcher-side `kill -0` is always false (remote case)
+
+Hard architectural fact: `lib-dispatch.sh::pid_alive` does `kill -0 $(cat $PID_FILE)` against `${XDG_RUNTIME_DIR}/autonomous-${PROJECT_ID}/issue-N.pid` (PR-7 path). For a remote project, the PID file is on the remote dev box, not on the dispatcher box. The dispatcher's `kill -0` always fails → the dispatcher always sees DEAD.
+
+Effects on Step 5 (stale detection):
+
+- **Step 5a (ALIVE + PR ready, idle 5min, CI green) is unreachable** for remote projects — the dispatcher never sees ALIVE. Remote projects lose the proactive "SIGTERM when PR-ready" optimization. Review delay grows from "next tick after CI passes" to "next tick after the wrapper exits naturally." In practice this is ~the same — by the time CI passes the wrapper is mostly done — but the difference is observable for long auxiliary work.
+- **Step 5b DEAD-branch is the *only* path** for remote tasks. Each tick treats all active remote issues as DEAD. Step 5b reads PR state and decides:
+  - DEAD + new commits since last review → `pending-review` (correct)
+  - DEAD + no new commits → `pending-dev` (correct)
+  - DEAD + no PR → `pending-dev` (correct)
+- **Wrapper-side wall-clock timeout (PR-6, default 4h) bounds the worst case**.
+
+This is acceptable. Adding a real remote-alive check (per-tick `aws ssm send-command kill -0 $PID`) would 2-3x the SSM call volume and add latency; not worth doing speculatively.
+
+The DEAD-branch correctness depends only on labeled-state-plus-PR-state ([INV-04], [INV-06], [INV-07]) — none of those need an accurate `pid_alive`.
+
+## Backwards compat
+
+- `dispatcher-tick.sh` standalone (no multi-tick wrapper, no `EXECUTION_BACKEND`) → identical to today's behavior. Existing single-machine deployments need zero changes.
+- PR-8's local-project entry shape (path string ending in `autonomous.conf`) keeps working in `dispatcher-multi-tick.sh`.
+- `dispatch-local.sh` byte-identical.
+
+## Tests
+
+`tests/unit/test-dispatch-remote-aws-ssm.sh`:
+
+1. Required env validation: `SSM_INSTANCE_ID` / `SSM_REMOTE_PROJECT_DIR` / `SSM_REMOTE_PROJECT_ID` missing → rc=1 with diagnostic.
+2. Input validation: bad issue / session / project ids → rc=1.
+3. `SSM_REMOTE_PROFILE` empty → no `source` prefix; non-empty → prefix added.
+4. Constructed `INNER_CMD` shape verified by stubbing `aws` and capturing argv.
+5. Stubbed `aws` returns failure → script propagates rc=1.
+6. Source-of-truth grep: `jq -n --arg cmd` (not literal interpolation) — guards shell-injection.
+7. `SSM_REMOTE_USER` / `SSM_REMOTE_SHELL` defaults work; overrides honored.
+
+`tests/unit/test-dispatcher-tick-router.sh`:
+
+1. `EXECUTION_BACKEND=local` (or unset) → calls `dispatch-local.sh`.
+2. `EXECUTION_BACKEND=remote-aws-ssm` → calls `dispatch-remote-aws-ssm.sh`.
+3. `EXECUTION_BACKEND=bogus` → log diagnostic + return 1 (no spawn).
+4. Source-of-truth: tick script defines `dispatch()` and step bodies use it (not direct `bash dispatch-local.sh`).
+
+`tests/unit/test-multi-tick-inline-projects.sh`:
+
+1. PROJECTS array with mix of file path + inline block: each handled correctly.
+2. Inline block missing REPO → warn-and-skip; sibling projects still tick.
+3. Inline block contains a non-assignment line (`rm -rf /`) → rejected before eval.
+4. Inline block correctly populates `EXECUTION_BACKEND` etc. for the subshell.
+
+## What's explicitly out of scope
+
+- Per-tick remote `kill -0` over SSM. Add later only if DEAD-branch turns out to mishandle something in production.
+- Other remote backends (`remote-k8s`, `remote-gha-runner`). The router pattern accepts them with no schema changes.
+- Renaming `dispatch-local.sh` or moving things — keep the existing layout for zero migration burden.
+- Cross-project shared concurrency cap. Per-project remains the model.
+
+## Files touched
+
+New:
+- `skills/autonomous-dispatcher/scripts/dispatch-remote-aws-ssm.sh`
+- `tests/unit/test-dispatch-remote-aws-ssm.sh`
+- `tests/unit/test-dispatcher-tick-router.sh`
+- `tests/unit/test-multi-tick-inline-projects.sh`
+- `docs/designs/exec-backend-routing.md` (this file)
+- `docs/test-cases/exec-backend-routing.md`
+
+Modified:
+- `skills/autonomous-dispatcher/scripts/dispatcher-tick.sh` (3 callsites → `dispatch` helper)
+- `skills/autonomous-dispatcher/scripts/dispatcher-multi-tick.sh` (inline-block detection + eval path)
+- `skills/autonomous-dispatcher/scripts/dispatcher.conf.example` (mixed local + remote example)
+- `skills/autonomous-dispatcher/SKILL.md` (backend selection + remote topology note)
+- `docs/pipeline/dispatcher-flow.md` (routing layer + DEAD-branch caveat for remote)

--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -6,11 +6,37 @@ The behavior described here is implemented by `skills/autonomous-dispatcher/scri
 
 ## Multi-project outer loop (PR-8, #62)
 
-For deployments that scan more than one repository per cron, `dispatcher-multi-tick.sh` wraps `dispatcher-tick.sh` in an outer iteration over a `PROJECTS=()` array declared in a separate `dispatcher.conf` file. Each iteration sets `AUTONOMOUS_CONF` to a per-project path and runs `dispatcher-tick.sh` in a subshell, so per-project state cannot leak between iterations.
+For deployments that scan more than one repository per cron, `dispatcher-multi-tick.sh` wraps `dispatcher-tick.sh` in an outer iteration over a `PROJECTS=()` array declared in a separate `dispatcher.conf` file. Each iteration runs `dispatcher-tick.sh` in a subshell, so per-project state cannot leak between iterations.
 
-The outer loop intentionally does NOT carry shared state (no global concurrency cap, no cross-project JUST_DISPATCHED). Each project's tick is independent — concurrency is enforced per-project against that project's `MAX_CONCURRENT`. This keeps the multi-project layer minimal: just a `for` loop over `bash -c '... dispatcher-tick.sh'`. Per-project failures are logged but do not abort sibling projects.
+Each `PROJECTS[]` entry is one of two shapes (PR-9, #62 axis 2):
 
-The rest of this document describes the per-project tick in isolation; everything below applies whether `dispatcher-tick.sh` is invoked directly (single-project) or by the multi-tick wrapper (one of N projects).
+- **Local project — file path**: a path to a per-project `autonomous.conf` on this dispatcher box. The wrapper sources it via the `AUTONOMOUS_CONF` priority-1 path. Used when the dispatcher and project source live on the same machine.
+- **Remote project — inline metadata block**: a multi-line string of bash assignments (REPO, EXECUTION_BACKEND=remote-aws-ssm, SSM_INSTANCE_ID, SSM_REMOTE_PROJECT_DIR, etc.). Used when the project source lives on a remote dev EC2 — the dispatcher box does NOT have the project's `autonomous.conf`. The wrapper validates the block (KEY=VALUE lines only — defense-in-depth against accidental injection), eval's it in the subshell, and auto-derives `REPO_OWNER`/`REPO_NAME` from `REPO`.
+
+The outer loop intentionally does NOT carry shared state (no global concurrency cap, no cross-project JUST_DISPATCHED). Each project's tick is independent — concurrency is enforced per-project against that project's `MAX_CONCURRENT`. Per-project failures are logged but do not abort sibling projects.
+
+## Backend routing (PR-9, #62 axis 2)
+
+`dispatcher-tick.sh` defines a `dispatch()` helper that routes wrapper-spawn requests by `EXECUTION_BACKEND`:
+
+| Backend | Driver script | What happens |
+|---|---|---|
+| `local` (default) | `scripts/dispatch-local.sh` (in `$PROJECT_DIR/scripts/`) | Same as PR-8 single-machine flow: nohup-spawn the wrapper on this box. |
+| `remote-aws-ssm` | `scripts/dispatch-remote-aws-ssm.sh` (in the skill scripts dir) | Build a `sudo -u $SSM_REMOTE_USER $SSM_REMOTE_SHELL -l -c '<inner>'` command, JSON-escape via `jq -n --arg cmd`, and `aws ssm send-command` to `$SSM_INSTANCE_ID`. The inner command runs `dispatch-local.sh` on the remote box. SSM is purely transport — PID/process management still belongs to `dispatch-local.sh` on whatever box runs it. |
+| anything else | — | Logged as ERROR; that step skips the dispatch (issue stays in its current label state). Step 5b will re-evaluate next tick. |
+
+The rest of this document describes the per-project tick in isolation; everything below applies whether `dispatcher-tick.sh` is invoked directly (single-project), by the multi-tick wrapper (one of N projects), and whether the dispatch goes via `local` or `remote-aws-ssm`.
+
+### Caveat: remote backend + PID liveness
+
+`lib-dispatch.sh::pid_alive` does `kill -0 $(cat $PID_FILE)` against `${XDG_RUNTIME_DIR}/autonomous-${PROJECT_ID}/issue-N.pid` ([INV-01]). For a remote project, the PID file is on the remote dev box, not on the dispatcher box. The dispatcher's `kill -0` always fails → all remote projects appear DEAD to the dispatcher.
+
+Effects on Step 5:
+
+- **Step 5a (ALIVE + PR ready) is unreachable for remote projects.** The proactive "SIGTERM-when-PR-ready" optimization doesn't fire; review delay grows from "next tick after CI passes" to "next tick after the wrapper exits naturally."
+- **Step 5b DEAD-branch is the only path.** Each tick treats every active remote issue as DEAD and routes via the PR-state machine ([INV-04], [INV-06], [INV-07]). The wall-clock timeout in `lib-agent.sh::run_agent` ([INV-13], default 4h) bounds the worst case.
+
+This is acceptable for this PR's surface area. A real remote-alive check (per-tick `aws ssm send-command kill -0 $PID`) would 2-3x the SSM call volume; not worth doing speculatively.
 
 ## Tick lifecycle
 

--- a/docs/test-cases/exec-backend-routing.md
+++ b/docs/test-cases/exec-backend-routing.md
@@ -1,0 +1,115 @@
+# Test Cases — Pluggable Execution Backend (PR-9)
+
+## TC-EB-001: dispatch() routes to local backend (default)
+
+**Given** `EXECUTION_BACKEND` unset (or `=local`) and a stubbed `dispatch-local.sh` that records argv
+**When** `dispatch dev-new 99` is called from `dispatcher-tick.sh`
+**Then** the stub recorded `dev-new 99` and the remote driver was NOT invoked.
+
+## TC-EB-002: dispatch() routes to remote-aws-ssm backend
+
+**Given** `EXECUTION_BACKEND=remote-aws-ssm` and a stubbed `dispatch-remote-aws-ssm.sh` that records argv
+**When** `dispatch dev-new 99` is called
+**Then** the stub recorded `dev-new 99` and `dispatch-local.sh` was NOT invoked.
+
+## TC-EB-003: dispatch() rejects unknown backend
+
+**Given** `EXECUTION_BACKEND=bogus`
+**When** `dispatch dev-new 99` is called
+**Then** rc != 0, stderr names the bad value, no driver was invoked.
+
+## TC-EB-004: dispatcher-tick.sh source-of-truth uses dispatch()
+
+**Given** the source of `dispatcher-tick.sh`
+**When** grepping for direct `bash .../dispatch-local.sh` invocations in step 2/3/4 bodies
+**Then** none found — all dispatching goes through the `dispatch()` helper.
+
+## TC-EB-005: dispatch-remote-aws-ssm.sh requires SSM_INSTANCE_ID
+
+**Given** required env var `SSM_INSTANCE_ID` unset
+**When** `dispatch-remote-aws-ssm.sh dev-new 99` runs
+**Then** rc != 0, stderr explains the missing var, `aws` was NOT called.
+
+## TC-EB-006: dispatch-remote-aws-ssm.sh requires SSM_REMOTE_PROJECT_DIR / _PROJECT_ID
+
+**Given** SSM_INSTANCE_ID set, but SSM_REMOTE_PROJECT_DIR or SSM_REMOTE_PROJECT_ID unset
+**When** the script runs
+**Then** rc != 0, stderr names the missing var.
+
+## TC-EB-007: dispatch-remote-aws-ssm.sh validates issue number / session id / project id
+
+**Given** issue=`abc` (non-numeric) or session=`bad;chars` or project_id=`with/slash`
+**When** the script runs
+**Then** rc != 0, validation diagnostic in stderr.
+
+## TC-EB-008: dispatch-remote-aws-ssm.sh defaults
+
+**Given** SSM_REMOTE_USER, SSM_REMOTE_SHELL unset (and SSM_REGION unset, SSM_REMOTE_PROFILE empty)
+**When** the script builds INNER_CMD (verified by stubbing aws)
+**Then** SSM_REMOTE_USER defaults to `ubuntu`, SSM_REMOTE_SHELL to `bash`, SSM_REGION to `ap-southeast-1`, no `source $PROFILE` prefix.
+
+## TC-EB-009: dispatch-remote-aws-ssm.sh honors SSM_REMOTE_PROFILE
+
+**Given** SSM_REMOTE_PROFILE=`/home/ubuntu/.bash_aliases`
+**When** the script builds INNER_CMD
+**Then** the constructed command starts with `source /home/ubuntu/.bash_aliases; `.
+
+## TC-EB-010: dispatch-remote-aws-ssm.sh uses jq --arg for JSON escaping (CWE-78)
+
+**Given** the source of `dispatch-remote-aws-ssm.sh`
+**When** grepping for the SSM `--parameters` construction
+**Then** the command JSON is built via `jq -n --arg cmd ... '[$cmd]'`, NOT via literal string interpolation.
+
+## TC-EB-011: dispatch-remote-aws-ssm.sh propagates aws failure
+
+**Given** stubbed `aws` returning rc=2
+**When** the script runs
+**Then** rc != 0, stderr explains the failure with instance/region context.
+
+## TC-EB-012: dispatch-remote-aws-ssm.sh requires aws + jq on PATH
+
+**Given** `aws` (or `jq`) removed from PATH via `env -u`
+**When** the script runs
+**Then** rc != 0, stderr names the missing dependency.
+
+## TC-EB-013: multi-tick handles inline-block project
+
+**Given** dispatcher.conf with `PROJECTS+=( '<inline block with REPO=...>' )`
+**When** multi-tick runs
+**Then** it eval's the block in a subshell, exports the vars, and invokes dispatcher-tick.sh with the right env (REPO, EXECUTION_BACKEND, SSM_INSTANCE_ID propagated; REPO_OWNER/REPO_NAME auto-derived).
+
+## TC-EB-014: multi-tick auto-derives REPO_OWNER and REPO_NAME
+
+**Given** inline block contains only `REPO=myorg/projB` (no REPO_OWNER, no REPO_NAME)
+**When** multi-tick processes it
+**Then** the subshell has `REPO_OWNER=myorg` and `REPO_NAME=projB`.
+
+## TC-EB-015: multi-tick rejects inline block with non-assignment line
+
+**Given** inline block contains `rm -rf /` mixed with valid assignments
+**When** multi-tick processes it
+**Then** the block is rejected before eval, warning logged, sibling projects continue.
+
+## TC-EB-016: multi-tick warns and skips inline block missing REPO
+
+**Given** inline block has PROJECT_ID but no REPO
+**When** multi-tick processes it
+**Then** that project is skipped with a clear warning, rc=0 overall.
+
+## TC-EB-017: multi-tick mixed local + remote projects
+
+**Given** PROJECTS containing one path entry (existing local project) and one inline block (remote project)
+**When** multi-tick runs
+**Then** both projects' ticks are attempted; local goes via source-autonomous.conf path, remote goes via inline-eval path; per-project failure isolation preserved.
+
+## TC-EB-018: backwards compat — dispatcher-tick.sh standalone unchanged
+
+**Given** the existing PR-8 single-project entry (path string in PROJECTS)
+**When** multi-tick processes it
+**Then** behavior is byte-identical to PR-8: source autonomous.conf via AUTONOMOUS_CONF env override, run dispatcher-tick.sh in subshell, exit code captured.
+
+## TC-EB-019: source-of-truth — dispatch-local.sh byte-identical
+
+**Given** main branch's dispatch-local.sh and PR-9's dispatch-local.sh
+**When** diffed
+**Then** zero changes. Backwards compat is structural.

--- a/skills/autonomous-dispatcher/SKILL.md
+++ b/skills/autonomous-dispatcher/SKILL.md
@@ -33,7 +33,12 @@ DISPATCHER_CONF="$HOME/.autonomous/dispatcher.conf" \
   bash "$PROJECT_DIR/scripts/dispatcher-multi-tick.sh"
 ```
 
-The multi-tick wrapper iterates `PROJECTS=()` from `dispatcher.conf` and runs one `dispatcher-tick.sh` per project, with each project's `autonomous.conf` sourced in a subshell via the `AUTONOMOUS_CONF` env override. Per-project failures are logged to stderr but do not stall other projects. See `scripts/dispatcher.conf.example` for the schema.
+The multi-tick wrapper iterates `PROJECTS=()` from `dispatcher.conf` and runs one `dispatcher-tick.sh` per project. Per-project failures are logged to stderr but do not stall other projects. See `scripts/dispatcher.conf.example` for the schema.
+
+Each `PROJECTS[]` entry is one of two shapes:
+
+- **Local project** (file path): a path to a per-project `autonomous.conf` on this dispatcher box. The dispatcher and the project source live on the same machine. The wrapper sources the conf via the `AUTONOMOUS_CONF` priority-1 path (PR-4 / [INV-14]).
+- **Remote project** (inline metadata block): used when the project source lives on a remote dev box reached via AWS SSM. The dispatcher box does NOT have the project's `autonomous.conf` — everything the dispatcher needs to scan issues + dispatch is declared inline in `dispatcher.conf`. `EXECUTION_BACKEND=remote-aws-ssm` and `SSM_INSTANCE_ID` route the actual `dispatch-local.sh` invocation to the remote box via `aws ssm send-command`. (#62)
 
 Either form runs the same 5-step tick:
 
@@ -58,15 +63,24 @@ export GH_TOKEN
 
 The token is valid for 1 hour and scoped to the target repo only. `dispatcher-tick.sh` typically completes in well under a minute, so a single token covers the whole tick.
 
-## Local Dispatch Helper
+## Dispatch Helpers
 
-`dispatcher-tick.sh` invokes `scripts/dispatch-local.sh` for each task type. **Do NOT spawn agent processes any other way.** The helper handles `nohup`, input validation (numeric issue numbers, safe session IDs), pre-creating log files at mode 0600 (agent output may contain secrets), and killing stale wrappers before spawning new ones (see [INV-09](../../docs/pipeline/invariants.md#inv-09-just_dispatched-skip-rule), `dispatch-local.sh::kill_stale_wrapper`).
+`dispatcher-tick.sh` calls a `dispatch()` helper for each task type, which routes to the configured execution backend. **Do NOT spawn agent processes any other way.** Each backend handles `nohup`, input validation, log-file mode 0600, and stale-wrapper kill ([INV-09](../../docs/pipeline/invariants.md#inv-09-just_dispatched-skip-rule)).
+
+Backends today:
+
+| `EXECUTION_BACKEND` | Driver | When to use |
+|---|---|---|
+| `local` (default, also when unset) | `scripts/dispatch-local.sh` | Wrapper runs on the same box as the dispatcher. |
+| `remote-aws-ssm` | `scripts/dispatch-remote-aws-ssm.sh` | Wrapper runs on a remote dev EC2 reached via AWS Systems Manager. The dispatcher sends `aws ssm send-command` to invoke `dispatch-local.sh` on the remote box. |
+
+Per-task command shapes (passed through both backends identically):
 
 | Type | Command |
 |---|---|
-| New dev task | `bash "$PROJECT_DIR/scripts/dispatch-local.sh" dev-new ISSUE_NUM` |
-| Review task | `bash "$PROJECT_DIR/scripts/dispatch-local.sh" review ISSUE_NUM` |
-| Resume dev task | `bash "$PROJECT_DIR/scripts/dispatch-local.sh" dev-resume ISSUE_NUM SESSION_ID` |
+| New dev task | `dispatch dev-new ISSUE_NUM` |
+| Review task | `dispatch review ISSUE_NUM` |
+| Resume dev task | `dispatch dev-resume ISSUE_NUM SESSION_ID` |
 
 ## What the dispatcher MUST NOT do
 
@@ -74,7 +88,7 @@ The dispatcher is a label-and-spawn coordinator, not a code-changer:
 
 - MUST NOT commit or push to the target repository.
 - MUST NOT modify source files in `$PROJECT_DIR`.
-- MUST ONLY read issue labels/comments via the GitHub API, update labels via the GitHub API, and dispatch local processes via `dispatch-local.sh`.
+- MUST ONLY read issue labels/comments via the GitHub API, update labels via the GitHub API, and dispatch wrapper processes via the configured backend (`dispatch-local.sh` or `dispatch-remote-aws-ssm.sh`).
 
 Any code changes happen via the wrapper-spawned dev / review agents.
 

--- a/skills/autonomous-dispatcher/scripts/dispatch-remote-aws-ssm.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatch-remote-aws-ssm.sh
@@ -58,10 +58,25 @@ if ! [[ "$SSM_REMOTE_PROJECT_ID" =~ ^[a-zA-Z0-9_-]+$ ]]; then
   echo "ERROR: SSM_REMOTE_PROJECT_ID contains unsafe characters: '$SSM_REMOTE_PROJECT_ID'" >&2
   exit 1
 fi
-# SSM_REMOTE_PROJECT_DIR must be an absolute path; reject command-injection
-# shapes ($, `, ;, newline). The remote shell would expand them otherwise.
-if [[ "$SSM_REMOTE_PROJECT_DIR" != /* ]] \
-   || [[ "$SSM_REMOTE_PROJECT_DIR" == *[\$\`\;\&\|]* ]]; then
+# Shell-metachar reject. Any of these in an operator-controlled value can
+# break out of the `sudo -u $USER $SHELL -l -c '<INNER_CMD>'` single-quote
+# wrap on the remote side and execute arbitrary code as $SSM_REMOTE_USER:
+#   $ ` ; & | ' " < > * ? newline carriage-return
+# Found via PR-9 code review (C1+C2): the prior validator missed `'`, `"`,
+# `<`, `>`, `\n`, which reach the remote shell verbatim.
+_has_shell_metachar() {
+  local val="$1"
+  case "$val" in
+    *['$`;&|<>*?'\'\"]*) return 0 ;;
+    *)                   ;;
+  esac
+  case "$val" in
+    *$'\n'*|*$'\r'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [[ "$SSM_REMOTE_PROJECT_DIR" != /* ]] || _has_shell_metachar "$SSM_REMOTE_PROJECT_DIR"; then
   echo "ERROR: SSM_REMOTE_PROJECT_DIR must be an absolute path with no shell metachars: '$SSM_REMOTE_PROJECT_DIR'" >&2
   exit 1
 fi
@@ -108,10 +123,11 @@ DISPATCH_LOCAL="${SSM_REMOTE_PROJECT_DIR}/scripts/dispatch-local.sh"
 # login shell PATH only).
 prefix=""
 if [[ -n "$SSM_REMOTE_PROFILE" ]]; then
-  # The profile path is operator-controlled; quote it so a path with spaces
-  # works, but allow standard absolute paths only.
-  if [[ "$SSM_REMOTE_PROFILE" != /* ]]; then
-    echo "ERROR: SSM_REMOTE_PROFILE must be an absolute path: '$SSM_REMOTE_PROFILE'" >&2
+  # The profile path is operator-controlled; same metachar gate as
+  # SSM_REMOTE_PROJECT_DIR (PR-9 review C2: previously this only checked
+  # absoluteness, leaving `'` / newlines / `$()` open to remote RCE).
+  if [[ "$SSM_REMOTE_PROFILE" != /* ]] || _has_shell_metachar "$SSM_REMOTE_PROFILE"; then
+    echo "ERROR: SSM_REMOTE_PROFILE must be an absolute path with no shell metachars: '$SSM_REMOTE_PROFILE'" >&2
     exit 1
   fi
   prefix="source ${SSM_REMOTE_PROFILE}; "

--- a/skills/autonomous-dispatcher/scripts/dispatch-remote-aws-ssm.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatch-remote-aws-ssm.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# dispatch-remote-aws-ssm.sh — Send an SSM command to a remote dev box to
+# spawn the wrapper there. Closes #62 axis 2 (pluggable execution backend).
+#
+# This script is purely a transport layer. The actual process spawning,
+# kill-stale-wrapper, and PID file management all happen on the remote box,
+# inside the existing dispatch-local.sh — same code path as a local-backend
+# deployment, just one machine over.
+#
+# Usage (called via dispatcher-tick.sh::dispatch when EXECUTION_BACKEND=remote-aws-ssm):
+#   bash dispatch-remote-aws-ssm.sh <type> <issue_num> [session_id]
+#     type: dev-new | dev-resume | review
+#
+# Required env (set by dispatcher-tick.sh after sourcing per-project conf):
+#   SSM_INSTANCE_ID         — EC2 instance ID running the wrapper
+#   SSM_REMOTE_PROJECT_DIR  — absolute project root on the remote box
+#   SSM_REMOTE_PROJECT_ID   — project_id used in remote PID/log paths
+#
+# Optional env (with defaults):
+#   SSM_REGION         (default: ap-southeast-1)
+#   SSM_REMOTE_USER    (default: ubuntu)              — sudo -u target
+#   SSM_REMOTE_SHELL   (default: bash)                — bash | zsh; runs as login shell
+#   SSM_REMOTE_PROFILE (default: empty, no source)    — file to source before INNER_CMD
+#                                                       e.g. /home/ubuntu/.bash_aliases
+#
+# Exit codes:
+#   0 — SSM send-command accepted (the remote command is now in flight)
+#   1 — input/env validation failure, missing dependency, or aws send-command failed
+
+set -euo pipefail
+
+TYPE="${1:?Usage: dispatch-remote-aws-ssm.sh <dev-new|dev-resume|review> <issue_num> [session_id]}"
+ISSUE_NUM="${2:?Missing issue number}"
+SESSION_ID="${3:-}"
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+if ! [[ "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: issue_num must be a positive integer, got: '$ISSUE_NUM'" >&2
+  exit 1
+fi
+if [[ -n "$SESSION_ID" ]] && ! [[ "$SESSION_ID" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+  echo "ERROR: session_id contains unsafe characters: '$SESSION_ID'" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Required env validation
+# ---------------------------------------------------------------------------
+: "${SSM_INSTANCE_ID:?SSM_INSTANCE_ID required for remote-aws-ssm backend}"
+: "${SSM_REMOTE_PROJECT_DIR:?SSM_REMOTE_PROJECT_DIR required (absolute path on remote box)}"
+: "${SSM_REMOTE_PROJECT_ID:?SSM_REMOTE_PROJECT_ID required (project_id on remote box)}"
+
+# Validate SSM_REMOTE_PROJECT_ID — used in remote PID/log paths and command
+# strings; reject anything that could break shell parsing or path resolution.
+if ! [[ "$SSM_REMOTE_PROJECT_ID" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+  echo "ERROR: SSM_REMOTE_PROJECT_ID contains unsafe characters: '$SSM_REMOTE_PROJECT_ID'" >&2
+  exit 1
+fi
+# SSM_REMOTE_PROJECT_DIR must be an absolute path; reject command-injection
+# shapes ($, `, ;, newline). The remote shell would expand them otherwise.
+if [[ "$SSM_REMOTE_PROJECT_DIR" != /* ]] \
+   || [[ "$SSM_REMOTE_PROJECT_DIR" == *[\$\`\;\&\|]* ]]; then
+  echo "ERROR: SSM_REMOTE_PROJECT_DIR must be an absolute path with no shell metachars: '$SSM_REMOTE_PROJECT_DIR'" >&2
+  exit 1
+fi
+
+# Defaults
+SSM_REGION="${SSM_REGION:-ap-southeast-1}"
+SSM_REMOTE_USER="${SSM_REMOTE_USER:-ubuntu}"
+SSM_REMOTE_SHELL="${SSM_REMOTE_SHELL:-bash}"
+SSM_REMOTE_PROFILE="${SSM_REMOTE_PROFILE:-}"
+
+# Validate user/shell — embedded into a shell command on the remote side.
+if ! [[ "$SSM_REMOTE_USER" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+  echo "ERROR: SSM_REMOTE_USER contains unsafe characters: '$SSM_REMOTE_USER'" >&2
+  exit 1
+fi
+if ! [[ "$SSM_REMOTE_SHELL" =~ ^(bash|zsh|sh)$ ]]; then
+  echo "ERROR: SSM_REMOTE_SHELL must be bash, zsh, or sh; got: '$SSM_REMOTE_SHELL'" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Dependency checks
+# ---------------------------------------------------------------------------
+for cmd in aws jq; do
+  command -v "$cmd" >/dev/null 2>&1 || {
+    echo "ERROR: required command '$cmd' not found in PATH" >&2
+    exit 1
+  }
+done
+
+# ---------------------------------------------------------------------------
+# Build the remote command
+# ---------------------------------------------------------------------------
+# The remote box runs its own dispatch-local.sh, which handles PID guard,
+# kill-stale-wrapper, and nohup'd wrapper spawn. SSM is just a shell over it.
+#
+# The remote dispatch-local.sh is at $SSM_REMOTE_PROJECT_DIR/scripts/dispatch-local.sh.
+# We pass PROJECT_DIR and PROJECT_ID via env so the remote script picks
+# them up — same convention dispatch-local.sh uses today.
+DISPATCH_LOCAL="${SSM_REMOTE_PROJECT_DIR}/scripts/dispatch-local.sh"
+
+# Build inner command — what runs on the remote box as $SSM_REMOTE_USER.
+# Profile-source prefix is opt-in; default is no profile load (vanilla
+# login shell PATH only).
+prefix=""
+if [[ -n "$SSM_REMOTE_PROFILE" ]]; then
+  # The profile path is operator-controlled; quote it so a path with spaces
+  # works, but allow standard absolute paths only.
+  if [[ "$SSM_REMOTE_PROFILE" != /* ]]; then
+    echo "ERROR: SSM_REMOTE_PROFILE must be an absolute path: '$SSM_REMOTE_PROFILE'" >&2
+    exit 1
+  fi
+  prefix="source ${SSM_REMOTE_PROFILE}; "
+fi
+
+case "$TYPE" in
+  dev-new)
+    INNER_CMD="${prefix}PROJECT_DIR=${SSM_REMOTE_PROJECT_DIR} PROJECT_ID=${SSM_REMOTE_PROJECT_ID} bash ${DISPATCH_LOCAL} dev-new ${ISSUE_NUM}"
+    COMMENT="${SSM_REMOTE_PROJECT_ID}: new dev task for issue #${ISSUE_NUM}"
+    ;;
+  dev-resume)
+    if [[ -z "$SESSION_ID" ]]; then
+      echo "ERROR: session_id required for dev-resume" >&2
+      exit 1
+    fi
+    INNER_CMD="${prefix}PROJECT_DIR=${SSM_REMOTE_PROJECT_DIR} PROJECT_ID=${SSM_REMOTE_PROJECT_ID} bash ${DISPATCH_LOCAL} dev-resume ${ISSUE_NUM} ${SESSION_ID}"
+    COMMENT="${SSM_REMOTE_PROJECT_ID}: resume dev for issue #${ISSUE_NUM}"
+    ;;
+  review)
+    INNER_CMD="${prefix}PROJECT_DIR=${SSM_REMOTE_PROJECT_DIR} PROJECT_ID=${SSM_REMOTE_PROJECT_ID} bash ${DISPATCH_LOCAL} review ${ISSUE_NUM}"
+    COMMENT="${SSM_REMOTE_PROJECT_ID}: review task for issue #${ISSUE_NUM}"
+    ;;
+  *)
+    echo "ERROR: unknown type '$TYPE'. Use dev-new, dev-resume, or review" >&2
+    exit 1
+    ;;
+esac
+
+# Wrap in sudo + login shell so the remote profile (when set) is loaded
+# correctly. -l on bash/zsh means "act as a login shell" → reads
+# /etc/profile, ~/.profile (or ~/.zprofile), making PATH and env vars
+# available. The explicit `source $SSM_REMOTE_PROFILE` above is for
+# files that interactive shells normally don't load (~/.bash_aliases).
+FULL_CMD="sudo -u ${SSM_REMOTE_USER} ${SSM_REMOTE_SHELL} -l -c '${INNER_CMD}'"
+
+# Build the SSM commands JSON safely. jq -n --arg quotes the value as a JSON
+# string with all escaping handled — guards against shell-injection in any
+# of the operator-controlled fields above (CWE-78).
+COMMANDS_JSON=$(jq -n --arg cmd "$FULL_CMD" '[$cmd]')
+
+# ---------------------------------------------------------------------------
+# Send the SSM command
+# ---------------------------------------------------------------------------
+SSM_OUTPUT=$(aws ssm send-command \
+  --instance-ids "$SSM_INSTANCE_ID" \
+  --document-name "AWS-RunShellScript" \
+  --region "$SSM_REGION" \
+  --parameters "{\"commands\": $COMMANDS_JSON}" \
+  --comment "$COMMENT" \
+  --output json) || {
+  echo "ERROR: SSM send-command failed for instance $SSM_INSTANCE_ID in region $SSM_REGION" >&2
+  exit 1
+}
+
+# Surface CommandId so cron logs can tie back to the remote-side run.
+echo "$SSM_OUTPUT" | jq '{CommandId: .Command.CommandId, Status: .Command.Status, InstanceId: "'"$SSM_INSTANCE_ID"'"}'

--- a/skills/autonomous-dispatcher/scripts/dispatcher-multi-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-multi-tick.sh
@@ -118,30 +118,135 @@ if [[ "${#PROJECTS[@]}" -eq 0 ]]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Inline-block validator (#62 axis 2)
+# ---------------------------------------------------------------------------
+# Remote projects describe themselves inline in dispatcher.conf because the
+# dispatcher box does NOT have their autonomous.conf on disk (autonomous.conf
+# lives on the remote dev box). The block contains bash KEY=VALUE lines.
+#
+# Before eval we sanity-check: every non-blank, non-comment line must look
+# like KEY=value (allow optional `export KEY=`). Reject anything else —
+# in particular, function calls or commands that would be code-executed.
+# `dispatcher.conf` is already trusted (PR-8 trust gate), so this is
+# defense-in-depth against accidental injection from copy-paste.
+validate_inline_block() {
+  local block="$1"
+  local line
+  while IFS= read -r line; do
+    # Strip leading whitespace.
+    line="${line#"${line%%[![:space:]]*}"}"
+    # Allow blank lines and comments.
+    [[ -z "$line" || "${line:0:1}" == "#" ]] && continue
+    # Allow `KEY=value` and `export KEY=value` (optional spaces around `=`
+    # NOT allowed — bash itself rejects that anyway).
+    if ! [[ "$line" =~ ^(export[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*= ]]; then
+      return 1
+    fi
+  done <<<"$block"
+  return 0
+}
+
+# Run a per-project tick from an inline metadata block.
+# Eval'd inside a subshell so vars cannot leak between projects.
+# Auto-derives REPO_OWNER and REPO_NAME from REPO when missing.
+tick_inline_project() {
+  local block="$1" entry_label="$2"
+
+  if ! validate_inline_block "$block"; then
+    warn "  WARN: skipping $entry_label — inline block contains non-assignment lines (refusing to eval)"
+    return 1
+  fi
+
+  (
+    set +u
+    # shellcheck disable=SC2294
+    eval "$block"
+    : "${REPO:?inline project missing REPO}"
+    : "${PROJECT_ID:?inline project missing PROJECT_ID}"
+    # Auto-derive owner/name from REPO=owner/name.
+    : "${REPO_OWNER:=${REPO%%/*}}"
+    : "${REPO_NAME:=${REPO##*/}}"
+    export REPO REPO_OWNER REPO_NAME PROJECT_ID
+    # Optional vars consumed by the router and dispatch-remote-aws-ssm.sh.
+    [[ -n "${EXECUTION_BACKEND:-}" ]]      && export EXECUTION_BACKEND
+    [[ -n "${SSM_INSTANCE_ID:-}" ]]        && export SSM_INSTANCE_ID
+    [[ -n "${SSM_REGION:-}" ]]             && export SSM_REGION
+    [[ -n "${SSM_REMOTE_USER:-}" ]]        && export SSM_REMOTE_USER
+    [[ -n "${SSM_REMOTE_SHELL:-}" ]]       && export SSM_REMOTE_SHELL
+    [[ -n "${SSM_REMOTE_PROFILE:-}" ]]     && export SSM_REMOTE_PROFILE
+    [[ -n "${SSM_REMOTE_PROJECT_DIR:-}" ]] && export SSM_REMOTE_PROJECT_DIR
+    [[ -n "${SSM_REMOTE_PROJECT_ID:-}" ]]  && export SSM_REMOTE_PROJECT_ID
+    [[ -n "${DISPATCHER_APP_ID:-}" ]]      && export DISPATCHER_APP_ID
+    [[ -n "${DISPATCHER_APP_PEM:-}" ]]     && export DISPATCHER_APP_PEM
+    [[ -n "${GH_AUTH_MODE:-}" ]]           && export GH_AUTH_MODE
+    [[ -n "${MAX_CONCURRENT:-}" ]]         && export MAX_CONCURRENT
+    [[ -n "${MAX_RETRIES:-}" ]]            && export MAX_RETRIES
+    # Inline projects don't have a dispatcher-side PROJECT_DIR (the source
+    # lives on the remote box). dispatcher-tick.sh validates PROJECT_DIR is
+    # non-empty; for the local backend it's the project root, for remote
+    # it's only used by lib-config.sh's autonomous.conf fallback path
+    # (which we don't need — AUTONOMOUS_CONF is empty for inline). Set it
+    # to a placeholder that is harmless on the dispatcher side; the actual
+    # remote PROJECT_DIR is in SSM_REMOTE_PROJECT_DIR.
+    : "${PROJECT_DIR:=/}"
+    export PROJECT_DIR
+    # AUTONOMOUS_CONF must be UNSET for inline projects so lib-config.sh
+    # doesn't try to source a stale path from the parent multi-tick env.
+    unset AUTONOMOUS_CONF
+    set -u
+    bash "$SCRIPT_DIR/dispatcher-tick.sh"
+  )
+}
+
+# Classify a PROJECTS[i] entry: file path (PR-8 local) vs inline metadata (#62).
+# A file path is detected by: contains "/" AND exists as a regular file.
+# Anything else is treated as inline metadata.
+is_path_entry() {
+  local entry="$1"
+  [[ "$entry" == *"/"* && -f "$entry" ]]
+}
+
+# ---------------------------------------------------------------------------
 # Per-project tick loop
 # ---------------------------------------------------------------------------
-# Each iteration runs dispatcher-tick.sh in a subshell (parentheses) with
-# AUTONOMOUS_CONF set to the project's conf path. The subshell's exit code
-# is captured but does NOT short-circuit the loop — one bad project must
-# not block ticks for the others.
+# Each iteration runs dispatcher-tick.sh in a subshell. For path entries
+# (PR-8 local), AUTONOMOUS_CONF is set so lib-config.sh sources that file.
+# For inline entries (#62 remote), the metadata is eval'd in the subshell.
+# Subshell exit codes are captured but do NOT short-circuit the loop —
+# one bad project must not block ticks for the others.
 log "scanning ${#PROJECTS[@]} project(s) from $CONF"
 
 OK=0
 FAIL=0
-for proj_conf in "${PROJECTS[@]}"; do
-  if [[ ! -r "$proj_conf" ]]; then
-    warn "  WARN: skipping unreadable project conf: $proj_conf"
-    FAIL=$((FAIL + 1))
-    continue
-  fi
-
-  log "  ticking project: $proj_conf"
-  if ( AUTONOMOUS_CONF="$proj_conf" bash "$SCRIPT_DIR/dispatcher-tick.sh" ); then
-    OK=$((OK + 1))
+for entry in "${PROJECTS[@]}"; do
+  if is_path_entry "$entry"; then
+    if [[ ! -r "$entry" ]]; then
+      warn "  WARN: skipping unreadable project conf: $entry"
+      FAIL=$((FAIL + 1))
+      continue
+    fi
+    log "  ticking local project: $entry"
+    if ( AUTONOMOUS_CONF="$entry" bash "$SCRIPT_DIR/dispatcher-tick.sh" ); then
+      OK=$((OK + 1))
+    else
+      rc=$?
+      warn "  WARN: tick failed for $entry (rc=$rc)"
+      FAIL=$((FAIL + 1))
+    fi
   else
-    rc=$?
-    warn "  WARN: tick failed for $proj_conf (rc=$rc)"
-    FAIL=$((FAIL + 1))
+    # Inline metadata. Identify it by a stable label for log lines —
+    # extract REPO from the block on a best-effort basis.
+    label=$(grep -oE '^[[:space:]]*(export[[:space:]]+)?REPO=[^[:space:]]+' <<<"$entry" \
+            | head -1 | sed 's/^[[:space:]]*\(export[[:space:]]\+\)\?REPO=//')
+    [[ -z "$label" ]] && label="<inline-$((OK+FAIL+1))>"
+    log "  ticking remote project: $label"
+    if tick_inline_project "$entry" "$label"; then
+      OK=$((OK + 1))
+    else
+      rc=$?
+      warn "  WARN: tick failed for inline project $label (rc=$rc)"
+      FAIL=$((FAIL + 1))
+    fi
   fi
 done
 

--- a/skills/autonomous-dispatcher/scripts/dispatcher-multi-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-multi-tick.sh
@@ -131,17 +131,30 @@ fi
 # defense-in-depth against accidental injection from copy-paste.
 validate_inline_block() {
   local block="$1"
-  local line
+  local line lhs rhs
   while IFS= read -r line; do
     # Strip leading whitespace.
     line="${line#"${line%%[![:space:]]*}"}"
     # Allow blank lines and comments.
     [[ -z "$line" || "${line:0:1}" == "#" ]] && continue
-    # Allow `KEY=value` and `export KEY=value` (optional spaces around `=`
-    # NOT allowed — bash itself rejects that anyway).
+    # The line must look like KEY=value or `export KEY=value`. Optional
+    # spaces around `=` are NOT allowed — bash itself rejects that anyway.
     if ! [[ "$line" =~ ^(export[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*= ]]; then
       return 1
     fi
+    # Q PR-80 finding (CWE-95): the LHS check above doesn't constrain the
+    # RHS, so values like `REPO=$(malicious_command)` or `KEY=`cmd`` would
+    # pass validation and execute on `eval`. Block code-injection metachars
+    # in the value portion. `$` blocks both `$(cmd)` and `${VAR}`/`$VAR`
+    # expansion (we don't have any schema field that legitimately uses
+    # variable expansion). Backticks block legacy command substitution.
+    # `;`/`&`/`|` block chained commands. Backslash blocks line
+    # continuations and escape sequences.
+    rhs="${line#*=}"
+    case "$rhs" in
+      *'$'*|*'`'*|*';'*|*'&'*|*'|'*|*'\'*)
+        return 1 ;;
+    esac
   done <<<"$block"
   return 0
 }

--- a/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
@@ -30,6 +30,27 @@ source "${SCRIPT_DIR}/lib-dispatch.sh"
 
 log() { echo "[dispatcher-tick] $(date -u +%H:%M:%S) $*"; }
 
+# dispatch — route a wrapper-spawn request to the configured backend (#62 axis 2).
+# Backends today: "local" (default — same-box dispatch-local.sh) and
+# "remote-aws-ssm" (sends an `aws ssm send-command` to a remote dev box).
+# Other backends (k8s, gha-runner) can be added with one case arm here.
+#
+# Args: <type> <issue_num> [session_id]   — passed through verbatim.
+dispatch() {
+  case "${EXECUTION_BACKEND:-local}" in
+    local)
+      bash "$PROJECT_DIR/scripts/dispatch-local.sh" "$@"
+      ;;
+    remote-aws-ssm)
+      bash "$SCRIPT_DIR/dispatch-remote-aws-ssm.sh" "$@"
+      ;;
+    *)
+      log "  ERROR: unknown EXECUTION_BACKEND='${EXECUTION_BACKEND}' — skipping dispatch"
+      return 1
+      ;;
+  esac
+}
+
 # Tick-local state. JUST_DISPATCHED holds issue numbers dispatched in
 # Steps 2/3/4 of this tick, so Step 5 can skip them ([INV-09]).
 JUST_DISPATCHED=()
@@ -69,7 +90,7 @@ for i in $(seq 0 $((new_count - 1))); do
   label_swap "$issue_num" "" "in-progress"
   gh issue comment "$issue_num" --repo "$REPO" \
     --body "Dispatching autonomous development..."
-  bash "$PROJECT_DIR/scripts/dispatch-local.sh" dev-new "$issue_num"
+  dispatch dev-new "$issue_num"
   JUST_DISPATCHED+=("$issue_num")
 done
 
@@ -94,7 +115,7 @@ for i in $(seq 0 $((pr_count - 1))); do
   label_swap "$issue_num" "pending-review" "reviewing"
   gh issue comment "$issue_num" --repo "$REPO" \
     --body "Dispatching autonomous review..."
-  bash "$PROJECT_DIR/scripts/dispatch-local.sh" review "$issue_num"
+  dispatch review "$issue_num"
   JUST_DISPATCHED+=("$issue_num")
 done
 
@@ -149,7 +170,7 @@ for i in $(seq 0 $((pd_count - 1))); do
   label_swap "$issue_num" "pending-dev" "in-progress"
   gh issue comment "$issue_num" --repo "$REPO" \
     --body "Resuming development (session: ${session_id})..."
-  bash "$PROJECT_DIR/scripts/dispatch-local.sh" dev-resume "$issue_num" "$session_id"
+  dispatch dev-resume "$issue_num" "$session_id"
   JUST_DISPATCHED+=("$issue_num")
 done
 

--- a/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
@@ -30,10 +30,26 @@ source "${SCRIPT_DIR}/lib-dispatch.sh"
 
 log() { echo "[dispatcher-tick] $(date -u +%H:%M:%S) $*"; }
 
+# Validate EXECUTION_BACKEND ONCE upfront, before any label transitions.
+# H1 (PR-9 review): if dispatch() returned 1 from inside a step body, the
+# step had already swapped the issue's label to in-progress and posted a
+# comment — leaving a stuck issue + burning retries every tick. Catching
+# the typo here aborts the tick before any side effect.
+case "${EXECUTION_BACKEND:-local}" in
+  local|remote-aws-ssm) ;;
+  *)
+    echo "[dispatcher-tick] FATAL: unknown EXECUTION_BACKEND='${EXECUTION_BACKEND}'. Allowed: local, remote-aws-ssm." >&2
+    exit 1
+    ;;
+esac
+
 # dispatch — route a wrapper-spawn request to the configured backend (#62 axis 2).
 # Backends today: "local" (default — same-box dispatch-local.sh) and
 # "remote-aws-ssm" (sends an `aws ssm send-command` to a remote dev box).
 # Other backends (k8s, gha-runner) can be added with one case arm here.
+# The unknown-backend case is unreachable because we validate above; the
+# `*)` arm is a defensive assertion in case allowed-list values get out of
+# sync between the upfront check and the runtime dispatch.
 #
 # Args: <type> <issue_num> [session_id]   — passed through verbatim.
 dispatch() {
@@ -45,8 +61,10 @@ dispatch() {
       bash "$SCRIPT_DIR/dispatch-remote-aws-ssm.sh" "$@"
       ;;
     *)
-      log "  ERROR: unknown EXECUTION_BACKEND='${EXECUTION_BACKEND}' — skipping dispatch"
-      return 1
+      # Should never reach here because of the upfront check, but be loud
+      # if invariants drift.
+      echo "[dispatcher-tick] BUG: dispatch() reached unknown EXECUTION_BACKEND='${EXECUTION_BACKEND}' at runtime" >&2
+      exit 1
       ;;
   esac
 }

--- a/skills/autonomous-dispatcher/scripts/dispatcher.conf.example
+++ b/skills/autonomous-dispatcher/scripts/dispatcher.conf.example
@@ -1,35 +1,99 @@
 # dispatcher.conf — multi-project dispatcher configuration
 #
-# Copied to:
-#   $DISPATCHER_CONF                              (env override; takes priority)
+# Lookup priority:
+#   $DISPATCHER_CONF                              (env override)
 #   $HOME/.autonomous/dispatcher.conf             (default)
 #   $XDG_CONFIG_HOME/autonomous/dispatcher.conf   (XDG fallback)
 #
 # Read by `dispatcher-multi-tick.sh`. Each cron tick iterates PROJECTS[]
-# and runs one `dispatcher-tick.sh` per project, sourcing the project's
-# own `autonomous.conf` via the AUTONOMOUS_CONF env override (#62).
+# and runs one `dispatcher-tick.sh` per project. Per-project values are
+# sourced fresh in a subshell each iteration so settings cannot leak
+# between projects.
 #
-# This file does NOT replace per-project `autonomous.conf` — REPO,
-# PROJECT_ID, DISPATCHER_APP_ID, MAX_CONCURRENT, etc. all stay there.
-# Per-project values are sourced fresh in a subshell each iteration so
-# settings cannot leak between projects.
-
-# Trust gate: dispatcher-multi-tick.sh refuses to source a `dispatcher.conf`
-# (or its parent dir) that is group/other-writable, or owned by a different
-# user, because `source` of an attacker-writable file means arbitrary code
-# execution as the dispatcher user (CWE-94). Recommended file mode: 0644
-# owned by the dispatcher user, or 0600 if the conf has secrets. Recommended
-# parent dir mode: 0755 (or 0700).
+# Each PROJECTS[] entry is one of two shapes:
 #
-# Set AUTONOMOUS_TRUST_CONF=1 to disable the trust gate (e.g. shared dev
-# VMs where the conf is owned by a tooling uid distinct from the runtime
-# uid). Off by default — opt in only when you understand the risk.
+#   1. A FILE PATH to a per-project autonomous.conf (PR-8 — local backend).
+#      The file lives on this dispatcher box. Used when the dispatcher and
+#      the project source live on the same machine.
+#
+#   2. An INLINE METADATA BLOCK (PR-9, #62 — remote-aws-ssm backend).
+#      Used when the dispatcher and the project source live on DIFFERENT
+#      machines (the project lives on a remote dev box reached via AWS SSM).
+#      The dispatcher box doesn't have the project's autonomous.conf —
+#      everything the dispatcher needs is declared inline here.
+#
+# Mix and match in the same array.
 
-# Required: paths to per-project `autonomous.conf` files.
-# Each path is sourced in a subshell before running one tick for that
-# project. Missing paths cause that project's tick to be skipped with a
-# warning — they do NOT block other projects.
-PROJECTS=(
-  "/data/git/myrepo-a/scripts/autonomous.conf"
-  "/data/git/myrepo-b/scripts/autonomous.conf"
-)
+# === Trust gate ===
+# dispatcher-multi-tick.sh refuses to source a `dispatcher.conf` that is
+# group/other-writable or owned by a different user (CWE-94 mitigation —
+# `source` of an attacker-writable file is arbitrary code execution).
+# Recommended: file mode 0644 (or 0600 if it has secrets), parent dir 0755.
+# Override with AUTONOMOUS_TRUST_CONF=1 (only when you know what you're doing).
+
+PROJECTS=()
+
+# ---------------------------------------------------------------------------
+# Example 1: LOCAL project (PR-8 — autonomous.conf on this box)
+# ---------------------------------------------------------------------------
+PROJECTS+=( "/data/git/myrepo-local/scripts/autonomous.conf" )
+
+# ---------------------------------------------------------------------------
+# Example 2: REMOTE project (PR-9 — autonomous.conf on a remote dev box)
+# ---------------------------------------------------------------------------
+# The dispatcher box uses these vars to scan issues + dispatch over SSM.
+# The remote box has its own autonomous.conf for the wrapper to use.
+#
+# Required:
+#   PROJECT_ID, REPO        — for GitHub API calls from the dispatcher
+#   EXECUTION_BACKEND=remote-aws-ssm
+#   SSM_INSTANCE_ID         — EC2 instance running dispatch-local.sh + wrapper
+#   SSM_REMOTE_PROJECT_DIR  — absolute path to the project root on remote
+#   SSM_REMOTE_PROJECT_ID   — project_id used in remote PID/log paths
+#
+# Auto-derived:
+#   REPO_OWNER, REPO_NAME   — split from REPO=owner/name
+#
+# Optional (with defaults):
+#   SSM_REGION         (default ap-southeast-1)
+#   SSM_REMOTE_USER    (default ubuntu)         — sudo -u target on remote
+#   SSM_REMOTE_SHELL   (default bash)           — bash | zsh | sh; runs as login shell
+#   SSM_REMOTE_PROFILE (default empty, no source)  — file to source before INNER_CMD
+#                       e.g. /home/ubuntu/.bash_aliases for env-var setup that
+#                       interactive shells normally don't load
+#
+# GitHub App auth (when GH_AUTH_MODE=app):
+#   DISPATCHER_APP_ID, DISPATCHER_APP_PEM   — read by gh-app-token.sh
+#
+PROJECTS+=( '
+PROJECT_ID=projB
+REPO=myorg/projB
+EXECUTION_BACKEND=remote-aws-ssm
+SSM_INSTANCE_ID=i-0abc1234567890def
+SSM_REGION=ap-southeast-1
+SSM_REMOTE_USER=ubuntu
+SSM_REMOTE_SHELL=bash
+SSM_REMOTE_PROFILE=/home/ubuntu/.bash_aliases
+SSM_REMOTE_PROJECT_DIR=/data/git/projB
+SSM_REMOTE_PROJECT_ID=projB
+GH_AUTH_MODE=app
+DISPATCHER_APP_ID=3013418
+DISPATCHER_APP_PEM=/data/auth/projB.pem
+MAX_CONCURRENT=5
+MAX_RETRIES=3
+' )
+
+# ---------------------------------------------------------------------------
+# Example 3: another remote project on a DIFFERENT EC2 (per-project mapping)
+# ---------------------------------------------------------------------------
+PROJECTS+=( '
+PROJECT_ID=projC
+REPO=myorg/projC
+EXECUTION_BACKEND=remote-aws-ssm
+SSM_INSTANCE_ID=i-0def4567890abc123
+SSM_REMOTE_PROJECT_DIR=/data/git/projC
+SSM_REMOTE_PROJECT_ID=projC
+GH_AUTH_MODE=app
+DISPATCHER_APP_ID=3013418
+DISPATCHER_APP_PEM=/data/auth/projC.pem
+' )

--- a/tests/unit/test-dispatch-remote-aws-ssm.sh
+++ b/tests/unit/test-dispatch-remote-aws-ssm.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+# test-dispatch-remote-aws-ssm.sh — Unit tests for the SSM transport driver
+# added in PR-9 (closes #62 axis 2).
+#
+# Strategy: stub `aws` and `jq` selectively, capture argv to a record file,
+# and assert on the constructed remote command shape + JSON escaping path.
+#
+# Run: bash tests/unit/test-dispatch-remote-aws-ssm.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DRIVER="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/dispatch-remote-aws-ssm.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_rc() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected_rc=$expected actual_rc=$actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      needle='$needle'"
+    echo "      haystack='$haystack'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      should NOT contain: '$needle'"
+    echo "      haystack='$haystack'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Sandbox: stub `aws` to record argv; jq stays real.
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+STUB_BIN="$TMPROOT/bin"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/aws" <<'EOF'
+#!/bin/bash
+# Record full argv to AWS_RECORD_FILE; emit a fake send-command JSON.
+printf '%s\n' "$@" >> "$AWS_RECORD_FILE"
+exitcode="${AWS_FAIL_RC:-0}"
+if [[ "$exitcode" != "0" ]]; then
+  echo "stub aws: simulated failure" >&2
+  exit "$exitcode"
+fi
+echo '{"Command":{"CommandId":"abc-stub","Status":"Pending"}}'
+EOF
+chmod +x "$STUB_BIN/aws"
+export PATH="$STUB_BIN:$PATH"
+
+run_driver() {
+  AWS_RECORD_FILE="$TMPROOT/aws-record" \
+  bash "$DRIVER" "$@"
+}
+
+# ---------------------------------------------------------------------------
+echo "=== TC-EB-005: dispatch-remote-aws-ssm.sh requires SSM_INSTANCE_ID ==="
+# ---------------------------------------------------------------------------
+: > "$TMPROOT/aws-record"
+unset SSM_INSTANCE_ID
+export SSM_REMOTE_PROJECT_DIR=/data/git/test SSM_REMOTE_PROJECT_ID=test
+err=$(run_driver dev-new 99 2>&1 >/dev/null)
+rc=$?
+assert_rc "rc=1 when SSM_INSTANCE_ID unset" 1 "$rc"
+assert_contains "stderr names SSM_INSTANCE_ID" "SSM_INSTANCE_ID" "$err"
+[[ ! -s "$TMPROOT/aws-record" ]] && {
+  echo -e "  ${GREEN}PASS${NC}: aws was NOT invoked"
+  PASS=$((PASS + 1))
+} || {
+  echo -e "  ${RED}FAIL${NC}: aws was invoked despite missing SSM_INSTANCE_ID"
+  FAIL=$((FAIL + 1))
+}
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-006: requires SSM_REMOTE_PROJECT_DIR / _PROJECT_ID ==="
+# ---------------------------------------------------------------------------
+export SSM_INSTANCE_ID=i-test
+unset SSM_REMOTE_PROJECT_DIR
+err=$(run_driver dev-new 99 2>&1 >/dev/null)
+rc=$?
+assert_rc "rc=1 when SSM_REMOTE_PROJECT_DIR unset" 1 "$rc"
+assert_contains "stderr names SSM_REMOTE_PROJECT_DIR" "SSM_REMOTE_PROJECT_DIR" "$err"
+
+export SSM_REMOTE_PROJECT_DIR=/data/git/test
+unset SSM_REMOTE_PROJECT_ID
+err=$(run_driver dev-new 99 2>&1 >/dev/null)
+rc=$?
+assert_rc "rc=1 when SSM_REMOTE_PROJECT_ID unset" 1 "$rc"
+
+# Reset to valid
+export SSM_REMOTE_PROJECT_ID=test
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-007: input + env validation rejects unsafe values ==="
+# ---------------------------------------------------------------------------
+run_driver dev-new abc >/dev/null 2>&1
+assert_rc "non-numeric issue → rc=1" 1 "$?"
+
+run_driver dev-resume 99 'bad;chars' >/dev/null 2>&1
+assert_rc "session_id with semicolons → rc=1" 1 "$?"
+
+# Each invalid-env case runs in a subshell so the bad value doesn't leak to
+# subsequent tests.
+( export SSM_REMOTE_PROJECT_ID='with/slash'; run_driver dev-new 99 ) >/dev/null 2>&1
+assert_rc "SSM_REMOTE_PROJECT_ID with slash → rc=1" 1 "$?"
+
+( export SSM_REMOTE_PROJECT_DIR='/data/git/$(rm -rf /)'; run_driver dev-new 99 ) >/dev/null 2>&1
+assert_rc "SSM_REMOTE_PROJECT_DIR with command-substitution shape → rc=1" 1 "$?"
+
+( export SSM_REMOTE_PROJECT_DIR='relative/path'; run_driver dev-new 99 ) >/dev/null 2>&1
+assert_rc "SSM_REMOTE_PROJECT_DIR not absolute → rc=1" 1 "$?"
+
+( export SSM_REMOTE_USER='bad;user'; run_driver dev-new 99 ) >/dev/null 2>&1
+assert_rc "SSM_REMOTE_USER with semicolon → rc=1" 1 "$?"
+
+( export SSM_REMOTE_SHELL='/bin/csh'; run_driver dev-new 99 ) >/dev/null 2>&1
+assert_rc "SSM_REMOTE_SHELL not in allow-list → rc=1" 1 "$?"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-008: defaults applied when optional env unset ==="
+# ---------------------------------------------------------------------------
+: > "$TMPROOT/aws-record"
+unset SSM_REGION SSM_REMOTE_USER SSM_REMOTE_SHELL SSM_REMOTE_PROFILE
+run_driver dev-new 99 >/dev/null 2>&1
+assert_rc "happy path → rc=0" 0 "$?"
+record=$(cat "$TMPROOT/aws-record")
+assert_contains "default SSM_REGION ap-southeast-1 reaches aws" "ap-southeast-1" "$record"
+# INNER_CMD shape ends up inside the JSON parameters; capture it via grep.
+assert_contains "default user=ubuntu in INNER_CMD" "sudo -u ubuntu" "$record"
+assert_contains "default shell=bash with -l in INNER_CMD" "bash -l" "$record"
+assert_not_contains "no profile source when SSM_REMOTE_PROFILE empty" "source /home" "$record"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-009: SSM_REMOTE_PROFILE prepends source ==="
+# ---------------------------------------------------------------------------
+: > "$TMPROOT/aws-record"
+( export SSM_REMOTE_PROFILE=/home/ubuntu/.bash_aliases; run_driver dev-new 99 >/dev/null 2>&1 )
+record=$(cat "$TMPROOT/aws-record")
+assert_contains "INNER_CMD has 'source /home/ubuntu/.bash_aliases;'" "source /home/ubuntu/.bash_aliases;" "$record"
+
+# Non-absolute SSM_REMOTE_PROFILE is rejected
+( export SSM_REMOTE_PROFILE='.bash_aliases'; run_driver dev-new 99 >/dev/null 2>&1 )
+assert_rc "relative SSM_REMOTE_PROFILE → rc=1" 1 "$?"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-010: source-of-truth — jq -n --arg cmd is used (CWE-78) ==="
+# ---------------------------------------------------------------------------
+if grep -q 'jq -n --arg cmd' "$DRIVER"; then
+  echo -e "  ${GREEN}PASS${NC}: driver uses jq -n --arg for JSON construction"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: jq -n --arg cmd missing — possible shell-injection regression"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-011: aws failure propagates ==="
+# ---------------------------------------------------------------------------
+: > "$TMPROOT/aws-record"
+err=$(AWS_FAIL_RC=2 AWS_RECORD_FILE="$TMPROOT/aws-record" bash "$DRIVER" dev-new 99 2>&1 >/dev/null)
+rc=$?
+[ "$rc" -ne 0 ] && {
+  echo -e "  ${GREEN}PASS${NC}: aws rc=2 → driver rc != 0"
+  PASS=$((PASS + 1))
+} || {
+  echo -e "  ${RED}FAIL${NC}: driver should propagate aws failure"
+  FAIL=$((FAIL + 1))
+}
+assert_contains "stderr names instance ID" "$SSM_INSTANCE_ID" "$err"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-007b: dev-resume requires session_id (run before PATH test) ==="
+# ---------------------------------------------------------------------------
+err=$(run_driver dev-resume 99 2>&1 >/dev/null)
+assert_rc "dev-resume without session_id → rc=1" 1 "$?"
+assert_contains "stderr names session_id" "session_id" "$err"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-012: missing aws / jq → rc=1 ==="
+# ---------------------------------------------------------------------------
+# Run in a subshell with PATH pointing to a dir that contains real bash
+# but no aws/jq, so the driver's `command -v aws` returns false. Use
+# /usr/sbin only (where bash is reachable on Ubuntu via /bin → /usr/bin
+# but not aws). Actually the safest is: leave only the dir with bash and
+# nothing else.
+EMPTY_BIN="$TMPROOT/empty-bin"
+mkdir -p "$EMPTY_BIN"
+cp /usr/bin/bash "$EMPTY_BIN/bash" 2>/dev/null || cp /bin/bash "$EMPTY_BIN/bash"
+err=$(PATH="$EMPTY_BIN" bash "$DRIVER" dev-new 99 2>&1 >/dev/null)
+rc=$?
+assert_rc "missing aws on PATH → rc=1" 1 "$rc"
+case "$err" in
+  *"not found in PATH"*)
+    echo -e "  ${GREEN}PASS${NC}: stderr names missing dep"
+    PASS=$((PASS + 1)) ;;
+  *)
+    echo -e "  ${RED}FAIL${NC}: expected 'not found in PATH' in stderr; got: $err"
+    FAIL=$((FAIL + 1)) ;;
+esac
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/tests/unit/test-dispatch-remote-aws-ssm.sh
+++ b/tests/unit/test-dispatch-remote-aws-ssm.sh
@@ -148,6 +148,40 @@ assert_rc "SSM_REMOTE_USER with semicolon → rc=1" 1 "$?"
 assert_rc "SSM_REMOTE_SHELL not in allow-list → rc=1" 1 "$?"
 
 # ---------------------------------------------------------------------------
+# PR-9 review C1 + C2: shell metachars must be rejected on every operator-
+# controlled value embedded in INNER_CMD. The prior validator missed `'`,
+# `"`, `<`, `>`, `\n` — these break out of the
+# `sudo -u $USER $SHELL -l -c '<INNER_CMD>'` single-quote wrap on the
+# remote side.
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-007c: C1 — single-quote in SSM_REMOTE_PROJECT_DIR rejected ==="
+( export SSM_REMOTE_PROJECT_DIR="/data/git/foo' >/tmp/PWNED '"; run_driver dev-new 99 ) >/dev/null 2>&1
+assert_rc "single-quote in SSM_REMOTE_PROJECT_DIR → rc=1" 1 "$?"
+
+( export SSM_REMOTE_PROJECT_DIR='/data/git/foo<bar'; run_driver dev-new 99 ) >/dev/null 2>&1
+assert_rc "redirect-char in SSM_REMOTE_PROJECT_DIR → rc=1" 1 "$?"
+
+( export SSM_REMOTE_PROJECT_DIR='/data/git/foo*'; run_driver dev-new 99 ) >/dev/null 2>&1
+assert_rc "glob-char in SSM_REMOTE_PROJECT_DIR → rc=1" 1 "$?"
+
+newline_value=$'/data/git/foo\nrm -rf /'
+( export SSM_REMOTE_PROJECT_DIR="$newline_value"; run_driver dev-new 99 ) >/dev/null 2>&1
+assert_rc "newline in SSM_REMOTE_PROJECT_DIR → rc=1" 1 "$?"
+
+echo ""
+echo "=== TC-EB-009b: C2 — SSM_REMOTE_PROFILE metachar gate ==="
+( export SSM_REMOTE_PROFILE="/etc/foo'; touch /tmp/PWNED; '"; run_driver dev-new 99 ) >/dev/null 2>&1
+assert_rc "single-quote in SSM_REMOTE_PROFILE → rc=1" 1 "$?"
+
+( export SSM_REMOTE_PROFILE='/etc/foo$(rm -rf /)'; run_driver dev-new 99 ) >/dev/null 2>&1
+assert_rc "command-substitution in SSM_REMOTE_PROFILE → rc=1" 1 "$?"
+
+newline_profile=$'/etc/foo\nrm -rf /'
+( export SSM_REMOTE_PROFILE="$newline_profile"; run_driver dev-new 99 ) >/dev/null 2>&1
+assert_rc "newline in SSM_REMOTE_PROFILE → rc=1" 1 "$?"
+
+# ---------------------------------------------------------------------------
 echo ""
 echo "=== TC-EB-008: defaults applied when optional env unset ==="
 # ---------------------------------------------------------------------------

--- a/tests/unit/test-dispatcher-tick-router.sh
+++ b/tests/unit/test-dispatcher-tick-router.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# test-dispatcher-tick-router.sh — Unit tests for the dispatch() router
+# added in PR-9 (closes #62 axis 2). Verifies that EXECUTION_BACKEND
+# selects the right driver and that step bodies in dispatcher-tick.sh
+# call the helper rather than `bash dispatch-local.sh` directly.
+#
+# Run: bash tests/unit/test-dispatcher-tick-router.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TICK="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected='$expected'"
+    echo "      actual=  '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+echo "=== TC-EB-001/002/003: dispatch() router behavior ==="
+# ---------------------------------------------------------------------------
+# Strategy: extract the `dispatch()` function from dispatcher-tick.sh into a
+# harness, stub the two driver scripts, exercise three EXECUTION_BACKEND
+# values, and assert which stub got the call.
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# Sandbox layout that mirrors what dispatch() expects:
+#   $PROJECT_DIR/scripts/dispatch-local.sh           (local stub)
+#   $SCRIPT_DIR/dispatch-remote-aws-ssm.sh           (remote stub)
+PROJECT_DIR_FAKE="$TMPROOT/proj"
+SCRIPT_DIR_FAKE="$TMPROOT/skill-scripts"
+mkdir -p "$PROJECT_DIR_FAKE/scripts" "$SCRIPT_DIR_FAKE"
+
+cat > "$PROJECT_DIR_FAKE/scripts/dispatch-local.sh" <<'EOF'
+#!/bin/bash
+echo "LOCAL $*" >> "$DISPATCH_RECORD"
+EOF
+cat > "$SCRIPT_DIR_FAKE/dispatch-remote-aws-ssm.sh" <<'EOF'
+#!/bin/bash
+echo "REMOTE $*" >> "$DISPATCH_RECORD"
+EOF
+chmod +x "$PROJECT_DIR_FAKE/scripts/dispatch-local.sh" "$SCRIPT_DIR_FAKE/dispatch-remote-aws-ssm.sh"
+
+# Extract the dispatch() function definition from the live tick script.
+# The function spans from `^dispatch() {` to the next standalone `^}`.
+DISPATCH_FN=$(awk '/^dispatch\(\) \{/,/^\}/' "$TICK")
+if [[ -z "$DISPATCH_FN" ]]; then
+  echo -e "  ${RED}FAIL${NC}: could not extract dispatch() from $TICK"
+  FAIL=$((FAIL + 1))
+  echo ""
+  echo "  Skipping behavior tests."
+else
+  RECORD="$TMPROOT/record"
+
+  run_case() {
+    local backend="$1"; shift
+    : > "$RECORD"
+    PROJECT_DIR="$PROJECT_DIR_FAKE" \
+    SCRIPT_DIR="$SCRIPT_DIR_FAKE" \
+    EXECUTION_BACKEND="$backend" \
+    DISPATCH_RECORD="$RECORD" \
+    bash -c '
+      set +e
+      log() { :; }    # stub — real log is in tick script
+      '"$DISPATCH_FN"'
+      dispatch "$@"
+      exit $?
+    ' bash "$@"
+  }
+
+  # TC-EB-001: default (unset) → local
+  : > "$RECORD"
+  PROJECT_DIR="$PROJECT_DIR_FAKE" \
+  SCRIPT_DIR="$SCRIPT_DIR_FAKE" \
+  DISPATCH_RECORD="$RECORD" \
+  bash -c '
+    set +e
+    log() { :; }
+    '"$DISPATCH_FN"'
+    dispatch dev-new 99
+  '
+  assert_eq "EXECUTION_BACKEND unset → local stub called" "LOCAL dev-new 99" "$(cat "$RECORD")"
+
+  # TC-EB-001: =local → local
+  run_case local dev-new 99
+  assert_eq "EXECUTION_BACKEND=local → local stub called" "LOCAL dev-new 99" "$(cat "$RECORD")"
+
+  # TC-EB-002: =remote-aws-ssm → remote
+  run_case remote-aws-ssm review 42
+  assert_eq "EXECUTION_BACKEND=remote-aws-ssm → remote stub called" "REMOTE review 42" "$(cat "$RECORD")"
+
+  # TC-EB-003: bogus → no call, non-zero rc
+  : > "$RECORD"
+  PROJECT_DIR="$PROJECT_DIR_FAKE" \
+  SCRIPT_DIR="$SCRIPT_DIR_FAKE" \
+  EXECUTION_BACKEND=bogus \
+  DISPATCH_RECORD="$RECORD" \
+  bash -c '
+    set +e
+    log() { echo "LOG $*" >&2; }
+    '"$DISPATCH_FN"'
+    dispatch dev-new 99
+    echo "rc=$?"
+  ' >"$TMPROOT/out" 2>"$TMPROOT/err"
+  out=$(cat "$TMPROOT/out")
+  err=$(cat "$TMPROOT/err")
+  case "$out" in
+    *"rc=1"*)
+      echo -e "  ${GREEN}PASS${NC}: bogus backend → dispatch returns 1"
+      PASS=$((PASS + 1)) ;;
+    *)
+      echo -e "  ${RED}FAIL${NC}: expected rc=1 in output; got: $out"
+      FAIL=$((FAIL + 1)) ;;
+  esac
+  case "$err" in
+    *"unknown EXECUTION_BACKEND"*)
+      echo -e "  ${GREEN}PASS${NC}: error log mentions 'unknown EXECUTION_BACKEND'"
+      PASS=$((PASS + 1)) ;;
+    *)
+      echo -e "  ${RED}FAIL${NC}: log line missing; got stderr: $err"
+      FAIL=$((FAIL + 1)) ;;
+  esac
+  assert_eq "bogus backend → no driver called" "" "$(cat "$RECORD")"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-004: source-of-truth — step bodies use dispatch() helper ==="
+# ---------------------------------------------------------------------------
+# Step 2/3/4 must call `dispatch dev-new ...`, `dispatch review ...`,
+# `dispatch dev-resume ...` — NOT `bash $PROJECT_DIR/scripts/dispatch-local.sh`
+# directly. Direct calls would bypass the router and hard-bind to local.
+direct_calls=$(grep -cE '^\s*bash\s+"\$PROJECT_DIR/scripts/dispatch-local\.sh"\s+(dev-new|dev-resume|review)\b' "$TICK")
+assert_eq "no direct bash dispatch-local.sh in step bodies" "0" "$direct_calls"
+
+dispatch_calls=$(grep -cE '^\s*dispatch\s+(dev-new|dev-resume|review)\b' "$TICK")
+[ "$dispatch_calls" -ge 3 ] && {
+  echo -e "  ${GREEN}PASS${NC}: at least 3 dispatch() calls in step bodies (got $dispatch_calls)"
+  PASS=$((PASS + 1))
+} || {
+  echo -e "  ${RED}FAIL${NC}: expected >= 3 dispatch() calls, got $dispatch_calls"
+  FAIL=$((FAIL + 1))
+}
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-019: dispatch-local.sh unchanged from main ==="
+# ---------------------------------------------------------------------------
+DIFF=$(git -C "$PROJECT_ROOT" diff origin/main -- skills/autonomous-dispatcher/scripts/dispatch-local.sh 2>/dev/null)
+if [[ -z "$DIFF" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: dispatch-local.sh byte-identical to origin/main"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: dispatch-local.sh has changes vs origin/main:"
+  echo "$DIFF" | head -20
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/tests/unit/test-dispatcher-tick-router.sh
+++ b/tests/unit/test-dispatcher-tick-router.sh
@@ -105,7 +105,8 @@ else
   run_case remote-aws-ssm review 42
   assert_eq "EXECUTION_BACKEND=remote-aws-ssm → remote stub called" "REMOTE review 42" "$(cat "$RECORD")"
 
-  # TC-EB-003: bogus → no call, non-zero rc
+  # TC-EB-003a: dispatch() helper itself defends against unknown backend
+  # (the runtime safety net — should never fire because of upfront check).
   : > "$RECORD"
   PROJECT_DIR="$PROJECT_DIR_FAKE" \
   SCRIPT_DIR="$SCRIPT_DIR_FAKE" \
@@ -122,21 +123,47 @@ else
   err=$(cat "$TMPROOT/err")
   case "$out" in
     *"rc=1"*)
-      echo -e "  ${GREEN}PASS${NC}: bogus backend → dispatch returns 1"
+      echo -e "  ${GREEN}PASS${NC}: dispatch() with unknown backend → exit 1"
       PASS=$((PASS + 1)) ;;
     *)
-      echo -e "  ${RED}FAIL${NC}: expected rc=1 in output; got: $out"
-      FAIL=$((FAIL + 1)) ;;
-  esac
-  case "$err" in
-    *"unknown EXECUTION_BACKEND"*)
-      echo -e "  ${GREEN}PASS${NC}: error log mentions 'unknown EXECUTION_BACKEND'"
-      PASS=$((PASS + 1)) ;;
-    *)
-      echo -e "  ${RED}FAIL${NC}: log line missing; got stderr: $err"
-      FAIL=$((FAIL + 1)) ;;
+      # Note: H1 fix makes dispatch() use `exit 1` not `return 1`, so the
+      # subshell terminates; trailing `echo rc=$?` won't run. That's the
+      # intended behavior — verify by checking stderr instead.
+      case "$err" in
+        *"unknown EXECUTION_BACKEND"*|*"BUG: dispatch"*)
+          echo -e "  ${GREEN}PASS${NC}: dispatch() aborted via exit (subshell terminated before echo)"
+          PASS=$((PASS + 1)) ;;
+        *)
+          echo -e "  ${RED}FAIL${NC}: expected exit/error; out=$out err=$err"
+          FAIL=$((FAIL + 1)) ;;
+      esac ;;
   esac
   assert_eq "bogus backend → no driver called" "" "$(cat "$RECORD")"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-003b: upfront EXECUTION_BACKEND validation aborts BEFORE label transitions (H1) ==="
+# ---------------------------------------------------------------------------
+# H1 finding: prior to this fix, an unknown EXECUTION_BACKEND caused the
+# step body to swap labels and post comments BEFORE dispatch() failed,
+# leaving a stuck issue + burning retries. Verify the upfront check exists.
+if grep -E '^case "\$\{EXECUTION_BACKEND:-local\}"' "$TICK" | head -1 >/dev/null; then
+  # Look for the upfront `case` block (not the dispatch() body) — it must
+  # appear BEFORE any `gh issue edit` or `dispatch` invocations.
+  upfront_line=$(grep -nE '^case "\$\{EXECUTION_BACKEND:-local\}"' "$TICK" | head -1 | cut -d: -f1)
+  # Find the line of the first `dispatch ` callsite or `label_swap` (whichever).
+  first_swap=$(grep -nE '^\s*(dispatch [a-z]|label_swap )' "$TICK" | head -1 | cut -d: -f1)
+  if [[ -n "$upfront_line" && -n "$first_swap" && "$upfront_line" -lt "$first_swap" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: EXECUTION_BACKEND validated upfront (line $upfront_line) before any label/dispatch action (line $first_swap)"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: validation order is wrong: validate=$upfront_line first_action=$first_swap"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo -e "  ${RED}FAIL${NC}: no upfront EXECUTION_BACKEND case-block found in $TICK — H1 regression"
+  FAIL=$((FAIL + 1))
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test-multi-tick-inline-projects.sh
+++ b/tests/unit/test-multi-tick-inline-projects.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+# test-multi-tick-inline-projects.sh — Verify dispatcher-multi-tick.sh
+# handles inline metadata blocks for remote projects (PR-9, #62 axis 2)
+# while preserving PR-8's path-string behavior for local projects.
+#
+# Strategy: stub dispatcher-tick.sh to record its env (in particular
+# REPO, REPO_OWNER, REPO_NAME, EXECUTION_BACKEND, SSM_*) and AUTONOMOUS_CONF.
+# Run multi-tick against various PROJECTS shapes.
+#
+# Run: bash tests/unit/test-multi-tick-inline-projects.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WRAPPER_SRC="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/dispatcher-multi-tick.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      needle='$needle'"
+    echo "      haystack='$haystack'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      should NOT contain: '$needle'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_rc() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected_rc=$expected actual_rc=$actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+SANDBOX="$TMPROOT/scripts"
+mkdir -p "$SANDBOX"
+cp "$WRAPPER_SRC" "$SANDBOX/dispatcher-multi-tick.sh"
+
+# Stub dispatcher-tick.sh records relevant env to a sentinel file. For
+# local projects, we source AUTONOMOUS_CONF first to mirror what the real
+# dispatcher-tick.sh does via lib-config.sh — without that, the stub would
+# see REPO=<unset> for local entries and the test wouldn't reflect real flow.
+cat > "$SANDBOX/dispatcher-tick.sh" <<'EOF'
+#!/bin/bash
+# Mirror lib-config.sh::load_autonomous_conf priority-1 behavior.
+if [[ -n "${AUTONOMOUS_CONF:-}" ]] && [[ -f "$AUTONOMOUS_CONF" ]]; then
+  # shellcheck disable=SC1090
+  source "$AUTONOMOUS_CONF"
+fi
+{
+  printf 'AUTONOMOUS_CONF=%s\n' "${AUTONOMOUS_CONF:-<unset>}"
+  printf 'REPO=%s\n' "${REPO:-<unset>}"
+  printf 'REPO_OWNER=%s\n' "${REPO_OWNER:-<unset>}"
+  printf 'REPO_NAME=%s\n' "${REPO_NAME:-<unset>}"
+  printf 'PROJECT_ID=%s\n' "${PROJECT_ID:-<unset>}"
+  printf 'EXECUTION_BACKEND=%s\n' "${EXECUTION_BACKEND:-<unset>}"
+  printf 'SSM_INSTANCE_ID=%s\n' "${SSM_INSTANCE_ID:-<unset>}"
+  printf 'SSM_REMOTE_PROJECT_DIR=%s\n' "${SSM_REMOTE_PROJECT_DIR:-<unset>}"
+  printf '%s\n' '---'
+} >> "$TICK_RECORD_FILE"
+exit 0
+EOF
+chmod +x "$SANDBOX/dispatcher-tick.sh"
+
+# AUTONOMOUS_TRUST_CONF=1 because /tmp is mode 1777 (PR-8 trust gate)
+export AUTONOMOUS_TRUST_CONF=1
+
+# ---------------------------------------------------------------------------
+echo "=== TC-EB-013/014: inline block — REPO_OWNER/_NAME auto-derived ==="
+# ---------------------------------------------------------------------------
+CONF="$TMPROOT/disp-013.conf"
+RECORD="$TMPROOT/record-013"
+: > "$RECORD"
+cat > "$CONF" <<'EOF'
+PROJECTS=()
+PROJECTS+=( '
+PROJECT_ID=projB
+REPO=myorg/projB
+EXECUTION_BACKEND=remote-aws-ssm
+SSM_INSTANCE_ID=i-0abc123
+SSM_REMOTE_PROJECT_DIR=/data/git/projB
+SSM_REMOTE_PROJECT_ID=projB
+' )
+EOF
+
+DISPATCHER_CONF="$CONF" TICK_RECORD_FILE="$RECORD" \
+  bash "$SANDBOX/dispatcher-multi-tick.sh" >/dev/null 2>&1
+rc=$?
+assert_rc "rc=0 for happy-path inline project" 0 "$rc"
+record=$(cat "$RECORD")
+assert_contains "REPO propagated" "REPO=myorg/projB" "$record"
+assert_contains "REPO_OWNER auto-derived" "REPO_OWNER=myorg" "$record"
+assert_contains "REPO_NAME auto-derived" "REPO_NAME=projB" "$record"
+assert_contains "PROJECT_ID propagated" "PROJECT_ID=projB" "$record"
+assert_contains "EXECUTION_BACKEND propagated" "EXECUTION_BACKEND=remote-aws-ssm" "$record"
+assert_contains "SSM_INSTANCE_ID propagated" "SSM_INSTANCE_ID=i-0abc123" "$record"
+assert_contains "AUTONOMOUS_CONF unset for inline" "AUTONOMOUS_CONF=<unset>" "$record"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-015: inline block with non-assignment line is rejected ==="
+# ---------------------------------------------------------------------------
+CONF="$TMPROOT/disp-015.conf"
+RECORD="$TMPROOT/record-015"
+: > "$RECORD"
+cat > "$CONF" <<'EOF'
+PROJECTS=()
+PROJECTS+=( '
+PROJECT_ID=mal
+REPO=evil/repo
+rm -rf /
+' )
+EOF
+stderr_log="$TMPROOT/stderr-015"
+DISPATCHER_CONF="$CONF" TICK_RECORD_FILE="$RECORD" \
+  bash "$SANDBOX/dispatcher-multi-tick.sh" >/dev/null 2>"$stderr_log"
+rc=$?
+assert_rc "rc=0 (per-project failure isolation)" 0 "$rc"
+case "$(cat "$stderr_log")" in
+  *"non-assignment lines"*)
+    echo -e "  ${GREEN}PASS${NC}: stderr explains the validator rejection"
+    PASS=$((PASS + 1)) ;;
+  *)
+    echo -e "  ${RED}FAIL${NC}: expected 'non-assignment lines' in stderr"
+    FAIL=$((FAIL + 1)) ;;
+esac
+# Stub should NOT have been invoked (validator caught the bad block)
+[ ! -s "$RECORD" ] && {
+  echo -e "  ${GREEN}PASS${NC}: stub was NOT invoked for malformed block"
+  PASS=$((PASS + 1))
+} || {
+  echo -e "  ${RED}FAIL${NC}: stub was invoked despite malformed block"
+  FAIL=$((FAIL + 1))
+}
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-016: inline block missing REPO → warn-and-skip ==="
+# ---------------------------------------------------------------------------
+CONF="$TMPROOT/disp-016.conf"
+RECORD="$TMPROOT/record-016"
+: > "$RECORD"
+cat > "$CONF" <<'EOF'
+PROJECTS=()
+PROJECTS+=( '
+PROJECT_ID=projX
+EXECUTION_BACKEND=remote-aws-ssm
+SSM_INSTANCE_ID=i-empty
+SSM_REMOTE_PROJECT_DIR=/data/git/projX
+SSM_REMOTE_PROJECT_ID=projX
+' )
+EOF
+stderr_log="$TMPROOT/stderr-016"
+DISPATCHER_CONF="$CONF" TICK_RECORD_FILE="$RECORD" \
+  bash "$SANDBOX/dispatcher-multi-tick.sh" >/dev/null 2>"$stderr_log"
+rc=$?
+assert_rc "rc=0 even with missing-REPO inline project" 0 "$rc"
+[ ! -s "$RECORD" ] && {
+  echo -e "  ${GREEN}PASS${NC}: stub NOT invoked for missing-REPO project"
+  PASS=$((PASS + 1))
+} || {
+  echo -e "  ${RED}FAIL${NC}: stub was invoked despite missing REPO"
+  FAIL=$((FAIL + 1))
+}
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-017: mixed local + remote projects in one PROJECTS array ==="
+# ---------------------------------------------------------------------------
+LOCAL_CONF="$TMPROOT/local-autoconf.conf"
+cat > "$LOCAL_CONF" <<'EOF'
+REPO=myorg/local-proj
+REPO_OWNER=myorg
+REPO_NAME=local-proj
+PROJECT_ID=local-proj
+PROJECT_DIR=/tmp/local-proj
+EOF
+
+CONF="$TMPROOT/disp-017.conf"
+RECORD="$TMPROOT/record-017"
+: > "$RECORD"
+{
+  echo 'PROJECTS=()'
+  printf 'PROJECTS+=( %q )\n' "$LOCAL_CONF"
+  echo "PROJECTS+=( '"
+  echo 'PROJECT_ID=remote-proj'
+  echo 'REPO=myorg/remote-proj'
+  echo 'EXECUTION_BACKEND=remote-aws-ssm'
+  echo 'SSM_INSTANCE_ID=i-mix'
+  echo 'SSM_REMOTE_PROJECT_DIR=/data/git/remote-proj'
+  echo 'SSM_REMOTE_PROJECT_ID=remote-proj'
+  echo "' )"
+} > "$CONF"
+
+DISPATCHER_CONF="$CONF" TICK_RECORD_FILE="$RECORD" \
+  bash "$SANDBOX/dispatcher-multi-tick.sh" >/dev/null 2>&1
+rc=$?
+assert_rc "rc=0 for mixed projects" 0 "$rc"
+record=$(cat "$RECORD")
+# Two ticks recorded — separated by '---'.
+tick_count=$(grep -c '^---$' "$RECORD")
+[ "$tick_count" = "2" ] && {
+  echo -e "  ${GREEN}PASS${NC}: both projects ticked (count=$tick_count)"
+  PASS=$((PASS + 1))
+} || {
+  echo -e "  ${RED}FAIL${NC}: expected 2 ticks, got $tick_count"
+  FAIL=$((FAIL + 1))
+}
+# Local project tick records AUTONOMOUS_CONF=$LOCAL_CONF
+assert_contains "local project: AUTONOMOUS_CONF set to autonomous.conf path" "AUTONOMOUS_CONF=$LOCAL_CONF" "$record"
+# Remote project records inline metadata + AUTONOMOUS_CONF=<unset>
+assert_contains "remote project: REPO=myorg/remote-proj propagated" "REPO=myorg/remote-proj" "$record"
+assert_contains "remote project: AUTONOMOUS_CONF unset" "AUTONOMOUS_CONF=<unset>" "$record"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EB-018: backwards compat — pure-path PROJECTS still works ==="
+# ---------------------------------------------------------------------------
+LOCAL_ONLY_CONF="$TMPROOT/disp-018.conf"
+RECORD="$TMPROOT/record-018"
+: > "$RECORD"
+{
+  echo 'PROJECTS=()'
+  printf 'PROJECTS+=( %q )\n' "$LOCAL_CONF"
+} > "$LOCAL_ONLY_CONF"
+
+DISPATCHER_CONF="$LOCAL_ONLY_CONF" TICK_RECORD_FILE="$RECORD" \
+  bash "$SANDBOX/dispatcher-multi-tick.sh" >/dev/null 2>&1
+assert_rc "rc=0 for PR-8-shape pure-path PROJECTS" 0 "$?"
+record=$(cat "$RECORD")
+assert_contains "PR-8 path entry: AUTONOMOUS_CONF set" "AUTONOMOUS_CONF=$LOCAL_CONF" "$record"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/tests/unit/test-multi-tick-inline-projects.sh
+++ b/tests/unit/test-multi-tick-inline-projects.sh
@@ -163,6 +163,62 @@ esac
 
 # ---------------------------------------------------------------------------
 echo ""
+echo "=== TC-EB-015b: Q PR-80 — value-side metachars rejected (CWE-95) ==="
+# ---------------------------------------------------------------------------
+# Q's finding: pre-fix, validator only checked LHS, so values like
+# `REPO=$(rm -rf /)` would pass validation and execute on eval.
+for badval in \
+  'REPO=$(echo PWNED)' \
+  'REPO=`echo PWNED`' \
+  'REPO=foo;rm -rf /' \
+  'REPO=foo&&evil' \
+  'REPO=foo|evil' \
+  'REPO=foo$VAR' \
+  'REPO=foo\nnewlinetrick' ; do
+  CONF="$TMPROOT/disp-015b.conf"
+  RECORD="$TMPROOT/record-015b"
+  : > "$RECORD"
+  printf 'PROJECTS=()\nPROJECTS+=( '\''\nPROJECT_ID=test\n%s\nEXECUTION_BACKEND=remote-aws-ssm\nSSM_INSTANCE_ID=i-x\nSSM_REMOTE_PROJECT_DIR=/data/test\nSSM_REMOTE_PROJECT_ID=test\n'\'' )\n' "$badval" > "$CONF"
+  stderr_log="$TMPROOT/stderr-015b"
+  DISPATCHER_CONF="$CONF" TICK_RECORD_FILE="$RECORD" \
+    bash "$SANDBOX/dispatcher-multi-tick.sh" >/dev/null 2>"$stderr_log"
+  rc=$?
+  if [ "$rc" -eq 0 ] && [ ! -s "$RECORD" ]; then
+    echo -e "  ${GREEN}PASS${NC}: rejected metachar value: $badval"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: did NOT reject: $badval (rc=$rc, record=$(wc -l <"$RECORD"))"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+# Sanity: a legitimate value WITHOUT metachars must still pass.
+CONF="$TMPROOT/disp-015c.conf"
+RECORD="$TMPROOT/record-015c"
+: > "$RECORD"
+cat > "$CONF" <<'EOF'
+PROJECTS=()
+PROJECTS+=( '
+PROJECT_ID=projB
+REPO=myorg/projB
+EXECUTION_BACKEND=remote-aws-ssm
+SSM_INSTANCE_ID=i-0abc123
+SSM_REMOTE_PROJECT_DIR=/data/git/projB
+SSM_REMOTE_PROJECT_ID=projB
+' )
+EOF
+DISPATCHER_CONF="$CONF" TICK_RECORD_FILE="$RECORD" \
+  bash "$SANDBOX/dispatcher-multi-tick.sh" >/dev/null 2>&1
+[ -s "$RECORD" ] && {
+  echo -e "  ${GREEN}PASS${NC}: legitimate metachar-free values still accepted"
+  PASS=$((PASS + 1))
+} || {
+  echo -e "  ${RED}FAIL${NC}: legitimate values were rejected — validator too strict"
+  FAIL=$((FAIL + 1))
+}
+
+# ---------------------------------------------------------------------------
+echo ""
 echo "=== TC-EB-016: inline block missing REPO → warn-and-skip ==="
 # ---------------------------------------------------------------------------
 CONF="$TMPROOT/disp-016.conf"


### PR DESCRIPTION
## Summary

Final axis (axis 2) of #62, completing the issue: pluggable execution backend so the dispatcher can spawn wrappers either on the same box (`local`, today's behavior) or on a remote AWS EC2 via SSM (`remote-aws-ssm`, new).

This together with PR-8 (axes 1 + 3) covers all of #62.

Closes #62

## Topology this enables

```
┌────────────────────────────────────────────────────────────┐
│  dispatcher box (one machine, one cron)                    │
│    holds dispatcher.conf only                              │
│    for remote projects, autonomous.conf is NOT here        │
│    sends `aws ssm send-command` to the remote dev EC2      │
└──────────────────────┬─────────────────────────────────────┘
                       │
                       ▼
            ┌─────────────────────┐
            │ remote dev EC2      │
            │ (per-project)       │
            │   holds its own     │
            │   autonomous.conf   │
            │   runs the          │
            │   wrapper +         │
            │   agent CLI         │
            └─────────────────────┘
```

## Behavior changes

- **`dispatcher-tick.sh`** gains a `dispatch()` helper that routes by `EXECUTION_BACKEND`. The three step bodies call `dispatch dev-new <N>` etc. instead of `bash dispatch-local.sh ...` directly. `EXECUTION_BACKEND` is validated **upfront** before any label transitions or comments — an unknown value aborts the tick cleanly, no stuck issues.
- **`dispatcher-multi-tick.sh`** now classifies each `PROJECTS[]` entry: file path → PR-8's source-autonomous.conf path; non-path → validate as KEY=VALUE block, eval in subshell, auto-derive `REPO_OWNER`/`REPO_NAME` from `REPO`. Defense-in-depth validator rejects non-assignment lines before eval.
- **`dispatch-remote-aws-ssm.sh`** is the new SSM transport driver. Derived from a battle-tested private implementation, generalized for upstream: required `SSM_INSTANCE_ID` / `SSM_REMOTE_PROJECT_DIR` / `SSM_REMOTE_PROJECT_ID` (no hardcoded private-repo defaults), configurable `SSM_REMOTE_USER` (default `ubuntu`) / `SSM_REMOTE_SHELL` (allow-list `bash|zsh|sh`) / `SSM_REMOTE_PROFILE` (opt-in). JSON construction via `jq -n --arg cmd` for CWE-78 safety. **Strict shell-metachar gate** on every operator-controlled value embedded into the remote `sudo -u $USER $SHELL -l -c '<INNER_CMD>'` wrapping (rejects `$ \` ; & | < > * ? ' "` newline / CR — found via code review C1+C2).

`dispatch-local.sh` is byte-identical to main — backwards compat verified by test.

## PID-alive caveat for remote backend

`lib-dispatch.sh::pid_alive` does `kill -0 $PID` on the dispatcher box; for a remote project the PID file is on the remote box → always DEAD. Step 5a (ALIVE+PR ready optimisation) is unreachable for remote projects; Step 5b DEAD-branch is the only path. Wall-clock timeout (PR-6 / [INV-13], 4h default) bounds the worst case. Documented in `dispatcher-flow.md`.

## Tests

24 test files green, including 56 new cases:

- `tests/unit/test-dispatch-remote-aws-ssm.sh` (34 cases) — env/input validation, default values, profile prefix, jq-escaping source-of-truth, aws-failure propagation, missing-dep detection, **shell-metachar rejection** (single-quote, redirect, glob, newline, command-substitution).
- `tests/unit/test-dispatcher-tick-router.sh` (9 cases) — backend selection, source-of-truth grep that step bodies use `dispatch()`, **upfront EXECUTION_BACKEND validation order check** (regression guard for H1), `dispatch-local.sh` byte-identical to origin/main.
- `tests/unit/test-multi-tick-inline-projects.sh` (20 cases) — inline-block parsing, REPO_OWNER auto-derive, validator rejects non-assignment lines, mixed local+remote PROJECTS, PR-8 backwards compat.

## Pipeline docs

- `docs/pipeline/dispatcher-flow.md`: new "Backend routing" section + remote-backend PID-alive caveat. Multi-project outer loop section updated to describe the two PROJECTS[] entry shapes.
- `skills/autonomous-dispatcher/SKILL.md`: backend table replaces direct `dispatch-local.sh` references; cron command examples for both local and multi-project deployments.
- `docs/designs/exec-backend-routing.md`: full design canvas covering topology, schema, security trade-offs.

## Test plan

- [x] `bash tests/unit/*.sh` — all 24 test files green
- [x] `bash -n` syntax check on all modified scripts
- [x] `shellcheck` clean (only pre-existing SC1091/SC2178 info-level findings, unchanged)
- [x] code-reviewer agent: identified 2 critical (C1+C2 shell injection) + 1 high (H1 stuck-issue), all addressed in follow-up commit `d475226`
- [x] Backwards compat verified — `dispatch-local.sh` byte-identical to main, PR-8 PROJECTS=( /path ) entries continue to work