### PR TITLE
feat(dispatcher): add opencode CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A fully automated development pipeline that turns GitHub issues into merged pull requests — no human intervention required. It scans for issues labeled `autonomous`, dispatches a **Dev Agent** to implement the feature with tests in an isolated worktree, and hands off to a **Review Agent** for code review with optional E2E verification. The entire cycle runs unattended on a cron schedule.
 
-Supports multiple coding agent CLIs — Claude Code, Codex CLI, Kiro CLI, Cursor Agent, Gemini CLI, and most CLIs with a `-p <prompt>` non-interactive flag — via a pluggable agent abstraction layer.
+Supports multiple coding agent CLIs — Claude Code, Codex CLI, Kiro CLI, opencode, Cursor Agent, Gemini CLI, and most CLIs with a `-p <prompt>` non-interactive flag — via a pluggable agent abstraction layer.
 
 ## Getting Started
 
@@ -168,7 +168,7 @@ The file is a bash script that's `source`d at every dispatcher tick and wrapper 
 | `REPO` | Yes | `owner/repo-name` | The GitHub repo the pipeline watches. |
 | `REPO_OWNER`, `REPO_NAME` | Yes | Split form of `REPO` | Used for App-token scoping. |
 | `PROJECT_DIR` | Yes | Absolute path to the project root on the dispatcher box | Where the agent runs. |
-| `AGENT_CMD` | No (default `claude`) | `claude`, `codex`, or `kiro` | The CLI used to spawn dev/review agents. Other CLIs work via the generic `<cli> -p <prompt>` fallback. See the Supported Agent CLIs table for resume semantics per CLI. |
+| `AGENT_CMD` | No (default `claude`) | `claude`, `codex`, `kiro`, or `opencode` | The CLI used to spawn dev/review agents. Other CLIs work via the generic `<cli> -p <prompt>` fallback. See the Supported Agent CLIs table for resume semantics per CLI. |
 | `AGENT_DEV_MODEL`, `AGENT_REVIEW_MODEL` | No (default empty / `sonnet`) | Model name passed to the agent CLI | Empty = let the CLI pick. The review model defaults to `sonnet` to keep review costs predictable. |
 | `AGENT_PERMISSION_MODE` | No (default `auto`) | `auto`, `plan`, or `bypassPermissions` | `bypassPermissions` grants the agent unrestricted shell access — only use in a trusted sandbox. |
 | `AGENT_TIMEOUT` | No (default `4h`) | coreutils `timeout` units (e.g. `30m`, `2h`, `1d`) | Wall-clock cap on each agent invocation. Prevents hung CLI processes (stale `--resume`, MCP stdio deadlock) from monopolizing wrapper PID slots. |
