### PR TITLE
fix(dispatcher): codex CLI invocation against current API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A fully automated development pipeline that turns GitHub issues into merged pull requests — no human intervention required. It scans for issues labeled `autonomous`, dispatches a **Dev Agent** to implement the feature with tests in an isolated worktree, and hands off to a **Review Agent** for code review with optional E2E verification. The entire cycle runs unattended on a cron schedule.
 
-Supports multiple coding agent CLIs — Claude Code, Kiro CLI, Cursor Agent, Gemini CLI, and most CLIs with a `-p <prompt>` non-interactive flag — via a pluggable agent abstraction layer. (Codex CLI is supported in principle but its branch is currently broken — see the Supported Agent CLIs table.)
+Supports multiple coding agent CLIs — Claude Code, Codex CLI, Kiro CLI, Cursor Agent, Gemini CLI, and most CLIs with a `-p <prompt>` non-interactive flag — via a pluggable agent abstraction layer.
 
 ## Getting Started
 
@@ -168,7 +168,7 @@ The file is a bash script that's `source`d at every dispatcher tick and wrapper 
 | `REPO` | Yes | `owner/repo-name` | The GitHub repo the pipeline watches. |
 | `REPO_OWNER`, `REPO_NAME` | Yes | Split form of `REPO` | Used for App-token scoping. |
 | `PROJECT_DIR` | Yes | Absolute path to the project root on the dispatcher box | Where the agent runs. |
-| `AGENT_CMD` | No (default `claude`) | `claude` (recommended) or `kiro` | The CLI used to spawn dev/review agents. `codex` is currently broken — `lib-agent.sh` uses the legacy `-p` flag, which today's Codex parses as `--profile`. See the Supported Agent CLIs table. Other CLIs work via the generic `<cli> -p <prompt>` fallback. |
+| `AGENT_CMD` | No (default `claude`) | `claude`, `codex`, or `kiro` | The CLI used to spawn dev/review agents. Other CLIs work via the generic `<cli> -p <prompt>` fallback. See the Supported Agent CLIs table for resume semantics per CLI. |
 | `AGENT_DEV_MODEL`, `AGENT_REVIEW_MODEL` | No (default empty / `sonnet`) | Model name passed to the agent CLI | Empty = let the CLI pick. The review model defaults to `sonnet` to keep review costs predictable. |
 | `AGENT_PERMISSION_MODE` | No (default `auto`) | `auto`, `plan`, or `bypassPermissions` | `bypassPermissions` grants the agent unrestricted shell access — only use in a trusted sandbox. |
 | `AGENT_TIMEOUT` | No (default `4h`) | coreutils `timeout` units (e.g. `30m`, `2h`, `1d`) | Wall-clock cap on each agent invocation. Prevents hung CLI processes (stale `--resume`, MCP stdio deadlock) from monopolizing wrapper PID slots. |
