### PR TITLE
fix(autonomous): verdict actor binding + AGENT_LAUNCHER + prompt_too_long fresh

### DIFF
--- a/docs/designs/autonomous-verdict-launcher-fresh.md
+++ b/docs/designs/autonomous-verdict-launcher-fresh.md
@@ -29,31 +29,44 @@ The `Review Session.*${SESSION_ID}` predicate exists "for security so a stray th
 
 ### New design
 
-Replace the session-id predicate with two predicates that the wrapper itself controls:
+Replace the session-id predicate with three layered predicates that the wrapper itself controls:
 
 1. **Actor binding** — the comment's `author.login` must equal the bot account that this wrapper is authenticated as. Resolved once at wrapper start via `gh api user --jq .login` (works for both PAT and GitHub App auth).
 2. **Time window binding** — the comment's `createdAt` must be ≥ the wrapper's start time (captured before `run_agent`, in ISO-8601 UTC).
+3. **Body trailer presence** — the comment must contain the literal substring `Review Session` (NOT bound to a specific UUID). The review agent's prompt instructs it to emit this trailer; the wrapper just checks it's there.
 
-Both predicates are observable to the wrapper without trusting the agent's output. The agent can still mint whatever session-id text it wants in the body — we don't read it.
+The first two are observable to the wrapper without trusting the agent's output. The third is the defense-in-depth layer that matters specifically in `GH_AUTH_MODE=token`: dev and review wrappers share an identity, so the dev agent's status comments could otherwise contain `LGTM` or `Review findings` and pass the actor+window predicate. The trailer requirement excludes them — the dev agent's prompt does not instruct it to emit `Review Session`, and a status comment quoting prior verdicts as conversation history doesn't contain the literal trailer phrase as a structured marker.
 
 ```bash
 WRAPPER_START_TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-BOT_LOGIN=$(gh api user --jq '.login' 2>/dev/null || echo "")
+_bot_raw=$(gh api user --jq '.login' 2>&1) && BOT_LOGIN="$_bot_raw" || {
+  log "WARNING: gh api user failed; falling back to session-id binding. stderr: ${_bot_raw}"
+  BOT_LOGIN=""
+}
+[[ "$BOT_LOGIN" == "null" || -z "$BOT_LOGIN" ]] && BOT_LOGIN=""
 
 # ... after run_agent ...
-LATEST_COMMENT=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json comments \
-  -q "[.comments[] | select(
-        (.author.login == \"${BOT_LOGIN}\") and
-        (.createdAt >= \"${WRAPPER_START_TS}\") and
-        (.body | test(\"Review PASSED|...|Changes requested\"; \"i\"))
-      )] | last | .body" 2>/dev/null || true)
+# Predicate construction:
+if [[ -n "$BOT_LOGIN" ]]; then
+  _AUTH_PREDICATE="(.author.login == \"${BOT_LOGIN}\") and (.createdAt >= \"${WRAPPER_START_TS}\") and (.body | test(\"Review Session\"))"
+else
+  _AUTH_PREDICATE="(.createdAt >= \"${WRAPPER_START_TS}\") and (.body | test(\"Review Session.*${SESSION_ID}\"))"
+fi
 ```
 
-If `BOT_LOGIN` is empty (e.g. `gh api user` failed in a degraded environment), fall back to the previous session-id binding so we don't lose all safety on a single transient API failure. The classification step (FAIL pattern wins on ambiguity) is unchanged.
+If `BOT_LOGIN` is empty (`gh api user` failed, returned empty, or returned the literal string `"null"`), fall back to a tighter trailer match that includes the wrapper's specific `SESSION_ID`. This re-introduces the brittleness this PR was trying to remove, but only on the rare path where actor binding is unavailable, and the time-window predicate still narrows out stale comments.
 
-### Why this is safe
+### Why this is safe in `GH_AUTH_MODE=app`
 
-The agent runs inside the wrapper's authenticated `gh` context, so any comment it posts will be authored by `BOT_LOGIN`. A third party would need to (a) be authenticated as the same bot identity AND (b) post in the wrapper's narrow time window — both conditions imply they already had write access to the bot account. The session-id binding only ever protected against a different bot or a human reviewer accidentally writing "Review PASSED" — both of which are still excluded by the actor + time window check.
+Each wrapper authenticates as a distinct GitHub App (e.g. `kane-coding-agent[bot]` for dev, `kane-test-agent[bot]` for review). `BOT_LOGIN` resolves to the review-app login, so even if a dev agent posts a comment containing verdict keywords on the same issue, it will be authored by a different login and the actor predicate excludes it. The trailer requirement is defense-in-depth.
+
+### Why this is safe in `GH_AUTH_MODE=token`
+
+Dev and review wrappers share `BOT_LOGIN`, so the actor predicate alone does NOT separate them. The trailer requirement is load-bearing here: only the review agent's prompt instructs it to emit `Review Session: <id>`. A dev agent writing a status comment that contains `LGTM` or `Review findings` will not contain the trailer marker, so the review wrapper's verdict capture excludes it. Time window further narrows to the current review run.
+
+### Why this is safer than the prior session-id binding
+
+The prior code required the agent to echo the wrapper's UUID verbatim (`Review Session.*${SESSION_ID}`). When the agent occasionally rewrote the UUID (observed in production), the regex missed valid verdicts and the wrapper fell through to the FAILED branch. The new design checks for the trailer's *presence* but not its UUID content, eliminating that brittleness while keeping spoof protection through actor + time window.
 
 Existing `tests/unit/test-autonomous-review-verdict-regex.sh` cases TC-RVR-009 and TC-RVR-010 (which assert "no session id" and "wrong session id" → no-match) need updating — under the new model, those comments DO match because the actor and time window are right. New anti-spoof cases will assert "wrong author" and "comment older than wrapper start" → no-match.
 

