### PR TITLE
feat(hooks): cross-agent installers — Claude-clone tier (Qoder + Antigravity)

### DIFF
--- a/docs/cross-agent-hooks.md
+++ b/docs/cross-agent-hooks.md
@@ -1,0 +1,72 @@
+# Cross-Agent Hook Support
+
+Reference for installing the autonomous-dev-team workflow hooks across coding agents that support hook-style enforcement (a shell command runs before/after a tool call, with the option to block).
+
+## Canonical hook intent (agent-agnostic)
+
+The hooks themselves live in `skills/autonomous-common/hooks/` and are agent-portable: they read JSON from stdin, exit `0` to allow or `2` to block, and use `$CLAUDE_PROJECT_DIR` to find scripts. This contract works on every agent in the table below.
+
+What differs between agents is **how to declare which script runs when** — i.e. the per-agent config file path, schema, event names, and tool-name matchers.
+
+## Per-agent matrix
+
+| CLI | Config path | Schema flavor | Tool-name matchers | Block exit | Installer |
+|---|---|---|---|---|---|
+| **Claude Code** | `.claude/settings.json` | Reference (JSON, `PreToolUse`, …) | `Bash`, `Write`, `Edit` | `2` | `install-claude-hooks.sh` (PR-5) |
+| **Qoder** | `.qoder/settings.json` | Identical to Claude Code | `Bash`, `Write`, `Edit` | `2` | `install-qoder-hooks.sh` (PR-11a) |
+| **Antigravity** | `.antigravity/hooks.json` | Identical to Claude Code (undocumented) | `Bash` | `2` | `install-antigravity-hooks.sh` (PR-11a) |
+| Cursor | `.cursor/hooks.json` | Claude-style + shell-specific event | `Shell` (or pipe regex on cmd) | `2` | PR-11b (planned) |
+| Kiro CLI / Amazon Q | `.kiro/agents/<name>.json` | camelCase events, `timeout_ms` | `execute_bash`, `fs_write` | `2` | PR-11b (planned) |
+| Gemini CLI | `.gemini/settings.json` | `BeforeTool`/`AfterTool` regex | `run_shell_command`, `write_file`, `replace` | `2` | PR-11b (planned) |
+| Codex CLI | `.codex/hooks.json` + `[features]codex_hooks=true` | Claude-style | undocumented | `2` | PR-11b (planned) |
+| Windsurf | `.windsurf/hooks.json` | snake_case, **no matcher field** | filter inside script | `2` | PR-11c (planned) |
+| Kimi CLI | `~/.kimi/config.toml` | TOML, `[[hooks]]` array | regex (e.g. `WriteFile\|StrReplaceFile`) | `2` | PR-11c (planned) |
+
+## Per-agent installation (PR-11a coverage)
+
+After `npx skills add zxkane/autonomous-dev-team`, run **one** of these from the project root:
+
+```bash
+# Claude Code
+bash .claude/skills/autonomous-common/scripts/install-claude-hooks.sh
+
+# Qoder
+bash .claude/skills/autonomous-common/scripts/install-qoder-hooks.sh
+
+# Antigravity (undocumented contract — see caveat below)
+bash .claude/skills/autonomous-common/scripts/install-antigravity-hooks.sh
+```
+
+Each installer is idempotent and preserves any other top-level keys you have in the agent's config file. They also install a per-worktree git pre-push hook (closes #65); pass `--no-git-hook` to skip.
+
+## Caveats
+
+- **Antigravity**: Google has not documented hook support. Community evidence shows the Claude Code schema works in practice, but it could change without notice. Treat as best-effort.
+- **Codex CLI** (PR-11b): hook support is behind an experimental feature flag (`codex_hooks = true` in `~/.codex/config.toml`). Tool-name matchers like `Bash`, `Write` are modeled on Claude Code but not officially documented.
+- **Windsurf** (PR-11c): no per-tool matcher field. The hook fires for every shell command (or every file write); filter inside your script using the stdin JSON.
+- **Kimi CLI** (PR-11c): TOML config, beta feature. Tool names differ (e.g. `WriteFile` not `Write`).
+
+## Hook-script portability
+
+Scripts under `skills/autonomous-common/hooks/` use the canonical contract:
+
+```
+stdin: {"hook_event_name": "...", "tool_name": "...", "tool_input": {...}, "cwd": "...", ...}
+exit 0: allow (stdout added to agent context)
+exit 2: block (stderr fed back to LLM as the reason)
+env:   $CLAUDE_PROJECT_DIR points at the repo root
+```
+
+This works on every agent in the matrix. **Gemini CLI explicitly provides `$CLAUDE_PROJECT_DIR`** as a Claude Code compatibility alias. The other agents either provide an equivalent (e.g. `CURSOR_PROJECT_DIR`) or run hooks with `cwd = project root` so the relative path inside `tool_input.cwd` works.
+
+## Adding a new agent
+
+If you want to support an agent not yet in the matrix:
+
+1. Verify the agent supports hooks at all (check official docs).
+2. Document the schema in this file's matrix.
+3. Add an `install-<agent>-hooks.sh` under `skills/autonomous-common/scripts/`. Use `lib-installer.sh` helpers (`require_jq`, `merge_hooks_settings`, `write_hooks_only_settings`, `install_per_worktree_pre_push`).
+4. Update `skills/autonomous-common/SKILL.md` Setup section.
+5. Add a unit test under `tests/unit/`.
+
+The canonical template at `skills/autonomous-common/scripts/claude-settings.template.json` is the single source of truth — your installer translates it to the agent's flavor at install time.