@@ -373,9 +373,9 @@ The dispatcher is an [OpenClaw](https://github.com/OpenClaw/OpenClaw) skill that
 | Kiro CLI | `kiro-cli` | `chat --no-interactive [--agent <name>]` | (falls back to new) | Basic support |
 | Cursor Agent | `agent` | `-p "<prompt>"` | `--resume=<chat-id>` | Generic fallback (untested explicit branch) |
 | Gemini CLI | `gemini` | `-p "<prompt>"` | (no documented resume flag) | Generic fallback (untested explicit branch) |
-| opencode (`anomalyco/opencode`) | `opencode` | `run "<prompt>"` (positional) | `run --session <id>` — but **caller cannot pre-mint the session id**; opencode mints its own. Needs an explicit `lib-agent.sh` adapter (capture session id from `--format json` stdout, persist sidecar) before resume works. | Generic fallback only (currently); explicit branch tracked as a follow-up |
+| opencode | `opencode` | `run --format json [PROMPT]` | `run --session <sessionID>` (captured from JSON stream) | Full support |
 
-Configure via `AGENT_CMD` in `scripts/autonomous.conf`. The `claude`, `codex`, and `kiro` rows have explicit branches in `scripts/lib-agent.sh`; the others run through the generic `<cli> -p <prompt>` fallback. Any CLI not listed should still work if it accepts a `-p <prompt>` non-interactive flag — the abstraction layer is intentionally permissive.
+Configure via `AGENT_CMD` in `scripts/autonomous.conf`. The `claude`, `codex`, `kiro`, and `opencode` rows have explicit branches in `scripts/lib-agent.sh`; the others run through the generic `<cli> -p <prompt>` fallback. Any CLI not listed should still work if it accepts a `-p <prompt>` non-interactive flag — the abstraction layer is intentionally permissive.
 
 ## Development Workflow (Hook System)
 

--- a/skills/autonomous-dispatcher/scripts/autonomous.conf.example
+++ b/skills/autonomous-dispatcher/scripts/autonomous.conf.example
@@ -11,6 +11,10 @@ REPO_NAME="repo-name"
 PROJECT_DIR="/path/to/project"
 
 # === Agent Configuration ===
+# AGENT_CMD: which coding-agent CLI to spawn for dev/review wrappers.
+# First-class support: claude, codex, kiro, opencode. Other CLIs work via
+# the generic `<cli> -p <prompt>` fallback. See README "Supported Agent
+# CLIs" for resume semantics per CLI.
 AGENT_CMD="claude"
 AGENT_DEV_MODEL=""
 AGENT_REVIEW_MODEL="sonnet"

--- a/skills/autonomous-dispatcher/scripts/lib-agent.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-agent.sh
@@ -1,20 +1,27 @@
 #!/bin/bash
 # lib-agent.sh — Agent CLI abstraction layer.
 #
-# Supports: claude (default), codex, kiro, and generic fallback.
+# Supports: claude (default), codex, kiro, opencode, and generic fallback.
 # Source this file in autonomous-dev.sh and autonomous-review.sh.
 #
 # Session-id semantics differ across CLIs:
-#   claude — caller pre-mints `--session-id <UUID>`; same id used for both
-#            run and resume. Cleanest fit for the dispatcher's session_id.
-#   codex  — CLI mints its own thread_id per `codex exec` invocation. We
-#            capture it from `--json` stdout via _codex_capture_thread and
-#            persist a sidecar under pid_dir_for_project() keyed by the
-#            dispatcher's session_id, then feed it back to
-#            `codex exec resume <thread_id>` on resume.
-#   kiro   — no session model; every invocation is a fresh conversation.
-#            resume_agent falls back to run_agent.
-#   *      — generic <cli> -p <prompt> fallback; resume falls back to new.
+#   claude   — caller pre-mints `--session-id <UUID>`; same id used for
+#              both run and resume. Cleanest fit for the dispatcher's
+#              session_id.
+#   codex    — CLI mints its own thread_id per `codex exec` invocation.
+#              We capture it from `--json` stdout via
+#              _codex_capture_thread and persist a sidecar under
+#              pid_dir_for_project() keyed by the dispatcher's
+#              session_id, then feed it back to
+#              `codex exec resume <thread_id>` on resume.
+#   kiro     — no session model; every invocation is a fresh conversation.
+#              resume_agent falls back to run_agent.
+#   opencode — same CLI-minted-session-id wrinkle as codex but with a
+#              `sessionID` field on every JSON event. Captured the same
+#              way (_opencode_capture_session) and fed back to
+#              `opencode run --session <id>` on resume.
+#   *        — generic <cli> -p <prompt> fallback; resume falls back to
+#              a fresh run.
 
 # Load project config via the shared helper (closes #58).
 # Note: ${BASH_SOURCE[0]:-$0} (NOT readlink -f) so the symlink-vendor
@@ -149,6 +156,74 @@ _codex_thread_id() {
   printf '%s\n' "$tid"
 }
 
+# Opencode session-id capture/recall.
+#
+# opencode `run` mints its own session id (`ses_<base62>`) per invocation
+# and accepts `--session <id>` only for resuming an existing one — same
+# CLI-minted-id wrinkle as codex. Mirror the codex helpers, with two
+# differences:
+#   - Field name is `sessionID` (camelCase, capital ID), not `thread_id`.
+#   - The id is on EVERY event in the JSON stream, not gated on a single
+#     event type. We still capture the first occurrence, which arrives in
+#     the very first event.
+
+_opencode_session_file() {
+  local session_id="$1"
+  local pid_dir
+  pid_dir=$(pid_dir_for_project) || return 1
+  printf '%s/opencode-session-%s\n' "$pid_dir" "$session_id"
+}
+
+# _opencode_capture_session <dispatcher_session_id>
+#
+# Pipeline filter: pass-through awk filter that streams stdin → stdout
+# unchanged and writes the first observed sessionID to a sidecar. Same
+# pattern + safety properties as _codex_capture_thread.
+#
+# opencode emits one JSON event per line with a `"sessionID":"ses_..."`
+# field on every event. Format verified against opencode v1.14.46 output.
+_opencode_capture_session() {
+  local session_id="$1"
+  local sess_file
+  sess_file=$(_opencode_session_file "$session_id") || { cat; return 0; }
+  awk -v out="$sess_file" '
+    BEGIN {
+      # opencode session ids look like `ses_<base62>` (e.g. ses_1ee2d8d...).
+      # Tracked together with the regex below so the math stays in sync.
+      prefix = "\"sessionID\":\""
+    }
+    {
+      print
+      fflush()
+      if (!captured) {
+        if (match($0, /"sessionID":"ses_[A-Za-z0-9]+"/)) {
+          sid = substr($0, RSTART + length(prefix), RLENGTH - length(prefix) - 1)
+          # Same CWE-59 defense as _codex_capture_thread.
+          cmd = "test -L \"" out "\" && exit 0; printf \"%s\\n\" \"" sid "\" > \"" out "\""
+          system(cmd)
+          captured = 1
+        }
+      }
+    }'
+}
+
+# _opencode_session_id <dispatcher_session_id>
+#
+# Read the captured opencode sessionID from the sidecar. Echo + rc=0 on
+# hit, echo nothing + rc=1 on miss/malformed. The `^ses_[A-Za-z0-9]+$`
+# regex matches the documented opencode format and protects the
+# downstream `opencode run --session <id>` invocation from injection.
+_opencode_session_id() {
+  local session_id="$1"
+  local sess_file sid
+  sess_file=$(_opencode_session_file "$session_id") || return 1
+  [[ -L "$sess_file" ]] && return 1
+  [[ -f "$sess_file" ]] || return 1
+  sid=$(head -n1 "$sess_file" 2>/dev/null)
+  [[ "$sid" =~ ^ses_[A-Za-z0-9]+$ ]] || return 1
+  printf '%s\n' "$sid"
+}
+
 # Acquire PID guard: prevent duplicate instances for the same issue.
 # Checks for symlink attacks, running processes, then writes current PID.
 # Args: $1=pid_file, $2=label (e.g. "autonomous-dev"), $3=issue_number
@@ -214,6 +289,21 @@ run_agent() {
         ${model:+--model "$model"} \
         "$prompt"
       ;;
+    opencode)
+      # opencode `run [message..]` is the headless invocation. opencode
+      # mints its own session id and emits it on every event in the JSON
+      # event stream, so we capture it the same way as codex.
+      #
+      # The session_name we got from the dispatcher is passed to --title
+      # so opencode's session list shows a human-readable handle alongside
+      # the ses_<base62> id.
+      _run_with_timeout "$AGENT_CMD" run --format json \
+        ${model:+--model "$model"} \
+        ${session_name:+--title "$session_name"} \
+        "$prompt" \
+        | _opencode_capture_session "$session_id"
+      return "${PIPESTATUS[0]}"
+      ;;
     *)
       _run_with_timeout "$AGENT_CMD" -p "$prompt"
       ;;