@@ -369,10 +369,11 @@ The dispatcher is an [OpenClaw](https://github.com/OpenClaw/OpenClaw) skill that
 | Agent CLI | Command | New Session | Resume | Status |
 |-----------|---------|-------------|--------|--------|
 | Claude Code | `claude` | `--session-id <UUID>` | `--resume <id>` | Full support |
-| Codex CLI ⚠️ | `codex` | `exec "<prompt>"` | `exec resume --last` / `resume <id>` | **Code-side broken** — `lib-agent.sh` still uses the legacy `-p` flag, which today's Codex parses as `--profile`. A follow-up `fix(dispatcher)` PR will switch to `codex exec`. |
+| Codex CLI | `codex` | `exec --json "<prompt>"` | `exec resume <thread-id>` (captured from JSON stream) | Full support |
 | Kiro CLI | `kiro-cli` | `chat --no-interactive [--agent <name>]` | (falls back to new) | Basic support |
 | Cursor Agent | `agent` | `-p "<prompt>"` | `--resume=<chat-id>` | Generic fallback (untested explicit branch) |
 | Gemini CLI | `gemini` | `-p "<prompt>"` | (no documented resume flag) | Generic fallback (untested explicit branch) |
+| opencode (`anomalyco/opencode`) | `opencode` | `run "<prompt>"` (positional) | `run --session <id>` — but **caller cannot pre-mint the session id**; opencode mints its own. Needs an explicit `lib-agent.sh` adapter (capture session id from `--format json` stdout, persist sidecar) before resume works. | Generic fallback only (currently); explicit branch tracked as a follow-up |
 
 Configure via `AGENT_CMD` in `scripts/autonomous.conf`. The `claude`, `codex`, and `kiro` rows have explicit branches in `scripts/lib-agent.sh`; the others run through the generic `<cli> -p <prompt>` fallback. Any CLI not listed should still work if it accepts a `-p <prompt>` non-interactive flag — the abstraction layer is intentionally permissive.
 

--- a/skills/autonomous-dispatcher/scripts/lib-agent.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-agent.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 # lib-agent.sh — Agent CLI abstraction layer.
+#
 # Supports: claude (default), codex, kiro, and generic fallback.
 # Source this file in autonomous-dev.sh and autonomous-review.sh.
+#
+# Session-id semantics differ across CLIs:
+#   claude — caller pre-mints `--session-id <UUID>`; same id used for both
+#            run and resume. Cleanest fit for the dispatcher's session_id.
+#   codex  — CLI mints its own thread_id per `codex exec` invocation. We
+#            capture it from `--json` stdout via _codex_capture_thread and
+#            persist a sidecar under pid_dir_for_project() keyed by the
+#            dispatcher's session_id, then feed it back to
+#            `codex exec resume <thread_id>` on resume.
+#   kiro   — no session model; every invocation is a fresh conversation.
+#            resume_agent falls back to run_agent.
+#   *      — generic <cli> -p <prompt> fallback; resume falls back to new.
 
 # Load project config via the shared helper (closes #58).
 # Note: ${BASH_SOURCE[0]:-$0} (NOT readlink -f) so the symlink-vendor
@@ -56,6 +69,86 @@ _run_with_timeout() {
   fi
 }
 
+# Codex thread-id capture/recall.
+#
+# Codex `exec` mints its own thread (UUID) per invocation and does NOT accept
+# a caller-provided ID — unlike Claude Code, which lets us pre-mint
+# `--session-id <UUID>`. To resume a codex session correctly we must capture
+# the CLI-assigned thread_id after `run_agent` and feed it into
+# `codex exec resume <id>` on `resume_agent`. We persist it in a sidecar
+# under pid_dir_for_project() (mode 0700, per-user, already used for PID
+# files) keyed by the dispatcher's session_id.
+
+_codex_thread_file() {
+  local session_id="$1"
+  local pid_dir
+  pid_dir=$(pid_dir_for_project) || return 1
+  printf '%s/codex-thread-%s\n' "$pid_dir" "$session_id"
+}
+
+# _codex_capture_thread <session_id>
+#
+# Pipeline filter: streams stdin → stdout unchanged so the wrapper still sees
+# every JSON event for logging, and as a side effect writes the first
+# observed thread_id to the sidecar. Robust to:
+#   - thread.started not being literally the first line (we keep scanning)
+#   - the agent crashing before any thread_id arrives (sidecar stays empty
+#     → resume_agent falls back to a fresh run_agent, same pattern as kiro)
+#   - re-runs against the same dispatcher session_id (we overwrite, not
+#     append)
+#
+# Why awk and not jq: jq is not a hard dependency of this lib; awk is
+# universal. Codex `--json` emits one event per line (JSONL), and the
+# `thread.started` event has the shape `{"type":"thread.started",
+# "thread_id":"<UUID>"}` — a single line with no embedded newlines.
+_codex_capture_thread() {
+  local session_id="$1"
+  local thread_file
+  thread_file=$(_codex_thread_file "$session_id") || { cat; return 0; }
+  awk -v out="$thread_file" '
+    BEGIN {
+      # Tracked together with the regex below so length math stays correct
+      # if either is edited later. prefix matches the literal lead-in of a
+      # codex thread.started JSON line; the inner [a-f0-9-]+ is the part we
+      # want to extract.
+      prefix = "\"thread_id\":\""
+    }
+    {
+      print
+      fflush()
+      if (!captured && /"type":"thread.started"/) {
+        if (match($0, /"thread_id":"[a-f0-9-]+"/)) {
+          # Strip the prefix and the trailing closing quote.
+          tid = substr($0, RSTART + length(prefix), RLENGTH - length(prefix) - 1)
+          # Symlink-defense: refuse to clobber an existing symlink at the
+          # sidecar path. pid_dir is mode 0700 so this is defense in depth,
+          # but cheap to keep (CWE-59).
+          cmd = "test -L \"" out "\" && exit 0; printf \"%s\\n\" \"" tid "\" > \"" out "\""
+          system(cmd)
+          captured = 1
+        }
+      }
+    }'
+}
+
+# _codex_thread_id <session_id>
+#
+# Read the captured thread_id from the sidecar, validating the format.
+# Echo the id and rc=0 on hit; echo nothing and rc=1 on miss / malformed.
+# The UUID-only regex protects against a future bug overwriting the sidecar
+# with attacker-controlled data — pid_dir is 0700 so the surface is small,
+# but the explicit failure mode is worth the two extra lines.
+_codex_thread_id() {
+  local session_id="$1"
+  local thread_file tid
+  thread_file=$(_codex_thread_file "$session_id") || return 1
+  [[ -L "$thread_file" ]] && return 1
+  [[ -f "$thread_file" ]] || return 1
+  tid=$(head -n1 "$thread_file" 2>/dev/null)
+  [[ "$tid" =~ ^[a-f0-9-]+$ ]] || return 1
+  printf '%s\n' "$tid"
+}
+
 # Acquire PID guard: prevent duplicate instances for the same issue.
 # Checks for symlink attacks, running processes, then writes current PID.
 # Args: $1=pid_file, $2=label (e.g. "autonomous-dev"), $3=issue_number
@@ -92,9 +185,23 @@ run_agent() {
         --output-format json
       ;;
     codex)
-      _run_with_timeout "$AGENT_CMD" \
+      # Codex CLI: headless invocation is `codex exec [PROMPT]` (positional
+      # prompt). The legacy `-p` flag now means `--profile` and would parse
+      # the prompt as a TOML config profile name — silent breakage.
+      #
+      # `--json` streams JSONL events to stdout, including the
+      # `thread.started` event from which we capture the thread_id for
+      # resume_agent. We pipe through _codex_capture_thread (pass-through
+      # filter) to keep the wrapper's stdout consumption untouched while
+      # writing the sidecar.
+      #
+      # PIPESTATUS[0] surfaces codex's exit code (the awk filter at the end
+      # of the pipeline is well-behaved and rc=0 on every input).
+      _run_with_timeout "$AGENT_CMD" exec --json \
         ${model:+--model "$model"} \
-        -p "$prompt"
+        "$prompt" \
+        | _codex_capture_thread "$session_id"
+      return "${PIPESTATUS[0]}"
       ;;
     kiro)
       # Kiro CLI does not support named sessions (session_id is ignored).
