### PR TITLE
docs(readme): describe configurable review bots feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The review agent finds the PR linked to an issue, performs code review, optional
 | **PR discovery** | Finds the linked PR via body reference, issue comments, or search |
 | **Merge conflict resolution** | Automatically rebases if the PR conflicts with main |
 | **Code review checklist** | Verifies design docs, tests, CI status, and PR conventions |
-| **Amazon Q integration** | Triggers and monitors Amazon Q Developer review |
+| **Configurable bot reviewers** | Triggers and monitors PR review bots per `REVIEW_BOTS` setting (built-in: Amazon Q `/q`, Codex `/codex`, Claude `@claude`; custom bots via env vars) |
 | **E2E verification** | Optional Chrome DevTools MCP testing with screenshot evidence |
 | **Acceptance criteria tracking** | Marks `## Acceptance Criteria` checkboxes as verified |
 | **Auto-merge** | Squash-merges and closes the issue on review pass |


### PR DESCRIPTION
## Summary

One-line README update: the "Amazon Q integration" row in the Review Agent capability table was stale after #85 generalized bot enforcement to all configured bots. Replace it with a row that names the `REVIEW_BOTS` setting plus the three built-in bots (`/q`, `/codex`, `@claude`) and mentions the custom-bot extension.

## Test Plan

- [x] Markdown renders cleanly (table cell, no formatting changes outside the row)
- [ ] CI checks pass

## Checklist

- [x] No code changes — single-row update in `README.md`
- [x] Build/tests not affected
- [x] PR review skipped (trivial copy change in a documentation table)