@@ -270,6 +360,23 @@ resume_agent() {
       # Fall back to a new session so the full prompt (with review findings)
       # is treated as fresh instructions.
       run_agent "$session_id" "$prompt" "$model" "$session_name"
+      ;;
+    opencode)
+      # `opencode run --session <id> [PROMPT]` resumes the conversation.
+      # Same pattern as the codex branch: read the captured opencode
+      # session id from the sidecar, fall back to a new run if missing
+      # (run_agent crashed before the first JSON event reached us).
+      local _opencode_sid
+      if _opencode_sid=$(_opencode_session_id "$session_id"); then
+        _run_with_timeout "$AGENT_CMD" run --format json --session "$_opencode_sid" \
+          ${model:+--model "$model"} \
+          "$prompt" \
+          | _opencode_capture_session "$session_id"
+        return "${PIPESTATUS[0]}"
+      else
+        echo "[lib-agent] no captured opencode sessionID for session $session_id; starting a new opencode session" >&2
+        run_agent "$session_id" "$prompt" "$model" "$session_name"
+      fi
       ;;
     *)
       # Agents without resume support start a new session

--- a/tests/unit/test-lib-agent-opencode.sh
+++ b/tests/unit/test-lib-agent-opencode.sh
@@ -1,0 +1,338 @@
+#!/bin/bash
+# test-lib-agent-opencode.sh — Unit tests for the opencode branches of
+# lib-agent.sh.
+#
+# Verifies:
+#   - run_agent opencode branch invokes `opencode run --format json` (no -p)
+#   - The sessionID from the opencode JSON stream is captured to a sidecar
+#     under pid_dir_for_project(), keyed by the dispatcher's session_id
+#   - resume_agent opencode branch reads the sidecar and invokes
+#     `opencode run --session <sessionID>` with the follow-up prompt
+#   - resume_agent falls back to run_agent when the sidecar is missing
+#   - The capture filter is pass-through (does not corrupt stdout)
+#   - --title is forwarded when session_name is provided
+#
+# JSON shape used in stubs is the actual format emitted by opencode v1.14.46
+# (verified against `opencode run --format json --pure "test"`):
+#   {"type":"step_start","timestamp":...,"sessionID":"ses_<base62>",...}
+#
+# Run: bash tests/unit/test-lib-agent-opencode.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-agent.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected='$expected'"
+    echo "      actual=  '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      needle='$needle'"
+    echo "      haystack='${haystack:0:300}'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      should not contain: '$needle'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+echo "=== TC-LA-OC-01: source-of-truth grep — opencode branch shape ==="
+# ---------------------------------------------------------------------------
+if grep -qE '^\s*opencode\)\s*$' "$LIB"; then
+  echo -e "  ${GREEN}PASS${NC}: opencode case present"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: opencode case missing"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q '"\$AGENT_CMD" run --format json' "$LIB"; then
+  echo -e "  ${GREEN}PASS${NC}: opencode invocation uses 'run --format json'"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: opencode invocation missing 'run --format json'"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q '"\$AGENT_CMD" run --format json --session' "$LIB"; then
+  echo -e "  ${GREEN}PASS${NC}: resume_agent opencode case calls 'run --session'"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: resume_agent opencode case missing 'run --session'"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-LA-OC-02: behavioral — run_agent captures sessionID ==="
+# ---------------------------------------------------------------------------
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+PID_DIR="$TMPROOT/pid"
+mkdir -p "$PID_DIR"
+chmod 700 "$PID_DIR"
+
+BIN="$TMPROOT/bin"
+mkdir -p "$BIN"
+
+# Stub opencode: record argv, emit a known JSONL stream that mirrors the
+# real opencode v1.14.46 output shape.
+cat > "$BIN/opencode" <<'EOF'
+#!/bin/bash
+echo "$@" > "$OPENCODE_ARGS_FILE"
+cat <<JSONL
+{"type":"step_start","timestamp":1778415469963,"sessionID":"ses_TESTabc123XYZ456","part":{"id":"prt_a","messageID":"msg_b","sessionID":"ses_TESTabc123XYZ456","type":"step-start"}}
+{"type":"text","timestamp":1778415470449,"sessionID":"ses_TESTabc123XYZ456","part":{"id":"prt_c","type":"text","text":"ok"}}
+JSONL
+EOF
+chmod +x "$BIN/opencode"
+
+# Same timeout stub as the codex tests.
+cat > "$BIN/timeout" <<'EOF'
+#!/bin/bash
+shift 3
+exec "$@"
+EOF
+chmod +x "$BIN/timeout"
+
+ARGS_FILE="$TMPROOT/opencode-args"
+SESSION_ID="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+run_output=$(
+  PATH="$BIN:$PATH" \
+  AUTONOMOUS_PID_DIR="$PID_DIR" \
+  PROJECT_ID="testproj" \
+  PROJECT_DIR="$TMPROOT" \
+  AGENT_CMD=opencode \
+  AGENT_PERMISSION_MODE=auto \
+  OPENCODE_ARGS_FILE="$ARGS_FILE" \
+  bash -c '
+    source "'"$LIB"'"
+    run_agent "'"$SESSION_ID"'" "implement feature X" "" "issue-42-dev"
+  ' 2>&1
+)
+run_rc=$?
+
+assert_eq "run_agent opencode returns 0" 0 "$run_rc"
+assert_contains "stdout includes step_start event"  '"step_start"' "$run_output"
+assert_contains "stdout includes text event"        '"text"'       "$run_output"
+assert_contains "stdout includes sessionID"         'ses_TESTabc123XYZ456' "$run_output"
+
+sidecar="$PID_DIR/opencode-session-$SESSION_ID"
+if [[ -f "$sidecar" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: sidecar created at expected path"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: sidecar not created at $sidecar"
+  FAIL=$((FAIL + 1))
+fi
+assert_eq "sidecar contains the captured sessionID" \
+  "ses_TESTabc123XYZ456" "$(cat "$sidecar" 2>/dev/null)"
+
+opencode_argv=$(cat "$ARGS_FILE")
+assert_contains "argv contains 'run'"         "run"         "$opencode_argv"
+assert_contains "argv contains '--format json'" "--format json" "$opencode_argv"
+assert_contains "argv contains the prompt"    "implement feature X" "$opencode_argv"
+assert_contains "argv forwards --title from session_name" "--title issue-42-dev" "$opencode_argv"
+assert_not_contains "argv does NOT use legacy -p" "-p" "$opencode_argv"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-LA-OC-03: resume_agent uses captured sessionID ==="
+# ---------------------------------------------------------------------------
+: > "$ARGS_FILE"
+
+resume_output=$(
+  PATH="$BIN:$PATH" \
+  AUTONOMOUS_PID_DIR="$PID_DIR" \
+  PROJECT_ID="testproj" \
+  PROJECT_DIR="$TMPROOT" \
+  AGENT_CMD=opencode \
+  AGENT_PERMISSION_MODE=auto \
+  OPENCODE_ARGS_FILE="$ARGS_FILE" \
+  bash -c '
+    source "'"$LIB"'"
+    resume_agent "'"$SESSION_ID"'" "address review feedback" "" ""
+  ' 2>&1
+)
+resume_rc=$?
+
+assert_eq "resume_agent opencode returns 0" 0 "$resume_rc"
+
+resume_argv=$(cat "$ARGS_FILE")
+assert_contains "resume argv contains 'run'"             "run"         "$resume_argv"
+assert_contains "resume argv contains '--session'"       "--session"   "$resume_argv"
+assert_contains "resume argv contains the captured sid"  "ses_TESTabc123XYZ456" "$resume_argv"
+assert_contains "resume argv contains the follow-up prompt" \
+  "address review feedback" "$resume_argv"
+assert_not_contains "resume argv does NOT use legacy -p" "-p" "$resume_argv"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-LA-OC-04: resume falls back when sidecar missing ==="
+# ---------------------------------------------------------------------------
+NEW_SESSION_ID="11111111-2222-3333-4444-555555555555"
+: > "$ARGS_FILE"
+
+fallback_output=$(
+  PATH="$BIN:$PATH" \
+  AUTONOMOUS_PID_DIR="$PID_DIR" \
+  PROJECT_ID="testproj" \
+  PROJECT_DIR="$TMPROOT" \
+  AGENT_CMD=opencode \
+  AGENT_PERMISSION_MODE=auto \
+  OPENCODE_ARGS_FILE="$ARGS_FILE" \
+  bash -c '
+    source "'"$LIB"'"
+    resume_agent "'"$NEW_SESSION_ID"'" "fresh prompt" "" ""
+  ' 2>&1
+)
+fallback_rc=$?
+
+assert_eq "fallback resume_agent returns 0" 0 "$fallback_rc"
+assert_contains "fallback writes diagnostic about missing sessionID" \
+  "no captured opencode sessionID" "$fallback_output"
+
+fallback_argv=$(cat "$ARGS_FILE")
+assert_contains "fallback argv contains 'run'" "run" "$fallback_argv"
+assert_not_contains "fallback argv does NOT contain '--session'" \
+  "--session" "$fallback_argv"
+assert_contains "fallback argv contains the fresh prompt" \
+  "fresh prompt" "$fallback_argv"
+
+new_sidecar="$PID_DIR/opencode-session-$NEW_SESSION_ID"
+if [[ -f "$new_sidecar" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: fallback created sidecar for new session_id"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: fallback did not create sidecar for new session_id"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-LA-OC-05: capture is robust to no JSON event ==="
+# ---------------------------------------------------------------------------
+# Replace stub: no JSONL output, just stderr + non-zero exit (e.g. auth fail).
+cat > "$BIN/opencode" <<'EOF'
+#!/bin/bash
+echo "$@" > "$OPENCODE_ARGS_FILE"
+echo "ERROR: not authenticated" >&2
+exit 5
+EOF
+
+CRASH_SESSION_ID="22222222-aaaa-bbbb-cccc-333333333333"
+: > "$ARGS_FILE"
+
+crash_output=$(
+  PATH="$BIN:$PATH" \
+  AUTONOMOUS_PID_DIR="$PID_DIR" \
+  PROJECT_ID="testproj" \
+  PROJECT_DIR="$TMPROOT" \
+  AGENT_CMD=opencode \
+  AGENT_PERMISSION_MODE=auto \
+  OPENCODE_ARGS_FILE="$ARGS_FILE" \
+  bash -c '
+    source "'"$LIB"'"
+    run_agent "'"$CRASH_SESSION_ID"'" "crashy prompt" "" ""
+  ' 2>&1
+)
+crash_rc=$?
+
+assert_eq "run_agent surfaces opencode crash exit code" 5 "$crash_rc"
+
+crash_sidecar="$PID_DIR/opencode-session-$CRASH_SESSION_ID"
+if [[ ! -f "$crash_sidecar" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: no sidecar created when no sessionID arrived"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: sidecar incorrectly created on crash path"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-LA-OC-06: malformed sessionID in sidecar is rejected ==="
+# ---------------------------------------------------------------------------
+# Manually plant a malformed sidecar and confirm _opencode_session_id refuses
+# it (so resume_agent falls back to run_agent rather than passing garbage to
+# `opencode run --session ...`). Defense-in-depth on top of the awk-side
+# regex; cheap to test.
+BAD_SESSION_ID="33333333-bad0-bad0-bad0-444444444444"
+bad_sidecar="$PID_DIR/opencode-session-$BAD_SESSION_ID"
+echo 'ses_with;injection`hazard' > "$bad_sidecar"
+
+# Restore working stub for this test (resume_agent will fall back to run, so
+# we want the stub to succeed).
+cat > "$BIN/opencode" <<'EOF'
+#!/bin/bash
+echo "$@" > "$OPENCODE_ARGS_FILE"
+cat <<JSONL
+{"type":"step_start","sessionID":"ses_FRESHsessionID999"}
+JSONL
+EOF
+: > "$ARGS_FILE"
+
+malformed_output=$(
+  PATH="$BIN:$PATH" \
+  AUTONOMOUS_PID_DIR="$PID_DIR" \
+  PROJECT_ID="testproj" \
+  PROJECT_DIR="$TMPROOT" \
+  AGENT_CMD=opencode \
+  AGENT_PERMISSION_MODE=auto \
+  OPENCODE_ARGS_FILE="$ARGS_FILE" \
+  bash -c '
+    source "'"$LIB"'"
+    resume_agent "'"$BAD_SESSION_ID"'" "after bad sidecar" "" ""
+  ' 2>&1
+)
+
+assert_contains "malformed sidecar triggers fallback diagnostic" \
+  "no captured opencode sessionID" "$malformed_output"
+
+malformed_argv=$(cat "$ARGS_FILE")
+assert_not_contains "malformed sid not passed to opencode argv" \
+  "ses_with" "$malformed_argv"
+assert_not_contains "malformed sid not passed via --session" \
+  "--session" "$malformed_argv"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Add first-class opencode (`anomalyco/opencode`) support to the dispatcher's agent abstraction layer. opencode is a provider-agnostic open-source coding agent CLI that, like codex, mints its own session id per invocation. Mirrors the pattern established in #88: capture the CLI-minted id from the JSON stream into a sidecar, feed it back on resume.

## Why

After #88 fixed the codex branch with a session-id-capture pattern, opencode's identical wrinkle (CLI mints the id; caller can't pre-mint) became cheap to address with the same approach. README #87 already lists opencode as the next CLI to integrate; this closes that follow-up.

## Design

opencode JSON shape (verified against `opencode run --format json --pure "test"` on v1.14.46):

```json
{"type":"step_start","timestamp":1778415469963,"sessionID":"ses_1ee2d8d...","part":...}
```

Every event carries `"sessionID":"ses_<base62>"` — not gated on a specific event type. The capture filter records the first occurrence (which arrives in the very first event), validates the format with `^ses_[A-Za-z0-9]+$`, and writes it to `${pid_dir}/opencode-session-${dispatcher_session_id}`.

- `run_agent` opencode case: `opencode run --format json [--title <session_name>] [PROMPT]` piped through `_opencode_capture_session`.
- `resume_agent` opencode case: reads the captured id via `_opencode_session_id` and calls `opencode run --session <id> --format json [PROMPT]`. Falls back to `run_agent` when the sidecar is missing or malformed (defense-in-depth: even though pid_dir is mode 0700, a malformed sidecar value would otherwise be passed to `opencode run --session ...` as raw shell input).

## Test Plan

- [x] **Live verification**: installed opencode v1.14.46 locally, ran `opencode run --format json --pure "test"`, confirmed JSON shape; ran resume with the captured id, confirmed it works.
- [x] 31 new cases in `tests/unit/test-lib-agent-opencode.sh`:
   - Source-of-truth grep (opencode case present, uses `run --format json`, resume uses `--session`)
   - run_agent argv shape + sessionID capture (stub emits the actual opencode JSON shape)
   - resume_agent uses captured sessionID
   - Fallback when sidecar missing (logs diagnostic, calls run_agent shape, creates fresh sidecar)
   - Crash path (opencode exits before any JSON event → no sidecar, exit code surfaced)
   - **Malformed-sidecar regression** (manually planted `ses_with;injection\`hazard` → regex rejects, fallback triggers, garbage never reaches `opencode run --session`)
- [x] Codex tests still pass (27/27)
- [x] Full unit suite: 37/37 test files pass
- [x] `bash -n` clean on `lib-agent.sh`
- [x] shellcheck: only SC1091-info for `lib-config.sh` source
- [x] Code-reviewer agent run: zero findings ≥ 80 confidence
- [ ] CI checks pass

## Backwards Compatibility

- `AGENT_CMD=opencode` was previously routed to the generic `<cli> -p <prompt>` fallback. With this PR it's routed to a first-class branch — the new behavior is strictly more correct (no `-p` flag misuse).
- `claude` / `codex` / `kiro` branches unchanged.
- Sidecar paths are new files under an already-existing per-user dir (mode 0700).

## Open follow-ups (not in scope)

- `--dangerously-skip-permissions` flag wiring when `AGENT_PERMISSION_MODE=bypassPermissions`. The codex branch has the same gap; would prefer a single PR that addresses both consistently rather than per-CLI ad-hoc fixes.

## Checklist

- [x] Design described in commit message + this PR body
- [x] Test cases documented (31 cases with thorough behavioral + regression coverage)
- [x] Build/tests pass
- [x] Code review passed (zero blocking findings)