--- a/docs/designs/cross-agent-hooks.md
+++ b/docs/designs/cross-agent-hooks.md
@@ -1,0 +1,150 @@
+# Design Canvas — Cross-Agent Hook Installers (PR-11)
+
+**Branch**: `feat/cross-agent-hooks`
+**Closes**: nothing (no specific issue — extends PR-5 / PR-10 to cover 7 additional coding agents).
+**PR breakdown**: this is **PR-11a**. PR-11b adds near-clone installers (Cursor, Kiro, Gemini, Codex). PR-11c adds divergent installers (Windsurf, Kimi).
+
+---
+
+## Why
+
+Today the autonomous workflow only enforces hooks for Claude Code (`install-claude-hooks.sh` from PR-5). Users running the same skills under Cursor / Kiro / Gemini / etc. get the workflow logic but no guard rails — pushes to main, commits outside worktrees, etc. all become un-enforced.
+
+Research across 8 popular agents shows **all of them support hooks** with a remarkably consistent contract (JSON config, exit code 2 = block, stdin JSON payload). The schemas differ but translate cleanly.
+
+This PR (11a) ships:
+
+1. The **canonical hook intent** doc (`docs/cross-agent-hooks.md`) — one source of truth for what each hook does, used by all installers.
+2. **Schema mapping reference** — exactly how Claude Code's `PreToolUse + matcher: "Bash"` translates to each agent's flavor.
+3. Installers for the 2 easiest agents: **Qoder** and **Antigravity**, both of which adopted Claude Code's schema verbatim.
+
+PR-11b and PR-11c will pick up the harder translations.
+
+## Cross-agent landscape
+
+| CLI | Hook config | Schema flavor | Tool-name matcher | Block exit |
+|---|---|---|---|---|
+| **Claude Code** | `.claude/settings.json` | reference (JSON, `PreToolUse` etc.) | `Bash`, `Write`, `Edit` | 2 |
+| **Qoder** | `.qoder/settings.json` | **identical** to Claude Code | `Bash`, `Write`, `Edit` | 2 |
+| **Antigravity** | `.antigravity/hooks.json` | identical (undocumented but works) | `Bash` | 2 |
+| Cursor (PR-11b) | `.cursor/hooks.json` | Claude-style + shell-specific event | `Shell` (or pipe regex on cmd) | 2 |
+| Kiro CLI (PR-11b) | `.kiro/agents/*.json` | camelCase events, `timeout_ms` | `execute_bash`, `fs_write` | 2 |
+| Gemini CLI (PR-11b) | `.gemini/settings.json` | `BeforeTool`/`AfterTool` regex | `run_shell_command`, `write_file`, `replace` | 2 |
+| Codex CLI (PR-11b) | `.codex/hooks.json` + flag | Claude-style (modeled on it) | undocumented | 2 |
+| Windsurf (PR-11c) | `.windsurf/hooks.json` | snake_case, **no matcher** | filter inside script | 2 |
+| Kimi CLI (PR-11c) | `~/.kimi/config.toml` | TOML, `[[hooks]]` array | regex (e.g. `WriteFile\|StrReplaceFile`) | 2 |
+
+Universal: **exit 2 = block**, stdin = JSON context. Hook scripts under `skills/autonomous-common/hooks/` already use this contract.
+
+## Why Qoder + Antigravity first
+
+Both adopted Claude Code's schema 1:1:
+
+- Same event names (`PreToolUse`, `PostToolUse`, `Stop`, ...)
+- Same `matcher` field semantics
+- Same tool names (`Bash`, `Write`, `Edit`)
+- Same JSON nesting
+
+Their installers are essentially:
+
+```bash
+bash install-claude-hooks.sh   # but writes to .qoder/settings.json
+```
+
+Plus a few one-line tweaks (output path, friendly name in messages). No translation needed. This makes them the ideal proving ground for the canonical-hook-intent design.
+
+## Canonical hook intent
+
+The "hook intent" is what we want to enforce, agent-agnostic. From `claude-settings.template.json` (PR-5):
+
+| Intent | Hook script | When |
+|---|---|---|
+| Block direct push to trunk | `block-push-to-main.sh` | Before any shell command |
+| Block commit outside worktree | `block-commit-outside-worktree.sh` | Before any shell command |
+| Verify CI on completion | `verify-completion.sh` | On Stop |
+| (others under `hooks/`) | various | Before Bash / Edit / Write |
+
+These run identically on any agent that supports the canonical contract:
+
+```
+stdin:  {"hook_event_name": "...", "tool_name": "...", "tool_input": {...}, "cwd": "...", ...}
+exit 0: allow
+exit 2: block (stderr → LLM)
+```
+
+All 8 researched agents satisfy this contract. The differences are just **how to declare which script runs when** in their respective config files.
+
+## Schema mapping (PR-11a only — 11b/11c expand)
+
+### Claude Code → Qoder
+```diff
+- .claude/settings.json
++ .qoder/settings.json
+```
+That's it. Same file content.
+
+### Claude Code → Antigravity
+```diff
+- .claude/settings.json
++ .antigravity/hooks.json
+```
+Same content. Antigravity's `hooks.json` accepts the Claude `settings.json` `hooks` block verbatim (per community evidence — undocumented but consistent).
+
+## Installer architecture
+
+Every installer follows the same pattern:
+
+```bash
+install-${agent}-hooks.sh:
+  1. Load $SOURCE = path to claude-settings.template.json
+  2. Translate to agent-specific schema (for Qoder/Antigravity: identity)
+  3. Resolve $TARGET = agent's config path
+  4. Merge with existing $TARGET (preserve user's other settings) — same jq-based merge as install-claude-hooks.sh
+  5. Optionally install per-worktree git pre-push hook (same as install-claude-hooks.sh, untouched)
+```
+
+For PR-11a's two agents, the translation step is identity. The merge step is the existing jq pattern from `install-claude-hooks.sh`.
+
+## Refactor strategy
+
+`install-claude-hooks.sh` (177 lines, written in PR-5) has the merge logic + per-worktree-hook installation logic that we want to share across all installers. Two options:
+
+1. **Extract a shared lib** — `lib-installer.sh` with `merge_settings_into <source> <target>` and `install_per_worktree_pre_push`. Each agent installer becomes ~30 lines of "set source, set target, call lib".
+2. **Each installer copy-pastes** — fast but fragile.
+
+Option 1 is the right call. PR-11a includes the refactor.
+
+## Files (PR-11a only)
+
+New:
+- `docs/cross-agent-hooks.md` — canonical hook intent + per-agent schema mapping reference (this is the durable spec)
+- `skills/autonomous-common/scripts/lib-installer.sh` — shared merge/install logic
+- `skills/autonomous-common/scripts/install-qoder-hooks.sh`
+- `skills/autonomous-common/scripts/install-antigravity-hooks.sh`
+- `tests/unit/test-install-qoder-hooks.sh`
+- `tests/unit/test-install-antigravity-hooks.sh`
+- `tests/unit/test-lib-installer.sh`
+
+Modified:
+- `skills/autonomous-common/scripts/install-claude-hooks.sh` — switch to lib-installer.sh (preserve byte-equivalent behavior)
+- `skills/autonomous-common/SKILL.md` — Setup section now lists 3 installers (Claude / Qoder / Antigravity); other 5 marked as "coming in PR-11b/c"
+
+## Out of scope (deferred to PR-11b / PR-11c)
+
+- Cursor, Kiro CLI, Gemini CLI, Codex installers (need event-name + tool-name translation; PR-11b)
+- Windsurf, Kimi CLI installers (schema-divergent; PR-11c)
+- Updating `.kiro/agents/default.json` — already correct in this repo
+
+## Tests
+
+For each installer:
+- Sample `.qoder/settings.json` is created with the right hooks block when run on a clean dir
+- Existing `.qoder/settings.json` (with other operator config) is preserved + merged
+- Idempotent on second run
+- Trust-gate semantics inherited from PR-5's claude installer
+
+`tests/unit/test-lib-installer.sh` tests the shared merge logic in isolation.
+
+## Risk
+
+Low. New installers are additive — no existing user gets a different experience until they explicitly run them. The `install-claude-hooks.sh` refactor must preserve byte-identical output (regression test verifies).

