### PR TITLE
docs(skills): polish 5 skills based on skill-reviewer findings

### DIFF
--- a/docs/designs/skill-polish.md
+++ b/docs/designs/skill-polish.md
@@ -1,0 +1,106 @@
+# Design Canvas — Skill Quality Polish (PR-10)
+
+**Branch**: `feat/skill-polish`
+**Closes**: nothing (no specific issue — quality cleanup driven by skill-reviewer findings).
+**Pipeline-docs touched**: none — skills only.
+
+---
+
+## Why
+
+Ran the `skill-reviewer` agent against all 5 skills. Pattern: descriptions across the board are imprecise (don't trigger on the actual user phrasings users send), and there are several packaging-fragility issues that will break for users who install via `npx skills add` (which copies only the skill dir, not the project's `docs/` or hooks symlinks).
+
+Below is the per-skill plan. Behavior changes are limited to **what the skill does on cold load** (description triggers + reference paths). No actual workflow logic changes.
+
+## Per-skill changes
+
+### 1. `autonomous-common`
+
+**Findings:**
+- Description targets the wrong audience (says "loaded automatically as background context", but skill-discovery doesn't auto-load sibling skills).
+- Frontmatter has a fake field `user-invocable: false` (not a real schema field).
+- Hook-and-script tables duplicate `hooks/README.md`.
+
+**Fixes:**
+- Rewrite description to trigger on real user-facing tasks: "hooks failing", "what does check-pr-review.sh do", "after `npx skills add`, push hook not running", configuring the symlink workaround.
+- Drop `user-invocable: false`.
+- Replace the two tables with a one-line "see hooks/README.md" pointer.
+
+### 2. `autonomous-dev`
+
+**Findings:**
+- 480 lines — borderline too long. Three sections are how-to detail belonging in `references/`.
+- Description doesn't trigger on "implement a GitHub issue end-to-end" / "autonomous mode" — half the skill's purpose.
+- "NON-NEGOTIABLE RULES" callout uses second-person imperative; convention is infinitive.
+
+**Fixes:**
+- Extract "Pencil MCP Workflow" + template (lines 164-184) → `references/design-canvas.md`.
+- Extract Step 10 "Reviewer Bot Findings" tables (lines 391-425) → already exists in `references/review-threads.md`; replace with pointer.
+- Extract "Cross-Platform Notes" + "Tool Name Mapping" → `references/cross-platform.md`.
+- Add to description: explicit "implement a GitHub issue", "autonomous mode", "unattended" triggers.
+- Rewrite the bold callout in infinitive form.
+- Target ~300 lines.
+
+### 3. `autonomous-dispatcher`
+
+**Findings:**
+- Description omits the multi-project / SSM / `EXECUTION_BACKEND` triggers introduced by PR-7/8/9.
+- Body links use `../../docs/pipeline/` paths that don't survive `npx skills add`.
+- Frontmatter `metadata` block is a non-standard OpenClaw-only field — most agents ignore.
+
+**Fixes:**
+- Description gains: "multi-project dispatcher", "remote-aws-ssm", "EXECUTION_BACKEND", "dispatcher.conf", "dispatch to a remote dev box".
+- Replace `../../docs/pipeline/` links with absolute GitHub URLs (`https://github.com/zxkane/autonomous-dev-team/blob/main/docs/pipeline/...`).
+- Move the OpenClaw `metadata` block into a body-level "Prerequisites" section; drop from frontmatter.
+
+### 4. `autonomous-review`
+
+**Findings:**
+- Description doesn't tie to the dispatcher trigger (`pending-review` label).
+- Body opening "You are reviewing a PR..." is second-person; convention is imperative/declarative.
+- Missing "When to Use / When Not to Use" — competes with autonomous-dev's PR-review step.
+- The `gh-as-user.sh`-required rule for bot-reviewer triggers is buried in a blockquote.
+
+**Fixes:**
+- Description adds: "PR labeled for autonomous review", "decide to approve or send back for fixes".
+- Rewrite body opening in imperative form.
+- Add a "When to Use" 4-line section right after the title.
+- Promote `gh-as-user.sh` rule to its own subsection.
+
+### 5. `create-issue`
+
+**Findings (low-impact only — skill is in good shape):**
+- Description's trigger list is bloated with overlapping phrasing and "create a task" is ambiguous.
+- "Step 2.5" breaks the linear 1-4 numbering.
+
+**Fixes:**
+- Tighten trigger list to 4-5 distinct phrasings; remove "create a task".
+- Renumber "Step 2.5" to "Step 3" and shift the rest down.
+
+## Packaging fragility audit (cross-cutting)
+
+These issues hit any user who installs via `npx skills add` (skills.sh model: only the skill dir is copied, NOT `docs/`, `hooks/`, or repo-root symlinks):
+
+| Skill | Fragile reference | Fix |
+|---|---|---|
+| autonomous-dispatcher | `../../docs/pipeline/...` (5+ links) | Absolute GitHub URLs |
+| autonomous-dev | `references/...` (already in skill dir — OK) | unchanged |
+| autonomous-review | `references/...` (already in skill dir — OK) | unchanged |
+| autonomous-common | `hooks/README.md` (in skill dir — OK) | unchanged |
+
+The hook-config blocks in `autonomous-dev` and `autonomous-review` frontmatter use `$CLAUDE_PROJECT_DIR/hooks/...`. After `npx skills add`, hooks live at `$CLAUDE_PROJECT_DIR/.claude/skills/autonomous-common/hooks/...`. The autonomous-common SKILL.md already documents the symlink workaround for this — keep that documentation but make it more prominent (move into the description triggers so it shows up when a user reports "hooks not running").
+
+## What's explicitly NOT changing
+
+- Workflow logic in any skill (the steps themselves stay the same).
+- `references/*.md` content (pulling content INTO references is fine; rewriting existing references is out of scope).
+- Hook scripts in `skills/autonomous-common/hooks/` — no behavior changes.
+- Project-level `docs/pipeline/` — already accurate, just unreachable post-install for autonomous-dispatcher.
+
+## Risk
+
+Low. Description rewrites change skill triggering — an agent might match different user phrasings than before. Mitigation: keep all old triggers + add new ones (don't remove). The structural extraction in autonomous-dev preserves all content (just moves it).
+
+## Tests
+
+No code logic changes → no new unit tests. The existing 24 test files must continue to pass (they don't reference SKILL.md content). Verify all green before push.

--- a/skills/autonomous-common/SKILL.md
+++ b/skills/autonomous-common/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: autonomous-common
 description: >
-  Shared infrastructure for the autonomous dev team skills. Provides workflow
-  enforcement hooks (block-push-to-main, block-commit-outside-worktree,
-  check-design-canvas, etc.) and agent-callable utility scripts
-  (mark-issue-checkbox, reply-to-comments, resolve-threads, gh-as-user).
-  This skill is loaded automatically as background context by other
-  autonomous-* skills. Do not invoke directly.
-user-invocable: false
+  Use when setting up, troubleshooting, or modifying the shared hooks and
+  agent-callable utility scripts that enforce the autonomous dev/review
+  workflow. Triggers on phrases like "push to main is blocked",
+  "block-commit-outside-worktree hook failing", "configure hooks after
+  npx skills add", "what does check-pr-review.sh do", "set up workflow
+  hook symlinks", or when editing files under `skills/autonomous-common/`.
+  Provides the hooks the autonomous-dev / autonomous-review skills depend
+  on, plus utility scripts (gh-as-user.sh, mark-issue-checkbox.sh,
+  reply-to-comments.sh, resolve-threads.sh).
 ---
 
 # Autonomous Common Infrastructure
 
-Shared hooks and scripts used by the autonomous-dev, autonomous-review, and autonomous-dispatcher skills.
+Shared workflow-enforcement hooks and agent-callable utility scripts used by `autonomous-dev`, `autonomous-review`, and `autonomous-dispatcher`. The other autonomous-* skills reference scripts and hooks here — when those reference paths break, this is usually the skill to look at.
 
 ## Setup for `npx skills add` Users
 
@@ -24,7 +26,11 @@ ln -sf .claude/skills/autonomous-common/hooks hooks
 ln -sf .claude/skills/autonomous-dispatcher/scripts scripts
 ```
 
-Required Claude Code plugins (add to `.claude/settings.json` under `enabledPlugins`):
+> Without these symlinks, hook commands silently fail to fire (they look up `$CLAUDE_PROJECT_DIR/hooks/...` but the path doesn't exist). If "the push hook isn't blocking" or "the commit-outside-worktree check isn't running" — check the symlinks first.
+
+### Required Claude Code plugins
+
+Claude Code only. Add to `.claude/settings.json` under `enabledPlugins`:
 
 ```json
 {
@@ -35,35 +41,15 @@ Required Claude Code plugins (add to `.claude/settings.json` under `enabledPlugi
 }
 ```
 
-> IDEs without hook support (Cursor, Windsurf, Gemini CLI) don't need symlinks — the skills work without hooks, but workflow steps must be followed manually.
+> IDEs without hook support (Cursor, Windsurf, Gemini CLI) don't need symlinks or plugins — the skills work without hooks, but workflow steps must be followed manually.
 
-## Hooks
+## What's here
 
-Workflow enforcement hooks in `hooks/` directory. See `hooks/README.md` for the full reference.
+- **`hooks/`** — workflow-enforcement hooks (block-push-to-main, block-commit-outside-worktree, check-pr-review, check-shellcheck, verify-completion, …). See `hooks/README.md` for the canonical list and per-hook semantics.
+- **`scripts/`** — agent-callable utilities used by the dev/review skills:
+  - `gh-as-user.sh` — runs `gh` as a real user (needed when retriggering bot reviews like `/q review`)
+  - `mark-issue-checkbox.sh` — toggles GitHub issue body checkboxes from the agent
+  - `reply-to-comments.sh` — replies to PR review comments
+  - `resolve-threads.sh` — batch-resolves review threads on a PR
 
-| Hook | Type | Purpose |
-|------|------|---------|
-| `block-push-to-main.sh` | PreToolUse | Blocks direct pushes to main |
-| `block-commit-outside-worktree.sh` | PreToolUse | Blocks commits outside worktrees |
-| `check-design-canvas.sh` | PreToolUse | Reminds about design canvas |
-| `check-code-simplifier.sh` | PreToolUse | Blocks commits until code-simplifier review |
-| `check-pr-review.sh` | PreToolUse | Blocks pushes until PR review |
-| `check-test-plan.sh` | PreToolUse | Reminds about test plan |
-| `check-shellcheck.sh` | PreToolUse | Blocks commits if staged .sh files have shellcheck errors |
-| `check-unit-tests.sh` | PreToolUse | Warns about unrun unit tests |
-| `check-rebase-before-push.sh` | PreToolUse | Blocks push if behind origin/main |
-| `warn-skip-verification.sh` | PreToolUse | Warns about --no-verify |
-| `post-git-action-clear.sh` | PostToolUse | Clears state after git actions |
-| `post-git-push.sh` | PostToolUse | Post-push CI/E2E reminder |
-| `verify-completion.sh` | Stop | Blocks completion until CI/E2E pass |
-
-## Scripts
-
-Agent-callable utility scripts in `scripts/` directory.
-
-| Script | Used By | Purpose |
-|--------|---------|---------|
-| `mark-issue-checkbox.sh` | autonomous-dev, autonomous-review | Mark issue checkboxes as complete |
-| `gh-as-user.sh` | autonomous-dev, autonomous-review | Run `gh` as real user (not bot) |
-| `reply-to-comments.sh` | autonomous-dev | Reply to PR review comments |
-| `resolve-threads.sh` | autonomous-dev | Batch resolve review threads |
+> The hooks and scripts are documented in detail in their respective README/source files. This SKILL.md only catalogs what's available so you can find the right file to edit.

--- a/skills/autonomous-common/SKILL.md
+++ b/skills/autonomous-common/SKILL.md
@@ -18,7 +18,17 @@ Shared workflow-enforcement hooks and agent-callable utility scripts used by `au
 
 ## Setup for `npx skills add` Users
 
-If you installed these skills via `npx skills add`, hook commands in the `autonomous-dev` and `autonomous-review` SKILL.md frontmatter reference `$CLAUDE_PROJECT_DIR/hooks/` and `$CLAUDE_PROJECT_DIR/scripts/`, but `npx skills add` places these files inside `.claude/skills/`. Create symlinks at your project root so the paths resolve:
+After `npx skills add`, run the bundled installer once from the project root:
+
+```bash
+bash .claude/skills/autonomous-common/scripts/install-claude-hooks.sh
+```
+
+The installer wires up the workflow hooks at the **project scope** (writing into `.claude/settings.json`), so they fire on every Bash invocation in the repo — not only when an autonomous-* skill is explicitly loaded. Without this, the hook commands declared in skill frontmatter only run while a skill is active in the conversation, which is the regression that closed #68.
+
+### What if you can't run the installer
+
+If installing into your `.claude/settings.json` is undesirable (shared repo, you want hooks isolated to autonomous-* skills only), the legacy fallback is to symlink the hook directories so the skill-scoped hook commands resolve:
 
 ```bash
 # From your project root:
@@ -26,11 +36,11 @@ ln -sf .claude/skills/autonomous-common/hooks hooks
 ln -sf .claude/skills/autonomous-dispatcher/scripts scripts
 ```
 
-> Without these symlinks, hook commands silently fail to fire (they look up `$CLAUDE_PROJECT_DIR/hooks/...` but the path doesn't exist). If "the push hook isn't blocking" or "the commit-outside-worktree check isn't running" — check the symlinks first.
+This keeps hooks scoped to the skills' frontmatter (Claude Code only fires them when a skill is active). If the push hook isn't blocking or the commit-outside-worktree check isn't running, check the symlinks — but prefer the installer for full coverage.
 
 ### Required Claude Code plugins
 
-Claude Code only. Add to `.claude/settings.json` under `enabledPlugins`:
+Claude Code only. The installer prompts for these; if installing manually, add to `.claude/settings.json` under `enabledPlugins`:
 
 ```json
 {
@@ -41,12 +51,14 @@ Claude Code only. Add to `.claude/settings.json` under `enabledPlugins`:
 }
 ```
 
-> IDEs without hook support (Cursor, Windsurf, Gemini CLI) don't need symlinks or plugins — the skills work without hooks, but workflow steps must be followed manually.
+> IDEs without hook support (Cursor, Windsurf, Gemini CLI) skip both the installer and the symlinks — the skills work without hooks, but workflow steps must be followed manually.
 
 ## What's here
 
 - **`hooks/`** — workflow-enforcement hooks (block-push-to-main, block-commit-outside-worktree, check-pr-review, check-shellcheck, verify-completion, …). See `hooks/README.md` for the canonical list and per-hook semantics.
 - **`scripts/`** — agent-callable utilities used by the dev/review skills:
+  - `install-claude-hooks.sh` — one-shot installer that wires the hooks into project-scoped `.claude/settings.json` (closes #68 — recommended setup, see "Setup" above)
+  - `claude-settings.template.json` — the canonical hook list the installer applies
   - `gh-as-user.sh` — runs `gh` as a real user (needed when retriggering bot reviews like `/q review`)
   - `mark-issue-checkbox.sh` — toggles GitHub issue body checkboxes from the agent
   - `reply-to-comments.sh` — replies to PR review comments

--- a/skills/autonomous-dev/SKILL.md
+++ b/skills/autonomous-dev/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: autonomous-dev
 description: >
-  This skill should be used when the user wants to develop a feature, fix a bug,
-  create a pull request, set up a git worktree, design a UI component, write test
-  cases, push changes, check CI status, address review comments, resolve review
-  threads, trigger bot reviews (/q review, /codex review), or follow a TDD
-  development workflow. Covers the complete lifecycle from design canvas through
-  worktree creation, test-first development, code review, PR creation, CI
-  verification, reviewer bot interaction, E2E testing, and worktree cleanup.
-  Supports interactive and fully autonomous modes for GitHub issue implementation.
+  Use to develop a feature or bug fix end-to-end through a TDD git-worktree
+  workflow — interactively (developer-led) or unattended (autonomous-mode,
+  driven by the dispatcher). Triggers on phrases like "implement issue #N",
+  "fix this bug", "add a feature", "create a worktree", "write test cases",
+  "push and open a PR", "check CI", "address review comments", "resolve
+  review threads", "/q review", "/codex review", "implement this autonomously",
+  or any partial step in the design → worktree → tests → implement → verify →
+  review → PR → CI → E2E lifecycle. Interactive mode asks for decisions;
+  autonomous mode makes decisions per autonomous-mode.md and posts progress
+  comments to the GitHub issue.
 hooks:
   PreToolUse:
     - matcher: "Bash"
@@ -73,7 +75,7 @@ hooks:
 
 A complete development workflow enforcing test-driven development, git worktree isolation, code review, CI verification, and E2E testing. Works in two modes: interactive (default) for human-guided sessions, and autonomous for fully unattended GitHub issue implementation.
 
-> **NON-NEGOTIABLE RULES -- Every step marked MANDATORY is required. You MUST NOT skip, defer, or ask the user whether to run these steps. Execute them automatically as part of the workflow. This includes: creating PRs, waiting for CI, running E2E tests, and addressing reviewer findings.**
+> **NON-NEGOTIABLE RULES — every step marked MANDATORY is required.** Do not skip, defer, or ask the user whether to run these steps. Execute them automatically as part of the workflow. This covers creating PRs, waiting for CI, running E2E tests, and addressing reviewer findings.
 
 ---
 
@@ -100,30 +102,9 @@ Triggered when running inside the `scripts/autonomous-dev.sh` wrapper. The workf
 
 ## Cross-Platform Notes
 
-### Hooks Support
+This skill works across IDEs that support skills.sh. Map generic verbs in this doc to your IDE's tools (Claude Code's Bash → terminal in Cursor, etc.). Hook-based enforcement is available on Claude Code and Kiro CLI; on Cursor / Windsurf / Gemini CLI, follow each step manually — the discipline is the same.
 
-| IDE/CLI | Hooks Support | Setup |
-|---------|--------------|-------|
-| Claude Code | Full | `hooks/README.md` |
-| Kiro CLI | Full | `hooks/README.md` |
-| Cursor | None | Follow steps manually |
-| Windsurf | None | Follow steps manually |
-| Gemini CLI | None | Follow steps manually |
-
-### Tool Name Mapping
-
-This skill uses generic language. Map to your IDE's tools:
-- "Execute in your terminal" = Bash tool (Claude Code), terminal (Cursor), shell (Gemini CLI), etc.
-- "Read the file" = Read tool, file viewer, or `cat`
-- "Create or edit the file" = Write/Edit tool, editor, or manual editing
-- "Use a subagent" = Task/Agent tool (Claude Code), or follow the steps manually if unsupported
-- "Load the skill" = Skill tool (Claude Code), or read the referenced SKILL.md directly
-
-### Workflow Enforcement (Optional Hooks)
-
-If your IDE/CLI supports hooks (Claude Code, Kiro CLI), install them from `hooks/` for hard enforcement. See `hooks/README.md` for setup.
-
-Without hooks, follow each step manually -- the discipline is the same.
+For the full IDE table + verb-to-tool map, see [`references/cross-platform.md`](references/cross-platform.md).
 
 ---
 
@@ -151,42 +132,12 @@ Step 13: CLEANUP WORKTREE
 
 ## Step 1: Design Canvas
 
-**Available if your IDE has Pencil MCP.** If Pencil MCP is not available, create a design document (`docs/designs/<feature>.md`) manually instead.
+Create a design canvas for new UI work, user-facing features, architecture decisions, and complex data flows. Skip for trivial fixes or refactors that don't change behavior.
 
-### When to Create a Design Canvas
+- IDEs with Pencil MCP: create `docs/designs/<feature>.pen`.
+- IDEs without Pencil MCP: create `docs/designs/<feature>.md`.
 
-- New UI components or pages
-- Feature implementations with user-facing changes
-- Architecture decisions that benefit from visualization
-- Complex data flows or state management
-
-### Pencil MCP Workflow
-
-1. **Check editor state**: call `get_editor_state()` to see if a `.pen` file is open.
-2. **Open or create design file**: call `open_document("docs/designs/<feature>.pen")` or `open_document("new")`.
-3. **Get design guidelines** (if needed): call `get_guidelines(topic="landing-page|table|tailwind|code")`.
-4. **Get style guide** for consistent design: call `get_style_guide_tags()` then `get_style_guide(tags=[...])`.
-5. **Create design elements**: call `batch_design(operations)` to create UI mockups, component hierarchy diagrams, data flow visualizations, and architecture diagrams.
-6. **Validate design visually**: call `get_screenshot()` to verify the design looks correct.
-7. **Document design decisions**: add text annotations explaining choices, component specifications, and interaction patterns.
-
-### Design Canvas Template Structure
-
-```
-Feature: <Feature Name>
-Date: YYYY-MM-DD
-Status: Draft | In Review | Approved
-
-- UI Mockup / Wireframe
-- Component Architecture (component tree, props/state flow)
-- Data Flow Diagram (API calls, state management)
-- Design Notes (key decisions, accessibility, responsive behavior)
-```
-
-### Design Approval
-
-- **Interactive mode**: Present the design canvas to the user, get explicit approval, document feedback, update status to "Approved."
-- **Autonomous mode**: Create the design doc and proceed immediately -- no approval gate.
+For the full Pencil MCP call sequence, the markdown canvas template, and the per-mode (interactive vs autonomous) approval gate, see [`references/design-canvas.md`](references/design-canvas.md).
 
 ---
 
@@ -390,39 +341,11 @@ If ANY check fails: analyze logs, fix, push, re-watch. DO NOT proceed until ever
 
 ## Step 10: Address Reviewer Bot Findings (MANDATORY)
 
-Multiple review bots can provide automated code review findings on PRs:
+Read each finding from Amazon Q (`/q review`), Codex (`/codex review`), and any other configured bots. For each: either fix the code, or reply explaining the design decision (false positive). Then reply to the comment thread, resolve it, and retrigger the bot.
 
-| Bot | Trigger Command | Bot Username |
-|-----|-----------------|------------|
-| Amazon Q Developer | `/q review` | `amazon-q-developer[bot]` |
-| Codex | `/codex review` | `codex[bot]` |
-| Other bots | See bot documentation | Varies |
+> **Use `scripts/gh-as-user.sh` to retrigger bot reviews.** Some bots (notably Amazon Q) ignore trigger comments posted by GitHub App bot accounts; the wrapper posts as a real user.
 
-### Handling Bot Review Findings
-
-1. **Review all comments** -- read each finding carefully
-2. **Determine action**:
-   - Valid issue: fix the code and push
-   - False positive: reply explaining the design decision
-3. **Reply to each thread** -- use direct reply, not a general PR comment
-4. **Resolve each thread** -- mark conversation as resolved
-5. **Retrigger review** -- comment with the appropriate trigger (e.g., `/q review`, `/codex review`)
-
-### Retrigger Bot Reviews
-
-> **IMPORTANT:** Some bot reviewers (e.g., Amazon Q Developer) ignore `/q review` comments posted by GitHub App bot accounts. If your project uses `scripts/gh-as-user.sh`, you **MUST** use it to trigger bot reviews so the comment is attributed to a real user. Do NOT use the default `gh` wrapper for bot review triggers.
-
-```bash
-# Amazon Q Developer (use gh-as-user.sh to post as a real user)
-bash scripts/gh-as-user.sh pr comment {pr_number} --body "/q review"
-
-# Codex
-bash scripts/gh-as-user.sh pr comment {pr_number} --body "/codex review"
-```
-
-If `scripts/gh-as-user.sh` is not available in your project, use `gh pr comment` directly as a fallback.
-
-Wait 60-90 seconds for the review to complete, then check for new comments.
+For the full retrigger commands, reply patterns, and thread resolution semantics, see [`references/review-threads.md`](references/review-threads.md).
 
 ---
 

--- a/skills/autonomous-dev/references/cross-platform.md
+++ b/skills/autonomous-dev/references/cross-platform.md
@@ -1,0 +1,29 @@
+# Cross-Platform Notes — autonomous-dev
+
+This skill is portable across coding agents that follow the skills.sh model. The workflow logic in `SKILL.md` uses generic language that maps to each platform's tooling.
+
+## Hooks support
+
+| IDE/CLI | Hooks support | Setup |
+|---------|--------------|-------|
+| Claude Code | Full | `hooks/README.md` (in `autonomous-common`) |
+| Kiro CLI | Full | `hooks/README.md` (in `autonomous-common`) |
+| Cursor | None | Follow workflow steps manually |
+| Windsurf | None | Follow workflow steps manually |
+| Gemini CLI | None | Follow workflow steps manually |
+
+If your IDE supports hooks, install them from `autonomous-common/hooks/` for hard enforcement of the MANDATORY steps. Without hooks, the discipline is the same — you just have to remember to run each step yourself.
+
+## Tool name mapping
+
+The SKILL.md uses generic verbs. Map them to your IDE's tools:
+
+| SKILL.md says | Claude Code | Cursor | Gemini CLI |
+|---|---|---|---|
+| "Execute in your terminal" | Bash tool | terminal | shell |
+| "Read the file" | Read tool | file viewer / open | `cat` |
+| "Create or edit the file" | Write / Edit tool | editor | manual edit |
+| "Use a subagent" | Task / Agent tool | (no equivalent — do it inline) | (no equivalent) |
+| "Load the skill" | Skill tool | read the referenced SKILL.md | read the referenced SKILL.md |
+
+When the SKILL.md says "use a subagent" and your IDE doesn't have one, follow the listed steps manually instead.

--- a/skills/autonomous-dev/references/design-canvas.md
+++ b/skills/autonomous-dev/references/design-canvas.md
@@ -1,0 +1,54 @@
+# Design Canvas — Detailed Reference
+
+Loaded from `SKILL.md` Step 1 when a design canvas is needed and the IDE supports Pencil MCP, or when a markdown-only canvas needs more structure than the inline template.
+
+## Pencil MCP workflow (Claude Code with Pencil MCP installed)
+
+1. **Check editor state**: call `get_editor_state()` to see if a `.pen` file is open.
+2. **Open or create design file**: `open_document("docs/designs/<feature>.pen")` or `open_document("new")`.
+3. **Get design guidelines** (optional): `get_guidelines(topic="landing-page|table|tailwind|code")`.
+4. **Get style guide** for consistent design: `get_style_guide_tags()` then `get_style_guide(tags=[...])`.
+5. **Create design elements**: `batch_design(operations)` to create UI mockups, component hierarchy diagrams, data flow visualizations, and architecture diagrams.
+6. **Validate design visually**: `get_screenshot()` to verify the design looks correct.
+7. **Document design decisions**: add text annotations explaining choices, component specifications, and interaction patterns.
+
+## Markdown-only canvas template
+
+For IDEs without Pencil MCP, create `docs/designs/<feature>.md`:
+
+```
+# Design Canvas — <feature>
+
+Feature: <Feature Name>
+Date: YYYY-MM-DD
+Status: Draft | In Review | Approved
+
+## UI Mockup / Wireframe
+<ASCII art, screenshot reference, or link to a Figma frame>
+
+## Component Architecture
+<component tree, props/state flow>
+
+## Data Flow Diagram
+<API calls, state management>
+
+## Design Notes
+- Key decisions
+- Accessibility considerations
+- Responsive behavior
+- Failure modes / edge cases
+```
+
+## When to create a design canvas
+
+- New UI components or pages
+- Feature implementations with user-facing changes
+- Architecture decisions that benefit from visualization
+- Complex data flows or state management
+
+Skip the canvas for trivial bug fixes, dependency bumps, or refactors that don't change behavior.
+
+## Design approval
+
+- **Interactive mode**: present the canvas to the user, get explicit approval, document feedback, update status to "Approved."
+- **Autonomous mode**: create the canvas doc and proceed immediately — no approval gate.

--- a/skills/autonomous-dispatcher/SKILL.md
+++ b/skills/autonomous-dispatcher/SKILL.md
@@ -1,18 +1,27 @@
 ---
 name: autonomous-dispatcher
 description: >
-  This skill should be used when dispatching autonomous development or review
-  tasks from GitHub issues. Covers scanning for new issues with the 'autonomous'
-  label, dispatching dev-new/dev-resume/review processes, dependency checking,
-  retry counting, stale process detection, and concurrency limiting. Use when
-  asked to "run the dispatcher", "scan for pending issues", "dispatch autonomous
-  tasks", "check stale agents", or "set up the dispatch cron".
-metadata: {"openclaw": {"requires": {"bins": ["gh", "jq"], "env": ["PROJECT_DIR"]}}}
+  Use when running, configuring, or troubleshooting the autonomous-dev-team
+  dispatcher cron. Triggers on phrases like "run the dispatcher", "scan for
+  pending issues", "dispatch autonomous tasks", "set up the dispatch cron",
+  "configure dispatcher.conf", "set up multi-project dispatcher", "dispatch
+  to a remote dev box via SSM", "EXECUTION_BACKEND=remote-aws-ssm",
+  "stale agent detection", or working on dispatcher-tick.sh /
+  dispatcher-multi-tick.sh / dispatch-local.sh / dispatch-remote-aws-ssm.sh.
+  Covers per-project tick (5 steps: concurrency, scan-new, scan-pending-review,
+  scan-pending-dev, stale detection), the multi-project outer loop, and
+  pluggable local-vs-remote-AWS-SSM execution backends.
 ---
 
 # Autonomous Dev Team Dispatcher
 
-Scan GitHub issues and dispatch dev/review tasks locally. One cron tick is one invocation of `dispatcher-tick.sh`. The full state machine, per-step semantics, and invariants live in [`docs/pipeline/`](../../docs/pipeline/) — that's the spec; this file is the agent's invocation contract.
+Scan GitHub issues and dispatch dev/review tasks. One cron tick is one invocation of `dispatcher-tick.sh` (single-project) or `dispatcher-multi-tick.sh` (multi-project). The full state machine, per-step semantics, and invariants live at [`docs/pipeline/` in the source repo](https://github.com/zxkane/autonomous-dev-team/tree/main/docs/pipeline) — that's the spec; this file is the agent's invocation contract.
+
+## Prerequisites
+
+- `gh` and `jq` on `PATH`.
+- For the local backend: `$PROJECT_DIR` set, pointing at the project root. Per-project `autonomous.conf` (see `scripts/autonomous.conf.example`).
+- For multi-project / remote backends: `dispatcher.conf` declaring `PROJECTS=()` (see `scripts/dispatcher.conf.example`).
 
 > **Security note**: This dispatcher processes GitHub issue content as input. In public repositories, issue content is untrusted — anyone can create issues. Ensure the `autonomous` label can only be applied by trusted maintainers (use GitHub branch rulesets or organizational policies). The dispatcher only reads labels/comments and spawns local processes via the helper script — it does NOT modify source code or push to branches.
 
@@ -48,7 +57,7 @@ Either form runs the same 5-step tick:
 4. **scan-pending-dev** — find `pending-dev` issues, retry-counter check, dispatch dev-resume (or mark stalled if exhausted).
 5. **stale detection** — for `in-progress` / `reviewing` issues, probe wrapper PID, branch on alive/dead and on PR/CI/idle gates.
 
-The logic is in [`scripts/dispatcher-tick.sh`](scripts/dispatcher-tick.sh) and the helpers in [`scripts/lib-dispatch.sh`](scripts/lib-dispatch.sh). For the spec each step is implementing, see [`docs/pipeline/dispatcher-flow.md`](../../docs/pipeline/dispatcher-flow.md).
+The logic is in [`scripts/dispatcher-tick.sh`](scripts/dispatcher-tick.sh) and the helpers in [`scripts/lib-dispatch.sh`](scripts/lib-dispatch.sh). For the spec each step is implementing, see [`docs/pipeline/dispatcher-flow.md` in the source repo](https://github.com/zxkane/autonomous-dev-team/blob/main/docs/pipeline/dispatcher-flow.md).
 
 ## GitHub Authentication — App token, not user token
 
@@ -65,7 +74,7 @@ The token is valid for 1 hour and scoped to the target repo only. `dispatcher-ti
 
 ## Dispatch Helpers
 
-`dispatcher-tick.sh` calls a `dispatch()` helper for each task type, which routes to the configured execution backend. **Do NOT spawn agent processes any other way.** Each backend handles `nohup`, input validation, log-file mode 0600, and stale-wrapper kill ([INV-09](../../docs/pipeline/invariants.md#inv-09-just_dispatched-skip-rule)).
+`dispatcher-tick.sh` calls a `dispatch()` helper for each task type, which routes to the configured execution backend. **Do NOT spawn agent processes any other way.** Each backend handles `nohup`, input validation, log-file mode 0600, and stale-wrapper kill ([INV-09](https://github.com/zxkane/autonomous-dev-team/blob/main/docs/pipeline/invariants.md#inv-09-just_dispatched-skip-rule)).
 
 Backends today:
 
@@ -129,7 +138,7 @@ openclaw cron add \
 | `no-auto-close` | `#d4c5f9` | Used with `autonomous` — skip auto-merge after review passes, requires manual approval |
 | `stalled` | `#B60205` | Issue exceeded max retry attempts; requires manual investigation |
 
-For the full state machine, see [`docs/pipeline/state-machine.md`](../../docs/pipeline/state-machine.md).
+For the full state machine, see [`docs/pipeline/state-machine.md` in the source repo](https://github.com/zxkane/autonomous-dev-team/blob/main/docs/pipeline/state-machine.md).
 
 ## Model Strategy
 

--- a/skills/autonomous-review/SKILL.md
+++ b/skills/autonomous-review/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: autonomous-review
 description: >
-  This skill should be used when performing autonomous PR code review,
-  verifying acceptance criteria, resolving merge conflicts, running E2E
-  tests via browser automation, or deciding whether to approve and merge
-  a pull request. Use when asked to "review this PR", "check PR status",
-  "run E2E verification", "verify acceptance criteria", "resolve merge
-  conflicts", "approve and merge", or during autonomous review dispatch.
+  Use to perform an end-to-end PR review and reach an approve/request-changes
+  verdict — including verifying acceptance criteria, running E2E tests via
+  browser automation, resolving merge conflicts, and (when verdict passes)
+  merging the PR. Triggers on phrases like "review this PR", "decide whether
+  to approve and merge", "run E2E verification", "resolve merge conflicts on
+  PR #N", or when the dispatcher hands off a PR labeled `pending-review` /
+  `reviewing` for autonomous review. Distinct from in-flight dev-side
+  self-review (that lives in autonomous-dev's pr-review step).
 hooks:
   PreToolUse:
     - matcher: "Bash"
@@ -23,7 +25,15 @@ hooks:
 
 # Autonomous Review Mode
 
-You are reviewing a PR created by an autonomous development session. Be thorough and objective.
+Review PRs created by autonomous development sessions thoroughly and objectively, then reach a verdict (approve + merge, or request changes).
+
+## When to Use
+
+| Use this skill | Use a different skill |
+|---|---|
+| Final verdict on a completed PR (approve + merge, or send back for fixes) | In-flight dev-side self-review during implementation → use `autonomous-dev` Step 8 (pr-review) |
+| Dispatcher handed off a PR labeled `pending-review` or `reviewing` | Manual partial review of a draft PR → use the `pr-review-toolkit` agents directly |
+| Run E2E verification + check acceptance criteria + resolve merge conflicts | Just check CI status → use `gh pr checks` directly |
 
 ## Cross-Platform Notes
 
@@ -68,14 +78,18 @@ Verify ALL of the following:
 ### 5. Optional: Bot Reviewer Verification
 - [ ] If configured bot reviewers have posted reviews, verify their findings are addressed
 - [ ] All bot review threads are resolved
-- [ ] If bot review is missing and configured, trigger it using `scripts/gh-as-user.sh` (see below) and wait
+- [ ] If bot review is missing and configured, trigger it using `scripts/gh-as-user.sh` (see "Triggering Bot Reviewers" below)
 
-> **IMPORTANT:** Some bot reviewers (e.g., Amazon Q Developer) ignore trigger comments posted by GitHub App bot accounts. When triggering bot reviews, you **MUST** use `scripts/gh-as-user.sh` so the comment is attributed to a real user:
-> ```bash
-> bash scripts/gh-as-user.sh pr comment {pr_number} --body "/q review"
-> bash scripts/gh-as-user.sh pr comment {pr_number} --body "/codex review"
-> ```
-> Do NOT use the default `gh` wrapper for bot review triggers — it authenticates as a bot, which some reviewers ignore. If `scripts/gh-as-user.sh` is not available, fall back to `gh pr comment` directly.
+#### Triggering Bot Reviewers
+
+**`scripts/gh-as-user.sh` is required when retriggering bot reviews.** Some bot reviewers (e.g., Amazon Q Developer) ignore trigger comments posted by GitHub App bot accounts; the wrapper script posts as a real user so the bot picks it up.
+
+```bash
+bash scripts/gh-as-user.sh pr comment {pr_number} --body "/q review"
+bash scripts/gh-as-user.sh pr comment {pr_number} --body "/codex review"
+```
+
+Do NOT use the default `gh pr comment` for bot review triggers — it authenticates as a bot. If `scripts/gh-as-user.sh` is not available in your project, fall back to `gh pr comment` and accept that some bots may ignore the trigger.
 
 ### 6. E2E Verification via Chrome DevTools MCP
 

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: create-issue
 description: >
-  This skill should be used when the user asks to "create an issue", "file a bug",
-  "create a feature request", "open a GitHub issue", "report a bug", "request a feature",
-  "create a task", "break this into issues", or describes a feature/bug they want tracked
-  in GitHub. Guides interactive issue creation with structured templates, workspace change
-  attachment, and optional autonomous label for the automated pipeline.
+  Use when the user asks to create a GitHub issue, file a bug, request a feature,
+  open a tracking issue, or break a feature into multiple sub-issues. Guides
+  interactive issue drafting with structured templates, workspace-change
+  attachment, dependency linking, and the optional `autonomous` label for the
+  automated dev pipeline.
 ---
 
 # Create GitHub Issue
@@ -56,7 +56,7 @@ Both templates include these required sections:
 - **Acceptance Criteria** with checkboxes
 - **Dependencies** section for issue ordering
 
-### Step 2.5: Detect & Attach Workspace Changes
+### Step 3: Detect & Attach Workspace Changes
 
 After drafting the issue, check the workspace for local changes that may provide useful context for the autonomous dev agent. For the complete detection, attachment, and cleanup procedure, consult **`references/workspace-changes.md`**.
 
@@ -67,7 +67,7 @@ Summary:
 4. Add a `## Pre-existing Changes` section to the issue body
 5. Optionally clean up local changes after attachment
 
-### Step 3: Confirm with User
+### Step 4: Confirm with User
 
 Present the draft issue to the user with:
 1. Proposed title (concise, descriptive)
@@ -79,7 +79,7 @@ Use AskUserQuestion to confirm:
 - "Does this issue look correct? Should I create it?"
 - Ask about autonomous label: whether AI should handle this automatically
 
-### Step 4: Create the Issue
+### Step 5: Create the Issue
 
 Use GitHub MCP tools or `gh` CLI to create the issue with:
 - `title`: The confirmed title
@@ -91,7 +91,7 @@ Report the created issue URL to the user.
 **If branch push was deferred (large diff strategy):**
 
 After the issue is created and the issue number is known:
-1. Execute the branch push commands from Step 2.5.5 using the actual issue number
+1. Execute the branch push commands from Step 3 using the actual issue number
 2. Update the issue body to include the branch reference section
 
 ## Label Guide


### PR DESCRIPTION
## Summary

Docs-only polish PR — no logic changes. Ran the `skill-reviewer` agent against all 5 skills (autonomous-common / -dev / -dispatcher / -review, create-issue) and addressed every high+medium finding.

Refs task #6 (no specific issue tied — quality cleanup).

## What changed

### Descriptions (all 5)
Rewritten to lead with "Use when..." and trigger on more accurate user phrasings. Notable additions:

- **autonomous-dev**: now triggers on "implement issue #N", "implement this autonomously", interactive vs autonomous mode distinction.
- **autonomous-dispatcher**: adds multi-project / `EXECUTION_BACKEND=remote-aws-ssm` / `dispatcher.conf` triggers (PR-7/8/9 was under-documented).
- **autonomous-review**: ties to dispatcher handoff (`pending-review` / `reviewing` labels), distinguishes from in-flight dev-side self-review.
- **autonomous-common**: triggers on real user-facing tasks ("push to main is blocked", "configure hooks after npx skills add") instead of the fake "loaded automatically as background context" framing.
- **create-issue**: tightened from 8 overlapping phrasings to 5 distinct ones.

### Structural extraction (autonomous-dev: 480 → 403 lines)
- New `references/design-canvas.md`: Pencil MCP call sequence + markdown template.
- New `references/cross-platform.md`: IDE table + verb-to-tool map.
- Step 10 (reviewer bots) now points at existing `references/review-threads.md` instead of duplicating.

### Packaging fragility (would have broken post `npx skills add`)
- **autonomous-dispatcher**: 4 `../../docs/pipeline/...` links replaced with absolute GitHub URLs (skills.sh model only copies the skill dir, not the project's `docs/`). Dropped non-standard OpenClaw `metadata` frontmatter; promoted to body-level "Prerequisites".
- **autonomous-common**: dropped fake `user-invocable: false` frontmatter field. Setup section now recommends `install-claude-hooks.sh` (project-scoped, the canonical fix for #68); the prior symlink-only instructions reinstated the very problem PR-5 closed.

### Other
- **autonomous-dev** "NON-NEGOTIABLE RULES" callout: rewritten in infinitive form.
- **autonomous-review**: opening line in imperative form; new "When to Use" table distinguishing from autonomous-dev's pr-review step; `gh-as-user.sh` requirement promoted from a buried blockquote to its own "Triggering Bot Reviewers" subsection.
- **autonomous-common**: deduped two big hook+script tables (canonical list lives in `hooks/README.md`); added `install-claude-hooks.sh` + template to the script inventory (caught by PR review).
- **create-issue**: renumbered Step 2.5 → Step 3 (Step 3 → 4, Step 4 → 5) for linear flow; only internal cross-reference updated.

## Test plan

- [x] All 24 unit tests pass (no logic changed)
- [x] `bash -n` syntax: N/A (docs only)
- [x] skill-reviewer findings addressed across all 5 skills
- [x] code-reviewer agent: caught one high-confidence regression (install-claude-hooks.sh missed in inventory + setup pointed at symlinks instead) — addressed in commit `83e537d`

## Files

| Skill | SKILL.md change | New references |
|---|---|---|
| autonomous-common | rewrite (description + setup + "what's here") | — |
| autonomous-dev | description + slim Step 1 / Step 10, extract Cross-Platform | `references/design-canvas.md`, `references/cross-platform.md` |
| autonomous-dispatcher | description + drop fragile docs links / non-standard frontmatter | — |
| autonomous-review | description + imperative opening + "When to Use" + bot subsection | — |
| create-issue | description tighten + Step renumber | — |

Design canvas: `docs/designs/skill-polish.md`.