### PR TITLE
fix(dispatcher): cold-start grace period + suppress false-positive retries (#99)

### DIFF
--- a/docs/designs/dispatcher-reliability-99.md
+++ b/docs/designs/dispatcher-reliability-99.md
@@ -1,0 +1,78 @@
+# Dispatcher Reliability — Closes #99
+
+## Context
+
+Issue #99 reports five bugs causing false crash detection, incorrect retry counting, and wasted re-development of already-completed issues. Bugs 1, 3, and 5 were the direct cause of the observed incident; Bug 2 is the structural reliability fix that pairs with Bug 1; Bug 4 was already addressed in #97/#98.
+
+## Scope
+
+- **In scope**: Bugs 1, 2, 3, 5. Wrappers (`autonomous-dev.sh`, `autonomous-review.sh`) and dispatcher (`dispatcher-tick.sh` + `lib-dispatch.sh`).
+- **Out of scope**: Bug 4 — already shipped in #97/#98 (`chmod +x` self-heal at the top of `dispatcher-tick.sh`).
+
+## Root Causes
+
+| Bug | Root cause |
+|-----|-----------|
+| 1   | Step 5 (stale detection) treats a wrapper that hasn't yet written its PID file as DEAD. Cold-start (session spawn + model first call) can take 1–3 minutes, but the dispatcher polls `pid_alive` immediately on the next tick and posts "Task appears to have crashed". |
+| 2   | `extract_dev_session_id` reads the session ID from the agent's EXIT-trap session report. If the agent crashes before that trap fires, no session ID exists, and resume falls back to a full re-dispatch. |
+| 3   | Step 4 (scan-pending-dev) dispatches dev-resume without checking whether a PR already exists. Any crash AFTER `gh pr create` (e.g. cleanup-time failure with non-zero exit) lands the issue in `pending-dev` with a PR — and the next tick re-runs the full dev cycle. |
+| 5   | `count_retries` adds dispatcher-detected crashes (Step 5 DEAD branch comments) to agent-reported failures. Dispatcher false positives (Bug 1) thus consume `MAX_RETRIES` even when the agent never actually failed. |
+
+## Design
+
+### Fix 1 + 2 — Dispatch token + grace period
+
+At dispatch time the dispatcher writes a structured marker comment to the issue: `Dispatch token: <uuid> at <ISO-8601>`. This serves two roles:
+
+1. **Grace period probe (Fix 1).** Step 5 reads the most recent dispatch token's timestamp before classifying any in-progress / reviewing issue. If `now - dispatch_time < DISPATCH_GRACE_PERIOD_SECONDS` (default 1800 = 30 min), skip stale detection for this issue this tick. JUST_DISPATCHED already covers the current-tick case; this extends protection across the cold-start window.
+2. **Dispatcher-side dispatch identity (Fix 2).** The token does NOT replace the agent's session report (which is needed for `--resume <session-id>`), but it gives the dispatcher a marker it controls — used by Fix 5 below to distinguish "agent never started" from "agent ran and failed".
+
+Marker format:
+
+    <!-- dispatcher-token: a1b2c3d4 at 2026-05-11T14:30:00Z mode=dev-new -->
+    Dispatching autonomous development...
+
+The HTML comment carries machine-parseable fields (token, timestamp, mode); the human-readable body matches the existing wording for backward compat.
+
+`mode` is one of `dev-new`, `dev-resume`, `review` so Fix 5 can filter by the kind of dispatch.
+
+A new helper `latest_dispatch_token_age_seconds` extracts the latest token's age. `is_within_grace_period` returns 0 if `age < DISPATCH_GRACE_PERIOD_SECONDS`. Step 5 calls it after the JUST_DISPATCHED check and before the DEAD/ALIVE branching. Returning 0 means "leave alone, still in grace period".
+
+`DISPATCH_GRACE_PERIOD_SECONDS` defaults to 1800 (30 min) and is configurable in `autonomous.conf`.
+
+### Fix 3 — Step 4 PR-exists short-circuit
+
+Before dispatching dev-resume, check `fetch_pr_for_issue` (the same helper Step 5 uses). If a PR exists, transition `pending-dev` → `pending-review` and post a comment: `PR #N exists for this issue; transitioning to pending-review instead of retrying dev.` Do NOT count this as a retry.
+
+This catches the "crash after PR creation" path: the agent published a PR, then any error (token expiry, network, bash trap quirk) caused a non-zero exit → cleanup() routed to pending-dev → next tick would re-develop. Now it goes to review.
+
+### Fix 5 — Distinguish agent failures from dispatcher false positives
+
+`count_retries` is split into two counters:
+
+- `agent_failures` — agent session reports with `Exit code: <non-zero>`. **Counts** toward `MAX_RETRIES`.
+- `dispatcher_crashes` — Step 5 "Task appears to have crashed" comments. **Only counts** when at least one Dev Session ID exists in the issue comments (i.e., the agent had confirmed startup at some point in this retry cycle). Otherwise treat as a dispatcher false positive — don't consume a retry.
+
+A separate read-only counter `dispatcher_false_positives` is reported in the `Marking as stalled` comment for operator visibility.
+
+Concretely, `count_retries` becomes:
+
+    agent_failures + (session_id_ever_seen ? dispatcher_crashes : 0)
+
+Where `session_id_ever_seen` looks for any "Dev Session ID: \`...\`" comment AFTER the most recent stalled-cutoff. This is the same cutoff already used for the failure counters, so the semantics compose cleanly.
+
+## Impact on Invariants
+
+- **[INV-05] stalled-cutoff rule**: extended — dispatcher crashes are now gated on session-id-ever-seen. Pre-stall-cutoff session IDs do NOT carry over (same as failure counts).
+- **[INV-06] dispatcher-crash keyword regex**: unchanged.
+- **[INV-09] JUST_DISPATCHED skip**: unchanged. Grace period is a longer-window superset.
+- New invariant **[INV-17] Dispatch-token grace**: every dispatch in Steps 2/3/4 writes a token comment; Step 5 must defer judgement on issues whose latest token is younger than `DISPATCH_GRACE_PERIOD_SECONDS`.
+
+## Backward Compatibility
+
+- Existing issues without dispatch-token markers: `latest_dispatch_token_age_seconds` returns empty → grace period not applied → existing behavior preserved.
+- `count_retries` for issues without any session-id comments: dispatcher_crashes is now ignored. This is intentional — those are exactly the false-positive cases. If the operator wants the old behavior, they can set `DISPATCH_GRACE_PERIOD_SECONDS=0` and accept retries from cold-start crashes (but the false-positive filter on count_retries still applies; this is the correct fix for Bug 5).
+
+## Test Plan
+
+See `docs/test-cases/dispatcher-reliability-99.md`.

--- a/docs/designs/dispatcher-reliability-99.md
+++ b/docs/designs/dispatcher-reliability-99.md
@@ -24,7 +24,7 @@ Issue #99 reports five bugs causing false crash detection, incorrect retry count
 
 At dispatch time the dispatcher writes a structured marker comment to the issue: `Dispatch token: <uuid> at <ISO-8601>`. This serves two roles:
 
-1. **Grace period probe (Fix 1).** Step 5 reads the most recent dispatch token's timestamp before classifying any in-progress / reviewing issue. If `now - dispatch_time < DISPATCH_GRACE_PERIOD_SECONDS` (default 1800 = 30 min), skip stale detection for this issue this tick. JUST_DISPATCHED already covers the current-tick case; this extends protection across the cold-start window.
+1. **Grace period probe (Fix 1).** Step 5 reads the most recent dispatch token's timestamp before classifying any in-progress / reviewing issue. If `now - dispatch_time < DISPATCH_GRACE_PERIOD_SECONDS` (default 600 = 10 min), skip stale detection for this issue this tick. JUST_DISPATCHED already covers the current-tick case; this extends protection across the cold-start window.
 2. **Dispatcher-side dispatch identity (Fix 2).** The token does NOT replace the agent's session report (which is needed for `--resume <session-id>`), but it gives the dispatcher a marker it controls — used by Fix 5 below to distinguish "agent never started" from "agent ran and failed".
 
 Marker format:

--- a/docs/designs/dispatcher-reliability-99.md
+++ b/docs/designs/dispatcher-reliability-99.md
@@ -38,7 +38,7 @@ The HTML comment carries machine-parseable fields (token, timestamp, mode); the 
 
 A new helper `latest_dispatch_token_age_seconds` extracts the latest token's age. `is_within_grace_period` returns 0 if `age < DISPATCH_GRACE_PERIOD_SECONDS`. Step 5 calls it after the JUST_DISPATCHED check and before the DEAD/ALIVE branching. Returning 0 means "leave alone, still in grace period".
 
-`DISPATCH_GRACE_PERIOD_SECONDS` defaults to 1800 (30 min) and is configurable in `autonomous.conf`.
+`DISPATCH_GRACE_PERIOD_SECONDS` defaults to 600 (10 min) and is configurable in `autonomous.conf`. Default chosen empirically: real-world wrapper startup → first agent activity is 1–7 seconds across 10 sampled runs on a real dev box; 10 min leaves 90× headroom while still catching genuinely-dead wrappers within ~2 ticks.
 
 ### Fix 3 — Step 4 PR-exists short-circuit
 

--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -121,12 +121,12 @@ For each match, in order:
 
 1. **Dependency check.** Read the issue body for a `## Dependencies` section. Extract every `#N` reference. For each, call `gh issue view N --json state` and require state `CLOSED` or `MERGED` ([INV-11](invariants.md#inv-11-dependency-state-includes-merged) — PRs report `MERGED`, not `CLOSED`). If any dependency is still open, **skip silently** — no comment, no label change. The issue picks up next tick once dependencies clear.
 2. **Add `in-progress` label.**
-3. **Comment**: "Dispatching autonomous development..."
+3. **Post dispatch token** ([INV-18](invariants.md#inv-18-cold-start-grace-period-before-stale-detection)): write `<!-- dispatcher-token: <id> at <iso> mode=dev-new -->` followed by the human-readable "Dispatching autonomous development..." line. The HTML comment encodes the dispatch timestamp for Step 5's grace-period check.
 4. **Dispatch**: `bash $PROJECT_DIR/scripts/dispatch-local.sh dev-new <issue>`
 5. **Append issue to `JUST_DISPATCHED`.**
 6. **Re-check concurrency** before processing the next match.
 
-The issue is now in `in-progress`; the dev wrapper is launching via `nohup`. Step 5 must skip this issue this tick ([INV-09](invariants.md#inv-09-just_dispatched-skip-rule)).
+The issue is now in `in-progress`; the dev wrapper is launching via `nohup`. Step 5 must skip this issue this tick ([INV-09](invariants.md#inv-09-just_dispatched-skip-rule)) and for the duration of the dispatch-token grace period ([INV-18](invariants.md#inv-18-cold-start-grace-period-before-stale-detection)).
 
 ## Step 3: scan-pending-review
 
@@ -137,7 +137,7 @@ Find issues labeled `autonomous` AND `pending-review` AND NOT `reviewing`.
 For each match, in order:
 
 1. **Atomic label swap**: `gh issue edit --remove-label pending-review --add-label reviewing` in a single call. (Two separate `gh issue edit` calls would create a `pending-review` + `reviewing` window — see [Forbidden transitions](state-machine.md#forbidden-transitions).)
-2. **Comment**: "Dispatching autonomous review..."
+2. **Post dispatch token** ([INV-18](invariants.md#inv-18-cold-start-grace-period-before-stale-detection)): `<!-- dispatcher-token: <id> at <iso> mode=review -->` + "Dispatching autonomous review...".
 3. **Dispatch**: `bash $PROJECT_DIR/scripts/dispatch-local.sh review <issue>`
 4. **Append to `JUST_DISPATCHED`.**
 
@@ -155,8 +155,8 @@ This is the most subtle gate in the dispatcher. Two failure events count toward 
 
 Failure events:
 
-- **`Agent Session Report (Dev)` comments with non-zero exit code.** Posted by the dev wrapper trap on agent failure ([INV-03](invariants.md#inv-03-dev-session-report-comment-format)).
-- **Dispatcher-detected crash comments matching the regex `Task appears to have crashed \(no PR found\)|process not found`.** This regex anchors only on Step 5b-DEAD-no-PR comments and explicit "process not found" wording. It MUST NOT match the forward-progress phrases — see [INV-06](invariants.md#inv-06-crashed--process-not-found-keyword-contract).
+- **`Agent Session Report (Dev)` comments with non-zero exit code.** Posted by the dev wrapper trap on agent failure ([INV-03](invariants.md#inv-03-dev-session-report-comment-format)). Always count.
+- **Dispatcher-detected crash comments matching the regex `Task appears to have crashed \(no PR found\)|process not found`.** This regex anchors only on Step 5b-DEAD-no-PR comments and explicit "process not found" wording. It MUST NOT match the forward-progress phrases — see [INV-06](invariants.md#inv-06-crashed--process-not-found-keyword-contract). **Only counts when the agent has confirmed startup** in this retry cycle (a `Dev Session ID:` comment exists post-cutoff) — see [INV-19](invariants.md#inv-19-retry-counter-requires-confirmed-agent-startup).
 
 Pseudocode:
 
@@ -164,13 +164,26 @@ Pseudocode:
 LAST_STALLED_AT = timestamp of last comment matching "Marking as stalled" (else epoch)
 AGENT_FAILURES = count of Dev Session Reports with non-zero exit AFTER LAST_STALLED_AT
 DISPATCHER_CRASHES = count of comments matching the crash regex AFTER LAST_STALLED_AT
-RETRY_COUNT = AGENT_FAILURES + DISPATCHER_CRASHES
+SESSION_SEEN = count of "Dev Session ID: ..." comments AFTER LAST_STALLED_AT (INV-19)
+RETRY_COUNT = AGENT_FAILURES + (SESSION_SEEN > 0 ? DISPATCHER_CRASHES : 0)
 
 if RETRY_COUNT >= MAX_RETRIES (default 3):
   remove pending-dev, add stalled
-  comment "Marking as stalled. @owner please investigate manually."
+  comment "Marking as stalled. <counter breakdown including suppressed false positives> @owner please investigate manually."
   skip
 ```
+
+### Step 4a.5: PR-exists short-circuit (#99 Bug 3)
+
+Before extracting the session-id and dispatching a resume, check `fetch_pr_for_issue`. If a PR is already open and references this issue, the agent had finished publishing — any subsequent crash that landed it in `pending-dev` (e.g. cleanup-trap fired with non-zero exit after `gh pr create` succeeded) does not warrant re-developing.
+
+Action when a PR exists:
+
+1. Comment: "PR #N exists for this issue; transitioning to pending-review instead of retrying dev (#99 Bug 3)."
+2. `gh issue edit --remove-label pending-dev --add-label pending-review`.
+3. Append the issue to `JUST_DISPATCHED` so Step 5 doesn't reprobe it on the same tick.
+
+This is the Step 4 mirror of Step 5b's "DEAD + in-progress + PR exists" branch — it covers the case where the cleanup trap got there first and the issue is already on `pending-dev` when the next tick arrives.
 
 ### Step 4b: extract session-id
 
@@ -193,7 +206,7 @@ This is a conservative gate: it only fires when the helper is certain the prior 
 ### Step 4c: dispatch resume
 
 1. **Atomic label swap**: `gh issue edit --remove-label pending-dev --add-label in-progress`.
-2. **Comment**: "Resuming development (session: <id>)..."
+2. **Post dispatch token** ([INV-18](invariants.md#inv-18-cold-start-grace-period-before-stale-detection)): `<!-- dispatcher-token: <id> at <iso> mode=dev-resume -->` + "Resuming autonomous development...".
 3. **Dispatch**: `bash $PROJECT_DIR/scripts/dispatch-local.sh dev-resume <issue> <session-id>`
 4. **Append to `JUST_DISPATCHED`.**
 
@@ -206,7 +219,8 @@ Find issues labeled `in-progress` OR `reviewing`.
 For each match:
 
 1. **Skip if in `JUST_DISPATCHED`** ([INV-09](invariants.md#inv-09-just_dispatched-skip-rule)).
-2. **Locate PID file** ([INV-01](invariants.md#inv-01-pid-file-naming)):
+2. **Skip if within cold-start grace period** ([INV-18](invariants.md#inv-18-cold-start-grace-period-before-stale-detection)) — `is_within_grace_period` reads the most recent `<!-- dispatcher-token: ... -->` marker comment. While its age is below `DISPATCH_GRACE_PERIOD_SECONDS` (default 1800), defer all stale-detection branching to a future tick. JUST_DISPATCHED only protects the current tick; this rule extends protection across the multi-minute cold-start window during which the wrapper has not yet written its PID file.
+3. **Locate PID file** ([INV-01](invariants.md#inv-01-pid-file-naming)):
    - `in-progress` → `${PID_DIR}/issue-<N>.pid`
    - `reviewing` → `${PID_DIR}/review-<N>.pid`
    - `${PID_DIR}` is computed by `lib-config.sh::pid_dir_for_project` (per-user runtime dir, mode 0700).

--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -219,7 +219,7 @@ Find issues labeled `in-progress` OR `reviewing`.
 For each match:
 
 1. **Skip if in `JUST_DISPATCHED`** ([INV-09](invariants.md#inv-09-just_dispatched-skip-rule)).
-2. **Skip if within cold-start grace period** ([INV-18](invariants.md#inv-18-cold-start-grace-period-before-stale-detection)) — `is_within_grace_period` reads the most recent `<!-- dispatcher-token: ... -->` marker comment. While its age is below `DISPATCH_GRACE_PERIOD_SECONDS` (default 1800), defer all stale-detection branching to a future tick. JUST_DISPATCHED only protects the current tick; this rule extends protection across the multi-minute cold-start window during which the wrapper has not yet written its PID file.
+2. **Skip if within cold-start grace period** ([INV-18](invariants.md#inv-18-cold-start-grace-period-before-stale-detection)) — `is_within_grace_period` reads the most recent `<!-- dispatcher-token: ... -->` marker comment. While its age is below `DISPATCH_GRACE_PERIOD_SECONDS` (default 600 = 10 min), defer all stale-detection branching to a future tick. JUST_DISPATCHED only protects the current tick; this rule extends protection across the cold-start window during which the wrapper has not yet written its PID file. (Empirical wrapper startup is 1–7 sec; 10 min leaves headroom for slow MCP / remote SSM paths.)
 3. **Locate PID file** ([INV-01](invariants.md#inv-01-pid-file-naming)):
    - `in-progress` → `${PID_DIR}/issue-<N>.pid`
    - `reviewing` → `${PID_DIR}/review-<N>.pid`

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -236,6 +236,47 @@ In environments without Layer 3 (server-side), Layers 1 and 2 must both be insta
 
 ---
 
+## INV-18: Cold-start grace period before stale detection
+
+**Rule**: every Step 2/3/4 dispatch in `dispatcher-tick.sh` MUST write a dispatcher-controlled marker comment in the form
+
+```
+<!-- dispatcher-token: <id> at <ISO-8601 UTC> mode=<dev-new|dev-resume|review> -->
+<human-readable line>
+```
+
+Step 5 stale detection MUST NOT classify an active issue as crashed while its latest dispatcher-token comment is younger than `DISPATCH_GRACE_PERIOD_SECONDS` (default 1800).
+
+**Why**: surfaced by #99 Bug 1. Agent startup (session spawn + model first call) takes 1–3 minutes; before the wrapper writes its PID file, `pid_alive` returns false → DEAD branch fires → the dispatcher posts "Task appears to have crashed (no PR found)" → after `MAX_RETRIES` of these false positives the issue stalls. `JUST_DISPATCHED` only protects the current tick; the very next tick (5 min later) was misclassifying a cold-starting wrapper as dead.
+
+**Producer**: `dispatcher-tick.sh` Steps 2/3/4 — `post_dispatch_token` is invoked inside each step body before `dispatch()`.
+
+**Consumer**: `dispatcher-tick.sh` Step 5 stale detection — calls `is_within_grace_period` after the JUST_DISPATCHED check and before DEAD/ALIVE branching.
+
+**Status**: **ENFORCED** in #99 fix.
+
+**Test**: `tests/unit/test-dispatcher-reliability-99.sh` covers `latest_dispatch_token_age_seconds`, `is_within_grace_period`, and `post_dispatch_token` roundtrip (10 cases).
+
+---
+
+## INV-19: Retry counter requires confirmed agent startup
+
+**Rule**: `count_retries` MUST count dispatcher-detected crash comments toward `MAX_RETRIES` ONLY when the agent has confirmed startup at some point in the current retry cycle — i.e., a `Dev Session ID:` comment exists after the most recent stalled-cutoff AND that comment is NOT a `Mode: startup-failure` report. Agent failure session reports (`Agent Session Report (Dev)` with non-zero exit code) always count regardless.
+
+The `Mode: startup-failure` exclusion matters: `autonomous-dev.sh`'s startup-failure trap (when the wrapper exits before invoking the agent — e.g., #92 missing-`gh` path) still emits a session report containing the SESSION_ID that was forwarded for dev-resume mode. Counting that as "agent confirmed startup" would re-arm dispatcher-crash counting on a wrapper that never actually invoked the agent.
+
+**Why**: surfaced by #99 Bug 5. Pre-fix, dispatcher-side false positives (Bug 1 cold-start, missing exec bit, broken auth handoff before agent ran) consumed `MAX_RETRIES` even though the agent never failed. By definition such crashes happen before the agent has had a chance to write its session-id comment, so gating the count on session-id presence cleanly suppresses them while preserving counting for legitimate post-startup crashes (network drop mid-session, segfault, OOM kill).
+
+**Producer**: `autonomous-dev.sh` cleanup() trap writes the `Agent Session Report (Dev)` comment containing `Dev Session ID: \`<id>\``. This is the post-startup checkpoint that arms dispatcher-crash counting.
+
+**Consumer**: `lib-dispatch.sh::count_retries` — gates dispatcher-crash counting on the presence of any post-cutoff session-id comment. `count_dispatcher_false_positives` reports the suppressed count for operator visibility in `mark_stalled`'s comment.
+
+**Status**: **ENFORCED** in #99 fix.
+
+**Test**: `tests/unit/test-dispatcher-reliability-99.sh` covers session-id-gate semantics (5 cases including stalled-cutoff interaction). `tests/unit/test-lib-dispatch.sh` regression cases updated to reflect the new gate.
+
+---
+
 ## Adding a new invariant
 
 When fixing a pipeline bug, after locating the bug on the state machine + flow docs:

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -245,9 +245,9 @@ In environments without Layer 3 (server-side), Layers 1 and 2 must both be insta
 <human-readable line>
 ```
 
-Step 5 stale detection MUST NOT classify an active issue as crashed while its latest dispatcher-token comment is younger than `DISPATCH_GRACE_PERIOD_SECONDS` (default 1800).
+Step 5 stale detection MUST NOT classify an active issue as crashed while its latest dispatcher-token comment is younger than `DISPATCH_GRACE_PERIOD_SECONDS` (default 600 = 10 min).
 
-**Why**: surfaced by #99 Bug 1. Agent startup (session spawn + model first call) takes 1–3 minutes; before the wrapper writes its PID file, `pid_alive` returns false → DEAD branch fires → the dispatcher posts "Task appears to have crashed (no PR found)" → after `MAX_RETRIES` of these false positives the issue stalls. `JUST_DISPATCHED` only protects the current tick; the very next tick (5 min later) was misclassifying a cold-starting wrapper as dead.
+**Why**: surfaced by #99 Bug 1. Agent startup involves wrapper spawn + auth setup + agent CLI cold start + first API call before the wrapper writes its PID file. Empirical measurements on a real dev box show this window is consistently 1–7 seconds for healthy invocations, but slow MCP negotiation, remote SSM dispatch, or upstream model latency can push it longer. Pre-fix, before the wrapper had written its PID file, `pid_alive` returned false → DEAD branch fired → dispatcher posted "Task appears to have crashed (no PR found)" → after `MAX_RETRIES` of these false positives the issue stalled. `JUST_DISPATCHED` only protects the current tick; the very next tick (5 min later) was misclassifying a cold-starting wrapper as dead. 10 min is roughly two cron ticks of headroom — enough for a slow-but-alive wrapper, short enough that genuinely-dead wrappers don't sit too long before retry.
 
 **Producer**: `dispatcher-tick.sh` Steps 2/3/4 — `post_dispatch_token` is invoked inside each step body before `dispatch()`.
 

--- a/docs/test-cases/dispatcher-reliability-99.md
+++ b/docs/test-cases/dispatcher-reliability-99.md
@@ -1,0 +1,82 @@
+# Test Cases — Dispatcher Reliability (#99)
+
+All tests live in `tests/unit/test-dispatcher-reliability-99.sh` unless otherwise noted. They mock `gh` by overriding the function in the test shell (same approach as `test-lib-dispatch.sh`).
+
+## TC-99-001: Grace period suppresses stale detection
+
+**Helper:** `is_within_grace_period`
+**Setup:** issue has a `<!-- dispatcher-token: ... at <iso> ... -->` comment dated 60s ago, `DISPATCH_GRACE_PERIOD_SECONDS=1800`.
+**Expected:** `is_within_grace_period 99` returns 0 (true).
+
+## TC-99-002: Grace period expires correctly
+
+**Setup:** dispatch-token comment dated 2000s ago, `DISPATCH_GRACE_PERIOD_SECONDS=1800`.
+**Expected:** `is_within_grace_period 99` returns 1 (false).
+
+## TC-99-003: No dispatch token → grace period not applied (backward compat)
+
+**Setup:** issue has no dispatch-token marker comments.
+**Expected:** `is_within_grace_period 99` returns 1 (false). Caller falls through to existing behavior.
+
+## TC-99-004: Latest token wins across multiple dispatches
+
+**Setup:** two dispatch-token comments — one 3000s ago, one 60s ago.
+**Expected:** `latest_dispatch_token_age_seconds 99` returns ~60.
+
+## TC-99-005: Dispatcher writes dispatch-token marker (helper)
+
+**Helper:** `post_dispatch_token`
+**Setup:** mock `gh issue comment` to capture the body.
+**Expected:** body contains `<!-- dispatcher-token: <uuid> at <iso8601> mode=dev-new -->` and a human-readable line.
+
+## TC-99-006: count_retries ignores dispatcher crashes when no session ID present
+
+**Setup:**
+- 2 dispatcher crash comments ("Task appears to have crashed (no PR found)").
+- 0 agent session reports.
+- 0 "Dev Session ID:" comments.
+**Expected:** `count_retries 99` returns 0.
+
+## TC-99-007: count_retries counts dispatcher crashes when session ID present
+
+**Setup:**
+- 1 agent session report with `Dev Session ID: \`abc-123\`` and Exit code 0 (success doesn't count by itself).
+- 2 dispatcher crash comments.
+**Expected:** `count_retries 99` returns 2 (dispatcher_crashes counted because session ID was confirmed at some point).
+
+## TC-99-008: count_retries — agent failure always counts
+
+**Setup:**
+- 1 agent session report Exit code 1 (no session ID listed).
+- 0 dispatcher crashes.
+**Expected:** `count_retries 99` returns 1.
+
+## TC-99-009: count_retries — stalled-cutoff still applies
+
+**Setup:**
+- 1 dispatcher crash + 1 dev-session-id-comment BEFORE "Marking as stalled" cutoff.
+- 1 dispatcher crash AFTER cutoff, NO session ID comment after cutoff.
+**Expected:** `count_retries 99` returns 0 (post-stall has no session ID, so post-stall dispatcher crashes don't count).
+
+## TC-99-010: Step 4 PR-exists short-circuit (integration-style)
+
+**Helper:** existing `fetch_pr_for_issue` — assert the new logic in dispatcher-tick.sh Step 4.
+**Setup:** mock `fetch_pr_for_issue` to return a PR object. Mock `gh issue edit` and `gh issue comment`.
+**Expected:** when scan-pending-dev encounters this issue, it calls `label_swap` from `pending-dev` to `pending-review` (NOT to `in-progress`), and does NOT call `dispatch dev-resume`.
+
+> Step 4 integration test deferred — tested via dry-run injection in test-dispatcher-tick-step4-pr-exists.sh in a follow-up if needed. The unit-level coverage of the helper is what gates the fix.
+
+## TC-99-011: post_dispatch_token writes parseable comment that survives a roundtrip
+
+**Setup:** call `post_dispatch_token 99 dev-new`, capture the body, then run it through `latest_dispatch_token_age_seconds`.
+**Expected:** age is < 5 seconds.
+
+## Acceptance Criteria → Test Mapping
+
+| Issue acceptance criterion | Tests |
+|----|----|
+| Newly dispatched agent not stalled within grace period | TC-99-001, TC-99-002 |
+| Dispatcher writes dispatch timestamp/token at dispatch time | TC-99-005, TC-99-011 |
+| If PR exists, stale detection transitions to pending-review | TC-99-010 (manual integration), Bug 3's existing in-progress branch already does this |
+| autonomous-dev.sh has executable permission after skill update | Already covered by `tests/unit/test-script-exec-bits.sh` (#97/#98) |
+| MAX_RETRIES only incremented when agent confirmed startup | TC-99-006, TC-99-007, TC-99-008, TC-99-009 |

--- a/skills/autonomous-dispatcher/scripts/autonomous.conf.example
+++ b/skills/autonomous-dispatcher/scripts/autonomous.conf.example
@@ -63,6 +63,15 @@ REAL_GH=""
 MAX_CONCURRENT=5
 MAX_RETRIES=3
 
+# Cold-start grace window for stale detection ([INV-17], #99 Bug 1).
+# After a Step 2/3/4 dispatch, the wrapper takes 1–3 minutes to spawn the
+# session and have the model make its first API call before it can write
+# its PID file. Step 5 must NOT classify the wrapper as crashed during
+# this window. Defaults to 1800 (30 min). Set to 0 to disable the grace
+# window entirely (not recommended — false-positive crash detection is
+# the failure mode this knob exists to prevent).
+DISPATCH_GRACE_PERIOD_SECONDS=1800
+
 # === Dev Agent ===
 DEV_SKILL_CMD="/autonomous-dev"
 

--- a/skills/autonomous-dispatcher/scripts/autonomous.conf.example
+++ b/skills/autonomous-dispatcher/scripts/autonomous.conf.example
@@ -63,14 +63,18 @@ REAL_GH=""
 MAX_CONCURRENT=5
 MAX_RETRIES=3
 
-# Cold-start grace window for stale detection ([INV-17], #99 Bug 1).
-# After a Step 2/3/4 dispatch, the wrapper takes 1–3 minutes to spawn the
-# session and have the model make its first API call before it can write
-# its PID file. Step 5 must NOT classify the wrapper as crashed during
-# this window. Defaults to 1800 (30 min). Set to 0 to disable the grace
-# window entirely (not recommended — false-positive crash detection is
-# the failure mode this knob exists to prevent).
-DISPATCH_GRACE_PERIOD_SECONDS=1800
+# Cold-start grace window for stale detection ([INV-18], #99 Bug 1).
+# After a Step 2/3/4 dispatch, the wrapper needs time to spawn the session,
+# have the agent CLI make its first API call, and write its PID file. Step 5
+# must NOT classify the wrapper as crashed during this window.
+#
+# Empirical measurements on a real dev box: wrapper startup → first agent
+# activity is consistently 1–7 seconds across 10 sampled runs. 600 (10 min)
+# leaves 90× headroom for slow MCP negotiation, model first-call slowness,
+# or remote SSM dispatch latency, while still catching genuinely-dead
+# wrappers within two ticks. Set to 0 to disable (not recommended — false-
+# positive crash detection is the failure mode this knob exists to prevent).
+DISPATCH_GRACE_PERIOD_SECONDS=600
 
 # === Dev Agent ===
 DEV_SKILL_CMD="/autonomous-dev"

--- a/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
@@ -173,8 +173,10 @@ for i in $(seq 0 $((new_count - 1))); do
 
   log "  dispatching dev-new for issue #${issue_num}"
   label_swap "$issue_num" "" "in-progress"
-  gh issue comment "$issue_num" --repo "$REPO" \
-    --body "Dispatching autonomous development..."
+  # Bug 1+2 (#99): write a dispatcher-controlled marker that records the
+  # dispatch timestamp ([INV-17]). Step 5 uses this to honor a cold-start
+  # grace window before classifying the wrapper as crashed.
+  post_dispatch_token "$issue_num" "dev-new"
   dispatch dev-new "$issue_num"
   JUST_DISPATCHED+=("$issue_num")
 done
@@ -198,8 +200,7 @@ for i in $(seq 0 $((pr_count - 1))); do
 
   log "  dispatching review for issue #${issue_num}"
   label_swap "$issue_num" "pending-review" "reviewing"
-  gh issue comment "$issue_num" --repo "$REPO" \
-    --body "Dispatching autonomous review..."
+  post_dispatch_token "$issue_num" "review"
   dispatch review "$issue_num"
   JUST_DISPATCHED+=("$issue_num")
 done
@@ -228,6 +229,23 @@ for i in $(seq 0 $((pd_count - 1))); do
     continue
   fi
 
+  # Bug 3 (#99): if a PR already exists for this issue, the agent already
+  # finished development — any subsequent crash (e.g. cleanup-time exit
+  # non-zero after gh pr create) routed us to pending-dev, but re-developing
+  # would just re-do work. Hand off to review instead.
+  pr_for_issue=$(fetch_pr_for_issue "$issue_num" "number")
+  if [ -n "$pr_for_issue" ]; then
+    pr_num=$(jq -r '.number // empty' <<<"$pr_for_issue")
+    pr_ref="${pr_num:+#${pr_num}}"
+    pr_ref="${pr_ref:-(number unknown)}"
+    log "  issue #${issue_num} has PR ${pr_ref} — transitioning to pending-review (Bug 3 fix)"
+    gh issue comment "$issue_num" --repo "$REPO" \
+      --body "PR ${pr_ref} exists for this issue; transitioning to pending-review instead of retrying dev (#99 Bug 3)."
+    label_swap "$issue_num" "pending-dev" "pending-review"
+    JUST_DISPATCHED+=("$issue_num")
+    continue
+  fi
+
   session_id=$(extract_dev_session_id "$issue_num")
 
   # [INV-12] Skip resume if the prior session ended normally (closes #59).
@@ -253,8 +271,7 @@ for i in $(seq 0 $((pd_count - 1))); do
 
   log "  dispatching dev-resume for issue #${issue_num} (session: ${session_id:-<none>})"
   label_swap "$issue_num" "pending-dev" "in-progress"
-  gh issue comment "$issue_num" --repo "$REPO" \
-    --body "Resuming development (session: ${session_id})..."
+  post_dispatch_token "$issue_num" "dev-resume"
   dispatch dev-resume "$issue_num" "$session_id"
   JUST_DISPATCHED+=("$issue_num")
 done
@@ -279,6 +296,16 @@ for i in $(seq 0 $((cand_count - 1))); do
   # Skip freshly dispatched ([INV-09]).
   if was_just_dispatched "$issue_num"; then
     log "  issue #${issue_num} just dispatched this tick — skipping"
+    continue
+  fi
+
+  # Bug 1 (#99) [INV-17]: skip stale detection during the cold-start grace
+  # window. JUST_DISPATCHED only protects the current tick; a wrapper that
+  # hasn't yet written its PID file (session spawn + model first call can
+  # take 1–3 min) must not be classified as crashed on the very next tick.
+  # Defaults to 30 min via DISPATCH_GRACE_PERIOD_SECONDS=1800.
+  if is_within_grace_period "$issue_num"; then
+    log "  issue #${issue_num} within dispatch grace period — skipping (#99 Bug 1)"
     continue
   fi
 

--- a/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
@@ -303,7 +303,7 @@ for i in $(seq 0 $((cand_count - 1))); do
   # window. JUST_DISPATCHED only protects the current tick; a wrapper that
   # hasn't yet written its PID file (session spawn + model first call can
   # take 1–3 min) must not be classified as crashed on the very next tick.
-  # Defaults to 30 min via DISPATCH_GRACE_PERIOD_SECONDS=1800.
+  # Defaults to 10 min via DISPATCH_GRACE_PERIOD_SECONDS=600.
   if is_within_grace_period "$issue_num"; then
     log "  issue #${issue_num} within dispatch grace period — skipping (#99 Bug 1)"
     continue

--- a/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
@@ -335,7 +335,7 @@ _iso_age_seconds() {
 # DISPATCH_GRACE_PERIOD_SECONDS=0 disables the grace window entirely.
 is_within_grace_period() {
   local issue_num="$1"
-  local grace="${DISPATCH_GRACE_PERIOD_SECONDS:-1800}"
+  local grace="${DISPATCH_GRACE_PERIOD_SECONDS:-600}"
   [ "$grace" -gt 0 ] || return 1
   local age
   age=$(latest_dispatch_token_age_seconds "$issue_num")

--- a/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
@@ -124,23 +124,65 @@ check_deps_resolved() {
 # Echoes the count of failure events on the issue, using the stalled-cutoff
 # rule [INV-05]: only count failures after the most recent
 # "Marking as stalled" comment. Two event sources are counted:
-#   - Agent Session Report (Dev) comments with non-zero exit code
-#   - Dispatcher-detected crash comments matching [INV-06]'s keyword regex
+#   - Agent Session Report (Dev) comments with non-zero exit code (always)
+#   - Dispatcher-detected crash comments matching [INV-06]'s keyword regex,
+#     BUT only when the agent has confirmed startup at some point in the
+#     current retry cycle (a "Dev Session ID:" comment exists post-cutoff).
+#     Without that gate, dispatcher false positives from the cold-start
+#     window (Bug 1 in #99) consume MAX_RETRIES even though the agent
+#     never actually failed. See [INV-18].
 #
 # When MAX_RETRIES is hit, mark_stalled() is the appropriate action.
 count_retries() {
   local issue_num="$1"
-  local last_stalled_at agent_failures dispatcher_crashes
+  local agent_failures dispatcher_crashes
+  agent_failures=$(count_agent_failures "$issue_num")
+  dispatcher_crashes=$(count_dispatcher_crashes "$issue_num")
+
+  # Bug 5 (#99): only count dispatcher-detected crashes when the agent has
+  # confirmed startup at some point in this retry cycle. Pre-confirmation
+  # crashes are dispatcher-side false positives (cold-start window, missing
+  # exec bit, broken auth handoff) and must NOT consume MAX_RETRIES.
+  if _agent_started_since_stall "$issue_num"; then
+    echo $((agent_failures + dispatcher_crashes))
+  else
+    echo "$agent_failures"
+  fi
+}
+
+# Echoes the count of dispatcher-detected false positives (no session ID
+# observed in this retry cycle). Reported alongside the canonical counters
+# in mark_stalled() so operators can see Bug 1 cold-start crashes are
+# being suppressed instead of silently absorbed.
+count_dispatcher_false_positives() {
+  local issue_num="$1"
+  if _agent_started_since_stall "$issue_num"; then
+    echo 0
+  else
+    count_dispatcher_crashes "$issue_num"
+  fi
+}
+
+# Returns 0 if at least one "Dev Session ID: <id>" comment appears after the
+# most recent "Marking as stalled" cutoff AND that comment did NOT come from
+# a startup-failure path (i.e., the agent really did start, not just
+# wrapper-side post-mortem with a forwarded session id). [INV-19] gate for
+# Bug 5.
+#
+# Why exclude `Mode: startup-failure`: autonomous-dev.sh's startup-failure
+# trap (when AGENT_RAN=false, e.g. gh-with-token-refresh couldn't find a
+# real gh — #92) still emits a session report containing the SESSION_ID
+# that was passed to --session for dev-resume mode. Counting that as
+# "agent confirmed startup" would arm dispatcher-crash counting on a
+# wrapper that never actually invoked the agent.
+_agent_started_since_stall() {
+  local issue_num="$1"
+  local last_stalled_at session_seen
   last_stalled_at=$(gh issue view "$issue_num" --repo "$REPO" --json comments \
     -q '[.comments[] | select(.body | test("Marking as stalled"))] | last | .createdAt // "1970-01-01T00:00:00Z"')
-
-  agent_failures=$(gh issue view "$issue_num" --repo "$REPO" --json comments \
-    -q "[.comments[] | select((.createdAt > \"${last_stalled_at}\") and (.body | test(\"Agent Session Report \\\\(Dev\\\\)\")) and (.body | test(\"Exit code: 0\") | not))] | length")
-
-  dispatcher_crashes=$(gh issue view "$issue_num" --repo "$REPO" --json comments \
-    -q "[.comments[] | select((.createdAt > \"${last_stalled_at}\") and (.body | test(\"Task appears to have crashed \\\\(no PR found\\\\)|process not found\")))] | length")
-
-  echo $((agent_failures + dispatcher_crashes))
+  session_seen=$(gh issue view "$issue_num" --repo "$REPO" --json comments \
+    -q "[.comments[] | select((.createdAt > \"${last_stalled_at}\") and (.body | test(\"Dev Session ID: .[a-zA-Z0-9_-]+\")) and (.body | test(\"Mode: startup-failure\") | not))] | length")
+  [ "${session_seen:-0}" -gt 0 ]
 }
 
 # Echoes the agent_failures count separately (used by mark_stalled comment).
@@ -166,14 +208,20 @@ count_dispatcher_crashes() {
 # stalled" comment that the next stalled-cutoff calculation will key off.
 mark_stalled() {
   local issue_num="$1"
-  local agent_failures dispatcher_crashes
+  local agent_failures dispatcher_crashes false_positives
   agent_failures=$(count_agent_failures "$issue_num")
   dispatcher_crashes=$(count_dispatcher_crashes "$issue_num")
+  false_positives=$(count_dispatcher_false_positives "$issue_num")
   gh issue edit "$issue_num" --repo "$REPO" \
     --remove-label "pending-dev" \
     --add-label "stalled"
+  # Operator visibility: counted vs. suppressed dispatcher events ([INV-18]).
+  # Suppressed events are dispatcher-detected crashes that occurred before the
+  # agent confirmed startup (no Dev Session ID written) — these are
+  # dispatcher-side false positives and do NOT consume MAX_RETRIES.
+  local counted_dispatcher_crashes=$(( dispatcher_crashes - false_positives ))
   gh issue comment "$issue_num" --repo "$REPO" \
-    --body "Issue has exceeded the maximum retry limit (${MAX_RETRIES} failed attempts: ${agent_failures} agent failures + ${dispatcher_crashes} dispatcher-detected crashes). Marking as stalled. @${REPO_OWNER} please investigate manually."
+    --body "Issue has exceeded the maximum retry limit (${MAX_RETRIES} failed attempts: ${agent_failures} agent failures + ${counted_dispatcher_crashes} dispatcher-detected crashes; ${false_positives} dispatcher false positives suppressed per #99). Marking as stalled. @${REPO_OWNER} please investigate manually."
 }
 
 # ---------------------------------------------------------------------------
@@ -229,6 +277,95 @@ is_session_completed() {
   local fields
   fields=$(jq -er '"\(.stop_reason // "")|\(.terminal_reason // "")"' <<<"$last_line" 2>/dev/null) || return 1
   [ "$fields" = "end_turn|completed" ]
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch-token marker (Bugs 1 + 2 in #99 — [INV-17])
+# ---------------------------------------------------------------------------
+#
+# At dispatch time the dispatcher writes a structured marker to the issue:
+#
+#   <!-- dispatcher-token: <uuid> at <iso8601> mode=<dev-new|dev-resume|review> -->
+#   Dispatching autonomous development...
+#
+# The HTML comment is machine-parseable; the human-readable line preserves
+# the existing wording for backward compat. Two roles:
+#
+#   1. Cold-start grace period (Bug 1). Step 5 reads the latest token's age
+#      via latest_dispatch_token_age_seconds and skips stale detection if
+#      `age < DISPATCH_GRACE_PERIOD_SECONDS`. Defaults to 30 min — long
+#      enough for session spawn + model first call without trapping
+#      genuinely-dead wrappers indefinitely.
+#
+#   2. Dispatcher-controlled dispatch identity (Bug 2). The dispatcher no
+#      longer relies on the agent's session-id-comment to know "did we just
+#      dispatch this?" — which used to fail when the agent crashed before
+#      its EXIT trap.
+
+# Echoes seconds since the most recent dispatch-token comment on the issue.
+# Empty if no token comment exists, or if the timestamp is unparseable.
+latest_dispatch_token_age_seconds() {
+  local issue_num="$1"
+  local latest_iso
+  latest_iso=$(gh issue view "$issue_num" --repo "$REPO" --json comments \
+    -q '[.comments[].body | capture("<!-- dispatcher-token: [a-zA-Z0-9_-]+ at (?<ts>[0-9TZ:-]+) mode=[a-z-]+ -->"; "g") | .ts] | last // empty')
+  [ -n "$latest_iso" ] || { echo ""; return; }
+  _iso_age_seconds "$latest_iso"
+}
+
+# Echoes seconds between now and an ISO-8601 UTC timestamp. Empty on parse
+# failure. Cross-platform (GNU `date -d` vs BSD `date -j -f`). Shared by
+# pr_idle_seconds and latest_dispatch_token_age_seconds.
+_iso_age_seconds() {
+  local iso="$1"
+  local epoch now_epoch
+  epoch=$(date -u -d "$iso" +%s 2>/dev/null \
+    || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null \
+    || echo "")
+  [ -n "$epoch" ] || { echo ""; return; }
+  now_epoch=$(date -u +%s)
+  echo $(( now_epoch - epoch ))
+}
+
+# Returns 0 if the issue's latest dispatch token is younger than
+# DISPATCH_GRACE_PERIOD_SECONDS. Returns 1 otherwise (also when no token
+# exists — backward-compat fallthrough). Strict `<`: at-or-past the
+# threshold is OUT of grace.
+#
+# DISPATCH_GRACE_PERIOD_SECONDS=0 disables the grace window entirely.
+is_within_grace_period() {
+  local issue_num="$1"
+  local grace="${DISPATCH_GRACE_PERIOD_SECONDS:-1800}"
+  [ "$grace" -gt 0 ] || return 1
+  local age
+  age=$(latest_dispatch_token_age_seconds "$issue_num")
+  [ -n "$age" ] || return 1
+  [ "$age" -lt "$grace" ]
+}
+
+# Post a dispatcher-controlled dispatch-token marker as an issue comment.
+# Args: <issue_num> <mode>   where mode ∈ dev-new|dev-resume|review.
+# Body retains the existing human-readable phrasing, prefixed with the
+# machine-parseable HTML comment.
+post_dispatch_token() {
+  local issue_num="$1" mode="$2"
+  local token now human
+  if command -v uuidgen >/dev/null 2>&1; then
+    token=$(uuidgen | tr 'A-Z' 'a-z' | tr -d '-' | cut -c1-12)
+  else
+    # Fallback: 12 hex chars from /dev/urandom.
+    token=$(od -An -N6 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n' || echo "$$$(date +%s%N)")
+  fi
+  now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  case "$mode" in
+    dev-new)     human="Dispatching autonomous development..." ;;
+    dev-resume)  human="Resuming autonomous development..." ;;
+    review)      human="Dispatching autonomous review..." ;;
+    *)           human="Dispatching ${mode}..." ;;
+  esac
+  gh issue comment "$issue_num" --repo "$REPO" \
+    --body "<!-- dispatcher-token: ${token} at ${now} mode=${mode} -->
+${human}"
 }
 
 # ---------------------------------------------------------------------------
@@ -298,20 +435,9 @@ ci_is_green() {
 }
 
 # Step 5a: echoes seconds since PR.updatedAt. Empty on parse failure
-# (caller should fail-closed and leave the issue alone). Cross-platform
-# date parsing (GNU `date -d` vs BSD `date -j -f`).
+# (caller should fail-closed and leave the issue alone).
 pr_idle_seconds() {
-  local pr_updated_at="$1"
-  local pr_updated_epoch now_epoch
-  pr_updated_epoch=$(date -u -d "$pr_updated_at" +%s 2>/dev/null \
-    || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$pr_updated_at" +%s 2>/dev/null \
-    || echo "")
-  if [ -z "$pr_updated_epoch" ]; then
-    echo ""
-    return
-  fi
-  now_epoch=$(date -u +%s)
-  echo $(( now_epoch - pr_updated_epoch ))
+  _iso_age_seconds "$1"
 }
 
 # Step 5b: echoes the SHA from the most recent "Reviewed HEAD: \`<sha>\`"

--- a/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
@@ -293,9 +293,10 @@ is_session_completed() {
 #
 #   1. Cold-start grace period (Bug 1). Step 5 reads the latest token's age
 #      via latest_dispatch_token_age_seconds and skips stale detection if
-#      `age < DISPATCH_GRACE_PERIOD_SECONDS`. Defaults to 30 min — long
-#      enough for session spawn + model first call without trapping
-#      genuinely-dead wrappers indefinitely.
+#      `age < DISPATCH_GRACE_PERIOD_SECONDS`. Defaults to 10 min — empirical
+#      wrapper startup is 1–7 sec, this leaves ~90× headroom for slow MCP
+#      negotiation or remote SSM dispatch without trapping genuinely-dead
+#      wrappers indefinitely.
 #
 #   2. Dispatcher-controlled dispatch identity (Bug 2). The dispatcher no
 #      longer relies on the agent's session-id-comment to know "did we just

--- a/tests/unit/test-dispatcher-reliability-99.sh
+++ b/tests/unit/test-dispatcher-reliability-99.sh
@@ -1,0 +1,311 @@
+#!/bin/bash
+# test-dispatcher-reliability-99.sh — Unit tests for issue #99 fixes.
+#
+# Covers:
+#   - is_within_grace_period (Bug 1 — cold-start grace period)
+#   - latest_dispatch_token_age_seconds (Bug 1 — token age extraction)
+#   - post_dispatch_token (Bug 2 — dispatcher-written marker)
+#   - count_retries with session-id gate (Bug 5 — false-positive filter)
+#
+# Run: bash tests/unit/test-dispatcher-reliability-99.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-dispatch.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Required env (lib-dispatch.sh enforces these via : "${VAR:?...}")
+export REPO=zxkane/autonomous-dev-team
+export REPO_OWNER=zxkane
+export PROJECT_ID=test-proj
+export MAX_RETRIES=3
+export MAX_CONCURRENT=5
+
+# Mocked gh: returns nothing by default. Tests override _MOCK_COMMENTS_JSON
+# to control what `gh issue view ... --json comments -q ...` returns.
+# _MOCK_LAST_COMMENT_BODY captures the most recent `gh issue comment ... --body ...` body.
+_MOCK_COMMENTS_JSON=""
+_MOCK_LAST_COMMENT_BODY=""
+gh() {
+  local cmd="${1:-}"
+  local sub="${2:-}"
+  if [[ "$cmd" == "issue" && "$sub" == "comment" ]]; then
+    # Find --body in args.
+    while [[ $# -gt 0 ]]; do
+      if [[ "$1" == "--body" ]]; then
+        _MOCK_LAST_COMMENT_BODY="$2"
+        return 0
+      fi
+      shift
+    done
+    return 0
+  fi
+  # Find the -q expression in the args, if any.
+  local q_expr=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -q) q_expr="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [[ -n "$q_expr" && -n "$_MOCK_COMMENTS_JSON" ]]; then
+    jq -r "$q_expr" <<<"$_MOCK_COMMENTS_JSON"
+  fi
+}
+export -f gh
+
+# shellcheck source=../../skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+source "$LIB"
+set +e
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected='$expected'"
+    echo "      actual=  '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_true() {
+  local desc="$1" rc="$2"
+  if [[ "$rc" -eq 0 ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (rc=$rc, expected 0)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_false() {
+  local desc="$1" rc="$2"
+  if [[ "$rc" -ne 0 ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (rc=$rc, expected non-zero)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+iso_minus_seconds() {
+  # Echo an ISO-8601 UTC timestamp $1 seconds in the past.
+  local seconds_ago="$1"
+  local epoch
+  epoch=$(( $(date -u +%s) - seconds_ago ))
+  date -u -d "@$epoch" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+    || date -u -r "$epoch" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+echo "=== latest_dispatch_token_age_seconds (Bug 1) ==="
+# ---------------------------------------------------------------------------
+
+# TC-99-001/004: latest token wins, age extracted correctly.
+T_OLD=$(iso_minus_seconds 3000)
+T_NEW=$(iso_minus_seconds 60)
+_MOCK_COMMENTS_JSON="{\"comments\":[
+  {\"body\":\"<!-- dispatcher-token: aaaaaaa at ${T_OLD} mode=dev-new -->\nDispatching autonomous development...\"},
+  {\"body\":\"<!-- dispatcher-token: bbbbbbb at ${T_NEW} mode=dev-resume -->\nResuming development...\"}
+]}"
+age=$(latest_dispatch_token_age_seconds 99)
+if [[ "$age" =~ ^[0-9]+$ ]] && (( age >= 50 && age <= 75 )); then
+  echo -e "  ${GREEN}PASS${NC}: latest token age ~60s (got $age)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: latest token age expected ~60s, got '$age'"
+  FAIL=$((FAIL + 1))
+fi
+
+# TC-99-003: no token comments → empty.
+_MOCK_COMMENTS_JSON='{"comments":[{"body":"some random comment"}]}'
+out=$(latest_dispatch_token_age_seconds 99)
+assert_eq "no token comments → empty age" "" "$out"
+
+# Empty comments list → empty.
+_MOCK_COMMENTS_JSON='{"comments":[]}'
+out=$(latest_dispatch_token_age_seconds 99)
+assert_eq "empty comments list → empty age" "" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== is_within_grace_period (Bug 1) ==="
+# ---------------------------------------------------------------------------
+
+export DISPATCH_GRACE_PERIOD_SECONDS=1800
+
+# TC-99-001: token 60s old, grace 1800s → true.
+T_RECENT=$(iso_minus_seconds 60)
+_MOCK_COMMENTS_JSON="{\"comments\":[
+  {\"body\":\"<!-- dispatcher-token: aaaaaaa at ${T_RECENT} mode=dev-new -->\"}
+]}"
+is_within_grace_period 99
+assert_true "token 60s old → in grace period" $?
+
+# TC-99-002: token 2000s old, grace 1800s → false.
+T_OLD=$(iso_minus_seconds 2000)
+_MOCK_COMMENTS_JSON="{\"comments\":[
+  {\"body\":\"<!-- dispatcher-token: aaaaaaa at ${T_OLD} mode=dev-new -->\"}
+]}"
+is_within_grace_period 99
+assert_false "token 2000s old → out of grace period" $?
+
+# TC-99-003: no token comments → false (backward compat).
+_MOCK_COMMENTS_JSON='{"comments":[]}'
+is_within_grace_period 99
+assert_false "no dispatch token → grace period not applied" $?
+
+# Boundary: token at exactly grace seconds → false (strict <).
+export DISPATCH_GRACE_PERIOD_SECONDS=100
+T_BOUNDARY=$(iso_minus_seconds 200)
+_MOCK_COMMENTS_JSON="{\"comments\":[
+  {\"body\":\"<!-- dispatcher-token: x at ${T_BOUNDARY} mode=dev-new -->\"}
+]}"
+is_within_grace_period 99
+assert_false "age > grace → out of grace" $?
+
+# DISPATCH_GRACE_PERIOD_SECONDS=0 → grace disabled.
+export DISPATCH_GRACE_PERIOD_SECONDS=0
+T_RECENT=$(iso_minus_seconds 5)
+_MOCK_COMMENTS_JSON="{\"comments\":[
+  {\"body\":\"<!-- dispatcher-token: x at ${T_RECENT} mode=dev-new -->\"}
+]}"
+is_within_grace_period 99
+assert_false "DISPATCH_GRACE_PERIOD_SECONDS=0 disables grace" $?
+
+unset DISPATCH_GRACE_PERIOD_SECONDS
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== post_dispatch_token (Bug 2) ==="
+# ---------------------------------------------------------------------------
+
+# TC-99-005: post_dispatch_token writes a comment containing the marker.
+_MOCK_LAST_COMMENT_BODY=""
+post_dispatch_token 99 "dev-new"
+if [[ "$_MOCK_LAST_COMMENT_BODY" == *"<!-- dispatcher-token: "*"mode=dev-new"*" -->"* ]]; then
+  echo -e "  ${GREEN}PASS${NC}: post_dispatch_token writes dispatcher-token marker"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: marker missing from comment body"
+  echo "      body='${_MOCK_LAST_COMMENT_BODY}'"
+  FAIL=$((FAIL + 1))
+fi
+
+# Also check the mode is in the marker for review and dev-resume.
+_MOCK_LAST_COMMENT_BODY=""
+post_dispatch_token 99 "review"
+if [[ "$_MOCK_LAST_COMMENT_BODY" == *"mode=review"* ]]; then
+  echo -e "  ${GREEN}PASS${NC}: post_dispatch_token records mode=review"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: mode=review missing"
+  FAIL=$((FAIL + 1))
+fi
+
+# TC-99-011: roundtrip — write a token, then parse its age. Should be < 5s.
+_MOCK_LAST_COMMENT_BODY=""
+post_dispatch_token 99 "dev-new"
+_MOCK_COMMENTS_JSON=$(jq -n --arg body "$_MOCK_LAST_COMMENT_BODY" \
+  '{comments: [{body: $body}]}')
+age=$(latest_dispatch_token_age_seconds 99)
+if [[ "$age" =~ ^[0-9]+$ ]] && (( age >= 0 && age <= 10 )); then
+  echo -e "  ${GREEN}PASS${NC}: token roundtrip age ~0s (got $age)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: token roundtrip age expected ~0s, got '$age'"
+  echo "      body='${_MOCK_LAST_COMMENT_BODY}'"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== count_retries session-id gate (Bug 5) ==="
+# ---------------------------------------------------------------------------
+
+# TC-99-006: dispatcher crashes alone (no session ID ever) → 0.
+_MOCK_COMMENTS_JSON='{"comments":[
+  {"createdAt":"2026-01-01T00:00:00Z","body":"Task appears to have crashed (no PR found). Moving to pending-dev for retry."},
+  {"createdAt":"2026-01-02T00:00:00Z","body":"Task appears to have crashed (no PR found). Moving to pending-dev for retry."}
+]}'
+assert_eq "2 dispatcher crashes, no session ID → 0 (false positives suppressed)" "0" "$(count_retries 99)"
+
+# TC-99-007: dispatcher crashes with session ID present → counts.
+_MOCK_COMMENTS_JSON='{"comments":[
+  {"createdAt":"2026-01-01T00:00:00Z","body":"**Agent Session Report (Dev)**\nDev Session ID: `abc-123`\n- Exit code: 0"},
+  {"createdAt":"2026-01-02T00:00:00Z","body":"Task appears to have crashed (no PR found). Moving to pending-dev for retry."},
+  {"createdAt":"2026-01-03T00:00:00Z","body":"Task appears to have crashed (no PR found). Moving to pending-dev for retry."}
+]}'
+assert_eq "2 dispatcher crashes WITH session ID → 2 (counted)" "2" "$(count_retries 99)"
+
+# TC-99-008: agent failure always counts even without session ID.
+_MOCK_COMMENTS_JSON='{"comments":[
+  {"createdAt":"2026-01-01T00:00:00Z","body":"**Agent Session Report (Dev)**\n- Exit code: 1\n- Mode: startup-failure"}
+]}'
+assert_eq "agent failure always counts → 1" "1" "$(count_retries 99)"
+
+# TC-99-009: stalled-cutoff still applies.
+# Pre-stall: 1 dispatcher crash + 1 session ID. Post-stall: 1 dispatcher crash, NO session ID.
+_MOCK_COMMENTS_JSON='{"comments":[
+  {"createdAt":"2026-01-01T00:00:00Z","body":"Dev Session ID: `pre-stall-id`"},
+  {"createdAt":"2026-01-02T00:00:00Z","body":"Task appears to have crashed (no PR found)"},
+  {"createdAt":"2026-01-03T00:00:00Z","body":"Marking as stalled"},
+  {"createdAt":"2026-01-04T00:00:00Z","body":"Task appears to have crashed (no PR found)"}
+]}'
+assert_eq "post-stall: dispatcher crash without post-stall session ID → 0" "0" "$(count_retries 99)"
+
+# Mixed post-stall: agent failure (counts) + dispatcher crash without session ID (suppressed).
+_MOCK_COMMENTS_JSON='{"comments":[
+  {"createdAt":"2026-01-01T00:00:00Z","body":"Marking as stalled"},
+  {"createdAt":"2026-01-02T00:00:00Z","body":"Task appears to have crashed (no PR found)"},
+  {"createdAt":"2026-01-03T00:00:00Z","body":"**Agent Session Report (Dev)**\n- Exit code: 1"}
+]}'
+assert_eq "post-stall: agent failure (1) + dispatcher crash w/o session-id (0) → 1" "1" "$(count_retries 99)"
+
+# Existing TCs from test-lib-dispatch.sh — make sure we don't regress them:
+# 2 failures, no stall comment → counter = 2
+_MOCK_COMMENTS_JSON='{"comments":[
+  {"createdAt":"2026-01-01T00:00:00Z","body":"Agent Session Report (Dev)\nExit code: 1"},
+  {"createdAt":"2026-01-02T00:00:00Z","body":"Agent Session Report (Dev)\nExit code: 1"}
+]}'
+assert_eq "regression: 2 agent failures, no stall comment → 2" "2" "$(count_retries 99)"
+
+# Bug 5 edge case (review feedback): startup-failure session report
+# (autonomous-dev.sh:144 — Mode: startup-failure) carries a forwarded
+# SESSION_ID for dev-resume but the agent never actually ran. It must
+# NOT arm dispatcher-crash counting.
+_MOCK_COMMENTS_JSON='{"comments":[
+  {"createdAt":"2026-01-01T00:00:00Z","body":"**Agent Session Report (Dev)**\n- Dev Session ID: `forwarded-id`\n- Exit code: 1\n- Mode: startup-failure"},
+  {"createdAt":"2026-01-02T00:00:00Z","body":"Task appears to have crashed (no PR found). Moving to pending-dev for retry."}
+]}'
+# Expected: 1 agent failure (startup-failure exit 1) + 0 dispatcher crashes
+# (gate not armed by startup-failure session ID) = 1.
+assert_eq "startup-failure session ID does NOT arm dispatcher-crash counting → 1" "1" "$(count_retries 99)"
+
+# But a NORMAL dev-mode session report DOES arm the gate, even if its exit
+# was 0 (proving the agent really did run).
+_MOCK_COMMENTS_JSON='{"comments":[
+  {"createdAt":"2026-01-01T00:00:00Z","body":"**Agent Session Report (Dev)**\n- Dev Session ID: `real-id`\n- Exit code: 0\n- Mode: new"},
+  {"createdAt":"2026-01-02T00:00:00Z","body":"Task appears to have crashed (no PR found). Moving to pending-dev for retry."}
+]}'
+assert_eq "Mode: new session report arms dispatcher-crash counting → 1" "1" "$(count_retries 99)"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "==============================================="
+echo -e "Total: $((PASS + FAIL)) tests, ${GREEN}${PASS} pass${NC}, ${RED}${FAIL} fail${NC}"
+echo "==============================================="
+
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tests/unit/test-dispatcher-tick-app-auth.sh
+++ b/tests/unit/test-dispatcher-tick-app-auth.sh
@@ -104,6 +104,15 @@ pid_alive() { return 1; }
 get_pid() { echo ""; }
 label_swap() { :; }
 was_just_dispatched() { return 1; }
+# Bug 1+2 (#99): dispatcher-tick.sh now calls these in Steps 2/3/4 + Step 5.
+# post_dispatch_token writes a marker comment via `gh issue comment`; the
+# stub mirrors that so the auth-runs-before-first-gh-call test still has a
+# real gh invocation to assert against.
+post_dispatch_token() {
+  gh issue comment "$1" --repo "$REPO" --body "Dispatch token (mode=$2)"
+}
+is_within_grace_period() { return 1; }
+latest_dispatch_token_age_seconds() { echo ""; }
 EOF
 
 # Stub gh-app-token.sh: record the call, return a sentinel token. The token

--- a/tests/unit/test-lib-dispatch.sh
+++ b/tests/unit/test-lib-dispatch.sh
@@ -125,10 +125,22 @@ _MOCK_COMMENTS_JSON='{"comments":[
 assert_eq "Exit code: 0 dev report does NOT count" "0" "$(count_retries 99)"
 
 # Dispatcher crash regex matches "Task appears to have crashed (no PR found)".
+# Bug 5 fix (#99) requires session-id confirmation for dispatcher crashes
+# to count — without a Dev Session ID comment in the cycle, this is treated
+# as a dispatcher false positive and suppressed (returns 0).
+_MOCK_COMMENTS_JSON='{"comments":[
+  {"createdAt":"2026-01-01T00:00:00Z","body":"Dev Session ID: `abc-confirmed`"},
+  {"createdAt":"2026-01-02T00:00:00Z","body":"Task appears to have crashed (no PR found). Moving to pending-dev for retry."}
+]}'
+assert_eq "dispatcher crash 'Task appears to have crashed (no PR found)' WITH session ID → 1" "1" "$(count_retries 99)"
+
+# Bug 5 (#99): dispatcher crash WITHOUT a session-id comment is a false
+# positive (cold-start window, missing exec bit, etc.) and must NOT consume
+# MAX_RETRIES.
 _MOCK_COMMENTS_JSON='{"comments":[
   {"createdAt":"2026-01-01T00:00:00Z","body":"Task appears to have crashed (no PR found). Moving to pending-dev for retry."}
 ]}'
-assert_eq "dispatcher crash 'Task appears to have crashed (no PR found)' → 1" "1" "$(count_retries 99)"
+assert_eq "dispatcher crash WITHOUT session ID → 0 (false positive suppressed, #99)" "0" "$(count_retries 99)"
 
 # Forward-progress comment must NOT count [INV-06].
 _MOCK_COMMENTS_JSON='{"comments":[


### PR DESCRIPTION
## Summary

Closes 4 of 5 bugs reported in #99 (Bug 4 was already fixed in #97/#98):

- **Bug 1** (cold-start false crashes): Step 5 stale detection now respects a configurable grace window (`DISPATCH_GRACE_PERIOD_SECONDS`, default 1800s). Each Step 2/3/4 dispatch posts a `<!-- dispatcher-token: ... -->` marker; Step 5 defers branching while the latest marker is younger than the grace window. (`JUST_DISPATCHED` only protected the *current* tick — not enough for the 1–3 min cold-start window.)
- **Bug 2** (session-id-not-yet-written): Dispatcher now writes its own dispatch identity at dispatch time, so the cold-start grace probe doesn't depend on the agent's EXIT-trap session report.
- **Bug 3** (re-development of issues with existing PRs): Step 4 now checks `fetch_pr_for_issue` before dispatching `dev-resume`. PR exists → transition to `pending-review`.
- **Bug 5** (dispatcher false positives consume `MAX_RETRIES`): `count_retries` now suppresses dispatcher-detected crashes when the agent has not confirmed startup in the current retry cycle (no non-startup-failure `Dev Session ID:` comment exists post-cutoff). Suppressed counts are surfaced in `mark_stalled`'s comment.

New invariants: **INV-18** (cold-start grace period) and **INV-19** (retry counter requires confirmed agent startup).

## Design

- `docs/designs/dispatcher-reliability-99.md`
- `docs/test-cases/dispatcher-reliability-99.md`
- `docs/pipeline/invariants.md` — INV-18, INV-19
- `docs/pipeline/dispatcher-flow.md` — Steps 2/3/4/5 updated

## Test Plan

- [x] Test cases documented (`docs/test-cases/dispatcher-reliability-99.md`)
- [x] 19 new test cases in `tests/unit/test-dispatcher-reliability-99.sh`
- [x] Existing tests updated to reflect Bug 5 gate (`test-lib-dispatch.sh`); stub added for new helpers (`test-dispatcher-tick-app-auth.sh`)
- [x] All 43 unit tests pass locally
- [x] Code simplification review passed
- [x] PR review agent review passed (2 findings addressed before push: startup-failure exclusion in INV-19 gate; defensive `pr_ref` fallback in PR-exists short-circuit)
- [ ] CI checks pass
- [ ] Reviewer bot findings addressed (no new findings)
- [ ] E2E tests not applicable (no UI; bash unit tests cover behavior)

## Checklist

- [x] New unit tests written for new functionality
- [x] Documentation updated (invariants + dispatcher-flow + design + test-cases)
- [x] Backward compatibility preserved: issues without `dispatcher-token` markers fall through to existing behavior; `DISPATCH_GRACE_PERIOD_SECONDS=0` disables the grace window.

Closes #99 (Bug 4 already shipped in #97/#98)