### PR TITLE
feat(hooks): cross-agent installers — near-clone tier (Cursor + Kiro + Gemini + Codex)

### DIFF
--- a/docs/cross-agent-hooks.md
+++ b/docs/cross-agent-hooks.md
@@ -15,14 +15,14 @@ What differs between agents is **how to declare which script runs when** — i.e
 | **Claude Code** | `.claude/settings.json` | Reference (JSON, `PreToolUse`, …) | `Bash`, `Write`, `Edit` | `2` | `install-claude-hooks.sh` (PR-5) |
 | **Qoder** | `.qoder/settings.json` | Identical to Claude Code | `Bash`, `Write`, `Edit` | `2` | `install-qoder-hooks.sh` (PR-11a) |
 | **Antigravity** | `.antigravity/hooks.json` | Identical to Claude Code (undocumented) | `Bash` | `2` | `install-antigravity-hooks.sh` (PR-11a) |
-| Cursor | `.cursor/hooks.json` | Claude-style + shell-specific event | `Shell` (or pipe regex on cmd) | `2` | PR-11b (planned) |
-| Kiro CLI / Amazon Q | `.kiro/agents/<name>.json` | camelCase events, `timeout_ms` | `execute_bash`, `fs_write` | `2` | PR-11b (planned) |
-| Gemini CLI | `.gemini/settings.json` | `BeforeTool`/`AfterTool` regex | `run_shell_command`, `write_file`, `replace` | `2` | PR-11b (planned) |
-| Codex CLI | `.codex/hooks.json` + `[features]codex_hooks=true` | Claude-style | undocumented | `2` | PR-11b (planned) |
+| **Cursor** | `.cursor/hooks.json` | Claude-style, camelCase events, `version: 1` envelope | `Shell` (or pipe regex on cmd) | `2` | `install-cursor-hooks.sh` (PR-11b) |
+| **Kiro CLI / Amazon Q** | `.kiro/agents/<name>.json` | Agent definition; camelCase events; `timeout_ms` (ms not seconds) | `execute_bash`, `fs_write` (Write+Edit unified) | `2` | `install-kiro-hooks.sh` (PR-11b) |
+| **Gemini CLI** | `.gemini/settings.json` | `BeforeTool`/`AfterTool` events; provides `$CLAUDE_PROJECT_DIR` env compat alias | `run_shell_command`, `write_file`, `replace` | `2` | `install-gemini-hooks.sh` (PR-11b) |
+| **Codex CLI** | `.codex/hooks.json` + `[features]codex_hooks=true` in `config.toml` | Claude-style (modeled verbatim) | `Bash`, `Write`, `Edit` (undocumented but inferred) | `2` | `install-codex-hooks.sh` (PR-11b) |
 | Windsurf | `.windsurf/hooks.json` | snake_case, **no matcher field** | filter inside script | `2` | PR-11c (planned) |
 | Kimi CLI | `~/.kimi/config.toml` | TOML, `[[hooks]]` array | regex (e.g. `WriteFile\|StrReplaceFile`) | `2` | PR-11c (planned) |
 
-## Per-agent installation (PR-11a coverage)
+## Per-agent installation
 
 After `npx skills add zxkane/autonomous-dev-team`, run **one** of these from the project root:
 
@@ -35,6 +35,18 @@ bash .claude/skills/autonomous-common/scripts/install-qoder-hooks.sh
 
 # Antigravity (undocumented contract — see caveat below)
 bash .claude/skills/autonomous-common/scripts/install-antigravity-hooks.sh