--- a/skills/autonomous-common/SKILL.md
+++ b/skills/autonomous-common/SKILL.md
@@ -18,13 +18,19 @@ Shared workflow-enforcement hooks and agent-callable utility scripts used by `au
 
 ## Setup for `npx skills add` Users
 
-After `npx skills add`, run the bundled installer once from the project root:
+After `npx skills add`, run the installer for your coding agent once from the project root:
 
-```bash
-bash .claude/skills/autonomous-common/scripts/install-claude-hooks.sh
-```
+| Agent | Installer | Writes to |
+|---|---|---|
+| Claude Code | `bash .claude/skills/autonomous-common/scripts/install-claude-hooks.sh` | `.claude/settings.json` |
+| Qoder | `bash .claude/skills/autonomous-common/scripts/install-qoder-hooks.sh` | `.qoder/settings.json` |
+| Antigravity | `bash .claude/skills/autonomous-common/scripts/install-antigravity-hooks.sh` | `.antigravity/hooks.json` |
+| Cursor / Kiro CLI / Gemini CLI / Codex CLI | _coming in PR-11b_ | — |
+| Windsurf / Kimi CLI | _coming in PR-11c_ | — |
 
-The installer wires up the workflow hooks at the **project scope** (writing into `.claude/settings.json`), so they fire on every Bash invocation in the repo — not only when an autonomous-* skill is explicitly loaded. Without this, the hook commands declared in skill frontmatter only run while a skill is active in the conversation, which is the regression that closed #68.
+Each installer wires up the workflow hooks at the **project scope**, so they fire on every shell command in the repo — not only when an autonomous-* skill is explicitly loaded. Without this, the hook commands declared in skill frontmatter only run while a skill is active in the conversation, which is the regression that closed #68.
+
+For the per-agent schema mapping reference, see [`docs/cross-agent-hooks.md`](https://github.com/zxkane/autonomous-dev-team/blob/main/docs/cross-agent-hooks.md).
 
 ### What if you can't run the installer
 
@@ -57,8 +63,11 @@ Claude Code only. The installer prompts for these; if installing manually, add t
 
 - **`hooks/`** — workflow-enforcement hooks (block-push-to-main, block-commit-outside-worktree, check-pr-review, check-shellcheck, verify-completion, …). See `hooks/README.md` for the canonical list and per-hook semantics.
 - **`scripts/`** — agent-callable utilities used by the dev/review skills:
-  - `install-claude-hooks.sh` — one-shot installer that wires the hooks into project-scoped `.claude/settings.json` (closes #68 — recommended setup, see "Setup" above)
-  - `claude-settings.template.json` — the canonical hook list the installer applies
+  - `lib-installer.sh` — shared merge/write helpers used by every per-agent installer
+  - `install-claude-hooks.sh` — Claude Code installer (writes `.claude/settings.json`)
+  - `install-qoder-hooks.sh` — Qoder installer (writes `.qoder/settings.json` — same schema as Claude Code)
+  - `install-antigravity-hooks.sh` — Antigravity installer (writes `.antigravity/hooks.json` — hooks-only file; contract is community-observed, undocumented by Google)
+  - `claude-settings.template.json` — canonical hook list applied by all per-agent installers
   - `gh-as-user.sh` — runs `gh` as a real user (needed when retriggering bot reviews like `/q review`)
   - `mark-issue-checkbox.sh` — toggles GitHub issue body checkboxes from the agent
   - `reply-to-comments.sh` — replies to PR review comments

--- a/skills/autonomous-common/scripts/install-antigravity-hooks.sh
+++ b/skills/autonomous-common/scripts/install-antigravity-hooks.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# install-antigravity-hooks.sh — bootstrap project-scoped Antigravity
+# (Google) hooks from the canonical template.
+#
+# Antigravity is undocumented officially but the community-observed
+# config (e.g. lehau007/AI-Auto-Log-Windows, AgusRdz/chop) confirms it
+# accepts Claude Code's hook schema verbatim. Its config path is
+# `.antigravity/hooks.json` — DIFFERENT from Claude / Qoder which use
+# settings.json — and the file is hooks-only (no other top-level keys).
+#
+# So the install strategy differs from Claude / Qoder: write the hooks
+# block + _managed_by + _managed_note as the entire file body, no merge.
+#
+# Caveat: Antigravity's hook contract is undocumented; Google could
+# change or remove it without notice. Use at your own risk.
+#
+# Usage:
+#   bash skills/autonomous-common/scripts/install-antigravity-hooks.sh
+#
+# Idempotent. --no-git-hook to skip the per-worktree git pre-push (#65).
+
+set -euo pipefail
+
+INSTALL_GIT_HOOK=1
+for arg in "$@"; do
+  case "$arg" in
+    --no-git-hook) INSTALL_GIT_HOOK=0 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+# shellcheck source=lib-installer.sh
+source "$SCRIPT_DIR/lib-installer.sh"
+
+require_jq
+
+TEMPLATE="$SCRIPT_DIR/claude-settings.template.json"
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "ERROR: canonical template not found at: $TEMPLATE" >&2
+  exit 1
+fi
+
+target="$(project_root)/.antigravity/hooks.json"
+
+# Antigravity's hooks.json holds ONLY the hooks block. No merge with
+# operator-maintained keys — the file's purpose is hooks. Use the
+# hooks-only writer, which still backs up before overwrite.
+write_hooks_only_settings "$TEMPLATE" "$target"
+
+if (( INSTALL_GIT_HOOK == 1 )); then
+  install_per_worktree_pre_push
+fi
+
+cat <<'EOF' >&2
+
+NOTE: Antigravity's hook contract is undocumented by Google. The
+schema and tool names (Bash, Write, Edit, etc.) are inferred from
+community usage and may change. If your hooks stop firing after an
+Antigravity update, check Google's release notes and re-verify.
+
+EOF
+echo "Done. Project-scoped Antigravity hooks installed at $target." >&2

--- a/skills/autonomous-common/scripts/install-claude-hooks.sh
+++ b/skills/autonomous-common/scripts/install-claude-hooks.sh
@@ -20,6 +20,11 @@
 #
 # Optionally also installs the per-worktree git pre-push hook (#65) by
 # calling install-git-pre-push.sh. Disable with --no-git-hook.
+#
+# Refactored in PR-11a: shared merge logic now lives in lib-installer.sh
+# alongside install-qoder-hooks.sh and install-antigravity-hooks.sh, all
+# of which use the same canonical claude-settings.template.json. This
+# script's behavior is byte-equivalent to the pre-PR-11 version.
 
 set -euo pipefail
 
@@ -35,80 +40,28 @@ for arg in "$@"; do
   esac
 done
 
-if ! command -v jq >/dev/null 2>&1; then
-  echo "ERROR: jq is required (apt: jq, brew: jq)." >&2
-  exit 1
-fi
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
-TEMPLATE="$SCRIPT_DIR/claude-settings.template.json"
 
+# shellcheck source=lib-installer.sh
+source "$SCRIPT_DIR/lib-installer.sh"
+
+require_jq
+
+TEMPLATE="$SCRIPT_DIR/claude-settings.template.json"
 if [[ ! -f "$TEMPLATE" ]]; then
   echo "ERROR: canonical template not found at: $TEMPLATE" >&2
   exit 1
 fi
 
-# Locate project root. Prefer git toplevel; fall back to CWD.
-project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-settings_dir="$project_root/.claude"
-settings_file="$settings_dir/settings.json"
-mkdir -p "$settings_dir"
+target="$(project_root)/.claude/settings.json"
 
-# Strategy:
-#   - If settings.json doesn't exist: write the template verbatim.
-#   - If it exists: merge our `hooks`, `_managed_by`, `_managed_note`
-#     into the existing file, preserving any other top-level keys.
-#     This OVERWRITES any prior `hooks` block (including hand-edits).
-#     The `_managed_note` field documents this contract loud-and-clear.
-#
-# Merge uses jq, which guarantees JSON-correctness regardless of
-# whitespace / comments in the input (`.claude/settings.json` is JSON,
-# not JSONC; comments aren't valid).
+# Claude Code's settings.json holds many other top-level keys the user
+# maintains (enabledPlugins, statusLine, ...). Merge in our hooks block,
+# preserve everything else.
+merge_hooks_settings "$TEMPLATE" "$target" '.hooks.PreToolUse | length > 0'
 
-if [[ ! -f "$settings_file" ]]; then
-  cp "$TEMPLATE" "$settings_file"
-  echo "Created: $settings_file (from template)" >&2
-else
-  # Backup the existing file before mutation.
-  # Append $$ for uniqueness if two installs race within the same second.
-  backup="$settings_file.bak.$(date +%s).$$"
-  cp "$settings_file" "$backup"
-
-  # Compose: existing settings + (template's _managed_by, _managed_note,
-  # hooks fields). Right side wins on key conflicts.
-  tmp=$(mktemp)
-  trap 'rm -f "$tmp"' EXIT
-  jq -s '
-    .[0] as $existing |
-    .[1] as $tmpl |
-    $existing
-      + ($tmpl | {_managed_by, _managed_note, hooks})
-  ' "$settings_file" "$TEMPLATE" > "$tmp"
-
-  # Sanity check: the merged file must still be valid JSON and contain
-  # the canonical hooks block. If anything went wrong, restore the
-  # backup and fail loudly.
-  if ! jq -e '.hooks.PreToolUse | length > 0' "$tmp" >/dev/null; then
-    mv "$backup" "$settings_file"
-    echo "ERROR: merge produced an unexpected result; restored backup" >&2
-    exit 1
-  fi
-
-  mv "$tmp" "$settings_file"
-  trap - EXIT
-  echo "Updated: $settings_file (backup at $backup)" >&2
-fi
-
-# Optional: also install the per-worktree git pre-push hook (#65).
 if (( INSTALL_GIT_HOOK == 1 )); then
-  git_hook_installer="$(dirname "$SCRIPT_DIR")/hooks/install-git-pre-push.sh"
-  if [[ -x "$git_hook_installer" ]]; then
-    echo "Installing git-side pre-push hook (#65)..." >&2
-    bash "$git_hook_installer"
-  else
-    echo "WARN: git-side hook installer not found at: $git_hook_installer" >&2
-    echo "      Skipping. Re-run with --no-git-hook to suppress this warning." >&2
-  fi
+  install_per_worktree_pre_push
 fi
 
 echo "Done. Project-scoped Claude hooks (#68) and git pre-push (#65) are installed." >&2

--- a/skills/autonomous-common/scripts/install-qoder-hooks.sh
+++ b/skills/autonomous-common/scripts/install-qoder-hooks.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# install-qoder-hooks.sh — bootstrap project-scoped Qoder (Alibaba) hooks
+# from the canonical template.
+#
+# Qoder adopted Claude Code's hook schema verbatim (events, matcher
+# field, JSON shape, exit code 2 = block). Its config file is
+# `.qoder/settings.json`, also a multi-key settings file with other
+# top-level keys the operator maintains (similar to .claude/settings.json).
+# So the merge strategy is identical to the Claude installer: merge the
+# canonical hooks block in, preserve everything else.
+#
+# Usage:
+#   bash skills/autonomous-common/scripts/install-qoder-hooks.sh
+#
+# Idempotent. Optional --no-git-hook to skip the per-worktree git
+# pre-push hook (#65). Source: docs.qoder.com/cli/hooks.
+
+set -euo pipefail
+
+INSTALL_GIT_HOOK=1
+for arg in "$@"; do
+  case "$arg" in
+    --no-git-hook) INSTALL_GIT_HOOK=0 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+# shellcheck source=lib-installer.sh
+source "$SCRIPT_DIR/lib-installer.sh"
+
+require_jq
+
+TEMPLATE="$SCRIPT_DIR/claude-settings.template.json"
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "ERROR: canonical template not found at: $TEMPLATE" >&2
+  exit 1
+fi
+
+target="$(project_root)/.qoder/settings.json"
+
+# Same merge contract as the Claude installer: Qoder's settings.json
+# holds other operator-managed keys; preserve them.
+merge_hooks_settings "$TEMPLATE" "$target" '.hooks.PreToolUse | length > 0'
+
+if (( INSTALL_GIT_HOOK == 1 )); then
+  install_per_worktree_pre_push
+fi
+
+echo "Done. Project-scoped Qoder hooks installed at $target." >&2

--- a/skills/autonomous-common/scripts/lib-installer.sh
+++ b/skills/autonomous-common/scripts/lib-installer.sh
@@ -86,8 +86,11 @@ merge_hooks_settings() {
   # field documents this).
   local tmp
   tmp=$(mktemp)
+  # EXIT (not RETURN) so cleanup fires even on `set -e` abort paths inside
+  # this function. Caller scripts run with `set -euo pipefail`; jq failures
+  # on a malformed existing target would otherwise leak the tmp file.
   # shellcheck disable=SC2064
-  trap "rm -f '$tmp'" RETURN
+  trap "rm -f '$tmp'" EXIT
   jq -s '
     .[0] as $existing |
     .[1] as $tmpl |
@@ -95,13 +98,21 @@ merge_hooks_settings() {
       + ($tmpl | {_managed_by, _managed_note, hooks})
   ' "$target" "$template" > "$tmp"
 
-  if ! jq -e "$verify_filter" "$tmp" >/dev/null; then
+  # Verify the merged file is sane:
+  #   - Caller-supplied filter (typically '.hooks.PreToolUse | length > 0')
+  #     catches wholesale hook-block destruction.
+  #   - We additionally hard-check `_managed_by == "autonomous-common"` so
+  #     a template edit that silently drops the management annotation is
+  #     also caught (without it, the "hand-edits will be overwritten on
+  #     re-run" contract documented in _managed_note is invisible).
+  if ! jq -e "($verify_filter) and (._managed_by == \"autonomous-common\")" "$tmp" >/dev/null; then
     mv "$backup" "$target"
     echo "ERROR: merge produced an unexpected result; restored backup" >&2
     exit 1
   fi
 
   mv "$tmp" "$target"
+  trap - EXIT
   echo "Updated: $target (backup at $backup)" >&2
 }
 

--- a/skills/autonomous-common/scripts/lib-installer.sh
+++ b/skills/autonomous-common/scripts/lib-installer.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# lib-installer.sh — shared logic for cross-agent hook installers.
+#
+# Sourced by install-{claude,qoder,antigravity,...}-hooks.sh. Provides:
+#
+#   - merge_hooks_settings <template> <target> <required-jq-check>
+#       Merge the canonical hook block from <template> into <target>,
+#       preserving any other top-level keys the user has set. Backs up
+#       the existing target before mutation. <required-jq-check> is a
+#       jq filter that must evaluate to true on the merged file (used
+#       to verify the merge produced sane output before committing).
+#
+#   - write_hooks_only_settings <template> <target>
+#       For agents whose config file holds ONLY the hooks block
+#       (e.g. Antigravity's .antigravity/hooks.json). Writes the
+#       template's `hooks` field as the entire file body.
+#
+#   - install_per_worktree_pre_push
+#       Runs the autonomous-common per-worktree git pre-push installer
+#       (closes #65). No-op-with-warning if the script isn't present.
+#
+# These helpers are agent-agnostic. The per-agent installer scripts
+# decide WHICH file to write to and WHICH merge strategy to use; this
+# lib provides the verified plumbing.
+#
+# Required: jq.
+
+set -euo pipefail
+
+# Path to the autonomous-common scripts dir (where this lib lives).
+_LIB_INSTALLER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+# require_jq — abort if jq isn't on PATH. All merges go through jq for
+# JSON correctness; no jq means no installer.
+require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq is required (apt: jq, brew: jq)." >&2
+    exit 1
+  fi
+}
+
+# project_root — best-effort project root: git toplevel, fall back to CWD.
+project_root() {
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+# backup_path <file>
+# Append epoch + PID for uniqueness if two installs race within the same
+# second. Echo the chosen backup path on stdout.
+backup_path() {
+  local f="$1"
+  echo "${f}.bak.$(date +%s).$$"
+}
+
+# merge_hooks_settings <template> <target> <verify-jq-filter>
+#
+# For agents whose config file is a settings.json that may have OTHER
+# top-level keys the user maintains (Claude Code, Qoder, ...). Merges
+# the template's `_managed_by`, `_managed_note`, `hooks` fields into the
+# existing settings file, preserving everything else.
+#
+# If <target> doesn't exist yet, copies the template verbatim.
+#
+# <verify-jq-filter> is a jq -e expression that must succeed on the
+# merged file before it's committed (typically: `.hooks.PreToolUse |
+# length > 0`). On failure, the backup is restored and we exit 1.
+merge_hooks_settings() {
+  local template="$1" target="$2" verify_filter="$3"
+  local target_dir
+  target_dir="$(dirname "$target")"
+  mkdir -p "$target_dir"
+
+  if [[ ! -f "$target" ]]; then
+    cp "$template" "$target"
+    echo "Created: $target (from template)" >&2
+    return 0
+  fi
+
+  local backup
+  backup="$(backup_path "$target")"
+  cp "$target" "$backup"
+
+  # Right side wins on key conflicts; the template's `hooks` block
+  # OVERWRITES any existing hooks (operators who hand-edit hooks must
+  # update the template, not the merged file — the `_managed_note`
+  # field documents this).
+  local tmp
+  tmp=$(mktemp)
+  # shellcheck disable=SC2064
+  trap "rm -f '$tmp'" RETURN
+  jq -s '
+    .[0] as $existing |
+    .[1] as $tmpl |
+    $existing
+      + ($tmpl | {_managed_by, _managed_note, hooks})
+  ' "$target" "$template" > "$tmp"
+
+  if ! jq -e "$verify_filter" "$tmp" >/dev/null; then
+    mv "$backup" "$target"
+    echo "ERROR: merge produced an unexpected result; restored backup" >&2
+    exit 1
+  fi
+
+  mv "$tmp" "$target"
+  echo "Updated: $target (backup at $backup)" >&2
+}
+
+# write_hooks_only_settings <template> <target>
+#
+# For agents whose config file holds ONLY the hooks block — e.g.
+# Antigravity's `.antigravity/hooks.json`. Writes the `hooks`,
+# `_managed_by`, and `_managed_note` fields from the template as the
+# entire file body. Existing file is backed up before overwrite.
+write_hooks_only_settings() {
+  local template="$1" target="$2"
+  local target_dir
+  target_dir="$(dirname "$target")"
+  mkdir -p "$target_dir"
+
+  local content
+  content=$(jq '{_managed_by, _managed_note, hooks}' "$template")
+
+  if [[ -f "$target" ]]; then
+    local backup
+    backup="$(backup_path "$target")"
+    cp "$target" "$backup"
+    printf '%s\n' "$content" > "$target"
+    echo "Updated: $target (backup at $backup)" >&2
+  else
+    printf '%s\n' "$content" > "$target"
+    echo "Created: $target" >&2
+  fi
+}
+
+# install_per_worktree_pre_push
+#
+# Calls the per-worktree git pre-push hook installer (closes #65).
+# No-op-with-warning if the script is missing. Used by every per-agent
+# installer's --git-hook (default-on) path.
+install_per_worktree_pre_push() {
+  local hooks_dir installer
+  hooks_dir="$(dirname "$_LIB_INSTALLER_DIR")/hooks"
+  installer="$hooks_dir/install-git-pre-push.sh"
+  if [[ -x "$installer" ]]; then
+    echo "Installing git-side pre-push hook (#65)..." >&2
+    bash "$installer"
+  else
+    echo "WARN: git-side hook installer not found at: $installer" >&2
+    echo "      Skipping. Re-run with --no-git-hook to suppress this warning." >&2
+  fi
+}