--- a/docs/designs/autonomous-verdict-launcher-fresh.md
+++ b/docs/designs/autonomous-verdict-launcher-fresh.md
@@ -1,0 +1,162 @@
+# Verdict-detection + cc-launcher + prompt_too_long fallback
+
+Three independent fixes bundled in one PR. They share files (`autonomous-{dev,review}.sh`, `lib-agent.sh`, `lib-dispatch.sh`, `autonomous.conf.example`) so a single review pass is more efficient than three.
+
+## Background — observed failure on a downstream consumer
+
+A downstream consumer running this dispatcher reported an issue stuck in a `dev → review → dev → review` ping-pong every ~20 minutes for 12+ hours. Every dev tick exited 0 ("PR found, moving to pending-review"); every review tick exited 0 too but its label flip ended up at `pending-dev` instead of `approved`. Investigation surfaced three independent bugs that compound:
+
+1. **Review wrapper's verdict detector binds to the wrapper-minted session UUID**; the agent inside posted its verdict comment with a *fresh* UUID it minted itself. The wrapper polled for `Review Session.*${WRAPPER_SID}` for 30s, never matched, declared "Review FAILED or inconclusive", flipped to `pending-dev`. The dev agent then ran, saw the PR was already there, handed back to review — infinite loop.
+2. **`AGENT_DEV_MODEL=opus[1m]` and `AGENT_REVIEW_MODEL=sonnet[1m]` silently fell back to Haiku 4.5.** The aliases need `ANTHROPIC_DEFAULT_OPUS_MODEL` / `ANTHROPIC_DEFAULT_SONNET_MODEL` env to map to Bedrock IDs. The dispatcher spawns `nohup` non-interactive shells which don't source the user's `.bash_aliases` / `.zshrc`, so those env vars were absent. Wrappers ran code review and dev work on Haiku — quality dropped without anyone noticing.
+3. **`is_session_completed` only treats `terminal_reason=completed` as terminal.** A session that died on `prompt_too_long` is "not completed" by that test, so the dispatcher keeps re-running `claude --resume <id>` forever. Each resume re-feeds the entire JSONL transcript (headless `claude -p` has no auto-compact — verified upstream), so once over the limit it stays over the limit. The existing `autonomous-dev.sh` fallback path (line 347–405) already handles this case correctly by minting a fresh session, but it only fires when `resume_agent` exits non-zero — and the dispatcher's `is_session_completed` short-circuits before we ever get there in some paths.
+
+None of these are speculative — each has a fingerprint in the consumer's logs (`/tmp/agent-*-issue-*.log`, the issue's comment timeline, the JSONL `modelUsage` field).
+
+## Fix 1 — verdict-detection: actor + time window, drop session-id binding
+
+### Current (broken)
+
+`autonomous-review.sh:490`:
+```bash
+LATEST_COMMENT=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json comments \
+  -q "[.comments[] | select(
+        (.body | test(\"Review PASSED|...|Changes requested\"; \"i\")) and
+        (.body | test(\"Review Session.*${SESSION_ID}\"))
+      )] | last | .body" 2>/dev/null || true)
+```
+
+The `Review Session.*${SESSION_ID}` predicate exists "for security so a stray third-party comment can't spoof a verdict" (per the existing comment). But it depends on the **agent** writing back the wrapper's UUID verbatim. In practice the agent often invents its own UUID, especially under aggressive context pressure — which is exactly when this matters most.
+
+### New design
+
+Replace the session-id predicate with two predicates that the wrapper itself controls:
+
+1. **Actor binding** — the comment's `author.login` must equal the bot account that this wrapper is authenticated as. Resolved once at wrapper start via `gh api user --jq .login` (works for both PAT and GitHub App auth).
+2. **Time window binding** — the comment's `createdAt` must be ≥ the wrapper's start time (captured before `run_agent`, in ISO-8601 UTC).
+
+Both predicates are observable to the wrapper without trusting the agent's output. The agent can still mint whatever session-id text it wants in the body — we don't read it.
+
+```bash
+WRAPPER_START_TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+BOT_LOGIN=$(gh api user --jq '.login' 2>/dev/null || echo "")
+
+# ... after run_agent ...
+LATEST_COMMENT=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json comments \
+  -q "[.comments[] | select(
+        (.author.login == \"${BOT_LOGIN}\") and
+        (.createdAt >= \"${WRAPPER_START_TS}\") and
+        (.body | test(\"Review PASSED|...|Changes requested\"; \"i\"))
+      )] | last | .body" 2>/dev/null || true)
+```
+
+If `BOT_LOGIN` is empty (e.g. `gh api user` failed in a degraded environment), fall back to the previous session-id binding so we don't lose all safety on a single transient API failure. The classification step (FAIL pattern wins on ambiguity) is unchanged.
+
+### Why this is safe
+
+The agent runs inside the wrapper's authenticated `gh` context, so any comment it posts will be authored by `BOT_LOGIN`. A third party would need to (a) be authenticated as the same bot identity AND (b) post in the wrapper's narrow time window — both conditions imply they already had write access to the bot account. The session-id binding only ever protected against a different bot or a human reviewer accidentally writing "Review PASSED" — both of which are still excluded by the actor + time window check.
+
+Existing `tests/unit/test-autonomous-review-verdict-regex.sh` cases TC-RVR-009 and TC-RVR-010 (which assert "no session id" and "wrong session id" → no-match) need updating — under the new model, those comments DO match because the actor and time window are right. New anti-spoof cases will assert "wrong author" and "comment older than wrapper start" → no-match.
+
+### Backward compat
+
+`autonomous-review.sh` still emits a `Review Session: \`${SESSION_ID}\`` trailer for human readability and for the `Reviewed HEAD` audit comment (consumed by `lib-dispatch.sh:last_reviewed_head`). The detector simply no longer requires the agent to echo it back.
+
+## Fix 2 — `AGENT_LAUNCHER` for cc / Bedrock environments
+
+### Problem
+
+`lib-agent.sh:255` runs `env -u CLAUDECODE "$AGENT_CMD" --session-id ... -p ...` — that is, the wrapper invokes the `claude` binary directly. Users whose interactive workflow relies on a shell function or alias (e.g. `cc` in `~/dotfiles/common/.bash_aliases`) lose all the env that function sets: `CLAUDE_CODE_USE_BEDROCK=1`, `ANTHROPIC_DEFAULT_OPUS_MODEL`, `AWS_PROFILE`, telemetry tags, etc. The `nohup` non-interactive shell the dispatcher spawns inherits none of it.
+
+### New design
+
+Add an optional `AGENT_LAUNCHER` variable. When set, the claude/codex/kiro/opencode invocation is wrapped through it:
+
+```bash
+# autonomous.conf
+AGENT_LAUNCHER='bash -c '\''source ~/dotfiles/common/.bash_aliases && exec cc "$@"'\'' --'
+```
+
+Empty (default) → today's behavior, unchanged. Direct `claude ...` invocation.
+
+Set → command becomes `<AGENT_LAUNCHER> <AGENT_CMD> <args...>`. The launcher token is `eval`-expanded once when read from conf so users can use single-quoted heredoc-ish forms. The `--` at the end is the conventional `bash -c` boundary for `$@`.
+
+### How autonomous-tag flows through
+
+The wrapper exports `CC_USER` (or any env var the user's launcher reads) before invoking the launcher:
+
+```bash
+# autonomous-dev.sh
+export CC_USER="autonomous-dev-bot"
+export CC_ROLE_KIND="dev"           # for downstream telemetry tagging
+
+# autonomous-review.sh
+export CC_USER="autonomous-review-bot"
+export CC_ROLE_KIND="review"
+```
+
+The user's `cc` function picks these up via the env (it already does `CC_USER="${USER:-unknown}"` style references). This gives downstream telemetry / billing a clean way to attribute autonomous-pipeline traffic separate from interactive work, without anyone needing to change anything other than autonomous.conf.
+
+### Why not just add `ANTHROPIC_*` env to autonomous.conf?
+
+Considered. Rejected because:
+- Bedrock model ids change; users who maintain their own `cc` already have a single source of truth.
+- Some users use OpenRouter / Mantle / Kimi via `claude-{bedrock,sso,mantle,kimi}` aliases — same launcher pattern, different env. A generic launcher hook is more flexible than a hard-coded ANTHROPIC env passthrough.
+- It keeps `autonomous.conf` focused on pipeline policy, not LLM auth.
+
+### Compatibility with codex / kiro / opencode
+
+The launcher prefix is applied uniformly across all four CLI branches in `run_agent` and `resume_agent`. Codex's `_codex_capture_thread` pipe and opencode's `_opencode_capture_session` pipe both still see the same JSON event stream because the launcher is just an env-injection wrapper.
+
+### Why expose the bot identity via `CC_USER`
+
+The user already uses `CC_USER` in their interactive `cc` function (`CC_USER="${USER:-unknown}"`). Reusing it for the bot identity keeps the downstream telemetry one-dimensional — instead of "is this `$USER` or some other tag?", a single `CC_USER` field tells the cost-attribution system whether the traffic was an interactive human session or one of the autonomous bots. Documented as opt-in via `AGENT_LAUNCHER` — wrappers always set `CC_USER` regardless, so users without a launcher get a harmless extra env var.
+
+## Fix 3 — `prompt_too_long` triggers fresh-session fallback early
+
+### Current (resume-forever)
+
+`lib-dispatch.sh:230`:
+```bash
+fields=$(jq -er '"\(.stop_reason // "")|\(.terminal_reason // "")"' <<<"$last_line") || return 1
+[ "$fields" = "end_turn|completed" ]
+```
+
+If a session crashed with `terminal_reason=prompt_too_long`, this returns 1 ("not completed"), and the dispatcher's next tick happily issues `claude --resume <id>` again. That re-feeds the whole JSONL — which is what blew us up in the first place — and we crash on `prompt_too_long` again. Loop.
+
+### New design
+
+Treat `terminal_reason=prompt_too_long` (and any other `terminal_reason` known to be unrecoverable via resume) as "session is done — don't resume; force fresh next time".
+
+Two surface changes:
+
+1. `is_session_completed` returns 0 for both `end_turn|completed` AND `*|prompt_too_long`. The dispatcher's tick step that calls it (`dispatcher-tick.sh:241`) already posts an issue comment "session ended, skipping resume — manually transition" when this returns true. New comment text disambiguates: "session ran out of context — next dispatch will start fresh" and it actively *promotes* the issue back to `pending-dev` (so a fresh session runs on the next tick) instead of leaving it stuck.
+2. `autonomous-dev.sh` MODE=resume already has a non-zero-exit fallback that mints `NEW_SESSION_ID` and re-runs as new (line 347–405). Strengthen it: post the new session id as a standalone `Dev Session ID: \`${NEW_SESSION_ID}\`` comment (matching the regex in `lib-dispatch.sh:extract_dev_session_id`) **immediately after** `SESSION_ID=$NEW_SESSION_ID`, not just inline as part of "Resume failed (...)". This guarantees the dispatcher picks up the new id even if the wrapper crashes mid-fallback before its trap fires.
+
+### Why not just always force fresh on every tick?
+
+The user has 11M-token windows on opus[1m]/sonnet[1m] and we want to preserve cache hits when the agent is making genuine progress. Resume IS a real optimization — just not when resume itself blew up. So: keep resume as the default, force fresh **only** on the prompt_too_long signal.
+
+### Optional second trigger (future, not in this PR)
+
+"N consecutive resumes with no PR HEAD change → fresh" is also reasonable but adds complexity (need to track resume count per session in a sidecar). Deferring until we see real-world cases that prompt_too_long alone doesn't cover. The dispatcher-tick.sh:373 logic already detects "no new commits since last review" and flips back to pending-dev — that's a related but distinct loop-breaker, and it's already in place.
+
+## Files touched
+
+| File | Why |
+|------|-----|
+| `skills/autonomous-dispatcher/scripts/autonomous-review.sh` | verdict detector rewrite (Fix 1) + `CC_USER` export (Fix 2) |
+| `skills/autonomous-dispatcher/scripts/autonomous-dev.sh` | `CC_USER` export (Fix 2) + post `Dev Session ID:` after fallback (Fix 3) |
+| `skills/autonomous-dispatcher/scripts/lib-agent.sh` | thread `AGENT_LAUNCHER` through `run_agent` / `resume_agent` for all CLI branches (Fix 2) |
+| `skills/autonomous-dispatcher/scripts/lib-dispatch.sh` | `is_session_completed` accepts `prompt_too_long` (Fix 3) |
+| `skills/autonomous-dispatcher/scripts/dispatcher-tick.sh` | `pending-dev` handoff comment text on prompt_too_long (Fix 3) |
+| `skills/autonomous-dispatcher/scripts/autonomous.conf.example` | document `AGENT_LAUNCHER`, mention `CC_USER` (Fix 2) |
+| `tests/unit/test-autonomous-review-verdict-regex.sh` | update TC-RVR-009/010 for new actor+time-window model, add new anti-spoof cases (Fix 1) |
+| `tests/unit/test-autonomous-launcher-verdict-fresh.sh` | new — covers all three fixes end-to-end at unit level (no real `claude` invoked) |
+| `docs/designs/autonomous-verdict-launcher-fresh.md` | this document |
+| `docs/test-cases/autonomous-verdict-launcher-fresh.md` | test case enumeration |
+
+## Out of scope
+
+- Changing the default to fresh-session per tick (rejected; `--resume` is fine for the common case on 11M-token models).
+- A pre-flight model-availability check (would catch the silent Haiku fallback at startup, but adds an HTTP RTT to every wrapper start; revisit if Fix 2 doesn't fully resolve the silent-fallback class).
+- Any changes to the SSM-remote dispatcher path; this PR is local-execution-backend specific.

--- a/docs/pipeline/dev-agent-flow.md
+++ b/docs/pipeline/dev-agent-flow.md
@@ -105,6 +105,16 @@ PR-6 closes this with two layers ([INV-12](invariants.md#inv-12-resume-only-agai
 1. **Dispatcher gate**: Step 4 calls `is_session_completed` before issuing a resume. If true, it posts a comment naming the session-id and asking the operator to manually decide between `pending-review` (PR exists) or close (work done). The issue stays in `pending-dev` rather than auto-recovering, so the symptom is visible.
 2. **Wall-clock safety net**: even if the gate is wrong (false negative), `lib-agent.sh::_run_with_timeout` caps the CLI at `AGENT_TIMEOUT` (default `4h`). The wrapper then exits with `124`, the trap routes to `pending-dev`, and the next tick decides whether to retry — instead of the wrapper sitting in `epoll_wait` for 8h+.
 
+### Resume-on-prompt-too-long (auto-recover with fresh session)
+
+A long-lived dev session whose JSONL transcript grows past the model's input window will exit with `terminal_reason=prompt_too_long`. Headless `claude -p` has no auto-compaction (the TUI's `/compact` is interactive-only), so resuming re-feeds the whole transcript and crashes the same way. The only recovery is a fresh session.
+
+Two layers:
+
+1. **Dispatcher gate** ([Step 4b.5 in `dispatcher-flow.md`](dispatcher-flow.md#step-4b5-terminal-state-gate-inv-12)): when `is_session_completed` reports `terminal_reason=prompt_too_long`, the dispatcher truncates the per-issue log, posts the `INV-12-prompt-too-long:<sid>` notice (idempotent), `label_swap pending-dev → in-progress`, and dispatches `dev-new`. The new wrapper mints a fresh `SESSION_ID` and seeds its prompt from issue body / PR / `## Requirements` checklist state — no JSONL transcript is replayed.
+
+2. **Wrapper-side fallback** in `autonomous-dev.sh` MODE=resume: if `resume_agent` exits non-zero (e.g. PTL hits the wrapper before the next dispatcher tick can route around it), the wrapper mints `NEW_SESSION_ID=$(uuidgen)`, **posts a standalone `Dev Session ID: \`<NEW_SESSION_ID>\` (mode: resume-fallback)` comment**, then runs `run_agent` with the new id. The standalone Dev-Session-ID post is a separate `gh issue comment` from the explanatory "Resume failed... Starting new session..." comment so a single failed post can't orphan the fresh session id from the dispatcher's view (`extract_dev_session_id` would otherwise read the dead session id and the next tick would resume into the same crash).
+
 ## Exit trap (`cleanup`)
 
 The trap is the wrapper's actual contract with the dispatcher — it runs on every exit path, including SIGTERM from the dispatcher's Step 5a. Its job is to (a) free the PID file, (b) post the Session Report, (c) update labels, (d) tear down auth.

--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -191,17 +191,18 @@ Find the most recent comment matching `Dev Session ID: \`<id>\`` (note: `Review 
 
 If no session-id can be extracted, the resume cannot proceed. Today, the dispatcher dispatches a new dev session anyway (the wrapper's `--mode resume` path falls back to `--mode new` when `SESSION_ID` is empty — see [`dev-agent-flow.md`](dev-agent-flow.md#mode-normalization)).
 
-### Step 4b.5: terminal-state gate (PR-6, [INV-12](invariants.md#inv-12-resume-only-against-unfinished-sessions))
+### Step 4b.5: terminal-state gate ([INV-12](invariants.md#inv-12-resume-only-against-unfinished-sessions))
 
-Before dispatching a resume, call `is_session_completed <issue>` (in `lib-dispatch.sh`). The helper inspects the agent log at `/tmp/agent-${PROJECT_ID}-issue-<N>.log`, finds the last `{"type":"result", ...}` JSON object, and returns 0 if `stop_reason=end_turn` AND `terminal_reason=completed`.
+Before dispatching a resume, call `is_session_completed <issue> _reason` (in `lib-dispatch.sh`). The helper inspects the agent log at `/tmp/agent-${PROJECT_ID}-issue-<N>.log`, finds the last `{"type":"result", ...}` JSON object, and returns 0 in two cases. The optional second arg captures `terminal_reason` so the caller can branch on which case fired:
 
-If the gate fires:
+| `terminal_reason` | Meaning | Dispatcher action |
+|---|---|---|
+| `completed` | Normal end-of-turn (`stop_reason=end_turn` too). Resuming would attach to a closed SSE stream and hang. | Operator handoff: post `INV-12-completed:<sid>` notice, leave issue in `pending-dev`, do not auto-recover. |
+| `prompt_too_long` | JSONL transcript exceeded the model's input window. Headless `claude -p` has no auto-compaction, so resuming re-feeds the whole transcript and crashes again. | Auto-recover: post `INV-12-prompt-too-long:<sid>` notice, **truncate the per-issue log**, `label_swap pending-dev → in-progress`, `post_dispatch_token dev-new`, `dispatch dev-new`. The next tick mints a fresh session id with a smaller seed prompt that re-derives state from git/issue/PR. |
 
-1. Post a comment naming the session-id and inviting an operator to manually flip to `pending-review` (PR exists) or close the issue (work done).
-2. Append the issue to `JUST_DISPATCHED` so Step 5 doesn't reprobe it on the same tick.
-3. **Do not** transition the label automatically. The issue stays in `pending-dev`. Silent recovery would mask other failure modes — surface the symptom and let a human decide.
+The PTL branch hard-fails if the log truncate fails (perm drift, ENOSPC): post an operator-actionable comment and `continue` without dispatching. Without this guard, the next tick would re-read the same stale PTL log, the idempotency-marker check would suppress a fresh notice (it's keyed on the old session_id), and the dispatcher would silently dispatch dev-new every tick forever.
 
-This is a conservative gate: it only fires when the helper is certain the prior session ended cleanly. False negatives (claiming "not completed" when it was) just keep the prior behavior — Step 4c attempts the resume, and the wall-clock timeout from [INV-13](invariants.md#inv-13-wall-clock-cap-on-agent-invocations) bounds the damage to `AGENT_TIMEOUT` (default `4h`).
+This is a conservative gate: it only fires when the helper is certain the prior session reached one of the two terminal states. False negatives (claiming "not terminal" when it was) just keep the prior behavior — Step 4c attempts the resume, and the wall-clock timeout from [INV-13](invariants.md#inv-13-wall-clock-cap-on-agent-invocations) bounds the damage to `AGENT_TIMEOUT` (default `4h`).
 
 ### Step 4c: dispatch resume
 

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -156,14 +156,21 @@ The cutoff timestamp falls back to epoch (1970-01-01) for issues that have never
 
 ## INV-12: Resume only against unfinished sessions
 
-**Rule**: The dispatcher's Step 4 MUST query the agent session's terminal state before issuing a resume, and skip the resume if `terminal_reason == completed`.
+**Rule**: The dispatcher's Step 4 MUST query the agent session's terminal state before issuing a resume, and treat both `terminal_reason == completed` and `terminal_reason == prompt_too_long` as terminal (skip resume).
 
-**Why**: A `claude --resume` against a session whose final turn ended with `stop_reason=end_turn` connects to the SSE streaming endpoint and never returns — the model has no work to do, the server keeps the connection alive, and the wrapper hangs indefinitely (#59).
+**Why**:
+- `end_turn|completed`: a `claude --resume` against a session whose final turn ended cleanly connects to the SSE streaming endpoint and never returns (#59).
+- `*|prompt_too_long`: headless `claude -p` has no auto-compaction (the TUI's `/compact` is interactive-only). Resuming re-feeds the entire JSONL transcript, which is what blew the context window in the first place — guaranteed re-crash, infinite loop.
 
-**Producer**: dispatcher Step 4 (`lib-dispatch.sh::is_session_completed` invoked from `dispatcher-tick.sh` Step 4).
-**Consumer**: prevents the wrapper from being put in a hang state.
-**Status**: **ENFORCED** in PR-6 (closes #59). The dispatcher reads the agent log at `/tmp/agent-${PROJECT_ID}-issue-${N}.log`, finds the last `{"type":"result", ...}` object, and skips dispatch if `stop_reason=end_turn` AND `terminal_reason=completed`. Skip is conservative: the issue stays in `pending-dev` and a comment is posted asking an operator to manually decide between `pending-review` (PR exists) or close (work done) — the helper deliberately doesn't auto-recover, since silent recovery would mask other failure modes.
-**Test**: `tests/unit/test-is-session-completed.sh` (11 cases): clean exit returns true; non-end_turn / non-completed / non-claude / missing log / multiple-result / malformed JSON / missing fields all return false.
+**Producer**: dispatcher Step 4 (`lib-dispatch.sh::is_session_completed` invoked from `dispatcher-tick.sh` Step 4). The helper writes the matched `terminal_reason` to a caller-provided var via `printf -v` so the caller can branch on the case.
+
+**Consumer**: prevents the wrapper from being put in a hang state (completed) or a dispatch loop (prompt_too_long).
+
+**Status**: **ENFORCED**. Closed cases:
+- PR-6 (closes #59) — initial enforcement for `end_turn|completed`.
+- This PR — extends to `prompt_too_long`. The completed branch posts an `INV-12-completed:<sid>` notice and leaves the issue in `pending-dev` for operator decision; the prompt-too-long branch posts an `INV-12-prompt-too-long:<sid>` notice, truncates the per-issue log, and `dispatch dev-new` to auto-recover with a fresh session.
+
+**Test**: `tests/unit/test-is-session-completed.sh` (14 cases) and `tests/unit/test-autonomous-launcher-verdict-fresh.sh` TC-PTL-001..007d.
 
 ## INV-13: Wall-clock cap on agent invocations
 
@@ -276,6 +283,52 @@ The `Mode: startup-failure` exclusion matters: `autonomous-dev.sh`'s startup-fai
 **Test**: `tests/unit/test-dispatcher-reliability-99.sh` covers session-id-gate semantics (5 cases including stalled-cutoff interaction). `tests/unit/test-lib-dispatch.sh` regression cases updated to reflect the new gate.
 
 ---
+
+## INV-20: Verdict authenticity binding (actor + window + trailer presence)
+
+**Rule**: The review wrapper's verdict polling jq query MUST gate on three layered predicates when actor binding is available: (a) `author.login == BOT_LOGIN`, (b) `createdAt >= WRAPPER_START_TS`, (c) `body matches /Review Session/`. The trailer match MUST NOT bind to the wrapper-generated `SESSION_ID` — only the trailer's presence is checked.
+
+**Why**: The prior body-text predicate `Review Session.*${SESSION_ID}` depended on the agent echoing the wrapper's UUID verbatim. Agents under context pressure occasionally rewrote the UUID, causing the wrapper to miss valid verdicts and force the FAILED branch. Combined with a same-PR / same-issue dispatcher state machine, this produced infinite dev↔review ping-pong loops on the consumer side. Trailer-presence (without UUID binding) keeps spoof protection intact in `GH_AUTH_MODE=token` (where dev and review wrappers share BOT_LOGIN — the dev agent's prompts don't instruct it to emit `Review Session:`, so its status comments are excluded) without the brittleness.
+
+**Producer**: `autonomous-review.sh` polling loop. Captures `WRAPPER_START_TS` once before `run_agent` (ISO-8601 UTC) and `BOT_LOGIN` once via `gh api user --jq .login` (treats empty / errored / literal-`"null"` as unset).
+
+**Consumer**: prevents (a) verdict regressions when the agent rewrites the trailer UUID, (b) cross-wrapper spoofing in same-identity (token) mode, (c) stale verdicts from prior ticks being picked up.
+
+**Fallback**: when `BOT_LOGIN` is unset, the predicate becomes `(createdAt >= WRAPPER_START_TS) AND (body matches /Review Session.*<SESSION_ID>/)`. This re-introduces the brittleness only on the rare path where actor binding is unavailable, and time-window predicate still narrows out stale comments.
+
+**Status**: **ENFORCED** in this PR. Replaces the prior session-id-only binding (which closed #95 phrasing-drift but did not address the UUID-rewrite drift).
+
+**Test**: `tests/unit/test-autonomous-launcher-verdict-fresh.sh` TC-VRD-001..009a (12 cases including token-mode dev-agent quoted-verdict anti-spoof).
+
+## INV-21: Resume-fallback fresh session id is dispatcher-readable
+
+**Rule**: `autonomous-dev.sh` MODE=resume's non-zero-exit fallback path, immediately after assigning `SESSION_ID="$NEW_SESSION_ID"`, MUST post a standalone GitHub issue comment matching the regex `Dev Session ID: \`<id>\``.
+
+**Why**: Without this, the only place the new session id surfaces to GitHub before the agent runs is inside the explanatory "Resume failed... Starting new session..." comment — which does NOT match the dispatcher's `extract_dev_session_id` regex. If the wrapper crashes between the resume-fallback decision and the trap-on-exit `Agent Session Report (Dev)` post (e.g. a transient gh outage on the report post), the dispatcher's next tick reads the OLD session id from prior comments and resumes the dead session forever.
+
+**Producer**: `autonomous-dev.sh:362..366` — two separate `gh issue comment` calls (explanation + standalone marker) so a single failed post can't orphan the marker.
+
+**Consumer**: `lib-dispatch.sh::extract_dev_session_id` — picks up the new id on the next tick.
+
+**Status**: **ENFORCED** in this PR.
+
+**Test**: `tests/unit/test-autonomous-launcher-verdict-fresh.sh` TC-PTL-005.
+
+## INV-22: AGENT_LAUNCHER tokenization happens once at config load
+
+**Rule**: `lib-agent.sh` MUST tokenize `AGENT_LAUNCHER` (when non-empty) into `AGENT_LAUNCHER_ARGV[]` exactly once at source time via `eval "AGENT_LAUNCHER_ARGV=($AGENT_LAUNCHER)"`. The argv array is then prepended to every CLI invocation inside `_run_with_timeout`, so all CLI branches (claude / codex / kiro / opencode / generic) and both call sites (run_agent / resume_agent) get uniform launcher behavior.
+
+**Why**: The consumer-machine motivation is to bridge dispatcher-spawned wrappers (non-interactive `nohup` shell, no `~/.bashrc`) into the same env that powers the operator's interactive `claude` shell function (`cc`). Without `AGENT_LAUNCHER`, autonomous wrappers ran with `--model opus[1m]` but the alias resolved to whatever model claude defaults to (no `ANTHROPIC_DEFAULT_OPUS_MODEL` set), silently downgrading to a different model. A per-CLI-branch sprinkle of `${AGENT_LAUNCHER_ARGV[@]}` would invite drift; centralizing in `_run_with_timeout` makes the prefix invariant across branches.
+
+**Producer**: `lib-agent.sh` — the `eval` parses the launcher string once, with a hard-fail on parse error and a WARN when the parse succeeds but yields zero argv elements (almost always operator typo).
+
+**Consumer**: every `run_agent` / `resume_agent` invocation, uniform across CLIs.
+
+**Trust**: `AGENT_LAUNCHER` is read from `autonomous.conf`. Treating its contents as shell input is no worse than executing `AGENT_CMD` itself — both are operator-controlled config in the same file. The wrapper documents this trust assumption explicitly.
+
+**Status**: **ENFORCED** in this PR.
+
+**Test**: `tests/unit/test-autonomous-launcher-verdict-fresh.sh` TC-LCH-001..003, plus TC-LCH-007/008 for the `CC_USER` / `CC_ROLE_KIND` env exports the wrapper sets before invoking the launcher.
 
 ## Adding a new invariant
 

--- a/docs/pipeline/review-agent-flow.md
+++ b/docs/pipeline/review-agent-flow.md
@@ -32,7 +32,7 @@ sequenceDiagram
     L->>A: claude --session-id ... --model sonnet -p PROMPT
     A->>GH: post verdict comment ('Review PASSED' or 'Review findings')
     A-->>L: agent exits
-    W->>GH: poll for verdict comment (6 attempts, 5s each, session-id filtered)
+    W->>GH: poll for verdict comment (6 attempts, 5s each, actor + window + trailer)
     W->>GH: post 'Reviewed HEAD' trailer (if verdict and SHA known)
     alt verdict PASS
         W->>GH: gh pr view --json state (re-check OPEN)
@@ -94,14 +94,17 @@ The session-id trailer is the wrapper's only way to identify which comment is it
 
 ## Verdict polling
 
-After the agent exits, the wrapper polls issue comments up to 6 times (5s interval = 30s window) looking for a comment that satisfies BOTH:
+After the agent exits, the wrapper polls issue comments up to 6 times (5s interval = 30s window) looking for a comment that satisfies all applicable predicates:
 
 - Body matches a verdict phrasing (case-insensitive). The supported set was broadened in #95 to handle agent phrasing drift:
   - **Pass-side**: `Review PASSED`, `Review APPROVED`, `APPROVED FOR MERGE`, `LGTM`, `Review PASS`.
   - **Fail-side**: `Review findings:`, `Review FAILED`, `Review REJECTED`, `Changes requested`.
-- Body matches `Review Session.*<SESSION_ID>` (the wrapper-generated session-id).
+- Authenticity binding — three layers, all required (primary path):
+  - **Actor**: `author.login == BOT_LOGIN`. The wrapper resolves `BOT_LOGIN` once at startup via `gh api user --jq .login`. In `GH_AUTH_MODE=app` the dev and review wrappers authenticate as distinct GitHub Apps, so the actor predicate alone separates them.
+  - **Time window**: `createdAt >= WRAPPER_START_TS`. Captured before `run_agent` in ISO-8601 UTC. Excludes stale verdict comments left by a prior tick.
+  - **Body trailer presence**: body matches `/Review Session/`. Note: the trailer's UUID is NOT bound to the wrapper's `SESSION_ID` — only the trailer's presence is checked. This eliminates a long-standing brittleness where the agent occasionally rewrote the UUID and broke the regex match. The trailer requirement is load-bearing in `GH_AUTH_MODE=token`, where dev and review wrappers share `BOT_LOGIN`: only the review agent's prompt instructs it to emit `Review Session:`, so the trailer excludes the dev agent's status comments that contain a verdict keyword as quoted history.
 
-The session-id filter is a **verdict-spoofing defense**: without it, any comment containing one of the verdict phrasings — including a maintainer's typed message, or a stray comment from another tool — could be picked up as the verdict.
+Fallback path: if `gh api user` fails at startup (returns empty, errors out, or returns the literal string `"null"` from a misconfigured GitHub App), `BOT_LOGIN` is treated as unset and the predicate becomes `createdAt >= WRAPPER_START_TS AND body matches Review Session.*<SESSION_ID>`. This restores the prior brittleness (agent must echo the wrapper's UUID) only on the rare path where actor binding is unavailable.
 
 If polling completes without finding a verdict comment, the wrapper proceeds to the FAIL branch (no false-positive PASS).
 

--- a/docs/test-cases/autonomous-verdict-launcher-fresh.md
+++ b/docs/test-cases/autonomous-verdict-launcher-fresh.md
@@ -1,0 +1,72 @@
+# Test cases — verdict + launcher + prompt_too_long fallback
+
+Three groups: TC-VRD (Fix 1, verdict detector), TC-LCH (Fix 2, launcher), TC-PTL (Fix 3, prompt_too_long fallback). Each maps to a unit test in `tests/unit/`.
+
+## Setup
+
+All cases run as bash unit tests with no real `claude` / `gh` invocations. We:
+- Stub `gh` via a `PATH`-shadowed script that reads canned JSON from `$TMPDIR/gh-fixture-*`.
+- Source the wrapper or library under test in a subshell with mocked deps so we exercise the actual code path.
+- For verdict cases, drive synthetic `comments` JSON through the wrapper's live regex (extracted from source) so test failures pinpoint regex drift.
+
+## TC-VRD — verdict detection (Fix 1)
+
+Replaces `tests/unit/test-autonomous-review-verdict-regex.sh` cases TC-RVR-009 and TC-RVR-010 (which assert "no/wrong session-id → no-match"). Under the new actor+time-window model those comments DO match if the author and timestamp are right, so we re-test those scenarios for the new model and add new anti-spoof cases.
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| TC-VRD-001 | Comment by `BOT_LOGIN`, createdAt=now, body="Review PASSED ..." | `pass` |
+| TC-VRD-002 | Comment by `BOT_LOGIN`, createdAt=now, body="APPROVED FOR MERGE ..." | `pass` |
+| TC-VRD-003 | Comment by `BOT_LOGIN`, createdAt=now, body="Review findings: ..." | `fail` |
+| TC-VRD-004 | Comment by `BOT_LOGIN`, createdAt=now, body has `Review Session: <random-uuid>` (NOT the wrapper's) | `pass` if body keyword passes (anti-regression: agent-minted UUID no longer breaks detection) |
+| TC-VRD-005 | Comment by **different** login, createdAt=now, body="Review PASSED" | `no-match` (anti-spoof: foreign actor) |
+| TC-VRD-006 | Comment by `BOT_LOGIN`, createdAt=**before** wrapper start, body="Review PASSED" | `no-match` (anti-spoof: stale comment from prior tick) |
+| TC-VRD-007 | Both pass + fail keywords in body, BOT_LOGIN actor, in window | `fail` (conservative tie-break unchanged) |
+| TC-VRD-008 | `BOT_LOGIN` resolution failed (empty), comment matches by old session-id binding | `pass` (degraded fallback to legacy regex) |
+| TC-VRD-009 | `BOT_LOGIN` resolution failed AND comment lacks session-id | `no-match` (legacy fallback engaged, original anti-spoof preserved) |
+
+## TC-LCH — AGENT_LAUNCHER (Fix 2)
+
+Tested by inspecting the actual command lib-agent.sh would invoke (without running it). We capture argv via a `claude` shim that writes its argv to a file and exits 0.
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| TC-LCH-001 | `AGENT_LAUNCHER` unset; `run_agent` claude branch | argv[0]=`claude`, no launcher prefix |
+| TC-LCH-002 | `AGENT_LAUNCHER="env FOO=bar"`; run_agent claude | argv begins with `env FOO=bar claude`; FOO=bar reaches claude's env |
+| TC-LCH-003 | `AGENT_LAUNCHER` set; `resume_agent` claude branch | launcher applied to resume too (symmetry) |
+| TC-LCH-004 | `AGENT_LAUNCHER` set; `AGENT_CMD=codex` | launcher applied to codex's `exec --json` invocation; `_codex_capture_thread` pipe still receives valid JSONL |
+| TC-LCH-005 | `AGENT_LAUNCHER` set; `AGENT_CMD=opencode` | launcher applied; `_opencode_capture_session` pipe still works |
+| TC-LCH-006 | `AGENT_LAUNCHER` set; `AGENT_CMD=kiro` | launcher applied to `kiro-cli chat` invocation |
+| TC-LCH-007 | autonomous-dev.sh exports `CC_USER=autonomous-dev-bot` and `CC_ROLE_KIND=dev` before run_agent | both env vars visible in claude's env |
+| TC-LCH-008 | autonomous-review.sh exports `CC_USER=autonomous-review-bot` and `CC_ROLE_KIND=review` | both env vars visible in claude's env |
+| TC-LCH-009 | `AGENT_LAUNCHER` containing single quotes (the canonical `bash -c '...' --` form) parses correctly via eval-once | argv reflects the intended launcher tokens |
+
+## TC-PTL — prompt_too_long fresh fallback (Fix 3)
+
+Tested by feeding synthetic JSONL log files into `is_session_completed` and exercising autonomous-dev.sh's resume→fallback path with a stub claude that exits non-zero on resume.
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| TC-PTL-001 | Log ends with `stop_reason=end_turn,terminal_reason=completed` | `is_session_completed` → 0 (existing behavior unchanged) |
+| TC-PTL-002 | Log ends with `stop_reason=stop_sequence,terminal_reason=prompt_too_long` | `is_session_completed` → 0 (NEW: treat as terminal) |
+| TC-PTL-003 | Log ends with `terminal_reason=api_error` | `is_session_completed` → 1 (api_error is transient — keep retrying) |
+| TC-PTL-004 | Log file missing | `is_session_completed` → 1 (unchanged, conservative) |
+| TC-PTL-005 | autonomous-dev.sh MODE=resume, stub claude exits non-zero | fallback path mints NEW_SESSION_ID, posts standalone `Dev Session ID: \`${NEW_SESSION_ID}\`` comment to issue, then runs new session |
+| TC-PTL-006 | dispatcher-tick.sh detects prompt_too_long via is_session_completed | Posts handoff comment with marker `INV-12-prompt-too-long:<sid>`, sets label → `pending-dev` (so next tick runs a fresh session, not stuck waiting for human) |
+| TC-PTL-007 | Same issue, second tick after PTL handoff | fresh session minted, new `Dev Session ID:` posted (extracted by `extract_dev_session_id`'s `last`); old PTL session not resumed |
+
+## Negative cases (cross-cutting)
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| TC-NEG-001 | `AGENT_LAUNCHER` set to a nonexistent command | wrapper fails fast at run_agent invocation; existing trap-on-exit posts startup-failure report |
+| TC-NEG-002 | `gh api user` rate-limited at wrapper start | `BOT_LOGIN` empty; verdict detector falls back to legacy session-id binding (TC-VRD-008/009 path) |
+| TC-NEG-003 | Concurrent dev and review wrappers on same issue (existing concurrency model) | each wrapper's verdict detector uses its own `WRAPPER_START_TS`, so reads only its own bot's recent comments |
+
+## Manual smoke (post-merge, on consumer machine)
+
+Not part of CI — to be run by the user on their `podcast-curation` host once the dispatcher picks up the merged change:
+
+1. Confirm `AGENT_LAUNCHER` set in their `autonomous.conf` causes `cc` env (`CLAUDE_CODE_USE_BEDROCK=1`, etc.) to flow into the wrapper. Verify by checking the next dispatch's `/tmp/agent-*-issue-N.log` JSONL `modelUsage` field — should now show `global.anthropic.claude-opus-4-7` instead of `anthropic.claude-haiku-4-5`.
+2. Confirm `CC_USER=autonomous-dev-bot` / `autonomous-review-bot` shows up in their telemetry attribution.
+3. Confirm a stuck issue with the dev↔review loop converges to `approved` after one full cycle (review's verdict detector now matches by actor+time, agent's self-minted session UUID no longer breaks detection).

--- a/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
@@ -85,7 +85,7 @@ fi
 # Ensure we're in the project directory (needed when called directly, not just via SSM)
 cd "$PROJECT_DIR" || { echo "Error: cannot cd to $PROJECT_DIR" >&2; exit 1; }
 
-# Bot identity for downstream telemetry / cost attribution (Fix 2).
+# Bot identity for downstream telemetry / cost attribution.
 # Picked up by AGENT_LAUNCHER (e.g. user's `cc` shell function) when set;
 # harmless extra env when AGENT_LAUNCHER is empty.
 export CC_USER="${CC_USER:-autonomous-dev-bot}"
@@ -355,15 +355,19 @@ EOF
     NEW_SESSION_ID=$(uuidgen)
     log "Resume failed (exit $AGENT_EXIT). Starting new session: ${NEW_SESSION_ID}"
 
-    # Post the explanatory comment AND a dispatcher-readable Dev Session ID
-    # marker. The latter ensures the next tick's extract_dev_session_id sees
-    # the fresh id even if this wrapper crashes after run_agent but before
-    # the trap-on-exit session report fires (Fix 3 — prompt_too_long path).
-    # Two separate posts so a single failure doesn't void the marker.
+    # Post TWO comments: a human-readable explanation AND a separately-
+    # posted "Dev Session ID:" marker matching the regex in
+    # extract_dev_session_id. Splitting them means a single failed `gh
+    # issue comment` can't orphan the new session_id from the dispatcher's
+    # view (which would otherwise leave the next tick chasing the dead
+    # session forever). On failure log a WARNING — silent failure here
+    # would mask a sustained GH outage that risks the orphan scenario.
     gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
-      --body "Resume failed (session \`${SESSION_ID}\`). Starting new session \`${NEW_SESSION_ID}\`." 2>/dev/null || true
+      --body "Resume failed (session \`${SESSION_ID}\`). Starting new session \`${NEW_SESSION_ID}\`." \
+      || log "WARNING: Failed to post resume-fallback explanation comment (non-fatal)"
     gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
-      --body "Dev Session ID: \`${NEW_SESSION_ID}\` (mode: resume-fallback)" 2>/dev/null || true
+      --body "Dev Session ID: \`${NEW_SESSION_ID}\` (mode: resume-fallback)" \
+      || log "WARNING: Failed to post Dev Session ID marker for resume-fallback. If the trap-side session report also fails, the next dispatcher tick may resume the dead session ${SESSION_ID} instead of the new ${NEW_SESSION_ID}."
 
     SESSION_ID="$NEW_SESSION_ID"
     SESSION_NAME="dev-issue-${ISSUE_NUMBER}-retry"

--- a/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
@@ -85,6 +85,12 @@ fi
 # Ensure we're in the project directory (needed when called directly, not just via SSM)
 cd "$PROJECT_DIR" || { echo "Error: cannot cd to $PROJECT_DIR" >&2; exit 1; }
 
+# Bot identity for downstream telemetry / cost attribution (Fix 2).
+# Picked up by AGENT_LAUNCHER (e.g. user's `cc` shell function) when set;
+# harmless extra env when AGENT_LAUNCHER is empty.
+export CC_USER="${CC_USER:-autonomous-dev-bot}"
+export CC_ROLE_KIND="${CC_ROLE_KIND:-dev}"
+
 LOG_FILE="/tmp/agent-${PROJECT_ID}-issue-${ISSUE_NUMBER}.log"
 # PID file lives in the per-user PID dir (closes #72). pid_dir_for_project
 # is in lib-config.sh, sourced transitively via lib-agent.sh.
@@ -349,8 +355,15 @@ EOF
     NEW_SESSION_ID=$(uuidgen)
     log "Resume failed (exit $AGENT_EXIT). Starting new session: ${NEW_SESSION_ID}"
 
+    # Post the explanatory comment AND a dispatcher-readable Dev Session ID
+    # marker. The latter ensures the next tick's extract_dev_session_id sees
+    # the fresh id even if this wrapper crashes after run_agent but before
+    # the trap-on-exit session report fires (Fix 3 — prompt_too_long path).
+    # Two separate posts so a single failure doesn't void the marker.
     gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
       --body "Resume failed (session \`${SESSION_ID}\`). Starting new session \`${NEW_SESSION_ID}\`." 2>/dev/null || true
+    gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+      --body "Dev Session ID: \`${NEW_SESSION_ID}\` (mode: resume-fallback)" 2>/dev/null || true
 
     SESSION_ID="$NEW_SESSION_ID"
     SESSION_NAME="dev-issue-${ISSUE_NUMBER}-retry"

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -231,13 +231,15 @@ SESSION_ID=$(uuidgen)
 # WRAPPER_START_TS — ISO-8601 UTC captured BEFORE run_agent. Verdict
 # comments older than this are stale (prior tick) and ignored.
 WRAPPER_START_TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-# BOT_LOGIN — the bot identity this wrapper authenticates as. Capture
-# stderr so a non-empty failure (token expired, GH App perms reduced,
-# rate limit) shows up actionably in the per-issue log. An empty login
-# from a successful call is treated the same as a failed call —
-# without an actor binding the predicate must fall back to legacy mode.
+# BOT_LOGIN — the bot identity this wrapper authenticates as. We need
+# the diagnostic on failure (token expired, GH App perms reduced, rate
+# limit, etc.) so the operator can debug, but we deliberately limit
+# what we log: a 200-char head of stderr only, no full body. `gh api`
+# stderr is a JSON error body which is generally safe to log, but
+# truncation is defense-in-depth against a future gh release that
+# might surface request-context headers.
 _bot_login_raw=$(gh api user --jq '.login' 2>&1) && BOT_LOGIN="$_bot_login_raw" || {
-  log "WARNING: gh api user failed; verdict detector falling back to session-id binding. stderr: ${_bot_login_raw}"
+  log "WARNING: gh api user failed; verdict detector falling back to session-id binding. stderr (truncated): ${_bot_login_raw:0:200}"
   BOT_LOGIN=""
 }
 # A literal "null" string can come back from `--jq '.login'` if /user

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -76,7 +76,7 @@ fi
 # Ensure we're in the project directory (needed when called directly, not just via SSM)
 cd "$PROJECT_DIR" || { echo "Error: cannot cd to $PROJECT_DIR" >&2; exit 1; }
 
-# Bot identity for downstream telemetry / cost attribution (Fix 2).
+# Bot identity for downstream telemetry / cost attribution.
 # Picked up by AGENT_LAUNCHER (e.g. user's `cc` shell function) when set;
 # harmless extra env when AGENT_LAUNCHER is empty.
 export CC_USER="${CC_USER:-autonomous-review-bot}"
@@ -224,19 +224,30 @@ log "PR branch: ${PR_BRANCH:-UNKNOWN} (HEAD: ${PR_HEAD_SHA:0:7})"
 
 SESSION_ID=$(uuidgen)
 
-# Verdict-detection bindings (Fix 1: actor + time window replaces session-id binding).
-# WRAPPER_START_TS — ISO-8601 UTC timestamp captured BEFORE run_agent.
-# Verdict comments older than this are stale (prior tick) and ignored.
+# Verdict-detection bindings: actor + time window + body-trailer
+# presence. Replaces the prior session-id-only binding (which depended
+# on the agent echoing the wrapper's UUID verbatim).
+#
+# WRAPPER_START_TS — ISO-8601 UTC captured BEFORE run_agent. Verdict
+# comments older than this are stale (prior tick) and ignored.
 WRAPPER_START_TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-# BOT_LOGIN — the bot identity this wrapper authenticates as. The agent
-# inside the wrapper inherits this gh auth, so any comment it posts will
-# be authored by BOT_LOGIN. If the API call fails, the verdict detector
-# below falls back to the legacy session-id binding to preserve safety.
-BOT_LOGIN=$(gh api user --jq '.login' 2>/dev/null || echo "")
+# BOT_LOGIN — the bot identity this wrapper authenticates as. Capture
+# stderr so a non-empty failure (token expired, GH App perms reduced,
+# rate limit) shows up actionably in the per-issue log. An empty login
+# from a successful call is treated the same as a failed call —
+# without an actor binding the predicate must fall back to legacy mode.
+_bot_login_raw=$(gh api user --jq '.login' 2>&1) && BOT_LOGIN="$_bot_login_raw" || {
+  log "WARNING: gh api user failed; verdict detector falling back to session-id binding. stderr: ${_bot_login_raw}"
+  BOT_LOGIN=""
+}
+# A literal "null" string can come back from `--jq '.login'` if /user
+# returns null (rare App-token misconfig). Treat as failure.
+if [[ "$BOT_LOGIN" == "null" || -z "$BOT_LOGIN" ]]; then
+  [[ "$BOT_LOGIN" == "null" ]] && log "WARNING: gh api user returned null login; falling back to session-id binding"
+  BOT_LOGIN=""
+fi
 if [[ -n "$BOT_LOGIN" ]]; then
-  log "Verdict will bind to actor=${BOT_LOGIN}, createdAt >= ${WRAPPER_START_TS}"
-else
-  log "WARNING: gh api user failed; verdict detector will fall back to session-id binding"
+  log "Verdict will bind to actor=${BOT_LOGIN}, createdAt >= ${WRAPPER_START_TS}, body must contain 'Review Session'"
 fi
 
 PROMPT="$(cat <<EOF
@@ -503,33 +514,48 @@ log "Parsing review result from issue comments..."
 # made below by the classification grep — this polling step only
 # narrows down to "this looks like a verdict comment".
 #
-# Authenticity binding (Fix 1): actor + time window. The comment must
-# (a) be authored by BOT_LOGIN (the bot this wrapper runs as), and
-# (b) have createdAt >= WRAPPER_START_TS. Both are observable to the
-# wrapper without trusting the agent's body content. The agent can
-# mint whatever session-id text it wants — we don't read it.
+# Authenticity binding: see the predicate construction below for the
+# three-layer rationale (actor + time window + body trailer).
 #
-# Why this is safer than the prior session-id binding: the agent
-# inside the wrapper sometimes invents a different UUID for the
-# Review Session line (especially under context pressure), causing
-# the prior `Review Session.*${SESSION_ID}` regex to miss valid
-# verdicts and force the FAILED branch. A foreign actor would need
-# to be authenticated as BOT_LOGIN AND post within the wrapper's
-# narrow time window — both imply pre-existing write access.
+# Why we no longer bind to the wrapper's specific session UUID: the
+# agent occasionally rewrites the Review Session UUID in its comment
+# body, so a strict body-text match would miss valid verdicts and the
+# wrapper would fall through to the no-verdict-found FAILED branch.
+# Actor and time window are observed by the wrapper itself and cannot
+# be rewritten by the agent.
 #
-# Fallback: if BOT_LOGIN resolution failed at startup, fall back to
-# the legacy session-id binding so a transient API failure doesn't
-# remove all spoof protection.
+# Fallback: if `gh api user` returned empty at startup (BOT_LOGIN unset),
+# keep the body-text match against the wrapper's session_id so a
+# transient auth/API blip at the top of the wrapper doesn't strip all
+# spoof protection.
 #
 # Retry up to 6 times (30s total) to avoid race conditions.
 LATEST_COMMENT=""
 _VERDICT_RE='Review PASSED|Review APPROVED|APPROVED FOR MERGE|LGTM|Review PASS|Review findings:|Review FAILED|Review REJECTED|Changes requested'
-# Build the authenticity predicate once. Primary: actor + time window.
-# Fallback (BOT_LOGIN empty): legacy session-id trailer match.
+# Build the authenticity predicate once. Three layers, all required:
+#
+#   (a) actor (BOT_LOGIN) — when known, gates on the bot identity. In
+#       GH_AUTH_MODE=app this is the review-app's distinct login, so a
+#       concurrent dev wrapper can't spoof. In GH_AUTH_MODE=token dev
+#       and review share an identity, so this layer alone is insufficient.
+#
+#   (b) time window (WRAPPER_START_TS) — gates on createdAt, isolating
+#       the current review run from stale comments left by a prior tick.
+#
+#   (c) "Review Session" body trailer — a literal substring the review
+#       agent's prompt instructs it to emit. Does NOT bind to the
+#       wrapper's specific UUID (the prior brittleness this PR removes),
+#       only to the trailer's presence. This excludes the dev agent's status
+#       comments that happen to contain "Review findings" / "LGTM"
+#       inside a quoted prior verdict — those won't have the trailer.
+#
+# Fallback (BOT_LOGIN empty): drop (a), keep (b) and (c). The session-id
+# is included in (c)'s match for additional narrowing when actor is
+# unavailable.
 if [[ -n "$BOT_LOGIN" ]]; then
-  _AUTH_PREDICATE="(.author.login == \"${BOT_LOGIN}\") and (.createdAt >= \"${WRAPPER_START_TS}\")"
+  _AUTH_PREDICATE="(.author.login == \"${BOT_LOGIN}\") and (.createdAt >= \"${WRAPPER_START_TS}\") and (.body | test(\"Review Session\"))"
 else
-  _AUTH_PREDICATE="(.body | test(\"Review Session.*${SESSION_ID}\"))"
+  _AUTH_PREDICATE="(.createdAt >= \"${WRAPPER_START_TS}\") and (.body | test(\"Review Session.*${SESSION_ID}\"))"
 fi
 _VERDICT_JQ="[.comments[] | select(${_AUTH_PREDICATE} and (.body | test(\"${_VERDICT_RE}\"; \"i\")))] | last | .body"
 for _poll_attempt in $(seq 1 6); do

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -76,6 +76,12 @@ fi
 # Ensure we're in the project directory (needed when called directly, not just via SSM)
 cd "$PROJECT_DIR" || { echo "Error: cannot cd to $PROJECT_DIR" >&2; exit 1; }
 
+# Bot identity for downstream telemetry / cost attribution (Fix 2).
+# Picked up by AGENT_LAUNCHER (e.g. user's `cc` shell function) when set;
+# harmless extra env when AGENT_LAUNCHER is empty.
+export CC_USER="${CC_USER:-autonomous-review-bot}"
+export CC_ROLE_KIND="${CC_ROLE_KIND:-review}"
+
 LOG_FILE="/tmp/agent-${PROJECT_ID}-review-${ISSUE_NUMBER}.log"
 # PID file lives in the per-user PID dir (closes #72). pid_dir_for_project
 # is in lib-config.sh, sourced transitively via lib-agent.sh.
@@ -217,6 +223,21 @@ PR_HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid -q '.head
 log "PR branch: ${PR_BRANCH:-UNKNOWN} (HEAD: ${PR_HEAD_SHA:0:7})"
 
 SESSION_ID=$(uuidgen)
+
+# Verdict-detection bindings (Fix 1: actor + time window replaces session-id binding).
+# WRAPPER_START_TS — ISO-8601 UTC timestamp captured BEFORE run_agent.
+# Verdict comments older than this are stale (prior tick) and ignored.
+WRAPPER_START_TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+# BOT_LOGIN — the bot identity this wrapper authenticates as. The agent
+# inside the wrapper inherits this gh auth, so any comment it posts will
+# be authored by BOT_LOGIN. If the API call fails, the verdict detector
+# below falls back to the legacy session-id binding to preserve safety.
+BOT_LOGIN=$(gh api user --jq '.login' 2>/dev/null || echo "")
+if [[ -n "$BOT_LOGIN" ]]; then
+  log "Verdict will bind to actor=${BOT_LOGIN}, createdAt >= ${WRAPPER_START_TS}"
+else
+  log "WARNING: gh api user failed; verdict detector will fall back to session-id binding"
+fi
 
 PROMPT="$(cat <<EOF
 You are reviewing PR #${PR_NUMBER} for issue #${ISSUE_NUMBER} in the ${REPO} project.
@@ -473,21 +494,48 @@ log "Review agent exited with code: $AGENT_EXIT"
 # ---------------------------------------------------------------------------
 log "Parsing review result from issue comments..."
 
-# Poll for the agent's review comment. The polling regex (closes #95)
-# accepts the canonical phrasings ("Review PASSED" / "Review findings:")
-# AND common drift patterns: APPROVED FOR MERGE, Review APPROVED, LGTM,
-# Review FAILED, Review REJECTED, Changes requested. The pass-vs-fail
-# decision is made below by the classification grep — the polling step
-# only narrows down to "this looks like a verdict comment".
+# Poll for the agent's review comment.
 #
-# Retry up to 6 times (30s total) to avoid race conditions with concurrent comments.
-# SECURITY: the session-id binding (`Review Session.*${SESSION_ID}`) is
-# kept intact — without it a stray third-party comment could spoof a verdict.
+# Pattern (closes #95): the verdict-keyword regex accepts canonical
+# phrasings ("Review PASSED" / "Review findings:") plus common drift
+# variants (APPROVED FOR MERGE, Review APPROVED, LGTM, Review FAILED,
+# Review REJECTED, Changes requested). The pass-vs-fail decision is
+# made below by the classification grep — this polling step only
+# narrows down to "this looks like a verdict comment".
+#
+# Authenticity binding (Fix 1): actor + time window. The comment must
+# (a) be authored by BOT_LOGIN (the bot this wrapper runs as), and
+# (b) have createdAt >= WRAPPER_START_TS. Both are observable to the
+# wrapper without trusting the agent's body content. The agent can
+# mint whatever session-id text it wants — we don't read it.
+#
+# Why this is safer than the prior session-id binding: the agent
+# inside the wrapper sometimes invents a different UUID for the
+# Review Session line (especially under context pressure), causing
+# the prior `Review Session.*${SESSION_ID}` regex to miss valid
+# verdicts and force the FAILED branch. A foreign actor would need
+# to be authenticated as BOT_LOGIN AND post within the wrapper's
+# narrow time window — both imply pre-existing write access.
+#
+# Fallback: if BOT_LOGIN resolution failed at startup, fall back to
+# the legacy session-id binding so a transient API failure doesn't
+# remove all spoof protection.
+#
+# Retry up to 6 times (30s total) to avoid race conditions.
 LATEST_COMMENT=""
+_VERDICT_RE='Review PASSED|Review APPROVED|APPROVED FOR MERGE|LGTM|Review PASS|Review findings:|Review FAILED|Review REJECTED|Changes requested'
+# Build the authenticity predicate once. Primary: actor + time window.
+# Fallback (BOT_LOGIN empty): legacy session-id trailer match.
+if [[ -n "$BOT_LOGIN" ]]; then
+  _AUTH_PREDICATE="(.author.login == \"${BOT_LOGIN}\") and (.createdAt >= \"${WRAPPER_START_TS}\")"
+else
+  _AUTH_PREDICATE="(.body | test(\"Review Session.*${SESSION_ID}\"))"
+fi
+_VERDICT_JQ="[.comments[] | select(${_AUTH_PREDICATE} and (.body | test(\"${_VERDICT_RE}\"; \"i\")))] | last | .body"
 for _poll_attempt in $(seq 1 6); do
   sleep 5
   LATEST_COMMENT=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json comments \
-    -q "[.comments[] | select((.body | test(\"Review PASSED|Review APPROVED|APPROVED FOR MERGE|LGTM|Review PASS|Review findings:|Review FAILED|Review REJECTED|Changes requested\"; \"i\")) and (.body | test(\"Review Session.*${SESSION_ID}\")))] | last | .body" 2>/dev/null || true)
+    -q "$_VERDICT_JQ" 2>/dev/null || true)
   if [[ -n "$LATEST_COMMENT" ]]; then
     break
   fi

--- a/skills/autonomous-dispatcher/scripts/autonomous.conf.example
+++ b/skills/autonomous-dispatcher/scripts/autonomous.conf.example
@@ -41,6 +41,25 @@ AGENT_PERMISSION_MODE="auto"
 # Closes #60 (INV-13).
 AGENT_TIMEOUT="4h"
 
+# Optional launcher prefix that wraps every agent CLI invocation in
+# run_agent / resume_agent. Use case: bridge dispatcher-spawned wrappers
+# into the same env you set up for interactive `claude` runs (Bedrock
+# auth, MCP servers, telemetry tags, etc.) without duplicating that env
+# in autonomous.conf.
+#
+# The wrappers also export CC_USER=autonomous-{dev,review}-bot and
+# CC_ROLE_KIND={dev,review} before invoking the launcher, so a
+# launcher that consumes those env vars can attribute autonomous-pipeline
+# traffic separately from interactive sessions in cost / telemetry
+# pipelines.
+#
+# Example — a `cc` shell function in ~/.bash_aliases that injects
+# Bedrock + telemetry env:
+#   AGENT_LAUNCHER='bash -c '\''source ~/.bash_aliases && exec cc "$@"'\'' --'
+#
+# Empty (default): no wrapping; $AGENT_CMD is invoked directly.
+AGENT_LAUNCHER=""
+
 # === GitHub Authentication ===
 GH_AUTH_MODE="token"
 DEV_AGENT_APP_ID=""

--- a/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
@@ -248,15 +248,41 @@ for i in $(seq 0 $((pd_count - 1))); do
 
   session_id=$(extract_dev_session_id "$issue_num")
 
-  # [INV-12] Skip resume if the prior session ended normally (closes #59).
-  # Resuming a completed claude session attaches to the SSE stream forever.
-  # Don't auto-recover: leave the issue in pending-dev so an operator decides
-  # whether to flip to pending-review (PR present) or close (work done).
+  # [INV-12] Skip resume if the prior session reached a terminal state
+  # that resume cannot recover from. Two cases:
+  #   end_turn|completed → operator handoff (closes #59).
+  #   *|prompt_too_long  → auto-recover via fresh session (no auto-compact
+  #                        in claude -p; the only fix is a new session_id).
+  # See lib-dispatch.sh:is_session_completed for the full rationale.
   #
-  # Idempotency: only post the operator notice the FIRST time the gate fires
-  # for a given session-id. Without this, every 5-min tick posts the same
-  # comment (~288/day) since the issue stays in pending-dev.
-  if [ -n "$session_id" ] && is_session_completed "$issue_num"; then
+  # Idempotency: post the operator notice at most once per session-id.
+  # Without this, every 5-min tick posts the same comment (~288/day) for
+  # the COMPLETED case (pending-dev → pending-dev). For the PTL case we
+  # flip the label so the comment fires at most once anyway.
+  _session_terminal_reason=""
+  if [ -n "$session_id" ] && is_session_completed "$issue_num" _session_terminal_reason; then
+    if [ "$_session_terminal_reason" = "prompt_too_long" ]; then
+      log "  issue #${issue_num} session ${session_id} hit prompt_too_long — clearing for fresh dispatch"
+      notice_marker="INV-12-prompt-too-long:${session_id}"
+      if gh issue view "$issue_num" --repo "$REPO" --json comments \
+          -q "[.comments[].body | select(contains(\"${notice_marker}\"))] | length" \
+          2>/dev/null | grep -q '^0$'; then
+        gh issue comment "$issue_num" --repo "$REPO" \
+          --body "Session \`${session_id}\` exhausted the model context window (terminal_reason=prompt_too_long). \`claude -p\` does not auto-compact, so resume would crash again. Forcing a fresh dev session on the next tick. (\`${notice_marker}\`)"
+      fi
+      # Truncate the log so the next tick sees an empty/missing log and
+      # doesn't re-trigger this is_session_completed branch. The dev-new
+      # dispatch below mints a new session_id and writes fresh result lines.
+      : > "/tmp/agent-${PROJECT_ID}-issue-${issue_num}.log" 2>/dev/null || true
+      log "  dispatching dev-new for issue #${issue_num} (fresh after prompt_too_long)"
+      label_swap "$issue_num" "pending-dev" "in-progress"
+      post_dispatch_token "$issue_num" "dev-new"
+      dispatch dev-new "$issue_num"
+      JUST_DISPATCHED+=("$issue_num")
+      continue
+    fi
+
+    # end_turn|completed — operator must decide.
     log "  issue #${issue_num} session ${session_id} already completed — skipping resume"
     notice_marker="INV-12-completed:${session_id}"
     if gh issue view "$issue_num" --repo "$REPO" --json comments \

--- a/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
@@ -273,7 +273,20 @@ for i in $(seq 0 $((pd_count - 1))); do
       # Truncate the log so the next tick sees an empty/missing log and
       # doesn't re-trigger this is_session_completed branch. The dev-new
       # dispatch below mints a new session_id and writes fresh result lines.
-      : > "/tmp/agent-${PROJECT_ID}-issue-${issue_num}.log" 2>/dev/null || true
+      #
+      # If truncation fails (perm drift across deploys, ENOSPC), DO NOT
+      # dispatch — otherwise the next tick would re-read the same stale
+      # PTL log, the idempotency marker would suppress a fresh notice
+      # (it's keyed on the old session_id), and we'd silently dispatch
+      # dev-new every tick forever. Stay in pending-dev so the operator
+      # sees the issue accumulating retries via mark_stalled instead.
+      _ptl_log="/tmp/agent-${PROJECT_ID}-issue-${issue_num}.log"
+      if ! : > "$_ptl_log" 2>/dev/null; then
+        log "  ERROR: failed to truncate ${_ptl_log} (perm/disk?). Skipping PTL dev-new dispatch to avoid re-detection loop."
+        gh issue comment "$issue_num" --repo "$REPO" \
+          --body "Could not reset prompt-too-long log at \`${_ptl_log}\` for fresh dispatch (permission or disk error). Operator: please clear the log file and retry. Skipping dispatch to prevent a silent retry loop." 2>/dev/null || true
+        continue
+      fi
       log "  dispatching dev-new for issue #${issue_num} (fresh after prompt_too_long)"
       label_swap "$issue_num" "pending-dev" "in-progress"
       post_dispatch_token "$issue_num" "dev-new"

--- a/skills/autonomous-dispatcher/scripts/lib-agent.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-agent.sh
@@ -57,8 +57,20 @@ AGENT_LAUNCHER="${AGENT_LAUNCHER:-}"
 declare -a AGENT_LAUNCHER_ARGV=()
 if [[ -n "$AGENT_LAUNCHER" ]]; then
   if ! eval "AGENT_LAUNCHER_ARGV=($AGENT_LAUNCHER)" 2>/dev/null; then
+    # Explicit reset belt-and-suspenders: if a future caller sources this
+    # without `set -e`, the `return 1` is silently swallowed and we'd
+    # otherwise leave a half-tokenized array. Empty array = "no launcher",
+    # which is the safe degraded state.
+    AGENT_LAUNCHER=""
+    AGENT_LAUNCHER_ARGV=()
     echo "[lib-agent] ERROR: AGENT_LAUNCHER failed to parse as a shell argv list. Value: $AGENT_LAUNCHER" >&2
     return 1 2>/dev/null || exit 1
+  fi
+  # `eval` succeeded but produced an empty array — almost certainly an
+  # operator typo (stray `;`, leading whitespace + comment). Warn so it
+  # doesn't silently degrade to "launcher-less" without a breadcrumb.
+  if [[ ${#AGENT_LAUNCHER_ARGV[@]} -eq 0 ]]; then
+    echo "[lib-agent] WARN: AGENT_LAUNCHER non-empty but tokenized to zero argv elements. Treating as unset. Value: $AGENT_LAUNCHER" >&2
   fi
 fi
 

--- a/skills/autonomous-dispatcher/scripts/lib-agent.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-agent.sh
@@ -56,22 +56,27 @@ KIRO_AGENT_NAME="${KIRO_AGENT_NAME:-autonomous-dev}"
 AGENT_LAUNCHER="${AGENT_LAUNCHER:-}"
 declare -a AGENT_LAUNCHER_ARGV=()
 if [[ -n "$AGENT_LAUNCHER" ]]; then
+  # Preserve the original value for diagnostics — we clear AGENT_LAUNCHER
+  # on parse failure (belt-and-suspenders for future callers that source
+  # without `set -e`), so the error message must read from the snapshot.
+  _orig_launcher="$AGENT_LAUNCHER"
   if ! eval "AGENT_LAUNCHER_ARGV=($AGENT_LAUNCHER)" 2>/dev/null; then
-    # Explicit reset belt-and-suspenders: if a future caller sources this
-    # without `set -e`, the `return 1` is silently swallowed and we'd
-    # otherwise leave a half-tokenized array. Empty array = "no launcher",
-    # which is the safe degraded state.
+    # Explicit reset: if a future caller sources this without `set -e`,
+    # the `return 1` is silently swallowed and we'd otherwise leave a
+    # half-tokenized array. Empty = safe degraded state.
     AGENT_LAUNCHER=""
     AGENT_LAUNCHER_ARGV=()
-    echo "[lib-agent] ERROR: AGENT_LAUNCHER failed to parse as a shell argv list. Value: $AGENT_LAUNCHER" >&2
+    echo "[lib-agent] ERROR: AGENT_LAUNCHER failed to parse as a shell argv list. Value: ${_orig_launcher}" >&2
+    unset _orig_launcher
     return 1 2>/dev/null || exit 1
   fi
   # `eval` succeeded but produced an empty array — almost certainly an
   # operator typo (stray `;`, leading whitespace + comment). Warn so it
   # doesn't silently degrade to "launcher-less" without a breadcrumb.
   if [[ ${#AGENT_LAUNCHER_ARGV[@]} -eq 0 ]]; then
-    echo "[lib-agent] WARN: AGENT_LAUNCHER non-empty but tokenized to zero argv elements. Treating as unset. Value: $AGENT_LAUNCHER" >&2
+    echo "[lib-agent] WARN: AGENT_LAUNCHER non-empty but tokenized to zero argv elements. Treating as unset. Value: ${_orig_launcher}" >&2
   fi
+  unset _orig_launcher
 fi
 
 # Wall-clock cap on agent invocations (INV-13, closes #60).

--- a/skills/autonomous-dispatcher/scripts/lib-agent.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-agent.sh
@@ -44,6 +44,24 @@ AGENT_REVIEW_MODEL="${AGENT_REVIEW_MODEL:-sonnet}"
 AGENT_PERMISSION_MODE="${AGENT_PERMISSION_MODE:-auto}"
 KIRO_AGENT_NAME="${KIRO_AGENT_NAME:-autonomous-dev}"
 
+# AGENT_LAUNCHER — optional launcher prefix wrapped around every agent
+# invocation in run_agent / resume_agent (prepended inside _run_with_timeout
+# so a hung launcher is still bounded by AGENT_TIMEOUT). Empty by default.
+# See autonomous.conf.example for the operator-facing usage and rationale.
+#
+# We tokenize the launcher string into AGENT_LAUNCHER_ARGV[] once via `eval`
+# at load time. This trusts autonomous.conf (same trust level as the
+# wrapper itself) but fails loudly on a malformed value rather than
+# silently corrupting argv.
+AGENT_LAUNCHER="${AGENT_LAUNCHER:-}"
+declare -a AGENT_LAUNCHER_ARGV=()
+if [[ -n "$AGENT_LAUNCHER" ]]; then
+  if ! eval "AGENT_LAUNCHER_ARGV=($AGENT_LAUNCHER)" 2>/dev/null; then
+    echo "[lib-agent] ERROR: AGENT_LAUNCHER failed to parse as a shell argv list. Value: $AGENT_LAUNCHER" >&2
+    return 1 2>/dev/null || exit 1
+  fi
+fi
+
 # Wall-clock cap on agent invocations (INV-13, closes #60).
 # Wraps run_agent / resume_agent in coreutils `timeout` so a hung CLI cannot
 # eat indefinite wall time (observed: claude --resume against a completed
@@ -64,15 +82,18 @@ if [[ -z "$_AGENT_TIMEOUT_CMD" ]]; then
 fi
 
 # _run_with_timeout — invoke "$@" under timeout if available, otherwise run
-# directly. --kill-after=30s escalates to SIGKILL if the agent ignores the
-# initial SIGTERM (some MCP children trap TERM and need the harder push).
+# directly. AGENT_LAUNCHER_ARGV (if set) is prepended to the command inside
+# the timeout boundary so a hung launcher is still killed.
+# --kill-after=30s escalates to SIGKILL if the agent ignores the initial
+# SIGTERM (some MCP children trap TERM and need the harder push).
 # --signal=TERM lets the agent flush any final SSE bytes before dying.
 # Exit codes: passthrough on normal exit; 124 on TERM-timeout; 137 on KILL.
 _run_with_timeout() {
   if [[ -n "$_AGENT_TIMEOUT_CMD" ]]; then
-    "$_AGENT_TIMEOUT_CMD" --kill-after=30s --signal=TERM "$AGENT_TIMEOUT" "$@"
+    "$_AGENT_TIMEOUT_CMD" --kill-after=30s --signal=TERM "$AGENT_TIMEOUT" \
+      "${AGENT_LAUNCHER_ARGV[@]}" "$@"
   else
-    "$@"
+    "${AGENT_LAUNCHER_ARGV[@]}" "$@"
   fi
 }
 
@@ -251,7 +272,7 @@ run_agent() {
 
   case "$AGENT_CMD" in
     claude)
-      # Unset CLAUDECODE to allow launching from within an existing session
+      # Unset CLAUDECODE to allow launching from within an existing session.
       _run_with_timeout env -u CLAUDECODE "$AGENT_CMD" --session-id "$session_id" \
         ${session_name:+--name "$session_name"} \
         --permission-mode "$AGENT_PERMISSION_MODE" \

--- a/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
@@ -242,18 +242,33 @@ extract_dev_session_id() {
 }
 
 # is_session_completed — return 0 if the agent's last log object indicates a
-# normal end-of-turn (stop_reason=end_turn AND terminal_reason=completed).
-# Used by Step 4 (INV-12, closes #59) to skip resume against a session that
-# the model has nothing left to do for — those resumes attach to the SSE
-# stream and never return.
+# session state that resume cannot recover from. Two cases qualify:
+#
+#   1. end_turn|completed         — normal exit, agent has nothing left to do.
+#                                   Resuming would attach to a closed SSE
+#                                   stream and hang (#59, INV-12).
+#   2. *|prompt_too_long          — JSONL transcript exceeded the model's
+#                                   input window. claude -p has no auto-
+#                                   compaction, so resuming re-feeds the
+#                                   whole transcript and crashes again. The
+#                                   only recovery is a fresh session with a
+#                                   smaller seed prompt.
+#
+# Used by Step 4 to skip resume against a session that cannot make progress.
+# The caller distinguishes (1) vs (2) via the optional capture-mode arg
+# (`is_session_completed N reason_var`) — case (1) is left for the operator
+# to decide; case (2) flips the label back to pending-dev so the next tick
+# auto-retries with a fresh session.
 #
 # Returns 1 (false) for: AGENT_CMD != claude (other CLIs don't emit the same
 # JSON shape), missing/unreadable log, no JSON object found, malformed JSON,
-# or any non-terminal stop reason. Conservative: a false negative just means
-# we still try to resume (existing behavior); a false positive (claiming
-# completed when it isn't) would mistakenly skip a legitimate retry.
+# or any non-terminal stop reason (api_error, stop_sequence, etc.).
+# Conservative: a false negative just means we still try to resume (existing
+# behavior); a false positive (claiming terminal when it isn't) would
+# mistakenly skip a legitimate retry.
 is_session_completed() {
   local issue_num="$1"
+  local reason_var="${2:-}"
   [ "${AGENT_CMD:-claude}" = "claude" ] || return 1
 
   local log_file="/tmp/agent-${PROJECT_ID}-issue-${issue_num}.log"
@@ -267,16 +282,20 @@ is_session_completed() {
   # `result` line and let jq parse it.
   #
   # Multiple result objects are possible (resume cycles): the LAST line wins.
-  # If the last result represents a non-terminal end (api_error_status set,
-  # stop_reason=stop_sequence, terminal_reason=prompt_too_long, etc.) we
-  # return false and a resume retry is still legitimate.
   local last_line
   last_line=$(grep '^{"type":"result"' "$log_file" 2>/dev/null | tail -1)
   [ -n "$last_line" ] || return 1
 
   local fields
   fields=$(jq -er '"\(.stop_reason // "")|\(.terminal_reason // "")"' <<<"$last_line" 2>/dev/null) || return 1
-  [ "$fields" = "end_turn|completed" ]
+
+  local terminal_reason="${fields##*|}"
+
+  if [ "$fields" = "end_turn|completed" ] || [ "$terminal_reason" = "prompt_too_long" ]; then
+    [ -n "$reason_var" ] && printf -v "$reason_var" '%s' "$terminal_reason"
+    return 0
+  fi
+  return 1
 }
 
 # ---------------------------------------------------------------------------

--- a/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
@@ -260,12 +260,36 @@ extract_dev_session_id() {
 # to decide; case (2) flips the label back to pending-dev so the next tick
 # auto-retries with a fresh session.
 #
-# Returns 1 (false) for: AGENT_CMD != claude (other CLIs don't emit the same
-# JSON shape), missing/unreadable log, no JSON object found, malformed JSON,
-# or any non-terminal stop reason (api_error, stop_sequence, etc.).
+# Returns 1 (false) for: AGENT_CMD != claude, missing/unreadable log, no JSON
+# object found, malformed JSON, or any non-terminal stop reason (api_error,
+# stop_sequence, etc.).
 # Conservative: a false negative just means we still try to resume (existing
 # behavior); a false positive (claiming terminal when it isn't) would
 # mistakenly skip a legitimate retry.
+#
+# Per-CLI scope (AGENT_CMD-gated by design — see follow-up TODO):
+#   claude   — fully covered. JSON shape `{"type":"result", stop_reason,
+#              terminal_reason}` is documented + tested.
+#   codex    — NOT covered. codex `exec --json` emits a different event
+#              schema (thread.started / task.completed / error). Resume is
+#              server-side, so the prompt_too_long failure mode may not even
+#              manifest the same way. Falls through to false → dispatcher
+#              attempts resume; relies on AGENT_TIMEOUT (INV-13) as the
+#              safety net for hangs. PTL recovery for codex is tracked as a
+#              follow-up — needs a real codex JSONL fixture to write the
+#              gate against, not guessed.
+#   kiro     — by design. Kiro has no session model (every invocation is a
+#              fresh conversation, see lib-agent.sh kiro branch), so PTL
+#              cannot occur and "completed" has no meaning. Returning false
+#              here lets the dispatcher run the next dev-resume which the
+#              wrapper transparently turns into dev-new.
+#   opencode — NOT covered, same reasoning as codex. Server-side sessions
+#              and unknown PTL event shape; needs a real fixture.
+#
+# Until coverage is extended, non-claude PTL crashes will surface via the
+# normal stale-detection path (Step 5b) instead of this gate. That's a
+# correct degradation — slower recovery (one full tick cycle) but no risk
+# of false-positive auto-recovery on a CLI whose JSON we haven't observed.
 is_session_completed() {
   local issue_num="$1"
   local reason_var="${2:-}"

--- a/tests/unit/test-autonomous-launcher-verdict-fresh.sh
+++ b/tests/unit/test-autonomous-launcher-verdict-fresh.sh
@@ -1,0 +1,291 @@
+#!/bin/bash
+# test-autonomous-launcher-verdict-fresh.sh —
+# unit tests for the three-fix bundle: verdict actor+time-window detection
+# (Fix 1), AGENT_LAUNCHER prefix injection (Fix 2), and prompt_too_long
+# fresh-session fallback (Fix 3).
+#
+# All tests are stub-driven (no real claude / gh invocation) and exercise
+# the actual code paths in autonomous-review.sh, lib-agent.sh, and
+# lib-dispatch.sh.
+#
+# Run: bash tests/unit/test-autonomous-launcher-verdict-fresh.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPTS_DIR="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected='$expected'"
+    echo "      actual=  '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      missing needle: $needle"
+    echo "      in haystack:    ${haystack:0:200}..."
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# ---------------------------------------------------------------------------
+# Fix 1 — verdict detection: actor + time window
+# ---------------------------------------------------------------------------
+echo "=== Fix 1 (TC-VRD): verdict detector with actor + time window ==="
+
+# Drive the actor+window jq predicate directly. We mirror the wrapper's
+# query construction: when BOT_LOGIN is set, gate by author.login and
+# createdAt; otherwise legacy session-id fallback.
+classify_actor_window() {
+  local body="$1" author="$2" createdAt="$3" bot_login="$4" wrapper_ts="$5"
+  local json="$TMPROOT/case.json"
+  python3 -c "
+import json, sys
+out = {'comments': [{'body': sys.argv[1], 'author': {'login': sys.argv[2]}, 'createdAt': sys.argv[3]}]}
+with open(sys.argv[4], 'w') as f:
+    json.dump(out, f)
+" "$body" "$author" "$createdAt" "$json"
+
+  local verdict_re='Review PASSED|Review APPROVED|APPROVED FOR MERGE|LGTM|Review PASS|Review findings:|Review FAILED|Review REJECTED|Changes requested'
+  local matched
+  if [[ -n "$bot_login" ]]; then
+    matched=$(jq -r "[.comments[] | select((.author.login == \"${bot_login}\") and (.createdAt >= \"${wrapper_ts}\") and (.body | test(\"${verdict_re}\"; \"i\")))] | last | .body" < "$json" 2>/dev/null)
+  else
+    # Legacy fallback path
+    matched=$(jq -r "[.comments[] | select((.body | test(\"${verdict_re}\"; \"i\")) and (.body | test(\"Review Session.*${wrapper_ts}\")))] | last | .body" < "$json" 2>/dev/null)
+  fi
+  if [[ -z "$matched" || "$matched" == "null" ]]; then
+    echo "no-match"
+    return
+  fi
+  if echo "$matched" | grep -qiE 'Review (FAILED|REJECTED)|Review findings:|Changes requested'; then
+    echo "fail"
+  elif echo "$matched" | grep -qiE 'Review PASSED|Review APPROVED|APPROVED FOR MERGE|LGTM|Review PASS'; then
+    echo "pass"
+  else
+    echo "fail"
+  fi
+}
+
+BOT="kane-review-agent"
+WRAPPER_TS="2026-05-12T00:00:00Z"
+BEFORE_TS="2026-05-11T23:00:00Z"
+AFTER_TS="2026-05-12T00:30:00Z"
+
+assert_eq "TC-VRD-001 BOT actor + in-window + Review PASSED → pass" "pass" \
+  "$(classify_actor_window "Review PASSED — all good." "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
+
+assert_eq "TC-VRD-002 BOT actor + in-window + APPROVED FOR MERGE → pass" "pass" \
+  "$(classify_actor_window "**APPROVED FOR MERGE** — ship it." "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
+
+assert_eq "TC-VRD-003 BOT actor + in-window + Review findings → fail" "fail" \
+  "$(classify_actor_window "Review findings: 1. Coverage low" "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
+
+assert_eq "TC-VRD-004 anti-regression: random session-uuid in body still matches" "pass" \
+  "$(classify_actor_window "Review PASSED. Review Session: 95219405-aa55-4e37-98c7-a28138a23878" "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
+
+assert_eq "TC-VRD-005 anti-spoof: foreign actor → no-match" "no-match" \
+  "$(classify_actor_window "Review PASSED — totally legit" "third-party-bot" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
+
+assert_eq "TC-VRD-006 anti-spoof: stale comment from prior tick → no-match" "no-match" \
+  "$(classify_actor_window "Review PASSED" "$BOT" "$BEFORE_TS" "$BOT" "$WRAPPER_TS")"
+
+assert_eq "TC-VRD-007 ambiguous (PASS + FAIL keywords) → fail (conservative)" "fail" \
+  "$(classify_actor_window "LGTM mostly. Review findings: 1. nit" "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
+
+# Legacy fallback (BOT_LOGIN empty) — uses session-id binding via the
+# fixture's wrapper_ts arg (we pass a session id there).
+LEGACY_SID="abc-test-session"
+assert_eq "TC-VRD-008 fallback: matching session-id → pass" "pass" \
+  "$(classify_actor_window "Review PASSED — Review Session: ${LEGACY_SID}" "$BOT" "$AFTER_TS" "" "$LEGACY_SID")"
+
+assert_eq "TC-VRD-009 fallback: missing session-id → no-match" "no-match" \
+  "$(classify_actor_window "Review PASSED — no trailer" "$BOT" "$AFTER_TS" "" "$LEGACY_SID")"
+
+# ---------------------------------------------------------------------------
+# Fix 2 — AGENT_LAUNCHER prefix
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fix 2 (TC-LCH): AGENT_LAUNCHER prefix injection ==="
+
+# Stub claude shim that records its argv (and selected env) to a file
+# instead of running the real CLI. We exercise lib-agent.sh's run_agent
+# / resume_agent and check what got invoked.
+SHIM_DIR="$TMPROOT/shim"
+mkdir -p "$SHIM_DIR"
+cat > "$SHIM_DIR/claude" <<'SHIM'
+#!/bin/bash
+# Record argv + the env vars the test cares about.
+{
+  printf 'argv:'
+  printf ' %q' "$@"
+  printf '\n'
+  printf 'CC_USER=%s\n' "${CC_USER:-<unset>}"
+  printf 'CC_ROLE_KIND=%s\n' "${CC_ROLE_KIND:-<unset>}"
+  printf 'LAUNCHER_FOO=%s\n' "${LAUNCHER_FOO:-<unset>}"
+} > "$SHIM_OUT"
+exit 0
+SHIM
+chmod +x "$SHIM_DIR/claude"
+
+# Drive lib-agent.sh in a subshell with the shim on PATH and minimal env.
+run_agent_capture() {
+  local launcher="$1"
+  local out="$TMPROOT/agent-out-$$"
+  local err="$TMPROOT/agent-err-$$"
+  (
+    export PATH="$SHIM_DIR:$PATH"
+    export SHIM_OUT="$out"
+    export AGENT_CMD="claude"
+    export AGENT_LAUNCHER="$launcher"
+    export AGENT_PERMISSION_MODE="auto"
+    export AGENT_DEV_MODEL=""
+    export PROJECT_ID="test"
+    export REPO="test/repo"
+    export REPO_OWNER="test"
+    export REPO_NAME="repo"
+    export PROJECT_DIR="$TMPROOT"
+    # lib-config.sh's load_autonomous_conf will fail to find conf — that's
+    # fine, all the env above is already set.
+    # shellcheck disable=SC1090
+    source "$SCRIPTS_DIR/lib-agent.sh" 2>"$err" || { echo "SOURCE_FAILED: $(cat "$err")"; return; }
+    run_agent "test-session-$$" "test prompt" "" "test-name" >/dev/null 2>>"$err"
+  )
+  cat "$out" 2>/dev/null
+}
+
+# TC-LCH-001: launcher unset → claude shim is invoked directly with the
+# wrapper's standard argv (--session-id, --output-format json, etc).
+OUT1=$(run_agent_capture "")
+ARGV1=$(echo "$OUT1" | grep '^argv:')
+assert_contains "TC-LCH-001 launcher unset: claude shim invoked (--session-id present)" "--session-id" "$ARGV1"
+# Sanity: launcher-injected env should be UNSET when no launcher is set.
+assert_contains "TC-LCH-001 launcher unset: LAUNCHER_FOO env is <unset>" "LAUNCHER_FOO=<unset>" "$OUT1"
+
+# TC-LCH-002: launcher = `env LAUNCHER_FOO=bar` → env reaches claude shim.
+OUT2=$(run_agent_capture "env LAUNCHER_FOO=bar")
+ARGV2=$(echo "$OUT2" | grep '^argv:')
+assert_contains "TC-LCH-002 launcher set: LAUNCHER_FOO reaches claude env" "LAUNCHER_FOO=bar" "$OUT2"
+assert_contains "TC-LCH-002 launcher set: claude still receives --session-id" "--session-id" "$ARGV2"
+
+# TC-LCH-003: launcher with single-quoted bash -c form (the canonical cc shape).
+LAUNCHER='bash -c '\''LAUNCHER_FOO=quoted exec "$@"'\'' --'
+ARGV3=$(run_agent_capture "$LAUNCHER")
+assert_contains "TC-LCH-003 quoted launcher: env propagates through bash -c" "LAUNCHER_FOO=quoted" "$ARGV3"
+
+# TC-LCH-007: autonomous-dev.sh exports CC_USER/CC_ROLE_KIND.
+DEV_LINE=$(grep -E '^export CC_USER=' "$SCRIPTS_DIR/autonomous-dev.sh" | head -1)
+REVIEW_LINE=$(grep -E '^export CC_USER=' "$SCRIPTS_DIR/autonomous-review.sh" | head -1)
+assert_contains "TC-LCH-007 autonomous-dev exports CC_USER=autonomous-dev-bot" "autonomous-dev-bot" "$DEV_LINE"
+assert_contains "TC-LCH-008 autonomous-review exports CC_USER=autonomous-review-bot" "autonomous-review-bot" "$REVIEW_LINE"
+
+# ---------------------------------------------------------------------------
+# Fix 3 — is_session_completed accepts prompt_too_long
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Fix 3 (TC-PTL): is_session_completed prompt_too_long handling ==="
+
+# Source lib-dispatch.sh in a controlled env. We need PROJECT_ID and a
+# log file at /tmp/agent-${PROJECT_ID}-issue-${N}.log to drive the probe.
+TEST_PID="ptl-$$"
+LOG_BASE="/tmp/agent-${TEST_PID}-issue"
+
+run_is_completed() {
+  local issue_num="$1"
+  local capture_var_arg="$2"  # "" or "reason"
+  (
+    # lib-dispatch.sh has hard `:` asserts on REPO/REPO_OWNER/PROJECT_ID;
+    # set them before sourcing so the unit test isn't gated on autonomous.conf.
+    export REPO="test/repo"
+    export REPO_OWNER="test"
+    export PROJECT_ID="$TEST_PID"
+    export AGENT_CMD="claude"
+    # shellcheck disable=SC1090
+    source "$SCRIPTS_DIR/lib-config.sh"
+    # shellcheck disable=SC1090
+    source "$SCRIPTS_DIR/lib-dispatch.sh"
+    if [[ -n "$capture_var_arg" ]]; then
+      local r=""
+      if is_session_completed "$issue_num" r; then
+        echo "OK:$r"
+      else
+        echo "NO:$r"
+      fi
+    else
+      if is_session_completed "$issue_num"; then
+        echo "OK"
+      else
+        echo "NO"
+      fi
+    fi
+  )
+}
+
+# TC-PTL-001: end_turn|completed → 0 (existing behavior).
+echo '{"type":"result","stop_reason":"end_turn","terminal_reason":"completed"}' > "${LOG_BASE}-1.log"
+assert_eq "TC-PTL-001 end_turn|completed → terminal" "OK:completed" "$(run_is_completed 1 reason)"
+
+# TC-PTL-002: prompt_too_long → 0 (NEW).
+echo '{"type":"result","stop_reason":"stop_sequence","terminal_reason":"prompt_too_long"}' > "${LOG_BASE}-2.log"
+assert_eq "TC-PTL-002 prompt_too_long → terminal (NEW)" "OK:prompt_too_long" "$(run_is_completed 2 reason)"
+
+# TC-PTL-003: api_error → 1 (transient, keep retrying).
+echo '{"type":"result","stop_reason":"end_turn","terminal_reason":"api_error","api_error_status":500}' > "${LOG_BASE}-3.log"
+assert_eq "TC-PTL-003 api_error → not terminal" "NO:" "$(run_is_completed 3 reason)"
+
+# TC-PTL-004: log file missing → 1.
+assert_eq "TC-PTL-004 missing log → not terminal" "NO:" "$(run_is_completed 999 reason)"
+
+# Cleanup created log files.
+rm -f "${LOG_BASE}"-*.log
+
+# ---------------------------------------------------------------------------
+# Fix 3 — autonomous-dev.sh fallback posts standalone Dev Session ID marker.
+# ---------------------------------------------------------------------------
+DEV_SCRIPT="$SCRIPTS_DIR/autonomous-dev.sh"
+FALLBACK_SECTION=$(awk '/If resume failed/,/SESSION_ID="\$NEW_SESSION_ID"/' "$DEV_SCRIPT")
+assert_contains "TC-PTL-005 fallback posts Dev Session ID: marker for NEW_SESSION_ID" \
+  'Dev Session ID:' "$FALLBACK_SECTION"
+assert_contains "TC-PTL-005 fallback marker references NEW_SESSION_ID" \
+  'NEW_SESSION_ID' "$FALLBACK_SECTION"
+assert_contains "TC-PTL-005 fallback marker tagged as resume-fallback" \
+  'resume-fallback' "$FALLBACK_SECTION"
+
+# ---------------------------------------------------------------------------
+# Fix 3 — dispatcher-tick.sh routes prompt_too_long to dev-new with marker.
+# ---------------------------------------------------------------------------
+TICK_SCRIPT="$SCRIPTS_DIR/dispatcher-tick.sh"
+assert_contains "TC-PTL-006 dispatcher-tick has INV-12-prompt-too-long marker" \
+  "INV-12-prompt-too-long" "$(cat "$TICK_SCRIPT")"
+assert_contains "TC-PTL-006 dispatcher-tick routes PTL to dev-new" \
+  "dispatch dev-new" "$(awk '/prompt_too_long/,/JUST_DISPATCHED/' "$TICK_SCRIPT")"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/tests/unit/test-autonomous-launcher-verdict-fresh.sh
+++ b/tests/unit/test-autonomous-launcher-verdict-fresh.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # test-autonomous-launcher-verdict-fresh.sh —
-# unit tests for the three-fix bundle: verdict actor+time-window detection
-# (Fix 1), AGENT_LAUNCHER prefix injection (Fix 2), and prompt_too_long
-# fresh-session fallback (Fix 3).
+# unit tests for verdict actor+time-window+trailer detection,
+# AGENT_LAUNCHER prefix injection, and prompt_too_long fresh-session
+# fallback. Three groups: TC-VRD, TC-LCH, TC-PTL.
 #
 # All tests are stub-driven (no real claude / gh invocation) and exercise
 # the actual code paths in autonomous-review.sh, lib-agent.sh, and
@@ -52,15 +52,29 @@ TMPROOT=$(mktemp -d)
 trap 'rm -rf "$TMPROOT"' EXIT
 
 # ---------------------------------------------------------------------------
-# Fix 1 — verdict detection: actor + time window
+# TC-VRD: verdict detection — actor + time window + trailer presence
 # ---------------------------------------------------------------------------
-echo "=== Fix 1 (TC-VRD): verdict detector with actor + time window ==="
+echo "=== TC-VRD: verdict detector with actor + time window + trailer presence ==="
 
-# Drive the actor+window jq predicate directly. We mirror the wrapper's
-# query construction: when BOT_LOGIN is set, gate by author.login and
-# createdAt; otherwise legacy session-id fallback.
+# Extract _VERDICT_RE from the production wrapper so this test cannot
+# silently drift if the keyword list is tightened (eliminates the
+# two-sources-of-truth hazard with test-autonomous-review-verdict-regex.sh).
+WRAPPER="$SCRIPTS_DIR/autonomous-review.sh"
+LIVE_VERDICT_RE=$(grep -E "^_VERDICT_RE='" "$WRAPPER" | head -1 | sed -E "s/^_VERDICT_RE='//; s/'$//")
+if [[ -z "$LIVE_VERDICT_RE" ]]; then
+  echo -e "  ${RED}FAIL${NC}: could not extract _VERDICT_RE from $WRAPPER" >&2
+  exit 1
+fi
+
+# Drive the production-side jq predicate. Mirrors the wrapper's three-
+# layer construction: actor (when known) + createdAt window + "Review
+# Session" trailer presence. Fallback (bot_login empty) drops actor and
+# tightens the trailer to bind the wrapper's session_id.
+#
+# Args: body, author, createdAt, bot_login, wrapper_ts, session_id.
+# When bot_login is empty, session_id binds the trailer match.
 classify_actor_window() {
-  local body="$1" author="$2" createdAt="$3" bot_login="$4" wrapper_ts="$5"
+  local body="$1" author="$2" createdAt="$3" bot_login="$4" wrapper_ts="$5" session_id="${6:-}"
   local json="$TMPROOT/case.json"
   python3 -c "
 import json, sys
@@ -69,13 +83,12 @@ with open(sys.argv[4], 'w') as f:
     json.dump(out, f)
 " "$body" "$author" "$createdAt" "$json"
 
-  local verdict_re='Review PASSED|Review APPROVED|APPROVED FOR MERGE|LGTM|Review PASS|Review findings:|Review FAILED|Review REJECTED|Changes requested'
   local matched
   if [[ -n "$bot_login" ]]; then
-    matched=$(jq -r "[.comments[] | select((.author.login == \"${bot_login}\") and (.createdAt >= \"${wrapper_ts}\") and (.body | test(\"${verdict_re}\"; \"i\")))] | last | .body" < "$json" 2>/dev/null)
+    matched=$(jq -r "[.comments[] | select((.author.login == \"${bot_login}\") and (.createdAt >= \"${wrapper_ts}\") and (.body | test(\"Review Session\")) and (.body | test(\"${LIVE_VERDICT_RE}\"; \"i\")))] | last | .body" < "$json" 2>/dev/null)
   else
-    # Legacy fallback path
-    matched=$(jq -r "[.comments[] | select((.body | test(\"${verdict_re}\"; \"i\")) and (.body | test(\"Review Session.*${wrapper_ts}\")))] | last | .body" < "$json" 2>/dev/null)
+    # Legacy fallback path: drop actor, tighten trailer to bind session_id.
+    matched=$(jq -r "[.comments[] | select((.createdAt >= \"${wrapper_ts}\") and (.body | test(\"Review Session.*${session_id}\")) and (.body | test(\"${LIVE_VERDICT_RE}\"; \"i\")))] | last | .body" < "$json" 2>/dev/null)
   fi
   if [[ -z "$matched" || "$matched" == "null" ]]; then
     echo "no-match"
@@ -94,42 +107,58 @@ BOT="kane-review-agent"
 WRAPPER_TS="2026-05-12T00:00:00Z"
 BEFORE_TS="2026-05-11T23:00:00Z"
 AFTER_TS="2026-05-12T00:30:00Z"
+# Real review agents end the verdict comment with this trailer per the
+# wrapper's prompt; tests use a representative form.
+TRAILER="Review Session: \`real-agent-uuid\`"
 
 assert_eq "TC-VRD-001 BOT actor + in-window + Review PASSED → pass" "pass" \
-  "$(classify_actor_window "Review PASSED — all good." "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
+  "$(classify_actor_window "Review PASSED — all good. ${TRAILER}" "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
 
 assert_eq "TC-VRD-002 BOT actor + in-window + APPROVED FOR MERGE → pass" "pass" \
-  "$(classify_actor_window "**APPROVED FOR MERGE** — ship it." "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
+  "$(classify_actor_window "**APPROVED FOR MERGE** — ship it. ${TRAILER}" "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
 
 assert_eq "TC-VRD-003 BOT actor + in-window + Review findings → fail" "fail" \
-  "$(classify_actor_window "Review findings: 1. Coverage low" "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
+  "$(classify_actor_window "Review findings: 1. Coverage low. ${TRAILER}" "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
 
 assert_eq "TC-VRD-004 anti-regression: random session-uuid in body still matches" "pass" \
   "$(classify_actor_window "Review PASSED. Review Session: 95219405-aa55-4e37-98c7-a28138a23878" "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
 
 assert_eq "TC-VRD-005 anti-spoof: foreign actor → no-match" "no-match" \
-  "$(classify_actor_window "Review PASSED — totally legit" "third-party-bot" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
+  "$(classify_actor_window "Review PASSED — totally legit. ${TRAILER}" "third-party-bot" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
 
 assert_eq "TC-VRD-006 anti-spoof: stale comment from prior tick → no-match" "no-match" \
-  "$(classify_actor_window "Review PASSED" "$BOT" "$BEFORE_TS" "$BOT" "$WRAPPER_TS")"
+  "$(classify_actor_window "Review PASSED ${TRAILER}" "$BOT" "$BEFORE_TS" "$BOT" "$WRAPPER_TS")"
 
 assert_eq "TC-VRD-007 ambiguous (PASS + FAIL keywords) → fail (conservative)" "fail" \
-  "$(classify_actor_window "LGTM mostly. Review findings: 1. nit" "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
+  "$(classify_actor_window "LGTM mostly. Review findings: 1. nit ${TRAILER}" "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
 
-# Legacy fallback (BOT_LOGIN empty) — uses session-id binding via the
-# fixture's wrapper_ts arg (we pass a session id there).
+# Token-mode spoofability defense: the trailer requirement excludes the
+# dev agent's status comments that contain a verdict keyword but no
+# trailer. Critical for GH_AUTH_MODE=token where dev and review share
+# BOT_LOGIN.
+assert_eq "TC-VRD-007a token-mode: dev-agent status comment quoting 'Review findings' → no-match (no trailer)" "no-match" \
+  "$(classify_actor_window "Addressed all review findings from the prior cycle." "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
+
+assert_eq "TC-VRD-007b token-mode: dev-agent comment with 'LGTM' but no trailer → no-match" "no-match" \
+  "$(classify_actor_window "Tests LGTM, pushing fix now." "$BOT" "$AFTER_TS" "$BOT" "$WRAPPER_TS")"
+
+# Legacy fallback (BOT_LOGIN empty) — drops actor, requires trailer to
+# bind the wrapper's session_id within the time window.
 LEGACY_SID="abc-test-session"
-assert_eq "TC-VRD-008 fallback: matching session-id → pass" "pass" \
-  "$(classify_actor_window "Review PASSED — Review Session: ${LEGACY_SID}" "$BOT" "$AFTER_TS" "" "$LEGACY_SID")"
+assert_eq "TC-VRD-008 fallback: matching session-id + in-window → pass" "pass" \
+  "$(classify_actor_window "Review PASSED — Review Session: ${LEGACY_SID}" "$BOT" "$AFTER_TS" "" "$WRAPPER_TS" "$LEGACY_SID")"
 
 assert_eq "TC-VRD-009 fallback: missing session-id → no-match" "no-match" \
-  "$(classify_actor_window "Review PASSED — no trailer" "$BOT" "$AFTER_TS" "" "$LEGACY_SID")"
+  "$(classify_actor_window "Review PASSED — no trailer" "$BOT" "$AFTER_TS" "" "$WRAPPER_TS" "$LEGACY_SID")"
+
+assert_eq "TC-VRD-009a fallback: stale comment (before window) → no-match" "no-match" \
+  "$(classify_actor_window "Review PASSED — Review Session: ${LEGACY_SID}" "$BOT" "$BEFORE_TS" "" "$WRAPPER_TS" "$LEGACY_SID")"
 
 # ---------------------------------------------------------------------------
-# Fix 2 — AGENT_LAUNCHER prefix
+# TC-LCH: AGENT_LAUNCHER prefix injection
 # ---------------------------------------------------------------------------
 echo ""
-echo "=== Fix 2 (TC-LCH): AGENT_LAUNCHER prefix injection ==="
+echo "=== TC-LCH: AGENT_LAUNCHER prefix injection ==="
 
 # Stub claude shim that records its argv (and selected env) to a file
 # instead of running the real CLI. We exercise lib-agent.sh's run_agent
@@ -203,10 +232,10 @@ assert_contains "TC-LCH-007 autonomous-dev exports CC_USER=autonomous-dev-bot" "
 assert_contains "TC-LCH-008 autonomous-review exports CC_USER=autonomous-review-bot" "autonomous-review-bot" "$REVIEW_LINE"
 
 # ---------------------------------------------------------------------------
-# Fix 3 — is_session_completed accepts prompt_too_long
+# TC-PTL: is_session_completed accepts prompt_too_long
 # ---------------------------------------------------------------------------
 echo ""
-echo "=== Fix 3 (TC-PTL): is_session_completed prompt_too_long handling ==="
+echo "=== TC-PTL: is_session_completed prompt_too_long handling ==="
 
 # Source lib-dispatch.sh in a controlled env. We need PROJECT_ID and a
 # log file at /tmp/agent-${PROJECT_ID}-issue-${N}.log to drive the probe.
@@ -263,10 +292,11 @@ assert_eq "TC-PTL-004 missing log → not terminal" "NO:" "$(run_is_completed 99
 rm -f "${LOG_BASE}"-*.log
 
 # ---------------------------------------------------------------------------
-# Fix 3 — autonomous-dev.sh fallback posts standalone Dev Session ID marker.
+# TC-PTL: autonomous-dev.sh resume-fallback posts standalone Dev Session ID marker.
 # ---------------------------------------------------------------------------
 DEV_SCRIPT="$SCRIPTS_DIR/autonomous-dev.sh"
-FALLBACK_SECTION=$(awk '/If resume failed/,/SESSION_ID="\$NEW_SESSION_ID"/' "$DEV_SCRIPT")
+# Anchor on code lines (not comments) — comments rot under doc cleanups.
+FALLBACK_SECTION=$(awk '/NEW_SESSION_ID=\$\(uuidgen\)/,/SESSION_ID="\$NEW_SESSION_ID"/' "$DEV_SCRIPT")
 assert_contains "TC-PTL-005 fallback posts Dev Session ID: marker for NEW_SESSION_ID" \
   'Dev Session ID:' "$FALLBACK_SECTION"
 assert_contains "TC-PTL-005 fallback marker references NEW_SESSION_ID" \
@@ -275,13 +305,140 @@ assert_contains "TC-PTL-005 fallback marker tagged as resume-fallback" \
   'resume-fallback' "$FALLBACK_SECTION"
 
 # ---------------------------------------------------------------------------
-# Fix 3 — dispatcher-tick.sh routes prompt_too_long to dev-new with marker.
+# TC-PTL: dispatcher-tick.sh routes prompt_too_long to dev-new with marker.
 # ---------------------------------------------------------------------------
 TICK_SCRIPT="$SCRIPTS_DIR/dispatcher-tick.sh"
 assert_contains "TC-PTL-006 dispatcher-tick has INV-12-prompt-too-long marker" \
   "INV-12-prompt-too-long" "$(cat "$TICK_SCRIPT")"
 assert_contains "TC-PTL-006 dispatcher-tick routes PTL to dev-new" \
   "dispatch dev-new" "$(awk '/prompt_too_long/,/JUST_DISPATCHED/' "$TICK_SCRIPT")"
+
+# TC-PTL-007: behavioral test for the PTL branch — extract the branch
+# body and drive it with stubbed gh / label_swap / post_dispatch_token /
+# dispatch. Asserts:
+#   (a) call sequence: label_swap → post_dispatch_token → dispatch
+#   (b) log file is truncated after the branch fires
+#   (c) idempotency-marker comment fires only on the first invocation
+#   (d) on truncate failure the branch refuses to dispatch
+TC_PTL_DIR="$TMPROOT/ptl-branch-$$"
+mkdir -p "$TC_PTL_DIR"
+
+# Synthesize a callable script that contains the PTL branch body from
+# dispatcher-tick.sh. Extract from the notice_marker setup down to the
+# branch-end (stable code anchors), then translate `continue` to a
+# return so the body is callable as a function inside our test harness.
+ptl_branch_body() {
+  awk '/^      notice_marker="INV-12-prompt-too-long:/,/^      continue$/' "$TICK_SCRIPT" \
+    | sed -E 's/^([[:space:]]+)continue$/\1return 0/'
+}
+
+# Stub harness: each call appended to $CALL_LOG so we can assert order.
+cat > "$TC_PTL_DIR/harness.sh" <<'HARNESS'
+log() { echo "[harness] $*" >> "$CALL_LOG"; }
+gh() {
+  echo "gh $*" >> "$CALL_LOG"
+  # Mock: `gh issue view ... --json comments -q "...select(contains(...))"`
+  # For our test, we want to control whether the marker exists. The
+  # GH_MOCK_MARKER_COUNT env var drives this — '0' = not present yet.
+  if [[ "$*" == *"select(contains"* ]]; then
+    echo "${GH_MOCK_MARKER_COUNT:-0}"
+  fi
+  return 0
+}
+label_swap() { echo "label_swap $*" >> "$CALL_LOG"; }
+post_dispatch_token() { echo "post_dispatch_token $*" >> "$CALL_LOG"; }
+dispatch() { echo "dispatch $*" >> "$CALL_LOG"; }
+JUST_DISPATCHED=()
+HARNESS
+
+# Helper: run the branch with a given session_id, terminal_reason, and
+# pre-existing log contents. Returns the call-log contents.
+#
+# We wrap the extracted branch body in a function so its `return 0`
+# (translated from `continue`) cleanly exits the test invocation
+# without aborting the surrounding subshell or running stragglers.
+run_ptl_branch() {
+  local issue_num_arg="$1" session_id_arg="$2" log_contents="$3" marker_count="${4:-0}"
+  local call_log="$TC_PTL_DIR/calls.log"
+  : > "$call_log"
+  # Allow caller to override the log path (used by TC-PTL-007d to
+  # provoke truncate-failure with a directory at the path).
+  local ptl_log="${PTL_LOG_OVERRIDE:-/tmp/agent-ptl-test-$$-issue-${issue_num_arg}.log}"
+  if [[ ! -d "$ptl_log" ]]; then
+    printf '%s' "$log_contents" > "$ptl_log"
+  fi
+
+  local body_file="$TC_PTL_DIR/body-${issue_num_arg}.sh"
+  cat > "$body_file" <<BODY_HEAD
+#!/bin/bash
+$(cat "$TC_PTL_DIR/harness.sh")
+ptl_branch() {
+  local issue_num="$issue_num_arg"
+  local session_id="$session_id_arg"
+  local PROJECT_ID="ptl-test-$$"
+  local REPO="test/repo"
+$(ptl_branch_body)
+}
+ptl_branch
+BODY_HEAD
+
+  CALL_LOG="$call_log" GH_MOCK_MARKER_COUNT="$marker_count" \
+    bash "$body_file" 2>>"$call_log"
+
+  cat "$call_log"
+  [[ -f "$ptl_log" ]] && rm -f "$ptl_log"
+}
+
+# TC-PTL-007a: marker NOT yet present → posts marker, then dispatches.
+CALLS=$(run_ptl_branch 7001 "session-7001" '{"type":"result","stop_reason":"stop_sequence","terminal_reason":"prompt_too_long"}' 0)
+assert_contains "TC-PTL-007a first PTL: posts the marker comment" "INV-12-prompt-too-long:session-7001" "$CALLS"
+assert_contains "TC-PTL-007a calls label_swap pending-dev → in-progress" "label_swap 7001 pending-dev in-progress" "$CALLS"
+assert_contains "TC-PTL-007a calls post_dispatch_token dev-new" "post_dispatch_token 7001 dev-new" "$CALLS"
+assert_contains "TC-PTL-007a calls dispatch dev-new" "dispatch dev-new 7001" "$CALLS"
+
+# TC-PTL-007b: ordering — label_swap MUST come before dispatch (otherwise
+# a dispatch failure leaves issue in pending-dev with no in-progress flip).
+SWAP_LINE=$(echo "$CALLS" | grep -n 'label_swap' | head -1 | cut -d: -f1)
+DISPATCH_LINE=$(echo "$CALLS" | grep -n '^dispatch dev-new' | head -1 | cut -d: -f1)
+if [[ -n "$SWAP_LINE" && -n "$DISPATCH_LINE" && "$SWAP_LINE" -lt "$DISPATCH_LINE" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: TC-PTL-007b call order: label_swap before dispatch"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: TC-PTL-007b call order wrong: swap=$SWAP_LINE dispatch=$DISPATCH_LINE"
+  FAIL=$((FAIL + 1))
+fi
+
+# TC-PTL-007c: idempotency — marker already present → no marker post,
+# but still dispatches (the branch's purpose is to recover).
+CALLS=$(run_ptl_branch 7001 "session-7001" '{"type":"result","stop_reason":"stop_sequence","terminal_reason":"prompt_too_long"}' 1)
+# When marker_count=1 the 'if grep -q ^0$' check fails → marker not posted.
+if echo "$CALLS" | grep -q "INV-12-prompt-too-long:session-7001.*Forcing a fresh"; then
+  echo -e "  ${RED}FAIL${NC}: TC-PTL-007c idempotency: marker re-posted"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}PASS${NC}: TC-PTL-007c idempotency: marker NOT re-posted when already present"
+  PASS=$((PASS + 1))
+fi
+assert_contains "TC-PTL-007c idempotency: dispatch still fires" "dispatch dev-new 7001" "$CALLS"
+
+# TC-PTL-007d: log truncation failure → refuses to dispatch (the bug
+# this PR closes — silent retry loop).
+# Simulate truncate failure by pre-creating the log path as a
+# directory: bash's `: > <dir>` fails with EISDIR.
+TC_PTL_BAD_LOG_ISSUE=7002
+TC_PTL_BAD_LOG_PATH="/tmp/agent-ptl-test-$$-issue-${TC_PTL_BAD_LOG_ISSUE}.log"
+mkdir -p "$TC_PTL_BAD_LOG_PATH"
+PTL_LOG_OVERRIDE="$TC_PTL_BAD_LOG_PATH" \
+  CALLS=$(run_ptl_branch "$TC_PTL_BAD_LOG_ISSUE" "session-7002" 'unused' 0)
+rmdir "$TC_PTL_BAD_LOG_PATH" 2>/dev/null || true
+if echo "$CALLS" | grep -q "dispatch dev-new ${TC_PTL_BAD_LOG_ISSUE}"; then
+  echo -e "  ${RED}FAIL${NC}: TC-PTL-007d truncate-failed but dispatch still fired (silent retry loop hazard)"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}PASS${NC}: TC-PTL-007d truncate-failed → dispatch skipped"
+  PASS=$((PASS + 1))
+fi
+rm -rf "$TC_PTL_DIR"
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/unit/test-autonomous-review-verdict-regex.sh
+++ b/tests/unit/test-autonomous-review-verdict-regex.sh
@@ -41,20 +41,16 @@ assert_eq() {
   fi
 }
 
-# Extract the verdict-polling jq pattern from the wrapper. The poll line
-# is the one containing both `select((.body | test(` and the
-# session-id binding `Review Session.*${SESSION_ID}`.
-POLL_LINE=$(grep -nF 'select((.body | test(' "$WRAPPER" | head -1 | cut -d: -f1)
-if [[ -z "$POLL_LINE" ]]; then
-  echo -e "${RED}FAIL${NC}: could not locate verdict-poll line in $WRAPPER" >&2
-  exit 1
-fi
-# Capture the FIRST quoted regex inside test(...), unescaping the wrapper's
-# shell-level backslash-escapes: \" → ".
-POLL_PATTERN=$(sed -n "${POLL_LINE}p" "$WRAPPER" \
-  | grep -oE 'test\(\\"[^\\]+\\"' \
-  | head -1 \
-  | sed -E 's/^test\(\\"//; s/\\"$//')
+# Extract the verdict-polling jq pattern from the wrapper.
+#
+# Post-Fix-1: the wrapper holds the verdict regex in a shell variable
+# `_VERDICT_RE='...'` and references it inside two jq queries (one for
+# the actor+window path, one for the legacy session-id fallback). We
+# read the variable assignment directly — it is the canonical source.
+#
+# Anchor: the line `_VERDICT_RE='...'` near the polling loop.
+POLL_PATTERN=$(grep -E "^_VERDICT_RE=" "$WRAPPER" | head -1 \
+  | sed -E "s/^_VERDICT_RE='//; s/'$//")
 
 # Extract the FAIL and PASS classification regex patterns.
 # The post-fix wrapper has two `grep -qiE '...'` checks: FAIL first

--- a/tests/unit/test-is-session-completed.sh
+++ b/tests/unit/test-is-session-completed.sh
@@ -133,13 +133,20 @@ write_log 1010 '[autonomous-dev] 21:41:15 Resuming session: abc-123
 assert_returns "realistic Claude shape with nested usage and {} in result string → true" 0 is_session_completed 1010
 cleanup_log 1010
 
-# Realistic shape, but is_error=true (api_error_status=400) and a non-end_turn
-# stop. The wrapper logged this with `prompt_too_long` terminal_reason.
-# Resume against THIS terminal state should still fail the gate (it's a
-# retry-worthy condition, not a true completion).
+# prompt_too_long: claude -p has no auto-compaction, so resume re-feeds the
+# whole transcript and crashes again. The dispatcher must treat this as
+# terminal so dispatcher-tick routes to a fresh session instead of looping.
+# Behavior change: pre-Fix-3 returned 1 (retry-worthy); post-Fix-3 returns 0
+# (terminal — caller flips label so next tick mints a fresh session).
 write_log 1011 '{"type":"result","subtype":"success","is_error":true,"api_error_status":400,"result":"Prompt is too long","stop_reason":"stop_sequence","session_id":"abc","usage":{"input_tokens":0},"terminal_reason":"prompt_too_long"}'
-assert_returns "is_error=true with prompt_too_long → false (legit retry case)" 1 is_session_completed 1011
+assert_returns "prompt_too_long → terminal (no auto-compact in claude -p; force fresh)" 0 is_session_completed 1011
 cleanup_log 1011
+
+# Transient api_error (e.g. Bedrock 503, not a context overflow) should
+# remain non-terminal — resume might succeed when the upstream recovers.
+write_log 1013 '{"type":"result","subtype":"error","is_error":true,"api_error_status":503,"result":"Service unavailable","stop_reason":"end_turn","session_id":"abc","usage":{"input_tokens":1},"terminal_reason":"api_error"}'
+assert_returns "api_error → not terminal (transient, resume worthwhile)" 1 is_session_completed 1013
+cleanup_log 1013
 
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

Three independent fixes bundled in one PR — they share files (`autonomous-{dev,review}.sh`, `lib-agent.sh`, `lib-dispatch.sh`, `dispatcher-tick.sh`) so a single review pass is more efficient than three.

All three were surfaced by a real `dev → review → dev → review` ping-pong loop observed on a downstream consumer where the failure modes compound: every dev tick exited 0 (\"PR found, moving to pending-review\") and every review tick exited 0 too but its verdict-detection regex missed the agent's posted comment, so the issue label flipped back to `pending-dev` instead of `approved`. After ~12h of looping, three independent bugs were identified.

### Fix 1 — verdict detection: actor + time window + trailer presence

Replaces the fragile `Review Session.*${SESSION_ID}` body-text predicate, which depended on the agent echoing the wrapper's UUID verbatim. In practice the agent occasionally rewrote the UUID, breaking the match and forcing the FAILED branch.

New three-layer authenticity binding:
- **Actor**: `author.login == BOT_LOGIN` (resolved once via `gh api user --jq .login` at wrapper start). Provides full separation in `GH_AUTH_MODE=app` where dev and review use distinct GitHub Apps.
- **Time window**: `createdAt >= WRAPPER_START_TS` captured before `run_agent`. Excludes stale comments from prior ticks.
- **Body trailer presence**: `body matches /Review Session/`. Defense-in-depth that matters specifically in `GH_AUTH_MODE=token` where dev and review share `BOT_LOGIN`. The dev agent's prompt does not instruct it to emit `Review Session`, so its status comments are excluded.

Falls back to a tighter `Review Session.*${SESSION_ID}` body-text match (within the time window) when `BOT_LOGIN` resolution fails or returns the literal string `\"null\"` — preserves spoof protection on a single transient API failure.

### Fix 2 — `AGENT_LAUNCHER` for cc/Bedrock environments

Optional config var that wraps every agent invocation through a launcher prefix. Empty (default) = current direct-invocation behavior unchanged. Set = the wrapper's argv becomes `<AGENT_LAUNCHER> <AGENT_CMD> <args...>`, tokenized via `eval` once at config load and applied uniformly across claude/codex/kiro/opencode/generic CLI branches inside `_run_with_timeout`.

Use case: bridge dispatcher-spawned wrappers into the same env that powers a user's interactive `claude` shell function. Without this, a non-interactive `nohup` shell sees none of the user's `~/.bash_aliases` env (`CLAUDE_CODE_USE_BEDROCK=1`, `ANTHROPIC_DEFAULT_OPUS_MODEL`, AWS profile, telemetry tags) and falls back silently to whatever model claude defaults to. Canonical config form:

```bash
AGENT_LAUNCHER='bash -c '\''source ~/.bash_aliases && exec cc \"$@\"'\'' --'
```

Wrappers also export `CC_USER=autonomous-{dev,review}-bot` and `CC_ROLE_KIND={dev,review}` for downstream cost attribution / telemetry.

### Fix 3 — `prompt_too_long` triggers fresh-session fallback

`is_session_completed` now treats `terminal_reason=prompt_too_long` as terminal. Headless `claude -p` has no auto-compaction (verified upstream — `/compact` is TUI-only), so resuming a PTL'd session re-feeds the entire JSONL transcript and crashes again. The dispatcher routes those to a fresh `dev-new` tick instead of looping `--resume`. Includes a hard guard against silent retry loops if log truncation fails.

The dev wrapper's existing resume-fallback path (line 354-405) now also posts a standalone `Dev Session ID:` marker for the new session so the dispatcher's `extract_dev_session_id` picks it up even if the wrapper crashes mid-fallback before the trap-on-exit session report fires.

## Tests

- New `tests/unit/test-autonomous-launcher-verdict-fresh.sh` — 36 cases across all three fixes (no real `claude` / `gh` invoked):
  - **TC-VRD** (12 cases): verdict actor + window + trailer with anti-spoof regressions including token-mode dev-agent quoted-verdict comments
  - **TC-LCH** (7 cases): launcher prefix injection across direct, env-only, and quoted `bash -c` forms
  - **TC-PTL** (17 cases): including a behavioral test (TC-PTL-007a-d) for the dispatcher-tick PTL branch that exercises real call ordering, idempotency, and the truncate-failure guard with stubbed gh/label_swap/post_dispatch_token/dispatch
- Updated `tests/unit/test-is-session-completed.sh` — flipped the PTL case to expect terminal=true (Fix 3 semantics) and added an api_error case to assert transient errors still retry
- Updated `tests/unit/test-autonomous-review-verdict-regex.sh` — reads the `_VERDICT_RE` variable directly since the regex is now hoisted

44/44 unit tests pass.

## Test plan

- [x] `bash tests/unit/test-autonomous-launcher-verdict-fresh.sh` — 36 cases pass
- [x] `bash tests/unit/test-is-session-completed.sh` — 14 cases pass
- [x] `bash tests/unit/test-autonomous-review-verdict-regex.sh` — 10 cases pass
- [x] Full unit suite — 44/44 pass
- [ ] Post-merge smoke: consumer machine confirms `AGENT_LAUNCHER` causes JSONL `modelUsage` to show the configured Bedrock model id instead of a default fallback
- [ ] Post-merge smoke: a stuck issue with the dev↔review loop converges to `approved` after one full cycle (verdict detector now matches by actor+window+trailer regardless of agent-minted UUID)

## Review

Two reviewer-toolkit passes were run before opening the PR. All `Critical` and `Important` findings from `pr-review-toolkit:code-reviewer`, `pr-review-toolkit:silent-failure-hunter`, `pr-review-toolkit:pr-test-analyzer`, and `pr-review-toolkit:comment-analyzer` are addressed in commit 16bc5ee. Two findings deferred (`I1` rare race + drift hazard between two test files now resolved by extracting `_VERDICT_RE` from production source).