@@ -133,6 +240,29 @@ resume_agent() {
         ${model:+--model "$model"} \
         -p "$prompt" \
         --output-format json
+      ;;
+    codex)
+      # Codex `exec resume <thread_id> [PROMPT]` resumes the conversation.
+      # The dispatcher's session_id and codex's thread_id are NOT the same:
+      # codex mints its own UUID and we capture it during run_agent into a
+      # sidecar keyed by our session_id. Read it back here.
+      #
+      # If the sidecar is missing (run_agent crashed before thread.started,
+      # or this resume_agent is being called without a prior run_agent),
+      # fall back to a fresh new-session run — same defensive pattern as
+      # the kiro branch, since resuming-a-nonexistent-thread is worse UX
+      # than starting clean with the full prompt.
+      local _codex_tid
+      if _codex_tid=$(_codex_thread_id "$session_id"); then
+        _run_with_timeout "$AGENT_CMD" exec resume "$_codex_tid" --json \
+          ${model:+--model "$model"} \
+          "$prompt" \
+          | _codex_capture_thread "$session_id"
+        return "${PIPESTATUS[0]}"
+      else
+        echo "[lib-agent] no captured codex thread_id for session $session_id; starting a new codex session" >&2
+        run_agent "$session_id" "$prompt" "$model" "$session_name"
+      fi
       ;;
     kiro)
       # Kiro CLI --resume cannot inject new review feedback effectively —

