### PR TITLE
fix(dispatcher): generate App token in dispatcher-tick when GH_AUTH_MODE=app (#91)

### DIFF
--- a/docs/designs/fix-dispatcher-app-token.md
+++ b/docs/designs/fix-dispatcher-app-token.md
@@ -1,0 +1,115 @@
+# Fix: dispatcher-tick uses user gh auth when GH_AUTH_MODE=app
+
+**Date:** 2026-05-10
+**Issue:** #91
+**Status:** Approved
+
+## Problem
+
+`dispatcher-tick.sh` calls `gh` directly (issue list / comment / label) but
+never generates a GitHub App token — even when `GH_AUTH_MODE=app`,
+`DISPATCHER_APP_ID`, and `DISPATCHER_APP_PEM` are all set. All dispatcher-side
+`gh` calls fall back to the user's `gh auth login` token, so issue comments
+and label changes appear under the **user's identity** instead of the bot
+app.
+
+Root cause: `lib-auth.sh::setup_github_auth` and `gh-app-token.sh` are only
+sourced from the agent wrappers (`autonomous-dev.sh`, `autonomous-review.sh`).
+The dispatcher tick never consumes `DISPATCHER_APP_ID` / `DISPATCHER_APP_PEM`
+to produce a `GH_TOKEN`. The original SKILL.md-based dispatcher (pre-refactor)
+called `get_gh_app_token` per project explicitly — the shell-script refactor
+did not carry this over.
+
+## Fix
+
+Generate the App installation token **inside `dispatcher-tick.sh`** (not in
+`dispatcher-multi-tick.sh`). This keeps the auth setup adjacent to the `gh`
+calls it protects, and handles all three invocation paths uniformly:
+
+1. **Inline remote projects** — vars come from `eval "$block"` in the subshell
+   set up by `tick_inline_project()`.
+2. **Path-entry local projects** — vars come from `load_autonomous_conf`
+   sourcing the per-project `autonomous.conf`.
+3. **Direct invocation** (single-project deployments) — vars come from
+   `load_autonomous_conf` finding `autonomous.conf` via the script-local or
+   `PROJECT_DIR` fallback.
+
+In all three cases, by the time we reach the App-token block, `GH_AUTH_MODE`,
+`DISPATCHER_APP_ID`, `DISPATCHER_APP_PEM`, `REPO_OWNER`, and `REPO_NAME`
+are already resolved.
+
+### Placement
+
+The block sits in `dispatcher-tick.sh` immediately after `lib-dispatch.sh` is
+sourced (which validates `REPO_OWNER`) and **before** any `gh` call. The
+upfront `EXECUTION_BACKEND` and `REVIEW_BOTS` validators stay where they are —
+they don't make `gh` calls, so they don't need the App token.
+
+### Behavior
+
+```bash
+if [[ "${GH_AUTH_MODE:-token}" == "app" ]]; then
+  if [[ -z "${DISPATCHER_APP_ID:-}" || -z "${DISPATCHER_APP_PEM:-}" ]]; then
+    echo "[dispatcher-tick] FATAL: GH_AUTH_MODE=app requires DISPATCHER_APP_ID and DISPATCHER_APP_PEM" >&2
+    exit 1
+  fi
+  source "${SCRIPT_DIR}/gh-app-token.sh"
+  _token=$(get_gh_app_token "$DISPATCHER_APP_ID" "$DISPATCHER_APP_PEM" "$REPO_OWNER" "$REPO_NAME") || {
+    echo "[dispatcher-tick] FATAL: failed to generate GitHub App token for $REPO_OWNER/$REPO_NAME" >&2
+    exit 1
+  }
+  if [[ -z "$_token" ]]; then
+    echo "[dispatcher-tick] FATAL: empty GitHub App token for $REPO_OWNER/$REPO_NAME" >&2
+    exit 1
+  fi
+  export GH_TOKEN="$_token"
+  unset _token
+fi
+```
+
+The token is valid for 1 hour and scoped to the target repo only;
+`dispatcher-tick.sh` typically completes in well under a minute, so a single
+token covers the whole tick. We do NOT use the background refresh daemon
+(`gh-token-refresh-daemon.sh`) here — that's only needed for long-running
+agent wrappers.
+
+### Why fail-fast on misconfig
+
+The previous behavior silently fell back to user auth, which is precisely the
+bug being reported. If an operator declares `GH_AUTH_MODE=app` they expect
+bot identity; failing the tick is more correct than silently impersonating
+the user.
+
+### Files to change
+
+- `skills/autonomous-dispatcher/scripts/dispatcher-tick.sh` — add token-gen
+  block after lib-dispatch.sh source.
+- `tests/unit/test-dispatcher-tick-app-auth.sh` — new test file.
+
+### What we deliberately do NOT change
+
+- `tick_inline_project()` in `dispatcher-multi-tick.sh` — the issue's
+  proposed fix put the block there, but doing it in `dispatcher-tick.sh` is
+  strictly more general and avoids duplicating logic across the inline +
+  path-entry branches.
+- `lib-auth.sh::setup_github_auth` — this orchestrates the token-refresh
+  daemon for long-lived agent processes. The dispatcher tick is short-lived
+  (<1 min), so a single token call is simpler and avoids the daemon-fork
+  cleanup path.
+- The existing wrappers' auth — they continue to use their own
+  `DEV_AGENT_APP_*` / `REVIEW_AGENT_APP_*` identities.
+
+## Test cases
+
+See `docs/test-cases/fix-dispatcher-app-token.md`.
+
+## Acceptance
+
+- `GH_AUTH_MODE=app` + valid `DISPATCHER_APP_ID` + valid `DISPATCHER_APP_PEM`:
+  the tick exports a non-empty `GH_TOKEN` before any `gh` call.
+- `GH_AUTH_MODE=app` + missing app id or pem: the tick exits 1 with a clear
+  FATAL message; no `gh` calls are made.
+- `GH_AUTH_MODE=token` (or unset): no token-gen attempted; existing
+  `gh auth`/`GH_TOKEN` flow preserved.
+- All three invocation paths (inline, path-entry, direct) reach the same
+  token-gen block.

--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -59,6 +59,32 @@ flowchart TD
 
 `JUST_DISPATCHED` is the only piece of state the tick maintains in memory — and it dies when the tick ends.
 
+## Pre-step: GitHub authentication (closes #91)
+
+`dispatcher-tick.sh` resolves auth before any `gh` call so the dispatcher's
+issue comments and label changes appear under the configured identity.
+
+Behavior:
+
+| `GH_AUTH_MODE` | Setup | Token source for `gh` |
+|---|---|---|
+| `app` | sources `gh-app-token.sh::get_gh_app_token`, exports `GH_TOKEN` | Installation token scoped to one repo, valid 1h. A single token covers the whole tick (typically <1 min) — no refresh daemon. |
+| `token` (default) | none | `GH_TOKEN` env or `gh auth login` token |
+
+Required when `GH_AUTH_MODE=app`: `DISPATCHER_APP_ID`, `DISPATCHER_APP_PEM`,
+`REPO`, `REPO_OWNER`. `REPO_NAME` is auto-derived from `REPO` if unset (older
+path-entry confs sometimes omit it).
+
+Failure modes — all exit 1 with `FATAL`, before any `gh` call:
+
+- Missing `DISPATCHER_APP_ID` or `DISPATCHER_APP_PEM` while `GH_AUTH_MODE=app`.
+- `get_gh_app_token` returns non-zero (network / API error / bad PEM / app not
+  installed for repo).
+- Token returned is empty.
+
+There is no silent fallback to user auth — silently impersonating the
+operator was the bug closed by #91.
+
 ## Step 1: concurrency gate
 
 Implementation: `lib-dispatch.sh::count_active`.

--- a/docs/test-cases/fix-dispatcher-app-token.md
+++ b/docs/test-cases/fix-dispatcher-app-token.md
@@ -1,0 +1,29 @@
+# Test Cases: dispatcher-tick App token integration (#91)
+
+## Strategy
+
+Stub `gh-app-token.sh::get_gh_app_token` with a function that records args
+and emits a sentinel token. Stub all `gh` calls (via PATH override) to
+record the value of `$GH_TOKEN` they observe. Run `dispatcher-tick.sh` in
+`bash -c` against a sandboxed temp dir so the real GitHub API is never hit.
+
+The list/scan steps return empty arrays (no issues), so the tick just
+exercises the auth setup + concurrency gate + empty steps and exits clean.
+
+## Cases
+
+| ID | Setup | Expected |
+|---|---|---|
+| TC-DISP-AUTH-001 | `GH_AUTH_MODE=app`, valid `DISPATCHER_APP_ID`+`DISPATCHER_APP_PEM` | `get_gh_app_token` invoked once with `(app_id, pem, owner, name)`; `GH_TOKEN` exported with the sentinel value before any `gh` call observes it |
+| TC-DISP-AUTH-002 | `GH_AUTH_MODE=app`, `DISPATCHER_APP_ID` empty | tick exits 1, FATAL message mentions missing `DISPATCHER_APP_ID`; `get_gh_app_token` NOT invoked; no `gh` calls made |
+| TC-DISP-AUTH-003 | `GH_AUTH_MODE=app`, `DISPATCHER_APP_PEM` empty | tick exits 1, FATAL message mentions missing `DISPATCHER_APP_PEM`; `get_gh_app_token` NOT invoked |
+| TC-DISP-AUTH-004 | `GH_AUTH_MODE=app`, `get_gh_app_token` returns rc=1 | tick exits 1, FATAL message; no `gh` calls made |
+| TC-DISP-AUTH-005 | `GH_AUTH_MODE=app`, `get_gh_app_token` echoes empty string | tick exits 1, FATAL message about empty token |
+| TC-DISP-AUTH-006 | `GH_AUTH_MODE=token` (or unset) | `get_gh_app_token` NOT sourced/called; `GH_TOKEN` unchanged; tick proceeds normally |
+
+## Out of scope
+
+- Real GitHub API: the integration with the App API is exercised by the
+  agent wrappers' own tests + manual run.
+- Multi-project inline-vs-path-entry: covered by
+  `test-multi-tick-inline-projects.sh` (env propagation).

--- a/skills/autonomous-dispatcher/SKILL.md
+++ b/skills/autonomous-dispatcher/SKILL.md
@@ -61,16 +61,19 @@ The logic is in [`scripts/dispatcher-tick.sh`](scripts/dispatcher-tick.sh) and t
 
 ## GitHub Authentication — App token, not user token
 
-All `gh` calls inside the dispatcher MUST use a GitHub App token, not the default user token. The wrappers (`autonomous-dev.sh`, `autonomous-review.sh`) handle their own auth via `lib-auth.sh`. The dispatcher itself runs in the OpenClaw cron session — generate the App token at the start of each tick using `scripts/gh-app-token.sh`:
+All `gh` calls inside the dispatcher use a GitHub App token, not the default user token. The wrappers (`autonomous-dev.sh`, `autonomous-review.sh`) handle their own auth via `lib-auth.sh`; the dispatcher tick handles its own.
 
-```bash
-source "${PROJECT_DIR}/scripts/gh-app-token.sh"
-GH_TOKEN=$(get_gh_app_token "$DISPATCHER_APP_ID" "$DISPATCHER_APP_PEM" "$REPO_OWNER" "$REPO_NAME") || exit 1
-[ -z "$GH_TOKEN" ] && { echo "FATAL: empty App token" >&2; exit 1; }
-export GH_TOKEN
+When `GH_AUTH_MODE=app`, `dispatcher-tick.sh` automatically calls `gh-app-token.sh::get_gh_app_token` after upfront validation and exports `GH_TOKEN` before any `gh` call (#91). Required vars in the project's autonomous.conf or the inline metadata block:
+
+```
+GH_AUTH_MODE=app
+DISPATCHER_APP_ID=<numeric app id>
+DISPATCHER_APP_PEM=<absolute path to PEM>
 ```
 
-The token is valid for 1 hour and scoped to the target repo only. `dispatcher-tick.sh` typically completes in well under a minute, so a single token covers the whole tick.
+If any of those are missing, or if token generation fails, the tick exits 1 with a `FATAL` message — there is no silent fallback to user auth.
+
+The token is valid for 1 hour and scoped to the target repo only. `dispatcher-tick.sh` typically completes in well under a minute, so a single token covers the whole tick. When `GH_AUTH_MODE=token` (default) or unset, the dispatcher uses whatever `GH_TOKEN` / `gh auth login` token the caller provides.
 
 ## Dispatch Helpers
 

--- a/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
@@ -72,6 +72,10 @@ if [[ "${GH_AUTH_MODE:-token}" == "app" ]]; then
     echo "[dispatcher-tick] FATAL: GH_AUTH_MODE=app requires DISPATCHER_APP_ID and DISPATCHER_APP_PEM (one or both are empty)." >&2
     exit 1
   fi
+  # Auto-derive REPO_NAME from REPO when an older path-entry autonomous.conf
+  # forgot to set it. Inline projects already do this in tick_inline_project;
+  # mirror it here so set -u doesn't trip on `"$REPO_NAME"` below.
+  : "${REPO_NAME:=${REPO##*/}}"
   # shellcheck source=gh-app-token.sh
   source "${SCRIPT_DIR}/gh-app-token.sh"
   _dispatcher_token=$(get_gh_app_token \

--- a/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
@@ -56,6 +56,38 @@ if ! parse_review_bots "${REVIEW_BOTS:-}" >/dev/null; then
   exit 1
 fi
 
+# Generate a GitHub App installation token for the dispatcher when
+# GH_AUTH_MODE=app (closes #91). Pre-fix, the dispatcher's `gh` calls fell
+# back to the user's `gh auth login` token, so issue comments + label
+# changes appeared as the user instead of the bot identity.
+#
+# A single token covers the whole tick (valid 1h, scope: this repo only).
+# We don't run gh-token-refresh-daemon here — that's for long-lived agent
+# wrappers; the tick completes in <1 min.
+#
+# Fail-fast on misconfig (missing id/pem, token API failure, empty result):
+# silently falling back to user auth is precisely the bug being closed.
+if [[ "${GH_AUTH_MODE:-token}" == "app" ]]; then
+  if [[ -z "${DISPATCHER_APP_ID:-}" || -z "${DISPATCHER_APP_PEM:-}" ]]; then
+    echo "[dispatcher-tick] FATAL: GH_AUTH_MODE=app requires DISPATCHER_APP_ID and DISPATCHER_APP_PEM (one or both are empty)." >&2
+    exit 1
+  fi
+  # shellcheck source=gh-app-token.sh
+  source "${SCRIPT_DIR}/gh-app-token.sh"
+  _dispatcher_token=$(get_gh_app_token \
+    "$DISPATCHER_APP_ID" "$DISPATCHER_APP_PEM" \
+    "$REPO_OWNER" "$REPO_NAME") || {
+    echo "[dispatcher-tick] FATAL: failed to generate GitHub App token for ${REPO_OWNER}/${REPO_NAME}." >&2
+    exit 1
+  }
+  if [[ -z "$_dispatcher_token" ]]; then
+    echo "[dispatcher-tick] FATAL: gh-app-token returned an empty token for ${REPO_OWNER}/${REPO_NAME}." >&2
+    exit 1
+  fi
+  export GH_TOKEN="$_dispatcher_token"
+  unset _dispatcher_token
+fi
+
 # dispatch — route a wrapper-spawn request to the configured backend (#62 axis 2).
 # Backends today: "local" (default — same-box dispatch-local.sh) and
 # "remote-aws-ssm" (sends an `aws ssm send-command` to a remote dev box).

--- a/tests/unit/test-dispatcher-tick-app-auth.sh
+++ b/tests/unit/test-dispatcher-tick-app-auth.sh
@@ -1,0 +1,313 @@
+#!/bin/bash
+# test-dispatcher-tick-app-auth.sh — Verify dispatcher-tick.sh generates
+# a GitHub App installation token before any `gh` call when GH_AUTH_MODE=app.
+# Closes #91 (dispatcher fell back to user `gh auth login` token, so
+# dispatcher-side issue comments + label changes appeared as the user
+# instead of the bot app).
+#
+# Strategy: sandbox the dispatcher script tree so the test can substitute
+# every external dependency (gh-app-token.sh, lib-dispatch.sh, gh CLI) with
+# a recording stub. Exercise the auth block under several configurations
+# and assert which stubs got which calls.
+#
+# Run: bash tests/unit/test-dispatcher-tick-app-auth.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TICK_SRC="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh"
+LIB_CONFIG_SRC="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-config.sh"
+LIB_REVIEW_BOTS_SRC="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-review-bots.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected='$expected'"
+    echo "      actual=  '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      needle='$needle'"
+    echo "      haystack='$haystack'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      should NOT contain: '$needle'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+SANDBOX="$TMPROOT/scripts"
+mkdir -p "$SANDBOX"
+
+# Real script under test.
+cp "$TICK_SRC" "$SANDBOX/dispatcher-tick.sh"
+cp "$LIB_CONFIG_SRC" "$SANDBOX/lib-config.sh"
+cp "$LIB_REVIEW_BOTS_SRC" "$SANDBOX/lib-review-bots.sh"
+
+# Stub lib-dispatch.sh: provide every helper dispatcher-tick.sh expects, but
+# return empty/no-op so the tick exercises only the upfront validation +
+# auth block. count_active=0 ensures the concurrency gate doesn't bail.
+cat > "$SANDBOX/lib-dispatch.sh" <<'EOF'
+#!/bin/bash
+: "${REPO:?REPO must be set in autonomous.conf}"
+: "${REPO_OWNER:?REPO_OWNER must be set in autonomous.conf}"
+: "${PROJECT_ID:?PROJECT_ID must be set in autonomous.conf}"
+MAX_RETRIES="${MAX_RETRIES:-3}"
+MAX_CONCURRENT="${MAX_CONCURRENT:-5}"
+
+count_active() { echo 0; }
+list_new_issues() { echo '[]'; }
+list_pending_review() { echo '[]'; }
+list_pending_dev() { echo '[]'; }
+list_stale_candidates() { echo '[]'; }
+check_deps_resolved() { return 0; }
+count_retries() { echo 0; }
+mark_stalled() { :; }
+extract_dev_session_id() { echo ""; }
+is_session_completed() { return 1; }
+fetch_pr_for_issue() { echo ""; }
+ci_is_green() { return 1; }
+pr_idle_seconds() { echo ""; }
+last_reviewed_head() { echo ""; }
+pid_alive() { return 1; }
+get_pid() { echo ""; }
+label_swap() { :; }
+was_just_dispatched() { return 1; }
+EOF
+
+# Stub gh-app-token.sh: record the call, return a sentinel token. The token
+# value AND the GH_TOKEN observed by the gh stub is asserted by each case.
+# Cases override the function body via a per-case override file.
+cat > "$SANDBOX/gh-app-token.sh" <<'EOF'
+#!/bin/bash
+get_gh_app_token() {
+  echo "GH_APP_TOKEN_CALL app_id=$1 pem=$2 owner=$3 name=$4" >> "$AUTH_RECORD"
+  if [[ -n "${GH_APP_TOKEN_OVERRIDE:-}" ]]; then
+    # Source the override which redefines get_gh_app_token's body via env.
+    case "$GH_APP_TOKEN_OVERRIDE" in
+      fail) return 1 ;;
+      empty) echo "" ;;
+      *) echo "$GH_APP_TOKEN_OVERRIDE" ;;
+    esac
+  else
+    echo "sentinel-token-abc123"
+  fi
+}
+EOF
+
+# Stub gh CLI on PATH. Records every invocation AND the GH_TOKEN it sees,
+# so we can assert the token was set before the first gh call.
+GH_STUB_DIR="$TMPROOT/bin"
+mkdir -p "$GH_STUB_DIR"
+cat > "$GH_STUB_DIR/gh" <<'EOF'
+#!/bin/bash
+echo "GH_CALL token=${GH_TOKEN:-<unset>} args=$*" >> "$GH_RECORD"
+# Mimic enough of gh's interface so callers can pipe through jq.
+case "$1" in
+  issue)
+    case "$2" in
+      list) echo '[]' ;;
+      view) echo '{"comments":[]}' ;;
+      *) echo "" ;;
+    esac
+    ;;
+  pr)
+    case "$2" in
+      list|checks) echo '[]' ;;
+      *) echo "" ;;
+    esac
+    ;;
+  *) echo "" ;;
+esac
+exit 0
+EOF
+chmod +x "$GH_STUB_DIR/gh"
+
+# Common autonomous.conf for tests. Each case overrides selected vars
+# via env.
+COMMON_CONF="$TMPROOT/autonomous.conf"
+cat > "$COMMON_CONF" <<'EOF'
+REPO=myorg/myrepo
+REPO_OWNER=myorg
+REPO_NAME=myrepo
+PROJECT_ID=test-proj
+PROJECT_DIR=/tmp/test-proj
+MAX_CONCURRENT=5
+MAX_RETRIES=3
+REVIEW_BOTS=""
+EOF
+
+# Helper to run dispatcher-tick.sh under the sandbox.
+# Args: $1=case_label (used to scope record files)
+# Env  : GH_AUTH_MODE, DISPATCHER_APP_ID, DISPATCHER_APP_PEM,
+#        GH_APP_TOKEN_OVERRIDE
+run_tick() {
+  local label="$1"
+  local auth_record="$TMPROOT/auth-${label}.log"
+  local gh_record="$TMPROOT/gh-${label}.log"
+  local stderr_log="$TMPROOT/stderr-${label}.log"
+  : > "$auth_record"
+  : > "$gh_record"
+  : > "$stderr_log"
+
+  AUTH_RECORD="$auth_record" \
+  GH_RECORD="$gh_record" \
+  GH_APP_TOKEN_OVERRIDE="${GH_APP_TOKEN_OVERRIDE:-}" \
+  AUTONOMOUS_CONF="$COMMON_CONF" \
+  GH_AUTH_MODE="${GH_AUTH_MODE:-token}" \
+  DISPATCHER_APP_ID="${DISPATCHER_APP_ID:-}" \
+  DISPATCHER_APP_PEM="${DISPATCHER_APP_PEM:-}" \
+  PATH="$GH_STUB_DIR:$PATH" \
+  bash "$SANDBOX/dispatcher-tick.sh" >/dev/null 2>"$stderr_log"
+  RC=$?
+  AUTH_LOG=$(cat "$auth_record")
+  GH_LOG=$(cat "$gh_record")
+  STDERR_LOG=$(cat "$stderr_log")
+}
+
+# Need a fake PEM file so `[[ ! -f "$pem_file" ]]` checks in the real code
+# would pass — but we stub gh-app-token.sh so the validation never runs.
+# Still create one for realism in the happy-path case.
+FAKE_PEM="$TMPROOT/fake.pem"
+echo "-----BEGIN RSA PRIVATE KEY-----" > "$FAKE_PEM"
+
+# ---------------------------------------------------------------------------
+echo "=== TC-DISP-AUTH-001: GH_AUTH_MODE=app + valid id/pem → token generated, exported, used ==="
+# ---------------------------------------------------------------------------
+GH_AUTH_MODE=app \
+DISPATCHER_APP_ID=12345 \
+DISPATCHER_APP_PEM="$FAKE_PEM" \
+GH_APP_TOKEN_OVERRIDE="" \
+  run_tick "001"
+
+assert_eq "tick exits 0" 0 "$RC"
+assert_contains "get_gh_app_token called once with correct args" \
+  "GH_APP_TOKEN_CALL app_id=12345 pem=$FAKE_PEM owner=myorg name=myrepo" "$AUTH_LOG"
+# Stubbed lib-dispatch helpers return [] so no gh calls fire in this run,
+# but the invariant we care about is: IF any gh runs, it sees the sentinel
+# token, never an unset one.
+assert_not_contains "no gh call observed token=<unset>" \
+  "token=<unset>" "$GH_LOG"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-DISP-AUTH-002: GH_AUTH_MODE=app + missing DISPATCHER_APP_ID → FATAL exit ==="
+# ---------------------------------------------------------------------------
+GH_AUTH_MODE=app \
+DISPATCHER_APP_ID="" \
+DISPATCHER_APP_PEM="$FAKE_PEM" \
+GH_APP_TOKEN_OVERRIDE="" \
+  run_tick "002"
+
+assert_eq "tick exits 1" 1 "$RC"
+assert_contains "FATAL message mentions DISPATCHER_APP_ID" \
+  "DISPATCHER_APP_ID" "$STDERR_LOG"
+assert_eq "get_gh_app_token NOT invoked" "" "$AUTH_LOG"
+assert_eq "no gh calls made" "" "$GH_LOG"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-DISP-AUTH-003: GH_AUTH_MODE=app + missing DISPATCHER_APP_PEM → FATAL exit ==="
+# ---------------------------------------------------------------------------
+GH_AUTH_MODE=app \
+DISPATCHER_APP_ID=12345 \
+DISPATCHER_APP_PEM="" \
+GH_APP_TOKEN_OVERRIDE="" \
+  run_tick "003"
+
+assert_eq "tick exits 1" 1 "$RC"
+assert_contains "FATAL message mentions DISPATCHER_APP_PEM" \
+  "DISPATCHER_APP_PEM" "$STDERR_LOG"
+assert_eq "get_gh_app_token NOT invoked" "" "$AUTH_LOG"
+assert_eq "no gh calls made" "" "$GH_LOG"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-DISP-AUTH-004: GH_AUTH_MODE=app + get_gh_app_token rc=1 → FATAL exit ==="
+# ---------------------------------------------------------------------------
+GH_AUTH_MODE=app \
+DISPATCHER_APP_ID=12345 \
+DISPATCHER_APP_PEM="$FAKE_PEM" \
+GH_APP_TOKEN_OVERRIDE=fail \
+  run_tick "004"
+
+assert_eq "tick exits 1" 1 "$RC"
+assert_contains "FATAL message references token generation" \
+  "GitHub App token" "$STDERR_LOG"
+assert_eq "no gh calls made after token failure" "" "$GH_LOG"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-DISP-AUTH-005: GH_AUTH_MODE=app + token empty → FATAL exit ==="
+# ---------------------------------------------------------------------------
+GH_AUTH_MODE=app \
+DISPATCHER_APP_ID=12345 \
+DISPATCHER_APP_PEM="$FAKE_PEM" \
+GH_APP_TOKEN_OVERRIDE=empty \
+  run_tick "005"
+
+assert_eq "tick exits 1" 1 "$RC"
+assert_contains "FATAL message mentions empty token" \
+  "empty" "$STDERR_LOG"
+assert_eq "no gh calls made after empty token" "" "$GH_LOG"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-DISP-AUTH-006: GH_AUTH_MODE=token (default) → no App-token codepath ==="
+# ---------------------------------------------------------------------------
+unset DISPATCHER_APP_ID
+unset DISPATCHER_APP_PEM
+unset GH_APP_TOKEN_OVERRIDE
+GH_AUTH_MODE=token \
+  run_tick "006"
+
+assert_eq "tick exits 0" 0 "$RC"
+assert_eq "get_gh_app_token NOT invoked in token mode" "" "$AUTH_LOG"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-DISP-AUTH-007: GH_AUTH_MODE unset → no App-token codepath ==="
+# ---------------------------------------------------------------------------
+unset GH_AUTH_MODE DISPATCHER_APP_ID DISPATCHER_APP_PEM GH_APP_TOKEN_OVERRIDE
+run_tick "007"
+
+assert_eq "tick exits 0 with GH_AUTH_MODE unset" 0 "$RC"
+assert_eq "get_gh_app_token NOT invoked when GH_AUTH_MODE unset" "" "$AUTH_LOG"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/tests/unit/test-dispatcher-tick-app-auth.sh
+++ b/tests/unit/test-dispatcher-tick-app-auth.sh
@@ -154,15 +154,28 @@ exit 0
 EOF
 chmod +x "$GH_STUB_DIR/gh"
 
+# Stub dispatch-local.sh under PROJECT_DIR/scripts/ so the tick's
+# dispatch() helper can spawn a no-op when a list_*() stub returns a
+# real issue (TC-001 needs this so a `gh issue comment` actually fires
+# through our PATH stub, otherwise the auth-block-runs-before-gh
+# invariant is asserted vacuously).
+FAKE_PROJECT_DIR="$TMPROOT/proj"
+mkdir -p "$FAKE_PROJECT_DIR/scripts"
+cat > "$FAKE_PROJECT_DIR/scripts/dispatch-local.sh" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+chmod +x "$FAKE_PROJECT_DIR/scripts/dispatch-local.sh"
+
 # Common autonomous.conf for tests. Each case overrides selected vars
-# via env.
+# via env. PROJECT_DIR points to the fake dir created above.
 COMMON_CONF="$TMPROOT/autonomous.conf"
-cat > "$COMMON_CONF" <<'EOF'
+cat > "$COMMON_CONF" <<EOF
 REPO=myorg/myrepo
 REPO_OWNER=myorg
 REPO_NAME=myrepo
 PROJECT_ID=test-proj
-PROJECT_DIR=/tmp/test-proj
+PROJECT_DIR=$FAKE_PROJECT_DIR
 MAX_CONCURRENT=5
 MAX_RETRIES=3
 REVIEW_BOTS=""
@@ -203,20 +216,33 @@ FAKE_PEM="$TMPROOT/fake.pem"
 echo "-----BEGIN RSA PRIVATE KEY-----" > "$FAKE_PEM"
 
 # ---------------------------------------------------------------------------
-echo "=== TC-DISP-AUTH-001: GH_AUTH_MODE=app + valid id/pem → token generated, exported, used ==="
+echo "=== TC-DISP-AUTH-001: GH_AUTH_MODE=app + valid id/pem → token generated, exported, observed by first gh call ==="
 # ---------------------------------------------------------------------------
+# Override list_new_issues so Step 2 actually fires `gh issue comment`
+# through the PATH stub. Without a non-empty issue list, GH_RECORD stays
+# empty and the "token observed by gh" assertion is vacuous.
+ORIG_LIB_DISPATCH=$(cat "$SANDBOX/lib-dispatch.sh")
+{
+  echo "$ORIG_LIB_DISPATCH"
+  echo 'list_new_issues() { echo '\''[{"number":42,"labels":[],"title":"t"}]'\''; }'
+} > "$SANDBOX/lib-dispatch.sh"
+
 GH_AUTH_MODE=app \
 DISPATCHER_APP_ID=12345 \
 DISPATCHER_APP_PEM="$FAKE_PEM" \
 GH_APP_TOKEN_OVERRIDE="" \
   run_tick "001"
 
+# Restore the empty-issue stub for subsequent cases.
+echo "$ORIG_LIB_DISPATCH" > "$SANDBOX/lib-dispatch.sh"
+
 assert_eq "tick exits 0" 0 "$RC"
 assert_contains "get_gh_app_token called once with correct args" \
   "GH_APP_TOKEN_CALL app_id=12345 pem=$FAKE_PEM owner=myorg name=myrepo" "$AUTH_LOG"
-# Stubbed lib-dispatch helpers return [] so no gh calls fire in this run,
-# but the invariant we care about is: IF any gh runs, it sees the sentinel
-# token, never an unset one.
+# Real assertion: at least one gh call DID fire and it carried the
+# sentinel token (proves the auth block ran before the first gh call).
+assert_contains "gh call observed sentinel token" \
+  "token=sentinel-token-abc123" "$GH_LOG"
 assert_not_contains "no gh call observed token=<unset>" \
   "token=<unset>" "$GH_LOG"
 
@@ -304,6 +330,44 @@ run_tick "007"
 
 assert_eq "tick exits 0 with GH_AUTH_MODE unset" 0 "$RC"
 assert_eq "get_gh_app_token NOT invoked when GH_AUTH_MODE unset" "" "$AUTH_LOG"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-DISP-AUTH-008: REPO_NAME missing in conf → auto-derived from REPO ==="
+# ---------------------------------------------------------------------------
+# Older path-entry autonomous.conf may set REPO=owner/name without REPO_NAME.
+# The auth block must auto-derive REPO_NAME so set -u doesn't trip.
+NO_REPO_NAME_CONF="$TMPROOT/autonomous-no-name.conf"
+cat > "$NO_REPO_NAME_CONF" <<EOF
+REPO=acme/widget
+REPO_OWNER=acme
+PROJECT_ID=test-proj
+PROJECT_DIR=$FAKE_PROJECT_DIR
+MAX_CONCURRENT=5
+MAX_RETRIES=3
+REVIEW_BOTS=""
+EOF
+
+auth_record="$TMPROOT/auth-008.log"
+gh_record="$TMPROOT/gh-008.log"
+stderr_log="$TMPROOT/stderr-008.log"
+: > "$auth_record"
+: > "$gh_record"
+: > "$stderr_log"
+
+AUTH_RECORD="$auth_record" GH_RECORD="$gh_record" \
+AUTONOMOUS_CONF="$NO_REPO_NAME_CONF" \
+GH_AUTH_MODE=app DISPATCHER_APP_ID=99 DISPATCHER_APP_PEM="$FAKE_PEM" \
+GH_APP_TOKEN_OVERRIDE="" \
+PATH="$GH_STUB_DIR:$PATH" \
+  bash "$SANDBOX/dispatcher-tick.sh" >/dev/null 2>"$stderr_log"
+RC=$?
+AUTH_LOG=$(cat "$auth_record")
+STDERR_LOG=$(cat "$stderr_log")
+
+assert_eq "tick exits 0 (no unbound-var error from set -u)" 0 "$RC"
+assert_contains "REPO_NAME auto-derived from REPO=acme/widget" \
+  "owner=acme name=widget" "$AUTH_LOG"
 
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

Closes #91. Pre-fix, `dispatcher-tick.sh` made `gh` calls (issue list / comment / label) without ever generating a GitHub App installation token, so even with `GH_AUTH_MODE=app` + `DISPATCHER_APP_ID` + `DISPATCHER_APP_PEM` set, every dispatcher-side `gh` invocation fell back to the user's `gh auth login` token. Result: bot-issue comments and label changes appeared as the operator's identity instead of the App.

This PR adds a dispatcher-side App-token block in `dispatcher-tick.sh` (after upfront validation, before any `gh` call) that sources `gh-app-token.sh::get_gh_app_token` and exports `GH_TOKEN`. Placing it in `dispatcher-tick.sh` (not `dispatcher-multi-tick.sh` per the issue's suggested patch) handles all three invocation paths uniformly: inline remote projects, path-entry local projects, and direct single-project ticks.

Fail-fast on misconfig (missing id/pem, token API failure, empty token) — silently falling back to user auth is precisely the bug being closed.

## Design

- [x] Design canvas created (`docs/designs/fix-dispatcher-app-token.md`)
- [x] Design approved

## Test Plan

- [x] Test cases documented (`docs/test-cases/fix-dispatcher-app-token.md`)
- [x] New unit test `tests/unit/test-dispatcher-tick-app-auth.sh` (24 assertions, 8 cases) — sandboxes the script tree, stubs `gh-app-token.sh` and the `gh` CLI, verifies token is generated, exported, and observed by the first `gh` call; misconfig paths exit 1 without firing any `gh` call
- [x] All 38 existing unit tests still pass (no regressions)
- [x] `shellcheck -S error` clean on `dispatcher-tick.sh`
- [x] Code-simplifier review passed
- [x] PR-review pass — addressed Medium (vacuous TC-001) and Low (REPO_NAME auto-derive) findings in commit 2
- [ ] CI checks pass
- [ ] Reviewer bot findings addressed
- [ ] E2E verification — manual run on a project with `GH_AUTH_MODE=app` confirms issue comments now show as the bot identity

## Checklist

- [x] New unit tests written
- [x] `SKILL.md` updated to document the automatic dispatcher-side auth
- [x] No silent fallback paths from `app` mode to user auth

## Behavior

| Setup | Before | After |
|---|---|---|
| `GH_AUTH_MODE=app`, valid id+pem | `gh` calls used user token | `gh` calls use App-installation token, scoped to repo, valid 1h |
| `GH_AUTH_MODE=app`, missing id or pem | `gh` calls used user token (silent) | tick exits 1 with FATAL message |
| `get_gh_app_token` fails / empty | `gh` calls used user token (silent) | tick exits 1 with FATAL message |
| `GH_AUTH_MODE=token` (default) / unset | unchanged | unchanged |