+
+# Cursor
+bash .claude/skills/autonomous-common/scripts/install-cursor-hooks.sh
+
+# Kiro CLI / Amazon Q (default agent name is "default"; override with --agent <name>)
+bash .claude/skills/autonomous-common/scripts/install-kiro-hooks.sh
+
+# Gemini CLI
+bash .claude/skills/autonomous-common/scripts/install-gemini-hooks.sh
+
+# Codex CLI (also enables [features] codex_hooks = true in .codex/config.toml)
+bash .claude/skills/autonomous-common/scripts/install-codex-hooks.sh
 ```
 
 Each installer is idempotent and preserves any other top-level keys you have in the agent's config file. They also install a per-worktree git pre-push hook (closes #65); pass `--no-git-hook` to skip.

--- a/skills/autonomous-common/SKILL.md
+++ b/skills/autonomous-common/SKILL.md
@@ -25,7 +25,10 @@ After `npx skills add`, run the installer for your coding agent once from the pr
 | Claude Code | `bash .claude/skills/autonomous-common/scripts/install-claude-hooks.sh` | `.claude/settings.json` |
 | Qoder | `bash .claude/skills/autonomous-common/scripts/install-qoder-hooks.sh` | `.qoder/settings.json` |
 | Antigravity | `bash .claude/skills/autonomous-common/scripts/install-antigravity-hooks.sh` | `.antigravity/hooks.json` |
-| Cursor / Kiro CLI / Gemini CLI / Codex CLI | _coming in PR-11b_ | — |
+| Cursor | `bash .claude/skills/autonomous-common/scripts/install-cursor-hooks.sh` | `.cursor/hooks.json` |
+| Kiro CLI | `bash .claude/skills/autonomous-common/scripts/install-kiro-hooks.sh [--agent <name>]` | `.kiro/agents/<name>.json` (default: `default`) |
+| Gemini CLI | `bash .claude/skills/autonomous-common/scripts/install-gemini-hooks.sh` | `.gemini/settings.json` |
+| Codex CLI | `bash .claude/skills/autonomous-common/scripts/install-codex-hooks.sh` | `.codex/hooks.json` + `.codex/config.toml` |
 | Windsurf / Kimi CLI | _coming in PR-11c_ | — |
 
 Each installer wires up the workflow hooks at the **project scope**, so they fire on every shell command in the repo — not only when an autonomous-* skill is explicitly loaded. Without this, the hook commands declared in skill frontmatter only run while a skill is active in the conversation, which is the regression that closed #68.
@@ -64,9 +67,14 @@ Claude Code only. The installer prompts for these; if installing manually, add t
 - **`hooks/`** — workflow-enforcement hooks (block-push-to-main, block-commit-outside-worktree, check-pr-review, check-shellcheck, verify-completion, …). See `hooks/README.md` for the canonical list and per-hook semantics.
 - **`scripts/`** — agent-callable utilities used by the dev/review skills:
   - `lib-installer.sh` — shared merge/write helpers used by every per-agent installer
+  - `lib-installer-translate.sh` — schema translation helpers for near-clone agents (event-name map, tool-name map, timeout-unit conversion)
   - `install-claude-hooks.sh` — Claude Code installer (writes `.claude/settings.json`)
   - `install-qoder-hooks.sh` — Qoder installer (writes `.qoder/settings.json` — same schema as Claude Code)
   - `install-antigravity-hooks.sh` — Antigravity installer (writes `.antigravity/hooks.json` — hooks-only file; contract is community-observed, undocumented by Google)
+  - `install-cursor-hooks.sh` — Cursor installer (writes `.cursor/hooks.json` — `version: 1` envelope, camelCase events, `Shell` matcher)
+  - `install-kiro-hooks.sh` — Kiro CLI / Amazon Q installer (writes `.kiro/agents/<name>.json` — agent definition with camelCase events, `execute_bash`/`fs_write` matchers, `timeout_ms` in milliseconds)
+  - `install-gemini-hooks.sh` — Gemini CLI installer (writes `.gemini/settings.json` — `BeforeTool`/`AfterTool` events, `run_shell_command`/`write_file`/`replace` matchers)
+  - `install-codex-hooks.sh` — Codex CLI installer (writes `.codex/hooks.json` + sets `[features] codex_hooks = true` in `.codex/config.toml`)
   - `claude-settings.template.json` — canonical hook list applied by all per-agent installers
   - `gh-as-user.sh` — runs `gh` as a real user (needed when retriggering bot reviews like `/q review`)
   - `mark-issue-checkbox.sh` — toggles GitHub issue body checkboxes from the agent

--- a/skills/autonomous-common/scripts/install-codex-hooks.sh
+++ b/skills/autonomous-common/scripts/install-codex-hooks.sh
@@ -59,29 +59,83 @@ config_toml="$target_dir/config.toml"
 write_hooks_only_settings "$TEMPLATE" "$target"
 
 # Toggle the [features] codex_hooks = true flag. This is required
-# upstream; without it, the hooks.json file is ignored. We append the
-# section if missing, or no-op if already set.
+# upstream; without it, the hooks.json file is ignored.
+#
+# TOML constraint (PR-11b code review C1): defining `[features]` more
+# than once is invalid TOML — the Rust `toml` crate that Codex uses
+# rejects the entire config. So we MUST NOT blindly append a second
+# `[features]` block. The strategy:
+#
+#   1. No file → create a fresh one with a single `[features]` block.
+#   2. File has `codex_hooks = true` already (anywhere) → no-op.
+#   3. File has `codex_hooks = false` → refuse + ask operator to fix.
+#      (We assume `false` is intentional; flipping it would surprise.)
+#   4. File has a `[features]` section → insert `codex_hooks = true` as
+#      the first line of that section.
+#   5. File has no `[features]` section → append a new one at EOF.
 mkdir -p "$target_dir"
-if [[ -f "$config_toml" ]]; then
-  if grep -qE '^\s*codex_hooks\s*=\s*true\s*$' "$config_toml"; then
-    echo "Note: codex_hooks already enabled in $config_toml" >&2
-  else
-    {
-      echo ""
-      echo "# Added by install-codex-hooks.sh — required for hooks.json to take effect."
-      echo "[features]"
-      echo "codex_hooks = true"
-    } >> "$config_toml"
-    echo "Updated: $config_toml (appended [features] codex_hooks = true)" >&2
-  fi
-else
-  cat > "$config_toml" <<'EOF'
+
+toggle_codex_hooks_flag() {
+  local file="$1"
+
+  if [[ ! -f "$file" ]]; then
+    cat > "$file" <<'EOF'
 # Created by install-codex-hooks.sh — required for hooks.json to take effect.
 [features]
 codex_hooks = true
 EOF
-  echo "Created: $config_toml" >&2
-fi
+    echo "Created: $file" >&2
+    return 0
+  fi
+
+  # Already enabled? (No-op.)
+  if grep -qE '^[[:space:]]*codex_hooks[[:space:]]*=[[:space:]]*true' "$file"; then
+    echo "Note: codex_hooks already enabled in $file" >&2
+    return 0
+  fi
+
+  # Explicitly disabled? Refuse — operator likely set it on purpose.
+  if grep -qE '^[[:space:]]*codex_hooks[[:space:]]*=[[:space:]]*false' "$file"; then
+    echo "ERROR: $file contains 'codex_hooks = false'. Hooks would not fire." >&2
+    echo "       Edit that line to 'true' (or remove it) and re-run." >&2
+    return 1
+  fi
+
+  # Insert into existing [features] section, or append a new section.
+  if grep -qE '^[[:space:]]*\[features\][[:space:]]*$' "$file"; then
+    # Use awk to insert `codex_hooks = true` as the first line after
+    # the `[features]` header. Robust against trailing whitespace and
+    # blank lines.
+    local tmp
+    tmp=$(mktemp)
+    # shellcheck disable=SC2064
+    trap "rm -f '$tmp'" RETURN
+    awk '
+      BEGIN { inserted = 0 }
+      /^[[:space:]]*\[features\][[:space:]]*$/ {
+        print
+        if (!inserted) {
+          print "codex_hooks = true  # added by install-codex-hooks.sh"
+          inserted = 1
+        }
+        next
+      }
+      { print }
+    ' "$file" > "$tmp"
+    mv "$tmp" "$file"
+    trap - RETURN
+    echo "Updated: $file (inserted codex_hooks = true into existing [features] section)" >&2
+  else
+    {
+      printf '\n# Added by install-codex-hooks.sh — required for hooks.json to take effect.\n'
+      printf '[features]\n'
+      printf 'codex_hooks = true\n'
+    } >> "$file"
+    echo "Updated: $file (appended new [features] section)" >&2
+  fi
+}
+
+toggle_codex_hooks_flag "$config_toml" || exit 1
 
 if (( INSTALL_GIT_HOOK == 1 )); then
   install_per_worktree_pre_push

--- a/skills/autonomous-common/scripts/install-codex-hooks.sh
+++ b/skills/autonomous-common/scripts/install-codex-hooks.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# install-codex-hooks.sh — bootstrap project-scoped OpenAI Codex CLI hooks
+# from the canonical template.
+#
+# Codex CLI's hook system is modeled directly on Claude Code's
+# (per github.com/openai/codex codex-rs/hooks/) and accepts the same
+# event names + matcher field. The differences:
+#
+#   1. Hooks live in `.codex/hooks.json` (NOT `.claude/settings.json`).
+#      The file is hooks-only — no other top-level keys.
+#   2. The feature is gated behind `[features] codex_hooks = true` in
+#      `~/.codex/config.toml` or the project's `.codex/config.toml`.
+#      We toggle the project-level flag here.
+#
+# Caveat: Codex hook support is experimental upstream. The exact tool-
+# name matchers ("Bash", "Write", "Edit") are modeled on Claude Code's
+# but not officially documented in the Codex docs at
+# developers.openai.com/codex/config-advanced. Verify your first hook
+# fires before relying on the install.
+#
+# Usage:
+#   bash skills/autonomous-common/scripts/install-codex-hooks.sh
+#
+# Idempotent. --no-git-hook to skip the per-worktree git pre-push (#65).
+
+set -euo pipefail
+
+INSTALL_GIT_HOOK=1
+for arg in "$@"; do
+  case "$arg" in
+    --no-git-hook) INSTALL_GIT_HOOK=0 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+# shellcheck source=lib-installer.sh
+source "$SCRIPT_DIR/lib-installer.sh"
+
+require_jq
+
+TEMPLATE="$SCRIPT_DIR/claude-settings.template.json"
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "ERROR: canonical template not found at: $TEMPLATE" >&2
+  exit 1
+fi
+
+target_dir="$(project_root)/.codex"
+target="$target_dir/hooks.json"
+config_toml="$target_dir/config.toml"
+
+# Codex's hooks.json is hooks-only (same shape as Antigravity). Use the
+# hooks-only writer.
+write_hooks_only_settings "$TEMPLATE" "$target"
+
+# Toggle the [features] codex_hooks = true flag. This is required
+# upstream; without it, the hooks.json file is ignored. We append the
+# section if missing, or no-op if already set.
+mkdir -p "$target_dir"
+if [[ -f "$config_toml" ]]; then
+  if grep -qE '^\s*codex_hooks\s*=\s*true\s*$' "$config_toml"; then
+    echo "Note: codex_hooks already enabled in $config_toml" >&2
+  else
+    {
+      echo ""
+      echo "# Added by install-codex-hooks.sh — required for hooks.json to take effect."
+      echo "[features]"
+      echo "codex_hooks = true"
+    } >> "$config_toml"
+    echo "Updated: $config_toml (appended [features] codex_hooks = true)" >&2
+  fi
+else
+  cat > "$config_toml" <<'EOF'
+# Created by install-codex-hooks.sh — required for hooks.json to take effect.
+[features]
+codex_hooks = true
+EOF
+  echo "Created: $config_toml" >&2
+fi
+
+if (( INSTALL_GIT_HOOK == 1 )); then
+  install_per_worktree_pre_push
+fi
+
+cat <<'EOF' >&2
+
+NOTE: Codex CLI hook support is experimental upstream. Tool-name
+matchers (Bash, Write, Edit) are modeled on Claude Code but not
+officially documented. Run a no-op test (e.g., a benign shell command
+that triggers the push-to-main hook by mistake) to verify hooks fire
+before relying on them.
+
+EOF
+echo "Done. Project-scoped Codex hooks installed at $target." >&2

--- a/skills/autonomous-common/scripts/install-cursor-hooks.sh
+++ b/skills/autonomous-common/scripts/install-cursor-hooks.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# install-cursor-hooks.sh — bootstrap project-scoped Cursor hooks from
+# the canonical template.
+#
+# Cursor's hook config is at `.cursor/hooks.json` (hooks-only file).
+# The schema is Claude-Code-style but with camelCase event names and
+# different tool-name matchers. Per cursor.com/docs/agent/hooks:
+#
+#   Events:    preToolUse, postToolUse, stop, sessionStart, sessionEnd,
+#              beforeShellExecution, afterShellExecution, ...
+#   Matchers:  Tool names for preToolUse — "Shell", "Write", "Edit", ...
+#              Pipe-regex against command text for beforeShellExecution.
+#
+# We translate the canonical template's PreToolUse/PostToolUse/Stop
+# events to Cursor's camelCase forms, and Bash/Write/Edit matchers to
+# Shell/Write/Edit. (Cursor's `Shell` tool covers Bash; Write/Edit names
+# are the same.)
+#
+# Cursor hooks expect a `version: 1` envelope at the top level.
+#
+# Usage:
+#   bash skills/autonomous-common/scripts/install-cursor-hooks.sh
+#
+# Idempotent. --no-git-hook to skip the per-worktree git pre-push (#65).
+
+set -euo pipefail
+
+INSTALL_GIT_HOOK=1
+for arg in "$@"; do
+  case "$arg" in
+    --no-git-hook) INSTALL_GIT_HOOK=0 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+# shellcheck source=lib-installer.sh
+source "$SCRIPT_DIR/lib-installer.sh"
+# shellcheck source=lib-installer-translate.sh
+source "$SCRIPT_DIR/lib-installer-translate.sh"
+
+require_jq
+
+TEMPLATE="$SCRIPT_DIR/claude-settings.template.json"
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "ERROR: canonical template not found at: $TEMPLATE" >&2
+  exit 1
+fi
+
+target="$(project_root)/.cursor/hooks.json"
+
+# Translate Claude → Cursor names.
+AGENT_EVENT_MAP="PreToolUse:preToolUse PostToolUse:postToolUse Stop:stop"
+AGENT_TOOL_MAP="Bash:Shell Write:Write Edit:Edit"
+export AGENT_EVENT_MAP AGENT_TOOL_MAP
+
+# Build the full Cursor hooks.json: {version: 1, _managed_*, hooks: {...}}.
+mkdir -p "$(dirname "$target")"
+translated_hooks=$(translate_template_hooks "$TEMPLATE")
+managed_meta=$(jq '{_managed_by, _managed_note}' "$TEMPLATE")
+content=$(jq -n --argjson meta "$managed_meta" --argjson hooks "$translated_hooks" \
+  '{version: 1} + $meta + {hooks: $hooks}')
+
+if [[ -f "$target" ]]; then
+  backup="$(backup_path "$target")"
+  cp "$target" "$backup"
+  printf '%s\n' "$content" > "$target"
+  echo "Updated: $target (backup at $backup)" >&2
+else
+  printf '%s\n' "$content" > "$target"
+  echo "Created: $target" >&2
+fi
+
+if (( INSTALL_GIT_HOOK == 1 )); then
+  install_per_worktree_pre_push
+fi
+
+echo "Done. Project-scoped Cursor hooks installed at $target." >&2

--- a/skills/autonomous-common/scripts/install-gemini-hooks.sh
+++ b/skills/autonomous-common/scripts/install-gemini-hooks.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# install-gemini-hooks.sh — bootstrap project-scoped Gemini CLI hooks
+# from the canonical template.
+#
+# Gemini CLI's hook config is at `.gemini/settings.json`, which is a
+# multi-key settings file (operators may have other top-level keys).
+# Schema reference: github.com/google-gemini/gemini-cli/blob/main/docs/hooks/index.md.
+#
+# Translation from Claude:
+#   Event names:  PreToolUse → BeforeTool, PostToolUse → AfterTool,
+#                 Stop → Stop (kept; Gemini's `Stop` event semantically matches).
+#   Tool matchers: regex against tool name. Built-in Gemini tool names:
+#                 Bash → run_shell_command
+#                 Write → write_file (covers new-file writes)
+#                 Edit → replace (covers in-place edits)
+#   Timeout unit: same as Claude (seconds via `timeout` field).
+#
+# Notable: Gemini explicitly provides a $CLAUDE_PROJECT_DIR env var for
+# Claude Code compatibility, so the existing hook scripts under
+# skills/autonomous-common/hooks/ run unchanged.
+#
+# Usage:
+#   bash skills/autonomous-common/scripts/install-gemini-hooks.sh
+#
+# Idempotent. --no-git-hook to skip the per-worktree git pre-push (#65).
+
+set -euo pipefail
+
+INSTALL_GIT_HOOK=1
+for arg in "$@"; do
+  case "$arg" in
+    --no-git-hook) INSTALL_GIT_HOOK=0 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+# shellcheck source=lib-installer.sh
+source "$SCRIPT_DIR/lib-installer.sh"
+# shellcheck source=lib-installer-translate.sh
+source "$SCRIPT_DIR/lib-installer-translate.sh"
+
+require_jq
+
+TEMPLATE="$SCRIPT_DIR/claude-settings.template.json"
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "ERROR: canonical template not found at: $TEMPLATE" >&2
+  exit 1
+fi
+
+target="$(project_root)/.gemini/settings.json"
+
+# Translate Claude → Gemini names.
+AGENT_EVENT_MAP="PreToolUse:BeforeTool PostToolUse:AfterTool Stop:Stop"
+AGENT_TOOL_MAP="Bash:run_shell_command Write:write_file Edit:replace"
+export AGENT_EVENT_MAP AGENT_TOOL_MAP
+
+# Build a "fake" template file that has Gemini-shaped hooks but the same
+# top-level _managed_by/_managed_note as the canonical template. Then
+# feed it through the same merge_hooks_settings used by Claude/Qoder.
+translated_hooks=$(translate_template_hooks "$TEMPLATE")
+managed_meta=$(jq '{_managed_by, _managed_note}' "$TEMPLATE")
+
+tmp_template=$(mktemp)
+# shellcheck disable=SC2064  # we want $tmp_template expanded NOW, not at trap fire
+trap "rm -f '$tmp_template'" EXIT
+jq -n --argjson meta "$managed_meta" --argjson hooks "$translated_hooks" \
+  '$meta + {hooks: $hooks}' > "$tmp_template"
+
+# Gemini's settings.json is multi-key, so use the merge writer. The
+# verify filter checks that BeforeTool (the new event name) is populated.
+merge_hooks_settings "$tmp_template" "$target" '.hooks.BeforeTool | length > 0'
+
+if (( INSTALL_GIT_HOOK == 1 )); then
+  install_per_worktree_pre_push
+fi
+
+echo "Done. Project-scoped Gemini hooks installed at $target." >&2

--- a/skills/autonomous-common/scripts/install-kiro-hooks.sh
+++ b/skills/autonomous-common/scripts/install-kiro-hooks.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# install-kiro-hooks.sh — bootstrap project-scoped Kiro CLI / Amazon Q
+# Developer CLI hooks from the canonical template.
+#
+# Kiro CLI uses agent definitions at `.kiro/agents/<name>.json`. Each
+# agent has a top-level shape with `name`, `prompt`, `tools`, `hooks`,
+# etc. We merge into the agent's `hooks` field, preserving everything
+# else.
+#
+# Schema reference: kiro.dev/docs/cli/hooks
+#
+# Translation from Claude:
+#   Event names:  PreToolUse → preToolUse, PostToolUse → postToolUse,
+#                 Stop → stop, UserPromptSubmit → userPromptSubmit (camelCase).
+#   Tool matchers: Bash → execute_bash, Write → fs_write, Edit → fs_write
+#                 (Kiro unifies write+edit into fs_write).
+#   Timeout unit: MILLISECONDS via `timeout_ms` field (Claude uses seconds
+#                 via `timeout`). We multiply by 1000.
+#
+# Default agent: `default`. Override with --agent <name>.
+#
+# Usage:
+#   bash skills/autonomous-common/scripts/install-kiro-hooks.sh
+#   bash skills/autonomous-common/scripts/install-kiro-hooks.sh --agent autonomous-dev
+#
+# Idempotent. --no-git-hook to skip the per-worktree git pre-push (#65).
+
+set -euo pipefail
+
+INSTALL_GIT_HOOK=1
+AGENT_NAME="default"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-git-hook) INSTALL_GIT_HOOK=0; shift ;;
+    --agent)
+      [[ $# -ge 2 ]] || { echo "ERROR: --agent requires a value" >&2; exit 2; }
+      AGENT_NAME="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! [[ "$AGENT_NAME" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+  echo "ERROR: --agent name must be alphanumeric, dash, or underscore: '$AGENT_NAME'" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+# shellcheck source=lib-installer.sh
+source "$SCRIPT_DIR/lib-installer.sh"
+# shellcheck source=lib-installer-translate.sh
+source "$SCRIPT_DIR/lib-installer-translate.sh"
+
+require_jq
+
+TEMPLATE="$SCRIPT_DIR/claude-settings.template.json"
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "ERROR: canonical template not found at: $TEMPLATE" >&2
+  exit 1
+fi
+
+target="$(project_root)/.kiro/agents/${AGENT_NAME}.json"
+
+# Translate Claude → Kiro names + convert timeouts to milliseconds.
+AGENT_EVENT_MAP="PreToolUse:preToolUse PostToolUse:postToolUse Stop:stop"
+AGENT_TOOL_MAP="Bash:execute_bash Write:fs_write Edit:fs_write"
+export AGENT_EVENT_MAP AGENT_TOOL_MAP
+
+translated_hooks=$(translate_template_hooks "$TEMPLATE" | convert_timeouts_to_ms)
+managed_meta=$(jq '{_managed_by, _managed_note}' "$TEMPLATE")
+
+# Kiro agent files have many top-level keys (name, prompt, tools, ...)
+# that the operator owns. We merge ONLY the hooks field + management
+# annotations. If the file doesn't exist, create a minimal stub with
+# just hooks — the operator can add name/prompt/tools if they want a
+# fully functional agent. (Kiro will run the agent without those fields
+# if it can fall back to defaults.)
+mkdir -p "$(dirname "$target")"
+
+if [[ ! -f "$target" ]]; then
+  # Stub the agent with sensible defaults pointing at this repo's
+  # AGENTS.md and skills. Operators can edit later.
+  jq -n --argjson meta "$managed_meta" --argjson hooks "$translated_hooks" \
+    --arg name "$AGENT_NAME" \
+    '$meta + {
+       name: $name,
+       description: "autonomous-dev workflow agent",
+       prompt: "file://../../CLAUDE.md",
+       tools: ["fs_read", "fs_write", "execute_bash"],
+       allowedTools: ["fs_read", "fs_write", "execute_bash"],
+       hooks: $hooks
+     }' > "$target"
+  echo "Created: $target (stub agent — edit prompt/tools/resources as needed)" >&2
+else
+  backup="$(backup_path "$target")"
+  cp "$target" "$backup"
+
+  tmp=$(mktemp)
+  # shellcheck disable=SC2064  # we want $tmp expanded NOW, not at trap fire
+  trap "rm -f '$tmp'" EXIT
+  jq --argjson meta "$managed_meta" --argjson hooks "$translated_hooks" \
+    '. + $meta + {hooks: $hooks}' "$target" > "$tmp"
+
+  # Verify before commit.
+  if ! jq -e '.hooks.preToolUse | length > 0' "$tmp" >/dev/null \
+     || ! jq -e '._managed_by == "autonomous-common"' "$tmp" >/dev/null; then
+    mv "$backup" "$target"
+    echo "ERROR: merge produced an unexpected result; restored backup" >&2
+    exit 1
+  fi
+
+  mv "$tmp" "$target"
+  trap - EXIT
+  echo "Updated: $target (backup at $backup)" >&2
+fi
+
+if (( INSTALL_GIT_HOOK == 1 )); then
+  install_per_worktree_pre_push
+fi
+
+echo "Done. Project-scoped Kiro hooks installed at $target." >&2

--- a/skills/autonomous-common/scripts/lib-installer-translate.sh
+++ b/skills/autonomous-common/scripts/lib-installer-translate.sh
@@ -112,11 +112,18 @@ translate_template_hooks() {
   done
   tool_remap="{${tool_remap%, }}"
 
+  # Three passes inside one jq:
+  #   1. with_entries: rename event keys.
+  #   2. map: rename matcher values (or drop if mapped to "").
+  #   3. group_by(.matcher) + reduce: merge entries with the same
+  #      matcher value (concat their `hooks` arrays). Many-to-one tool
+  #      mappings (e.g. Kiro's Write→fs_write + Edit→fs_write) would
+  #      otherwise produce duplicate matcher entries that fire the same
+  #      check twice (PR-11b code review C2).
   jq --argjson event_map "$event_remap" --argjson tool_map "$tool_remap" '
     .hooks
     | with_entries(
-        .key as $orig_event
-        | .key |= ($event_map[.] // .)
+        .key |= ($event_map[.] // .)
         | .value |= map(
             if has("matcher")
             then
@@ -128,6 +135,20 @@ translate_template_hooks() {
             else .
             end
           )
+        | .value |=
+            (
+              # Group by matcher (or by absence of matcher), then merge
+              # each group into a single entry whose .hooks is the
+              # concatenation of all source .hooks arrays.
+              group_by(.matcher // "__no_matcher__")
+              | map(
+                  reduce .[] as $entry (
+                    {hooks: []};
+                    (if $entry | has("matcher") then .matcher = $entry.matcher else . end)
+                    | .hooks += $entry.hooks
+                  )
+                )
+            )
       )
   ' "$template"
 }

--- a/skills/autonomous-common/scripts/lib-installer-translate.sh
+++ b/skills/autonomous-common/scripts/lib-installer-translate.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# lib-installer-translate.sh — schema translation helpers for hook installers.
+#
+# Used by per-agent installers whose hook config schema is a near-clone
+# of Claude Code's but uses different event names, tool-name matchers,
+# or timeout units. Sourced AFTER lib-installer.sh.
+#
+# The canonical hook intent lives in claude-settings.template.json. Each
+# near-clone installer translates that intent into the agent's flavor at
+# install time, with a small declarative mapping table.
+#
+# Translation primitives:
+#
+#   translate_event_name <claude-event>
+#     Echo the per-agent event name. Override AGENT_EVENT_MAP before
+#     calling. Example: AGENT_EVENT_MAP="PreToolUse:preToolUse PostToolUse:postToolUse Stop:stop"
+#
+#   translate_tool_matcher <claude-matcher>
+#     Echo the per-agent tool-name matcher. Override AGENT_TOOL_MAP before
+#     calling. Example: AGENT_TOOL_MAP="Bash:execute_bash Write:fs_write Edit:fs_write"
+#     Empty value means drop the matcher (event-only). "REGEX:..." prefix
+#     emits a regex literal (Gemini-style).
+#
+#   translate_template <source-template> <jq-projection>
+#     Run the source template through jq with all event/tool names
+#     remapped per AGENT_EVENT_MAP / AGENT_TOOL_MAP. Echo the resulting
+#     JSON to stdout. Caller wraps with their final shape (multi-key vs
+#     hooks-only, timeout unit conversion, etc.).
+#
+# Timeout unit conversion is small enough that callers handle it inline
+# via jq: `timeout * 1000` for milliseconds, `tonumber` to keep seconds.
+
+set -euo pipefail
+
+# Get the mapped event name. Returns the original if not in the map
+# (so unmapped events pass through unchanged — the caller is responsible
+# for verifying the agent supports them).
+translate_event_name() {
+  local claude_event="$1"
+  local pair
+  for pair in ${AGENT_EVENT_MAP:-}; do
+    if [[ "${pair%%:*}" == "$claude_event" ]]; then
+      echo "${pair#*:}"
+      return 0
+    fi
+  done
+  echo "$claude_event"
+}
+
+# Get the mapped tool matcher. Special return values:
+#   "" (empty)        → drop the matcher field (event fires for all tools)
+#   "REGEX:pattern"   → wrap as regex literal in the output
+#   anything else     → use as the verbatim matcher value
+translate_tool_matcher() {
+  local claude_matcher="$1"
+  local pair
+  for pair in ${AGENT_TOOL_MAP:-}; do
+    if [[ "${pair%%:*}" == "$claude_matcher" ]]; then
+      echo "${pair#*:}"
+      return 0
+    fi
+  done
+  echo "$claude_matcher"
+}
+
+# Translate the canonical template into the agent's schema.
+#
+# Strategy: for each top-level event key in the source template's `hooks`
+# object, look up the per-agent event name. For each entry's `matcher`
+# field, look up the per-agent tool matcher. Drop the matcher if empty.
+#
+# The output is a JSON object with the SAME top-level shape as the
+# source template's `hooks` field — just with translated keys and
+# matchers. The caller decides the final wrapping (multi-key
+# settings.json vs hooks-only file).
+#
+# Args:
+#   $1 — source template path (claude-settings.template.json)
+#
+# Output: JSON to stdout. Same hooks block shape, translated names.
+#
+# Limitations:
+#   - Doesn't handle PostToolUseFailure or other Claude-specific events
+#     beyond what the template currently uses (PreToolUse, PostToolUse,
+#     Stop). Add to the event map if needed.
+#   - Doesn't convert timeout units. Callers do that with a follow-up
+#     jq pass.
+translate_template_hooks() {
+  local template="$1"
+
+  # Build jq filter that remaps event names and matcher values via the
+  # bash-local maps. We do this by emitting a jq expression that uses
+  # bash-substituted constants (safe because we only emit known event
+  # names and matcher values).
+  #
+  # Build event-name remap as a jq object literal:
+  local event_remap=""
+  local pair
+  for pair in ${AGENT_EVENT_MAP:-}; do
+    local from="${pair%%:*}"
+    local to="${pair#*:}"
+    event_remap+="\"$from\": \"$to\", "
+  done
+  event_remap="{${event_remap%, }}"
+
+  # Tool-matcher remap: same shape, with empty values signaling "drop".
+  local tool_remap=""
+  for pair in ${AGENT_TOOL_MAP:-}; do
+    local from="${pair%%:*}"
+    local to="${pair#*:}"
+    tool_remap+="\"$from\": \"$to\", "
+  done
+  tool_remap="{${tool_remap%, }}"
+
+  jq --argjson event_map "$event_remap" --argjson tool_map "$tool_remap" '
+    .hooks
+    | with_entries(
+        .key as $orig_event
+        | .key |= ($event_map[.] // .)
+        | .value |= map(
+            if has("matcher")
+            then
+              ($tool_map[.matcher] // .matcher) as $new
+              | if $new == ""
+                then del(.matcher)
+                else .matcher = $new
+                end
+            else .
+            end
+          )
+      )
+  ' "$template"
+}
+
+# Convert all `timeout` field values from seconds to milliseconds
+# in-place inside a JSON blob. Used by Kiro (whose schema names the
+# field `timeout_ms` and expects ms).
+#
+# Reads from stdin, writes to stdout.
+convert_timeouts_to_ms() {
+  jq '
+    walk(
+      if type == "object" and (.timeout | type) == "number"
+      then .timeout_ms = (.timeout * 1000) | del(.timeout)
+      else .
+      end
+    )
+  '
+}

--- a/tests/unit/test-install-codex-hooks.sh
+++ b/tests/unit/test-install-codex-hooks.sh
@@ -118,11 +118,81 @@ else
   FAIL=$((FAIL + 1))
 fi
 
-if grep -qE '^\s*codex_hooks\s*=\s*true\s*$' "$TMPDIR/repo2/.codex/config.toml"; then
+if grep -qE '^\s*codex_hooks\s*=\s*true' "$TMPDIR/repo2/.codex/config.toml"; then
   echo -e "  ${GREEN}PASS${NC}: codex_hooks flag appended"
   PASS=$((PASS + 1))
 else
   echo -e "  ${RED}FAIL${NC}: codex_hooks flag NOT appended"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-CDX-06: existing [features] section → insert into it (don't duplicate the table) ==="
+# ---------------------------------------------------------------------------
+# C1 from PR-11b code review: TOML rejects duplicate table headers.
+mkdir -p "$TMPDIR/repo3/.codex"
+git -C "$TMPDIR/repo3" init --quiet --initial-branch=main
+cat > "$TMPDIR/repo3/.codex/config.toml" <<'EOF'
+# user config
+[features]
+some_other_flag = true
+EOF
+(cd "$TMPDIR/repo3" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+target3="$TMPDIR/repo3/.codex/config.toml"
+
+# Should have exactly ONE [features] header (not duplicated)
+header_count=$(grep -cE '^\[features\][[:space:]]*$' "$target3")
+if [[ "$header_count" -eq 1 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: only one [features] header (TOML stays valid)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: [features] appears $header_count times — TOML invalid"
+  FAIL=$((FAIL + 1))
+fi
+
+# Both flags should still be present
+if grep -qE '^\s*some_other_flag\s*=' "$target3" && \
+   grep -qE '^\s*codex_hooks\s*=\s*true' "$target3"; then
+  echo -e "  ${GREEN}PASS${NC}: both old and new flags inside same [features] block"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: missing flag — old: $(grep -c some_other_flag "$target3"), new: $(grep -c codex_hooks "$target3")"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-CDX-07: codex_hooks = false → installer refuses (operator set on purpose) ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo4/.codex"
+git -C "$TMPDIR/repo4" init --quiet --initial-branch=main
+cat > "$TMPDIR/repo4/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = false
+EOF
+err=$(cd "$TMPDIR/repo4" && bash "$INSTALLER" --no-git-hook 2>&1 >/dev/null) || rc=$?
+if [[ "${rc:-0}" -ne 0 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: installer refused (rc=${rc:-0})"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: installer should refuse when codex_hooks = false"
+  FAIL=$((FAIL + 1))
+fi
+case "$err" in
+  *"codex_hooks = false"*)
+    echo -e "  ${GREEN}PASS${NC}: stderr explains the conflict"
+    PASS=$((PASS + 1)) ;;
+  *)
+    echo -e "  ${RED}FAIL${NC}: stderr should mention 'codex_hooks = false'; got: $err"
+    FAIL=$((FAIL + 1)) ;;
+esac
+# Operator's `false` setting must NOT have been overwritten
+if grep -qE '^\s*codex_hooks\s*=\s*false' "$TMPDIR/repo4/.codex/config.toml"; then
+  echo -e "  ${GREEN}PASS${NC}: operator's codex_hooks = false preserved"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: operator's codex_hooks = false was modified"
   FAIL=$((FAIL + 1))
 fi
 

--- a/tests/unit/test-install-codex-hooks.sh
+++ b/tests/unit/test-install-codex-hooks.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# test-install-codex-hooks.sh — Tests for the Codex installer (PR-11b).
+#
+# Verifies: file paths .codex/hooks.json + .codex/config.toml, the
+# `[features] codex_hooks = true` flag toggle (required upstream), and
+# Claude-verbatim hooks block (Codex models its schema on Claude).
+#
+# Run: bash tests/unit/test-install-codex-hooks.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALLER="$PROJECT_ROOT/skills/autonomous-common/scripts/install-codex-hooks.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# ---------------------------------------------------------------------------
+echo "=== TC-CDX-01: first-time install creates both files ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo1"
+git -C "$TMPDIR/repo1" init --quiet --initial-branch=main
+(cd "$TMPDIR/repo1" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+
+hooks_file="$TMPDIR/repo1/.codex/hooks.json"
+config_file="$TMPDIR/repo1/.codex/config.toml"
+
+if [[ -f "$hooks_file" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: hooks.json created"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: hooks.json NOT created"
+  FAIL=$((FAIL + 1))
+fi
+
+if [[ -f "$config_file" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: config.toml created"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: config.toml NOT created"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-CDX-02: codex_hooks feature flag is enabled ==="
+# ---------------------------------------------------------------------------
+if grep -qE '^\s*codex_hooks\s*=\s*true\s*$' "$config_file"; then
+  echo -e "  ${GREEN}PASS${NC}: [features] codex_hooks = true present in config.toml"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: codex_hooks = true missing — hooks.json will be ignored upstream"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-CDX-03: hooks block uses Claude-verbatim event names ==="
+# ---------------------------------------------------------------------------
+# Codex modeled schema on Claude — should keep PreToolUse/PostToolUse/Stop.
+if jq -e '.hooks.PreToolUse | length > 0' "$hooks_file" >/dev/null 2>&1; then
+  echo -e "  ${GREEN}PASS${NC}: hooks.PreToolUse populated (Claude-verbatim)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: hooks.PreToolUse missing"
+  FAIL=$((FAIL + 1))
+fi
+
+# Bash matcher should be preserved verbatim
+matchers=$(jq -r '.hooks.PreToolUse[].matcher' "$hooks_file" | sort -u)
+if grep -q '^Bash$' <<<"$matchers"; then
+  echo -e "  ${GREEN}PASS${NC}: Bash matcher preserved (Claude-verbatim)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: Bash matcher missing"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-CDX-04: re-running installer doesn't duplicate config.toml flag ==="
+# ---------------------------------------------------------------------------
+(cd "$TMPDIR/repo1" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+flag_count=$(grep -cE '^\s*codex_hooks\s*=\s*true\s*$' "$config_file")
+if [[ "$flag_count" -eq 1 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: codex_hooks flag appears exactly once after re-run (got $flag_count)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: re-run duplicated the flag (got $flag_count occurrences)"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-CDX-05: existing config.toml without flag → flag appended (no overwrite) ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo2/.codex"
+git -C "$TMPDIR/repo2" init --quiet --initial-branch=main
+cat > "$TMPDIR/repo2/.codex/config.toml" <<'EOF'
+# Existing user config
+[some_other_section]
+foo = "bar"
+EOF
+(cd "$TMPDIR/repo2" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+
+if grep -q '\[some_other_section\]' "$TMPDIR/repo2/.codex/config.toml"; then
+  echo -e "  ${GREEN}PASS${NC}: existing user TOML preserved"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: existing user TOML lost"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -qE '^\s*codex_hooks\s*=\s*true\s*$' "$TMPDIR/repo2/.codex/config.toml"; then
+  echo -e "  ${GREEN}PASS${NC}: codex_hooks flag appended"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: codex_hooks flag NOT appended"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/tests/unit/test-install-cursor-hooks.sh
+++ b/tests/unit/test-install-cursor-hooks.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# test-install-cursor-hooks.sh — Tests for the Cursor installer (PR-11b).
+#
+# Verifies: file path, version envelope, event-name translation
+# (PreToolUse → preToolUse), tool-matcher translation (Bash → Shell).
+#
+# Run: bash tests/unit/test-install-cursor-hooks.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALLER="$PROJECT_ROOT/skills/autonomous-common/scripts/install-cursor-hooks.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# ---------------------------------------------------------------------------
+echo "=== TC-CUR-01: first-time install creates .cursor/hooks.json ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo1"
+git -C "$TMPDIR/repo1" init --quiet --initial-branch=main
+(cd "$TMPDIR/repo1" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+
+target="$TMPDIR/repo1/.cursor/hooks.json"
+if [[ -f "$target" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: hooks.json created"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: hooks.json NOT created"
+  FAIL=$((FAIL + 1))
+fi
+
+# Cursor expects version: 1
+if jq -e '.version == 1' "$target" >/dev/null 2>&1; then
+  echo -e "  ${GREEN}PASS${NC}: version: 1 envelope present"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: version: 1 missing"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-CUR-02: events are camelCase (PreToolUse → preToolUse) ==="
+# ---------------------------------------------------------------------------
+if jq -e '.hooks.preToolUse | length > 0' "$target" >/dev/null 2>&1; then
+  echo -e "  ${GREEN}PASS${NC}: hooks.preToolUse populated"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: hooks.preToolUse missing or empty"
+  FAIL=$((FAIL + 1))
+fi
+
+if jq -e '.hooks | has("PreToolUse")' "$target" >/dev/null 2>&1; then
+  echo -e "  ${RED}FAIL${NC}: PascalCase PreToolUse leaked into output"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}PASS${NC}: no PascalCase event leakage"
+  PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-CUR-03: tool matchers translated (Bash → Shell) ==="
+# ---------------------------------------------------------------------------
+matchers=$(jq -r '.hooks.preToolUse[].matcher' "$target" | sort -u)
+if grep -q '^Shell$' <<<"$matchers"; then
+  echo -e "  ${GREEN}PASS${NC}: Shell matcher present"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: Shell matcher missing"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q '^Bash$' <<<"$matchers"; then
+  echo -e "  ${RED}FAIL${NC}: Bash matcher leaked (should be Shell)"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}PASS${NC}: no Bash matcher leakage"
+  PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-CUR-04: _managed_by annotation present ==="
+# ---------------------------------------------------------------------------
+if jq -e '._managed_by == "autonomous-common"' "$target" >/dev/null 2>&1; then
+  echo -e "  ${GREEN}PASS${NC}: _managed_by annotation present"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: _managed_by annotation missing"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/tests/unit/test-install-gemini-hooks.sh
+++ b/tests/unit/test-install-gemini-hooks.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# test-install-gemini-hooks.sh — Tests for the Gemini installer (PR-11b).
+#
+# Verifies: file path .gemini/settings.json, event-name translation
+# (PreToolUse → BeforeTool, PostToolUse → AfterTool, Stop → Stop), tool
+# matchers (Bash → run_shell_command, Write → write_file, Edit → replace).
+#
+# Run: bash tests/unit/test-install-gemini-hooks.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALLER="$PROJECT_ROOT/skills/autonomous-common/scripts/install-gemini-hooks.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# ---------------------------------------------------------------------------
+echo "=== TC-GEM-01: first-time install creates .gemini/settings.json ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo1"
+git -C "$TMPDIR/repo1" init --quiet --initial-branch=main
+(cd "$TMPDIR/repo1" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+
+target="$TMPDIR/repo1/.gemini/settings.json"
+if [[ -f "$target" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: settings.json created"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: settings.json NOT created"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-GEM-02: events are PascalCase Gemini-style (BeforeTool/AfterTool) ==="
+# ---------------------------------------------------------------------------
+if jq -e '.hooks.BeforeTool | length > 0' "$target" >/dev/null 2>&1; then
+  echo -e "  ${GREEN}PASS${NC}: hooks.BeforeTool populated"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: hooks.BeforeTool missing"
+  FAIL=$((FAIL + 1))
+fi
+
+if jq -e '.hooks.AfterTool | length > 0' "$target" >/dev/null 2>&1; then
+  echo -e "  ${GREEN}PASS${NC}: hooks.AfterTool populated"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: hooks.AfterTool missing"
+  FAIL=$((FAIL + 1))
+fi
+
+if jq -e '.hooks | has("PreToolUse") or has("PostToolUse")' "$target" >/dev/null 2>&1; then
+  echo -e "  ${RED}FAIL${NC}: Claude-style PreToolUse/PostToolUse leaked"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}PASS${NC}: no Claude-style event leakage"
+  PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-GEM-03: tool matchers translated to Gemini built-in names ==="
+# ---------------------------------------------------------------------------
+matchers=$(jq -r '.hooks.BeforeTool[].matcher' "$target" | sort -u)
+for expected in run_shell_command write_file replace; do
+  if grep -q "^${expected}$" <<<"$matchers"; then
+    echo -e "  ${GREEN}PASS${NC}: matcher present: $expected"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: matcher missing: $expected"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+if grep -qE '^(Bash|Write|Edit)$' <<<"$matchers"; then
+  echo -e "  ${RED}FAIL${NC}: Claude-style matcher leaked"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}PASS${NC}: no Claude-style matcher leakage"
+  PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-GEM-04: re-install merges with existing top-level keys ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo2/.gemini"
+git -C "$TMPDIR/repo2" init --quiet --initial-branch=main
+cat > "$TMPDIR/repo2/.gemini/settings.json" <<'EOF'
+{
+  "userPreference": "preserve me",
+  "hooks": { "BeforeTool": [{ "matcher": "old", "hooks": [] }] }
+}
+EOF
+(cd "$TMPDIR/repo2" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+target2="$TMPDIR/repo2/.gemini/settings.json"
+
+if jq -e '.userPreference == "preserve me"' "$target2" >/dev/null 2>&1; then
+  echo -e "  ${GREEN}PASS${NC}: pre-existing top-level key preserved"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: pre-existing key lost"
+  FAIL=$((FAIL + 1))
+fi
+
+backups=("$TMPDIR/repo2/.gemini/settings.json.bak."*)
+if [[ -f "${backups[0]}" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: backup file created"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: no backup file"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/tests/unit/test-install-kiro-hooks.sh
+++ b/tests/unit/test-install-kiro-hooks.sh
@@ -120,6 +120,35 @@ fi
 
 # ---------------------------------------------------------------------------
 echo ""
+echo "=== TC-KIRO-04b: Write+Edit deduplicated to single fs_write entry (PR-11b C2) ==="
+# ---------------------------------------------------------------------------
+# Many-to-one tool mapping (Write → fs_write AND Edit → fs_write) must
+# merge into a single matcher entry, not two duplicates that fire the
+# same hook twice.
+fs_write_count=$(jq '[.hooks.preToolUse[] | select(.matcher == "fs_write")] | length' "$target")
+if [[ "$fs_write_count" -eq 1 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: exactly 1 fs_write matcher entry (no duplicates)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: expected 1 fs_write entry, got $fs_write_count (duplicate matchers fire hooks twice)"
+  FAIL=$((FAIL + 1))
+fi
+
+# The merged fs_write entry should contain hooks from BOTH Write and Edit.
+# In the canonical template, Write has 1 hook (check-test-plan.sh) and
+# Edit has 1 hook (also check-test-plan.sh). After dedup, fs_write should
+# have 2 hooks total (the concat).
+fs_write_hooks=$(jq '.hooks.preToolUse[] | select(.matcher == "fs_write") | .hooks | length' "$target")
+if [[ "$fs_write_hooks" -ge 2 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: fs_write entry has $fs_write_hooks merged hooks (Write+Edit both preserved)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: fs_write entry has only $fs_write_hooks hook(s) — Write+Edit not merged"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
 echo "=== TC-KIRO-05: --agent <name> overrides default agent name ==="
 # ---------------------------------------------------------------------------
 mkdir -p "$TMPDIR/repo2"

--- a/tests/unit/test-install-kiro-hooks.sh
+++ b/tests/unit/test-install-kiro-hooks.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# test-install-kiro-hooks.sh — Tests for the Kiro installer (PR-11b).
+#
+# Verifies: file path .kiro/agents/<name>.json, --agent flag, event
+# camelCase, tool name translation (Bash → execute_bash, Write/Edit → fs_write),
+# timeout-to-milliseconds conversion, agent-stub creation when file is new.
+#
+# Run: bash tests/unit/test-install-kiro-hooks.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALLER="$PROJECT_ROOT/skills/autonomous-common/scripts/install-kiro-hooks.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# ---------------------------------------------------------------------------
+echo "=== TC-KIRO-01: first-time install creates .kiro/agents/default.json ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo1"
+git -C "$TMPDIR/repo1" init --quiet --initial-branch=main
+(cd "$TMPDIR/repo1" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+
+target="$TMPDIR/repo1/.kiro/agents/default.json"
+if [[ -f "$target" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: default.json created"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: default.json NOT created"
+  FAIL=$((FAIL + 1))
+fi
+
+# Stub agent should have name and tools fields
+if jq -e '.name == "default" and (.tools | length > 0)' "$target" >/dev/null 2>&1; then
+  echo -e "  ${GREEN}PASS${NC}: stub agent has name + tools"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: stub agent missing name or tools"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-KIRO-02: events are camelCase ==="
+# ---------------------------------------------------------------------------
+if jq -e '.hooks.preToolUse | length > 0' "$target" >/dev/null 2>&1; then
+  echo -e "  ${GREEN}PASS${NC}: hooks.preToolUse populated"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: hooks.preToolUse missing"
+  FAIL=$((FAIL + 1))
+fi
+
+if jq -e '.hooks | has("PreToolUse")' "$target" >/dev/null 2>&1; then
+  echo -e "  ${RED}FAIL${NC}: PascalCase PreToolUse leaked"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}PASS${NC}: no PascalCase event leakage"
+  PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-KIRO-03: tool matchers translated (Bash → execute_bash, Write/Edit → fs_write) ==="
+# ---------------------------------------------------------------------------
+matchers=$(jq -r '.hooks.preToolUse[].matcher' "$target" | sort -u)
+if grep -q '^execute_bash$' <<<"$matchers"; then
+  echo -e "  ${GREEN}PASS${NC}: execute_bash matcher present"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: execute_bash matcher missing"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q '^fs_write$' <<<"$matchers"; then
+  echo -e "  ${GREEN}PASS${NC}: fs_write matcher present"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: fs_write matcher missing"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -qE '^(Bash|Write|Edit)$' <<<"$matchers"; then
+  echo -e "  ${RED}FAIL${NC}: Claude-style matcher leaked"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}PASS${NC}: no Claude-style matcher leakage"
+  PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-KIRO-04: timeouts converted to milliseconds ==="
+# ---------------------------------------------------------------------------
+# Canonical template uses timeout: 5 (seconds). Kiro expects timeout_ms: 5000.
+ms_value=$(jq '.hooks.preToolUse[0].hooks[0].timeout_ms' "$target")
+if [[ "$ms_value" -ge 1000 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: timeout_ms field present and >= 1000 (got $ms_value)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: timeout_ms missing or wrong unit (got $ms_value)"
+  FAIL=$((FAIL + 1))
+fi
+
+if jq -e '.hooks.preToolUse[0].hooks[0] | has("timeout")' "$target" >/dev/null 2>&1; then
+  echo -e "  ${RED}FAIL${NC}: seconds-based timeout field leaked (should be timeout_ms)"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}PASS${NC}: no seconds-based timeout leakage"
+  PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-KIRO-05: --agent <name> overrides default agent name ==="
+# ---------------------------------------------------------------------------
+mkdir -p "$TMPDIR/repo2"
+git -C "$TMPDIR/repo2" init --quiet --initial-branch=main
+(cd "$TMPDIR/repo2" && bash "$INSTALLER" --no-git-hook --agent autonomous-dev >/dev/null 2>&1)
+
+target2="$TMPDIR/repo2/.kiro/agents/autonomous-dev.json"
+if [[ -f "$target2" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: --agent autonomous-dev created the right file"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: --agent autonomous-dev did NOT create the expected file"
+  FAIL=$((FAIL + 1))
+fi
+
+# Bad agent name with /
+err=$(cd "$TMPDIR/repo2" && bash "$INSTALLER" --no-git-hook --agent "bad/name" 2>&1 >/dev/null) || rc=$?
+if [[ "${rc:-0}" -eq 2 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: --agent with slash → rc=2"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: --agent with slash should reject (rc=${rc:-0})"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

PR-11b of three: 4 agents whose hook schemas need event-name + tool-name translation from Claude Code's canonical template. Builds on PR-11a's `lib-installer.sh`; introduces `lib-installer-translate.sh` for declarative per-agent schema mapping.

After this PR merges, 7 of the 9 researched agents are covered with installers (Claude Code, Qoder, Antigravity, Cursor, Kiro CLI, Gemini CLI, Codex CLI). Windsurf and Kimi remain for PR-11c.

## What this PR ships

### `lib-installer-translate.sh` (new)

4 small helpers:

- `translate_event_name` / `translate_tool_matcher` — table-driven name lookup
- `translate_template_hooks` — applies both translations via a single jq filter that uses `--argjson` to pass the maps as JSON object literals. Includes **dedup pass** (group by matcher, concat hooks) so many-to-one mappings like Kiro's `Write+Edit → fs_write` produce a single entry, not two duplicates.
- `convert_timeouts_to_ms` — jq walk that converts `timeout: <seconds>` to `timeout_ms: <ms>` for agents whose timeout field is in milliseconds (Kiro)

### 4 new installers

| Installer | Target file | Translation |
|---|---|---|
| `install-cursor-hooks.sh` | `.cursor/hooks.json` (with `version: 1` envelope) | `PreToolUse → preToolUse`, `Bash → Shell` |
| `install-kiro-hooks.sh` `[--agent <name>]` | `.kiro/agents/<name>.json` | camelCase events, `Bash → execute_bash`, `Write/Edit → fs_write` (deduped), `timeout → timeout_ms` |
| `install-gemini-hooks.sh` | `.gemini/settings.json` | `PreToolUse → BeforeTool`, `PostToolUse → AfterTool`, `Bash → run_shell_command`, `Write → write_file`, `Edit → replace`. Gemini natively provides `$CLAUDE_PROJECT_DIR` env compat alias — hook scripts run unchanged. |
| `install-codex-hooks.sh` | `.codex/hooks.json` (Claude-verbatim) + sets `[features] codex_hooks = true` in `.codex/config.toml` | None (Codex modeled its schema verbatim on Claude Code) |

Each installer uses the shared `lib-installer.sh` (PR-11a) for the merge/write logic; `lib-installer-translate.sh` for the schema mapping. Result: each installer is ~50-70 lines of declaration + glue.

## Code review fixes (commit `ed44ac5`)

Code-reviewer caught 2 critical regressions, both addressed:

**C1 — Codex installer corrupted `config.toml` with duplicate `[features]` headers.** TOML spec: defining a table more than once is invalid. The original "append `[features]\ncodex_hooks = true` if not present" logic broke 3 cases:
- Existing `[features]` section with other flags → 2nd header appended → user's whole config rejected
- `codex_hooks = false` → installer didn't detect (matched only `=true`); appended contradictory duplicate
- `codex_hooks = true` under a non-`[features]` section → installer no-op'd but Codex doesn't read it there

Fixed with a 5-branch decision tree: insert into existing `[features]` (via awk, no header duplication) / refuse if `=false` / append a new section / write fresh / no-op if already true.

**C2 — Kiro installer emitted two `fs_write` matcher entries.** Many-to-one mapping (`Write → fs_write` AND `Edit → fs_write`) produced duplicate entries that fired the same hook twice. Fixed in `translate_template_hooks` with a generic dedup pass — benefits any future agent with many-to-one mappings.

## Tests

4 new test files, 43 cases:

- `test-install-cursor-hooks.sh` (7) — file path, `version: 1` envelope, camelCase events, Shell matcher
- `test-install-kiro-hooks.sh` (13) — file path, `--agent` override, camelCase, `execute_bash`/`fs_write`, timeout_ms conversion, agent stub creation, **dedup verification (TC-KIRO-04b)**
- `test-install-gemini-hooks.sh` (10) — file path, `BeforeTool`/`AfterTool` events, Gemini matcher names, multi-key merge
- `test-install-codex-hooks.sh` (13) — file path, codex_hooks flag, Claude-verbatim schema, **TC-CDX-06 (no duplicate `[features]` headers)**, **TC-CDX-07 (refuses when `codex_hooks = false`)**

30 test files green total (was 26, +4 new).

## Documentation

- `docs/cross-agent-hooks.md` — matrix updated; all 7 covered installers now show shipped status
- `skills/autonomous-common/SKILL.md` — Setup table now lists 7 supported agents

## Test plan

- [x] All 30 unit tests pass
- [x] `bash -n` syntax check on all new scripts
- [x] `shellcheck` clean (only pre-existing SC1091 info-level)
- [x] End-to-end smoke-tested all 4 installers against tmp repos
- [x] code-reviewer agent: C1 + C2 fixed in `ed44ac5`

## Follow-up (PR-11c)

Windsurf (no matcher field — filtering inside script) and Kimi CLI (TOML, beta).