--- a/tests/unit/test-lib-agent-codex.sh
+++ b/tests/unit/test-lib-agent-codex.sh
@@ -1,0 +1,327 @@
+#!/bin/bash
+# test-lib-agent-codex.sh — Unit tests for the codex branches of
+# lib-agent.sh after the legacy `-p` → `codex exec` migration.
+#
+# Verifies:
+#   - run_agent codex branch invokes `codex exec --json [PROMPT]` (not -p)
+#   - The thread_id from the codex JSON stream is captured to a sidecar
+#     under pid_dir_for_project(), keyed by the dispatcher's session_id
+#   - resume_agent codex branch reads the sidecar and invokes
+#     `codex exec resume <thread_id> [PROMPT]`
+#   - resume_agent falls back to run_agent when the sidecar is missing
+#   - The capture filter is pass-through (does not corrupt stdout)
+#
+# Strategy: source lib-agent.sh in a sandbox with a stub `codex` on PATH
+# that records its argv to a recorder file and emits a known JSONL payload
+# that includes thread.started.
+#
+# Run: bash tests/unit/test-lib-agent-codex.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-agent.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected='$expected'"
+    echo "      actual=  '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      needle='$needle'"
+    echo "      haystack='${haystack:0:300}'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      should not contain: '$needle'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+echo "=== TC-LA-CODEX-01: source-of-truth grep — codex branch shape ==="
+# ---------------------------------------------------------------------------
+# Cheap structural assertions before exercising behavior.
+
+if grep -qE '^\s*codex\)\s*$' "$LIB"; then
+  echo -e "  ${GREEN}PASS${NC}: codex case still present"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: codex case missing"
+  FAIL=$((FAIL + 1))
+fi
+
+# The legacy `codex ... -p "$prompt"` form is what we're removing. The
+# generic `*)` fallback below the codex case still uses `<cli> -p <prompt>`
+# correctly for non-codex CLIs, so a whole-file grep would false-positive.
+# Scope the check to just the run_agent codex case body.
+codex_case_body=$(awk '
+  /^[[:space:]]*codex\)[[:space:]]*$/,/^[[:space:]]*;;[[:space:]]*$/
+' "$LIB" | head -40)
+if [[ "$codex_case_body" != *'-p "$prompt"'* ]]; then
+  echo -e "  ${GREEN}PASS${NC}: codex case does not invoke 'codex -p \"\$prompt\"'"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: codex case still uses legacy '-p \$prompt'"
+  FAIL=$((FAIL + 1))
+fi
+
+# The new exec invocation must be there and use --json.
+if grep -q '"\$AGENT_CMD" exec --json' "$LIB"; then
+  echo -e "  ${GREEN}PASS${NC}: new 'codex exec --json' invocation present"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: new 'codex exec --json' invocation missing"
+  FAIL=$((FAIL + 1))
+fi
+
+# resume_agent codex case must call `exec resume`.
+if grep -q '"\$AGENT_CMD" exec resume' "$LIB"; then
+  echo -e "  ${GREEN}PASS${NC}: resume_agent codex case calls 'codex exec resume'"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: resume_agent codex case missing 'codex exec resume'"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-LA-CODEX-02: behavioral — run_agent captures thread_id ==="
+# ---------------------------------------------------------------------------
+# Build a sandbox: AUTONOMOUS_PID_DIR override + a stub `codex` on PATH that
+# records argv and emits a known JSONL stream.
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+PID_DIR="$TMPROOT/pid"
+mkdir -p "$PID_DIR"
+chmod 700 "$PID_DIR"
+
+BIN="$TMPROOT/bin"
+mkdir -p "$BIN"
+
+# Stub codex: print argv to a recorder, emit thread.started + a simple
+# completion event. Honors --json by emitting JSONL only.
+cat > "$BIN/codex" <<'EOF'
+#!/bin/bash
+echo "$@" > "$CODEX_ARGS_FILE"
+cat <<JSONL
+{"type":"thread.started","thread_id":"019e1234-aaaa-bbbb-cccc-deadbeefcafe"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"ok"}}
+{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":2}}
+JSONL
+EOF
+chmod +x "$BIN/codex"
+
+# Stub timeout: run argv directly (no real wall-clock cap needed for tests).
+# _run_with_timeout invokes us as: timeout --kill-after=30s --signal=TERM <DURATION> <CMD...>
+# That's 3 leading args before the real command.
+cat > "$BIN/timeout" <<'EOF'
+#!/bin/bash
+shift 3
+exec "$@"
+EOF
+chmod +x "$BIN/timeout"
+
+# Source lib-agent in a subshell with the sandbox set up.
+ARGS_FILE="$TMPROOT/codex-args"
+SESSION_ID="22222222-3333-4444-5555-666666666666"
+
+run_agent_output=$(
+  PATH="$BIN:$PATH" \
+  AUTONOMOUS_PID_DIR="$PID_DIR" \
+  PROJECT_ID="testproj" \
+  PROJECT_DIR="$TMPROOT" \
+  AGENT_CMD=codex \
+  AGENT_PERMISSION_MODE=auto \
+  CODEX_ARGS_FILE="$ARGS_FILE" \
+  bash -c '
+    source "'"$LIB"'"
+    run_agent "'"$SESSION_ID"'" "implement the thing" "" ""
+  ' 2>&1
+)
+run_agent_rc=$?
+
+assert_eq "run_agent codex returns 0 on success" 0 "$run_agent_rc"
+
+# stdout must be pass-through: every JSON line we emitted should appear.
+assert_contains "stdout includes thread.started event" \
+  '"thread.started"' "$run_agent_output"
+assert_contains "stdout includes turn.completed event" \
+  '"turn.completed"' "$run_agent_output"
+
+# Sidecar must exist and contain the captured thread_id.
+sidecar="$PID_DIR/codex-thread-$SESSION_ID"
+if [[ -f "$sidecar" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: sidecar file created at expected path"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: sidecar not created at $sidecar"
+  FAIL=$((FAIL + 1))
+fi
+assert_eq "sidecar contains the thread_id from JSONL" \
+  "019e1234-aaaa-bbbb-cccc-deadbeefcafe" "$(cat "$sidecar" 2>/dev/null)"
+
+# codex argv must use the new shape: `exec --json ... <prompt>` (no `-p`).
+codex_argv=$(cat "$ARGS_FILE")
+assert_contains "codex argv contains 'exec'"   "exec"        "$codex_argv"
+assert_contains "codex argv contains '--json'" "--json"      "$codex_argv"
+assert_contains "codex argv ends with the prompt as positional arg" \
+  "implement the thing" "$codex_argv"
+assert_not_contains "codex argv does NOT use legacy -p flag" "-p" "$codex_argv"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-LA-CODEX-03: behavioral — resume_agent uses captured thread_id ==="
+# ---------------------------------------------------------------------------
+# Same sandbox; sidecar is already populated by TC-LA-CODEX-02.
+: > "$ARGS_FILE"
+
+resume_output=$(
+  PATH="$BIN:$PATH" \
+  AUTONOMOUS_PID_DIR="$PID_DIR" \
+  PROJECT_ID="testproj" \
+  PROJECT_DIR="$TMPROOT" \
+  AGENT_CMD=codex \
+  AGENT_PERMISSION_MODE=auto \
+  CODEX_ARGS_FILE="$ARGS_FILE" \
+  bash -c '
+    source "'"$LIB"'"
+    resume_agent "'"$SESSION_ID"'" "follow-up: address review feedback" "" ""
+  ' 2>&1
+)
+resume_rc=$?
+
+assert_eq "resume_agent codex returns 0" 0 "$resume_rc"
+
+resume_argv=$(cat "$ARGS_FILE")
+assert_contains "resume argv contains 'exec resume'" \
+  "exec resume" "$resume_argv"
+assert_contains "resume argv contains the captured thread_id" \
+  "019e1234-aaaa-bbbb-cccc-deadbeefcafe" "$resume_argv"
+assert_contains "resume argv contains '--json'" "--json" "$resume_argv"
+assert_contains "resume argv contains the follow-up prompt" \
+  "follow-up: address review feedback" "$resume_argv"
+assert_not_contains "resume argv does NOT use legacy -p" "-p" "$resume_argv"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-LA-CODEX-04: resume falls back to new run when sidecar missing ==="
+# ---------------------------------------------------------------------------
+# Use a fresh session_id that has no sidecar.
+NEW_SESSION_ID="99999999-aaaa-bbbb-cccc-dddddddddddd"
+: > "$ARGS_FILE"
+
+fallback_output=$(
+  PATH="$BIN:$PATH" \
+  AUTONOMOUS_PID_DIR="$PID_DIR" \
+  PROJECT_ID="testproj" \
+  PROJECT_DIR="$TMPROOT" \
+  AGENT_CMD=codex \
+  AGENT_PERMISSION_MODE=auto \
+  CODEX_ARGS_FILE="$ARGS_FILE" \
+  bash -c '
+    source "'"$LIB"'"
+    resume_agent "'"$NEW_SESSION_ID"'" "fresh prompt" "" ""
+  ' 2>&1
+)
+fallback_rc=$?
+
+assert_eq "fallback resume_agent returns 0" 0 "$fallback_rc"
+assert_contains "fallback writes diagnostic about missing thread_id" \
+  "no captured codex thread_id" "$fallback_output"
+
+# Argv should be the run_agent shape, not exec resume.
+fallback_argv=$(cat "$ARGS_FILE")
+assert_contains "fallback argv contains 'exec'" "exec" "$fallback_argv"
+assert_not_contains "fallback argv does NOT contain 'resume'" \
+  "resume" "$fallback_argv"
+assert_contains "fallback argv contains the fresh prompt" \
+  "fresh prompt" "$fallback_argv"
+
+# A new sidecar should now exist for the fresh session_id.
+new_sidecar="$PID_DIR/codex-thread-$NEW_SESSION_ID"
+if [[ -f "$new_sidecar" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: fallback created sidecar for the new session_id"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: fallback did not create sidecar for the new session_id"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-LA-CODEX-05: capture is robust to no thread.started event ==="
+# ---------------------------------------------------------------------------
+# Replace stub codex with one that crashes before emitting thread.started.
+cat > "$BIN/codex" <<'EOF'
+#!/bin/bash
+echo "$@" > "$CODEX_ARGS_FILE"
+echo '{"type":"error","message":"auth failed"}'
+exit 7
+EOF
+
+CRASH_SESSION_ID="abcdef00-1111-2222-3333-444444444444"
+: > "$ARGS_FILE"
+
+crash_output=$(
+  PATH="$BIN:$PATH" \
+  AUTONOMOUS_PID_DIR="$PID_DIR" \
+  PROJECT_ID="testproj" \
+  PROJECT_DIR="$TMPROOT" \
+  AGENT_CMD=codex \
+  AGENT_PERMISSION_MODE=auto \
+  CODEX_ARGS_FILE="$ARGS_FILE" \
+  bash -c '
+    source "'"$LIB"'"
+    run_agent "'"$CRASH_SESSION_ID"'" "crashy prompt" "" ""
+  ' 2>&1
+)
+crash_rc=$?
+
+assert_eq "run_agent surfaces codex crash exit code" 7 "$crash_rc"
+
+crash_sidecar="$PID_DIR/codex-thread-$CRASH_SESSION_ID"
+if [[ ! -f "$crash_sidecar" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: no sidecar created when thread.started never arrived"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: sidecar incorrectly created on crash path"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

`lib-agent.sh` invoked codex as `codex ... -p "$prompt"`, which today's Codex CLI parses as `--profile <prompt>` (the prompt becomes a TOML profile name → silent breakage). This PR migrates the codex branch to `codex exec --json [PROMPT]` and adds first-class resume support.

## Why

Recent CLI research (during PR #87) verified the `-p` flag was redefined upstream — it now selects a config profile from `~/.codex/config.toml`, not a prompt. Anyone with `AGENT_CMD=codex` in their `autonomous.conf` was hitting silent breakage at every dev/review tick. The Supported Agent CLIs table in README #87 marked this with ⚠️; this PR removes the marker by making it actually work.

## Design — codex resume semantics

Codex `exec` mints its own `thread_id` per invocation and does NOT accept a caller-provided id (unlike Claude Code, which lets us pre-mint `--session-id <UUID>`). To enable `resume_agent`:

1. **Capture**: `run_agent` pipes `codex exec --json` stdout through `_codex_capture_thread`, a pass-through awk filter that streams events unchanged (so the wrapper's logging is untouched) and as a side effect writes the first `thread.started` event's `thread_id` to a sidecar at `${pid_dir}/codex-thread-${session_id}`.
2. **Recall**: `resume_agent` reads the sidecar via `_codex_thread_id` and invokes `codex exec resume <thread_id> --json [PROMPT]`. Falls back to a fresh `run_agent` when the sidecar is missing or malformed — same defensive pattern as the existing kiro branch.

The sidecar lives under `pid_dir_for_project()` (mode 0700, per-user, already used for PID files). The captured tid is regex-validated `[a-f0-9-]+` before any shell interpolation; CWE-59 symlink swaps are guarded at both write and read paths.

## README

- Codex row: drop the ⚠️ marker, status changes to `Full support`.
- New opencode row: noted as generic-fallback-only, with the CLI-minted-session-id wrinkle (caller can't pre-mint the id) flagged as a follow-up. Code-side adapter is out of scope here.

## Test Plan

- [x] 27 new cases in `tests/unit/test-lib-agent-codex.sh`:
   - Source-of-truth grep: codex case has no `-p`, has `exec --json`, resume case has `exec resume`
   - `run_agent` argv shape + thread_id capture (sandbox stub codex emits known JSONL)
   - `resume_agent` reads the captured thread_id and invokes `codex exec resume <id>`
   - Fallback to `run_agent` when sidecar missing
   - Crash path: codex exits before `thread.started` → no sidecar created, exit code surfaced
- [x] Full unit suite: 36/36 test files pass
- [x] `bash -n` clean on `lib-agent.sh`
- [x] shellcheck: only SC1091-info for the (intentionally) unspecified `lib-config.sh` source
- [x] Code-reviewer agent run: one Important finding (magic numbers in awk extraction); fixed in the same commit by using `length(prefix)` so the regex and offset math stay in lockstep
- [ ] CI checks pass

## Backwards Compatibility

- `AGENT_CMD=codex` previously didn't actually work, so no real-world regressions are possible.
- Sidecar paths are new files under an already-existing per-user dir; nothing else reads or writes them.
- `claude` / `kiro` / generic-fallback branches unchanged.

## Follow-ups

- `feat(dispatcher): add opencode CLI support` — opencode has the same CLI-minted-session-id wrinkle as codex; the design pattern in this PR (capture thread_id from JSON stdout into a sidecar) is reusable.

## Checklist

- [x] Design: described in commit message + this PR body (no separate canvas — pure code fix)
- [x] Test cases documented
- [x] Build/tests pass
- [x] Code review passed (1 Important finding addressed)