--- a/tests/unit/test-install-antigravity-hooks.sh
+++ b/tests/unit/test-install-antigravity-hooks.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# test-install-antigravity-hooks.sh — Tests for the Antigravity installer (PR-11a).
+#
+# Antigravity differs from Claude/Qoder: its config file is hooks-only
+# (.antigravity/hooks.json), so the installer uses write_hooks_only_settings
+# instead of merge_hooks_settings. Existing files ARE backed up before
+# overwrite (so an operator's hand-edited hooks aren't lost silently).
+#
+# Run: bash tests/unit/test-install-antigravity-hooks.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALLER="$PROJECT_ROOT/skills/autonomous-common/scripts/install-antigravity-hooks.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# ---------------------------------------------------------------------------
+echo "=== TC-AG-01: first-time install creates .antigravity/hooks.json ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo1"
+git -C "$TMPDIR/repo1" init --quiet --initial-branch=main
+(cd "$TMPDIR/repo1" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+
+target="$TMPDIR/repo1/.antigravity/hooks.json"
+if [[ -f "$target" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: .antigravity/hooks.json created"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: .antigravity/hooks.json NOT created"
+  FAIL=$((FAIL + 1))
+fi
+
+if python3 -c "import json; json.load(open('$target'))" 2>/dev/null; then
+  echo -e "  ${GREEN}PASS${NC}: hooks.json is valid JSON"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: hooks.json is not valid JSON"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q '"_managed_by": "autonomous-common"' "$target"; then
+  echo -e "  ${GREEN}PASS${NC}: _managed_by annotation present"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: _managed_by annotation missing"
+  FAIL=$((FAIL + 1))
+fi
+
+if jq -e '.hooks.PreToolUse | length > 0' "$target" >/dev/null 2>&1; then
+  echo -e "  ${GREEN}PASS${NC}: hooks.PreToolUse populated"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: hooks.PreToolUse missing"
+  FAIL=$((FAIL + 1))
+fi
+
+# Antigravity's hooks.json is hooks-only — should NOT contain other
+# top-level Claude-settings.json keys like enabledPlugins.
+if jq -e 'has("enabledPlugins")' "$target" >/dev/null 2>&1; then
+  echo -e "  ${RED}FAIL${NC}: hooks-only file unexpectedly contains enabledPlugins"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}PASS${NC}: hooks-only file (no settings.json bloat)"
+  PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-AG-02: re-install backs up the existing file before overwrite ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo2/.antigravity"
+git -C "$TMPDIR/repo2" init --quiet --initial-branch=main
+cat > "$TMPDIR/repo2/.antigravity/hooks.json" <<'EOF'
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [{ "command": "operator-custom.sh" }] }
+    ]
+  }
+}
+EOF
+(cd "$TMPDIR/repo2" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+target="$TMPDIR/repo2/.antigravity/hooks.json"
+
+# Old custom hook is gone (overwritten — this is the documented contract).
+if jq -e '.hooks.PreToolUse | map(.hooks[].command) | any(. == "operator-custom.sh")' "$target" >/dev/null 2>&1; then
+  echo -e "  ${RED}FAIL${NC}: operator's hand-edited hooks block was NOT overwritten"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}PASS${NC}: operator's hand-edited hooks overwritten by canonical template"
+  PASS=$((PASS + 1))
+fi
+
+# Backup must exist — otherwise we silently destroyed the operator's work.
+backups=("$TMPDIR/repo2/.antigravity/hooks.json.bak."*)
+if [[ -f "${backups[0]}" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: backup file created"
+  PASS=$((PASS + 1))
+  # Backup should still contain the operator's old content
+  if jq -e '.hooks.PreToolUse | map(.hooks[].command) | any(. == "operator-custom.sh")' "${backups[0]}" >/dev/null 2>&1; then
+    echo -e "  ${GREEN}PASS${NC}: backup contains the operator's old content"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: backup does NOT contain operator's old content"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo -e "  ${RED}FAIL${NC}: no backup file — operator's work would be silently destroyed"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-AG-03: --no-git-hook suppresses git pre-push install ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo3"
+git -C "$TMPDIR/repo3" init --quiet --initial-branch=main
+(cd "$TMPDIR/repo3" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+
+if [[ ! -f "$TMPDIR/repo3/.git/hooks/pre-push" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: --no-git-hook prevented pre-push install"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: --no-git-hook did NOT prevent pre-push install"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/tests/unit/test-install-qoder-hooks.sh
+++ b/tests/unit/test-install-qoder-hooks.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# test-install-qoder-hooks.sh — Tests for the Qoder installer (PR-11a).
+#
+# Verifies:
+#   1. First-time install creates .qoder/settings.json with the canonical hooks.
+#   2. Re-install merges with existing settings.json (preserves other top-level keys).
+#   3. _managed_by annotation is present.
+#   4. --no-git-hook flag suppresses the git pre-push install.
+#
+# The Qoder installer reuses lib-installer.sh's merge_hooks_settings, so the
+# happy-path behavior is byte-equivalent to install-claude-hooks.sh except
+# for the target path (.qoder/settings.json vs .claude/settings.json).
+#
+# Run: bash tests/unit/test-install-qoder-hooks.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALLER="$PROJECT_ROOT/skills/autonomous-common/scripts/install-qoder-hooks.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# ---------------------------------------------------------------------------
+echo "=== TC-Q-01: first-time install creates .qoder/settings.json ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo1"
+git -C "$TMPDIR/repo1" init --quiet --initial-branch=main
+(cd "$TMPDIR/repo1" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+
+settings="$TMPDIR/repo1/.qoder/settings.json"
+if [[ -f "$settings" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: .qoder/settings.json created"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: .qoder/settings.json NOT created"
+  FAIL=$((FAIL + 1))
+fi
+
+if python3 -c "import json; json.load(open('$settings'))" 2>/dev/null; then
+  echo -e "  ${GREEN}PASS${NC}: settings.json is valid JSON"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: settings.json is not valid JSON"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q '"_managed_by": "autonomous-common"' "$settings"; then
+  echo -e "  ${GREEN}PASS${NC}: _managed_by annotation present"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: _managed_by annotation missing"
+  FAIL=$((FAIL + 1))
+fi
+
+if jq -e '.hooks.PreToolUse | length > 0' "$settings" >/dev/null 2>&1; then
+  echo -e "  ${GREEN}PASS${NC}: hooks.PreToolUse populated"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: hooks.PreToolUse missing or empty"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-Q-02: re-install merges, preserves other top-level keys ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo2"
+git -C "$TMPDIR/repo2" init --quiet --initial-branch=main
+mkdir -p "$TMPDIR/repo2/.qoder"
+cat > "$TMPDIR/repo2/.qoder/settings.json" <<'EOF'
+{
+  "userPreference": "preserve me",
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [{ "command": "old-hook.sh" }] }
+    ]
+  }
+}
+EOF
+(cd "$TMPDIR/repo2" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+settings="$TMPDIR/repo2/.qoder/settings.json"
+
+if jq -e '.userPreference == "preserve me"' "$settings" >/dev/null 2>&1; then
+  echo -e "  ${GREEN}PASS${NC}: pre-existing top-level key preserved"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: pre-existing top-level key lost"
+  FAIL=$((FAIL + 1))
+fi
+
+# Old hooks block must have been overwritten by the canonical template.
+if jq -e '.hooks.PreToolUse | map(.hooks[].command) | any(. == "old-hook.sh")' "$settings" >/dev/null 2>&1; then
+  echo -e "  ${RED}FAIL${NC}: old hand-edited hooks block was NOT overwritten"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}PASS${NC}: old hooks block overwritten by canonical template"
+  PASS=$((PASS + 1))
+fi
+
+# Backup file should exist
+backups=("$TMPDIR/repo2/.qoder/settings.json.bak."*)
+if [[ -f "${backups[0]}" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: backup file created"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: no backup file found"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-Q-03: --no-git-hook suppresses git pre-push install ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo3"
+git -C "$TMPDIR/repo3" init --quiet --initial-branch=main
+(cd "$TMPDIR/repo3" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+
+if [[ ! -f "$TMPDIR/repo3/.git/hooks/pre-push" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: --no-git-hook prevented pre-push install"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: --no-git-hook did NOT prevent pre-push install"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

PR-11a of three: extends hook coverage from Claude Code (PR-5) to additional coding agents whose hook schemas adopted Claude Code's verbatim. Lays the foundations (shared installer lib + cross-agent reference doc) for PR-11b (near-clone agents — Cursor / Kiro / Gemini / Codex) and PR-11c (divergent — Windsurf / Kimi).

No specific issue tied. Refs task #6 follow-up — the autonomous-common skill now covers more agents per the user request to "extend hook enforcement to common coding agents".

## Cross-agent landscape

Researched all 8 agents. **All support hooks.** Exit code `2` = block is universal (Claude Code idiom became de facto standard). Tiers:

| Tier | Agents | Schema vs Claude Code | This PR? |
|---|---|---|---|
| Identical | **Qoder**, **Antigravity** | 1:1 — same events, same matchers, same JSON shape | ✅ PR-11a |
| Near-clone | Cursor, Kiro CLI, Gemini CLI, Codex CLI | Translatable event/tool names | PR-11b |
| Divergent | Windsurf (no matcher), Kimi (TOML) | Schema differs more substantially | PR-11c |

Full per-agent matrix (all 8) lives in the new `docs/cross-agent-hooks.md`.

## What this PR ships

### Refactor — extract shared installer logic

New `skills/autonomous-common/scripts/lib-installer.sh`:

- `merge_hooks_settings <template> <target> <verify-jq>` — merge into a multi-key settings file (Claude Code, Qoder); preserves user-maintained top-level keys
- `write_hooks_only_settings <template> <target>` — overwrite a hooks-only file (Antigravity); backs up first
- `install_per_worktree_pre_push` — shared call to `install-git-pre-push.sh`
- `require_jq`, `project_root`, `backup_path` — small primitives

`install-claude-hooks.sh` was 114 lines of inline merge logic; now ~50 lines that source `lib-installer.sh`. Behavior is byte-equivalent to PR-5 — the existing `test-install-claude-hooks.sh` still passes unchanged (regression verified).

### New installers

- `install-qoder-hooks.sh` — writes `.qoder/settings.json`. Qoder's docs (docs.qoder.com/cli/hooks) confirm the Claude schema is accepted as-is.
- `install-antigravity-hooks.sh` — writes `.antigravity/hooks.json`. Antigravity's hook contract is **undocumented by Google** but works in practice per community evidence (e.g. `lehau007/AI-Auto-Log-Windows`, `AgusRdz/chop`). The installer prints a stderr caveat that the schema could change without notice.

Both installers:
- Idempotent
- Back up existing files before mutation
- Optional `--no-git-hook` flag (matches `install-claude-hooks.sh`)
- Apply the canonical `claude-settings.template.json`

### Documentation

- `docs/cross-agent-hooks.md` — durable spec covering all 8 researched agents + the canonical hook-script contract that all of them satisfy
- `skills/autonomous-common/SKILL.md` — Setup section now lists all 3 supported installers + a "coming in PR-11b/c" stub for the rest

## Tests

- `tests/unit/test-install-qoder-hooks.sh` (8 cases) — first-time install, re-install merges and preserves user keys, `_managed_by` annotation present, `--no-git-hook` honored, backup created
- `tests/unit/test-install-antigravity-hooks.sh` (9 cases) — first-time install creates hooks-only file (no `enabledPlugins` etc bloat), re-install backs up the operator's hand-edited content before overwriting, `--no-git-hook` honored

26 unit-test files green total (was 24, +2 new).

## Code review

Code-reviewer agent caught 2 medium findings, both addressed in commit `835d67e`:

- **M1**: `trap ... RETURN` doesn't fire on `set -e` abort inside a sourced function → temp-file leak. Switched back to `EXIT` (matches the original PR-5 pattern).
- **M2**: verify-jq filter too weak — only checked hooks block, not the `_managed_by` annotation. Tightened to also verify `_managed_by == "autonomous-common"` so a future template edit that silently drops the annotation would be caught.

## Test plan

- [x] All 26 unit tests pass
- [x] `bash -n` syntax check on all new scripts
- [x] `shellcheck` clean (only pre-existing SC1091 info-level for sourced files)
- [x] `install-claude-hooks.sh` byte-equivalent verified (existing test still passes after refactor)
- [x] code-reviewer agent: M1 + M2 fixed in `835d67e`

## Follow-ups (not in this PR)

- **PR-11b**: Cursor / Kiro CLI / Gemini CLI / Codex CLI installers — these need event-name (`PreToolUse` → `preToolUse` / `BeforeTool` / etc.) and tool-name (`Bash` → `execute_bash` / `run_shell_command` / etc.) translation in their lib-installer extensions.
- **PR-11c**: Windsurf and Kimi CLI — schema-divergent (Windsurf has no per-tool matcher field, Kimi uses TOML).