### PR TITLE
fix(launcher): claude-only invocation contract + example pitfall doc

### DIFF
--- a/docs/designs/launcher-claude-only-contract.md
+++ b/docs/designs/launcher-claude-only-contract.md
@@ -1,0 +1,66 @@
+# AGENT_LAUNCHER claude-only contract + example pitfall doc
+
+Follow-up to PR #101's AGENT_LAUNCHER feature. Two production bugs surfaced after deployment to a downstream consumer's quant-scorer dispatch path:
+
+1. **Bug 1 — `exec cc` resolves to GCC.** The example value in `autonomous.conf.example` was `bash -c 'source ~/.bash_aliases && exec cc "$@"' --`. `exec` only runs external binaries; `cc` (the shell function) is never seen. Bash falls through to PATH lookup which finds `/usr/bin/cc` (GNU C compiler). The wrapper crashed with `cc: error: unrecognized command-line option '--resume'; did you mean '--ree'?` 5 seconds into every dispatch. Three retries → `stalled`.
+
+2. **Bug 2 — wrapper-side `env -u CLAUDECODE claude` becomes claude args.** Once the operator dropped `exec` and used plain `cc "$@"`, claude itself launched, but with garbage argv:
+   ```
+   error: unknown option '-u'
+   ```
+   Root cause: lib-agent.sh's claude branch passed `env -u CLAUDECODE claude --session-id ...` to `_run_with_timeout`. With AGENT_LAUNCHER set, the launcher's `bash -c '... cc "$@"'` received those tokens as `$@`, and cc's terminal `$CLAUDE_CMD "$@"` invoked `claude env -u CLAUDECODE claude --session-id ...`. claude saw `env`, `-u`, and a second `claude` as positional args before the real flags.
+
+Both bugs together meant the launcher feature was essentially broken for any user who copy-pasted the example. PR #101's TC-LCH tests passed because they used a synthetic launcher (`env LAUNCHER_FOO=bar`) that didn't end with `$CLAUDE_CMD "$@"` — the test setup assumed a transparent env-injecting prefix, which doesn't match how the canonical `cc` launcher actually works.
+
+## Fix
+
+### lib-agent.sh — branch claude path on AGENT_LAUNCHER state
+
+`run_agent` and `resume_agent`'s claude branches now check `${#AGENT_LAUNCHER_ARGV[@]}`:
+
+| AGENT_LAUNCHER | argv to `_run_with_timeout` | rationale |
+|---|---|---|
+| empty | `env -u CLAUDECODE claude --session-id <sid> ...` | wrapper drives claude directly, strips CLAUDECODE for safety |
+| set | `--session-id <sid> ...` (flags only) | launcher invokes claude itself; CLAUDECODE handling delegated to launcher |
+
+The codex / kiro / opencode branches are unchanged — they don't have `env -u CLAUDECODE` and their command shape is `$AGENT_CMD args...`.
+
+### lib-agent.sh — refuse AGENT_LAUNCHER + AGENT_CMD≠claude
+
+Hard-fail at config load if AGENT_LAUNCHER is set with non-claude AGENT_CMD. The canonical launcher form (cc shell function) is hardcoded to invoke claude — pointing it at codex would produce `claude codex ...`. Catching this at startup is better than crashing 5 seconds into the first dispatch.
+
+### autonomous.conf.example — fix two doc bugs
+
+1. Replace `exec cc "$@"` with plain `cc "$@"` in the worked example.
+2. Comment the variable out by default (`# AGENT_LAUNCHER=''`) so users explicitly opt in. Setting `AGENT_LAUNCHER=""` works (lib-agent.sh checks `[[ -n "$AGENT_LAUNCHER" ]]`) but isn't conventional config style.
+3. Document the `cc` shell-function-vs-alias trap. Bash non-interactive shells don't expand aliases by default, so a `cc` alias would silently fall through to PATH lookup and again find GCC.
+
+### tests — TC-LCH-002/003 align with new contract
+
+The pre-fix test launcher was `env LAUNCHER_FOO=bar` — a transparent env prefix that didn't match the canonical cc shape. Updated to use `bash -c 'LAUNCHER_FOO=bar exec claude "$@"' --` which mirrors how a real launcher (cc) works. Added a TC-LCH-002 anti-regression assertion: argv must NOT contain `-u` or the literal `claude` token under launcher mode.
+
+### invariants.md — INV-22 updated
+
+INV-22 now documents:
+- claude-only scope (rejection at config load for non-claude)
+- the flags-only contract for the launcher's `"$@"`
+- the two operator pitfalls (exec, alias)
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `skills/autonomous-dispatcher/scripts/lib-agent.sh` | claude branches in run_agent/resume_agent gate on `${#AGENT_LAUNCHER_ARGV[@]}`; config-load reject AGENT_LAUNCHER+non-claude |
+| `skills/autonomous-dispatcher/scripts/autonomous.conf.example` | exec→cc, commented by default, shell-function-vs-alias note |
+| `docs/pipeline/invariants.md` | INV-22 expanded with scope, contract, pitfalls |
+| `tests/unit/test-autonomous-launcher-verdict-fresh.sh` | TC-LCH-002/003 use canonical launcher form; added TC-LCH-002 anti-regression |
+| `docs/designs/launcher-claude-only-contract.md` | this doc |
+
+## What I deliberately did NOT do
+
+- Did not generalize the launcher contract to support codex/kiro/opencode. The canonical user case is "bridge into my interactive cc env"; cc only knows how to launch claude. A user who writes a codex-specific launcher today would have to fork lib-agent.sh anyway. Revisit if/when there's demand.
+- Did not auto-fix the operator's `autonomous.conf` files. They're project-local, gitignored, and operator-owned. The example file is the reference; the fix doc travels through the README/CHANGELOG.
+
+## Out of scope
+
+- Vendored skill copies on already-deployed boxes (each project has its own `.agents/skills/.../lib-agent.sh` from `npx skills add`). Operators must re-run `npx skills update` after this PR merges to pick up the fix. There's no programmatic way for upstream to reach into downstream worktrees.

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -314,21 +314,29 @@ The `Mode: startup-failure` exclusion matters: `autonomous-dev.sh`'s startup-fai
 
 **Test**: `tests/unit/test-autonomous-launcher-verdict-fresh.sh` TC-PTL-005.
 
-## INV-22: AGENT_LAUNCHER tokenization happens once at config load
+## INV-22: AGENT_LAUNCHER tokenization + claude-only invocation contract
 
-**Rule**: `lib-agent.sh` MUST tokenize `AGENT_LAUNCHER` (when non-empty) into `AGENT_LAUNCHER_ARGV[]` exactly once at source time via `eval "AGENT_LAUNCHER_ARGV=($AGENT_LAUNCHER)"`. The argv array is then prepended to every CLI invocation inside `_run_with_timeout`, so all CLI branches (claude / codex / kiro / opencode / generic) and both call sites (run_agent / resume_agent) get uniform launcher behavior.
+**Rule**: `lib-agent.sh` MUST tokenize `AGENT_LAUNCHER` (when non-empty) into `AGENT_LAUNCHER_ARGV[]` exactly once at source time via `eval "AGENT_LAUNCHER_ARGV=($AGENT_LAUNCHER)"`.
 
-**Why**: The consumer-machine motivation is to bridge dispatcher-spawned wrappers (non-interactive `nohup` shell, no `~/.bashrc`) into the same env that powers the operator's interactive `claude` shell function (`cc`). Without `AGENT_LAUNCHER`, autonomous wrappers ran with `--model opus[1m]` but the alias resolved to whatever model claude defaults to (no `ANTHROPIC_DEFAULT_OPUS_MODEL` set), silently downgrading to a different model. A per-CLI-branch sprinkle of `${AGENT_LAUNCHER_ARGV[@]}` would invite drift; centralizing in `_run_with_timeout` makes the prefix invariant across branches.
+**Scope**: `AGENT_LAUNCHER` is only valid with `AGENT_CMD=claude`. The combination is rejected at config load otherwise — the canonical launcher (a `cc` shell function ending with `$CLAUDE_CMD "$@"`) is hardcoded to invoke claude, so it cannot launch codex / kiro / opencode.
 
-**Producer**: `lib-agent.sh` — the `eval` parses the launcher string once, with a hard-fail on parse error and a WARN when the parse succeeds but yields zero argv elements (almost always operator typo).
+**Invocation contract** (claude branch only): the launcher script is responsible for invoking the claude binary itself. The wrapper passes only **flags + prompt** as `"$@"` to the launcher — NOT the binary name and NOT `env -u CLAUDECODE`. Pre-fix the wrapper passed `env -u CLAUDECODE claude --session-id ...` through to the launcher; the launcher's terminal `$CLAUDE_CMD "$@"` then invoked `claude env -u CLAUDECODE claude --session-id ...` and claude rejected `-u` as an unknown option (observed in production on a downstream consumer — wrapper exited 1 within 5 seconds of every dispatch). Post-fix, `lib-agent.sh::run_agent` / `resume_agent` branches on `${#AGENT_LAUNCHER_ARGV[@]}`: launcher set → flags-only argv; launcher unset → full `env -u CLAUDECODE claude args...` shape.
 
-**Consumer**: every `run_agent` / `resume_agent` invocation, uniform across CLIs.
+**Why**: The consumer-machine motivation is to bridge dispatcher-spawned wrappers (non-interactive `nohup` shell, no `~/.bashrc`) into the same env that powers the operator's interactive `claude` shell function. Without `AGENT_LAUNCHER`, autonomous wrappers ran with `--model opus[1m]` but the alias resolved to whatever model claude defaults to (no `ANTHROPIC_DEFAULT_OPUS_MODEL` set), silently downgrading to a different model.
+
+**Producer**: `lib-agent.sh` — the `eval` parses the launcher string once, with hard-fails on parse error and on `AGENT_CMD!=claude` mismatch, and a WARN when the parse succeeds but yields zero argv elements (almost always operator typo).
+
+**Consumer**: `_run_with_timeout` unconditionally prepends `${AGENT_LAUNCHER_ARGV[@]}` to every invocation; the claude branches in `run_agent` / `resume_agent` decide whether to include the binary name + `env -u CLAUDECODE` based on `AGENT_LAUNCHER_ARGV` length, while non-claude branches are guaranteed empty by the config-load claude-only check.
 
 **Trust**: `AGENT_LAUNCHER` is read from `autonomous.conf`. Treating its contents as shell input is no worse than executing `AGENT_CMD` itself — both are operator-controlled config in the same file. The wrapper documents this trust assumption explicitly.
 
-**Status**: **ENFORCED** in this PR.
+**Operator pitfalls** (documented in `autonomous.conf.example`):
+- The launcher must invoke claude with plain `cc "$@"` or `exec claude "$@"`, never `exec cc "$@"`. `exec` resolves `cc` to `/usr/bin/cc` (the GNU C compiler) instead of the shell function.
+- `cc` must be a shell *function*, not an alias. bash non-interactive shells do not expand aliases by default, so a `cc` alias would fall through to PATH lookup → again the C compiler.
 
-**Test**: `tests/unit/test-autonomous-launcher-verdict-fresh.sh` TC-LCH-001..003, plus TC-LCH-007/008 for the `CC_USER` / `CC_ROLE_KIND` env exports the wrapper sets before invoking the launcher.
+**Status**: **ENFORCED**.
+
+**Test**: `tests/unit/test-autonomous-launcher-verdict-fresh.sh` TC-LCH-001..003 (including the TC-LCH-002 anti-regression assertion: argv must NOT contain `-u` or the literal `claude` token under launcher mode), plus TC-LCH-007/008 for the `CC_USER` / `CC_ROLE_KIND` env exports the wrapper sets before invoking the launcher.
 
 ## Adding a new invariant
 

--- a/docs/test-cases/launcher-claude-only-contract.md
+++ b/docs/test-cases/launcher-claude-only-contract.md
@@ -1,0 +1,34 @@
+# Test cases — launcher claude-only contract + example fix
+
+Companion to `docs/designs/launcher-claude-only-contract.md`. All cases live in `tests/unit/test-autonomous-launcher-verdict-fresh.sh`.
+
+## TC-LCH (verdict + launcher) — updated for new contract
+
+| ID | Scenario | Expected | Status |
+|----|----------|----------|--------|
+| TC-LCH-001 | launcher unset → claude shim invoked with `--session-id`; `LAUNCHER_FOO` env unset | argv contains `--session-id`; env shows `LAUNCHER_FOO=<unset>` | unchanged |
+| TC-LCH-002 | launcher `bash -c 'LAUNCHER_FOO=bar exec claude "$@"' --` → claude env contains `LAUNCHER_FOO=bar` and argv contains `--session-id` | both present | rewritten — replaces old `env LAUNCHER_FOO=bar` form |
+| TC-LCH-002 anti-regression | argv must NOT contain `-u` or the literal `claude` token under launcher mode | no leak | NEW — guards against the `env -u CLAUDECODE claude` regression this PR fixes |
+| TC-LCH-003 | quoted launcher form `bash -c '...' --` → env propagates through bash -c | env shows propagated value | rewritten — uses canonical "exec claude" launcher shape |
+| TC-LCH-007 | autonomous-dev.sh exports CC_USER=autonomous-dev-bot | grep finds it | unchanged |
+| TC-LCH-008 | autonomous-review.sh exports CC_USER=autonomous-review-bot | grep finds it | unchanged |
+
+## Negative path coverage (already in lib-agent.sh, not separately unit-tested)
+
+| Scenario | Behavior |
+|----------|----------|
+| `AGENT_LAUNCHER` malformed (parse error) | hard-fail at config load, error message includes original value (TC-PTL-005-style snapshot) |
+| `AGENT_LAUNCHER` non-empty, tokenizes to zero argv | WARN, treat as unset |
+| `AGENT_LAUNCHER` set + `AGENT_CMD!=claude` | hard-fail at config load with actionable message |
+
+## Manual smoke (post-merge, on consumer machine)
+
+After merging this PR and re-running `npx skills update autonomous-dispatcher` in each downstream project:
+
+1. Confirm next dispatch on a project with `AGENT_LAUNCHER='bash -c '\''source ~/.bash_aliases && cc "$@"'\'' --'` produces a successful claude run. The agent log should show JSONL output, not `error: unknown option '-u'`.
+2. Confirm the JSONL `modelUsage` field shows the configured Bedrock model id (e.g. `global.anthropic.claude-opus-4-7`), not `anthropic.claude-haiku-4-5` (the silent-fallback fingerprint).
+3. Confirm CloudTrail `AssumeRole` events tagged via cc-creds carry `User=autonomous-dev-bot` / `autonomous-review-bot` and `Project=<project-name>` for autonomous traffic, separable from `User=ubuntu` interactive traffic.
+
+## Why no "test the example value parses" case
+
+The example file is doc, not code. Adding a CI test that grep-extracts AGENT_LAUNCHER from `autonomous.conf.example` and runs it through the lib-agent.sh tokenizer would couple the doc to a specific shape that we may want to evolve. The pitfall comments in the example are the contract; if a future operator copies the canonical form, the lib-agent.sh load-time validators (parse error, claude-only check) will catch their mistakes at runtime.

--- a/skills/autonomous-dispatcher/scripts/autonomous.conf.example
+++ b/skills/autonomous-dispatcher/scripts/autonomous.conf.example
@@ -41,24 +41,48 @@ AGENT_PERMISSION_MODE="auto"
 # Closes #60 (INV-13).
 AGENT_TIMEOUT="4h"
 
-# Optional launcher prefix that wraps every agent CLI invocation in
-# run_agent / resume_agent. Use case: bridge dispatcher-spawned wrappers
-# into the same env you set up for interactive `claude` runs (Bedrock
-# auth, MCP servers, telemetry tags, etc.) without duplicating that env
-# in autonomous.conf.
+# Optional launcher prefix wrapped around every claude CLI invocation
+# in run_agent / resume_agent. Use case: bridge dispatcher-spawned
+# wrappers into the same env you set up for interactive `claude` runs
+# (Bedrock auth, MCP servers, telemetry tags, etc.) without duplicating
+# that env in autonomous.conf.
 #
-# The wrappers also export CC_USER=autonomous-{dev,review}-bot and
-# CC_ROLE_KIND={dev,review} before invoking the launcher, so a
-# launcher that consumes those env vars can attribute autonomous-pipeline
-# traffic separately from interactive sessions in cost / telemetry
-# pipelines.
+# Contract: the launcher script is responsible for invoking the claude
+# binary itself (typically ending with `exec claude "$@"` or a shell
+# function that ends with `$CLAUDE_CMD "$@"`). The wrapper passes only
+# claude flags + prompt as "$@" — NOT the binary name. Required for the
+# claude branch only; mixing AGENT_LAUNCHER with AGENT_CMD≠claude is
+# rejected at startup since the canonical launchers are claude-specific.
 #
-# Example — a `cc` shell function in ~/.bash_aliases that injects
-# Bedrock + telemetry env:
-#   AGENT_LAUNCHER='bash -c '\''source ~/.bash_aliases && exec cc "$@"'\'' --'
+# The dev / review wrappers also export
+#   CC_USER=autonomous-{dev,review}-bot
+#   CC_ROLE_KIND={dev,review}
+# before invoking the launcher, so a launcher that consumes these (e.g.
+# the cc shell function piping CC_USER through to AWS STS session tags
+# via cc-creds) can attribute autonomous-pipeline traffic separately
+# from interactive sessions in cost / telemetry pipelines.
 #
-# Empty (default): no wrapping; $AGENT_CMD is invoked directly.
-AGENT_LAUNCHER=""
+# Example — a `cc` shell function defined in ~/.bash_aliases that
+# injects Bedrock + telemetry env and then invokes claude:
+#
+#   AGENT_LAUNCHER='bash -c '\''source ~/.bash_aliases && cc "$@"'\'' --'
+#
+# Notes:
+#   * Use `cc "$@"` — NOT `exec cc "$@"`. `exec` only runs external
+#     binaries, so on most Linux distros it resolves `cc` to
+#     /usr/bin/cc (the GNU C compiler) and the dispatch crashes with
+#     `unrecognized command-line option '--model'`.
+#   * `cc` must be defined as a shell *function* (not an alias). bash
+#     non-interactive shells do not expand aliases by default, so a cc
+#     alias would be ignored and PATH lookup would again find the
+#     C compiler.
+#   * The launcher is sourced once by lib-agent.sh and tokenized via
+#     `eval`. Treat its contents as code, not data.
+#
+# Default: leave AGENT_LAUNCHER unset (commented out). Most operators
+# use the wrapper's direct claude invocation.
+#
+# AGENT_LAUNCHER=''
 
 # === GitHub Authentication ===
 GH_AUTH_MODE="token"

--- a/skills/autonomous-dispatcher/scripts/lib-agent.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-agent.sh
@@ -79,6 +79,16 @@ if [[ -n "$AGENT_LAUNCHER" ]]; then
   unset _orig_launcher
 fi
 
+# AGENT_LAUNCHER is only supported with AGENT_CMD=claude today. The
+# canonical launcher (a `cc` shell function ending in `$CLAUDE_CMD "$@"`)
+# is hardcoded to invoke claude, so pointing it at codex/kiro/opencode
+# would produce `claude codex ...` and fail. Refuse the combination
+# rather than crashing 5 seconds into the next dispatch.
+if [[ ${#AGENT_LAUNCHER_ARGV[@]} -gt 0 && "$AGENT_CMD" != "claude" ]]; then
+  echo "[lib-agent] ERROR: AGENT_LAUNCHER is only supported with AGENT_CMD=claude (got AGENT_CMD=${AGENT_CMD}). Either unset AGENT_LAUNCHER or write a launcher tailored to your CLI." >&2
+  return 1 2>/dev/null || exit 1
+fi
+
 # Wall-clock cap on agent invocations (INV-13, closes #60).
 # Wraps run_agent / resume_agent in coreutils `timeout` so a hung CLI cannot
 # eat indefinite wall time (observed: claude --resume against a completed
@@ -289,13 +299,39 @@ run_agent() {
 
   case "$AGENT_CMD" in
     claude)
-      # Unset CLAUDECODE to allow launching from within an existing session.
-      _run_with_timeout env -u CLAUDECODE "$AGENT_CMD" --session-id "$session_id" \
-        ${session_name:+--name "$session_name"} \
-        --permission-mode "$AGENT_PERMISSION_MODE" \
-        ${model:+--model "$model"} \
-        -p "$prompt" \
+      # Flag list is identical across both invocation paths — only the
+      # command prefix differs (see below).
+      local claude_args=(
+        --session-id "$session_id"
+        ${session_name:+--name "$session_name"}
+        --permission-mode "$AGENT_PERMISSION_MODE"
+        ${model:+--model "$model"}
+        -p "$prompt"
         --output-format json
+      )
+      # Two invocation paths:
+      #
+      # (A) No AGENT_LAUNCHER → wrapper drives claude directly.
+      #     `env -u CLAUDECODE` strips a parent-process env var that
+      #     would otherwise make claude refuse to start (it treats
+      #     CLAUDECODE-set parents as "already inside a Claude session").
+      #     Only relevant when an operator runs the wrapper from inside
+      #     an interactive claude — dispatcher's nohup path doesn't have it.
+      #
+      # (B) AGENT_LAUNCHER set → launcher invokes claude itself.
+      #     The launcher (e.g. `cc` shell function) ends with
+      #     `$CLAUDE_CMD "$@"`, so we pass ONLY flags + prompt as "$@" —
+      #     NOT the binary name and NOT `env -u`. If we passed
+      #     `env -u CLAUDECODE claude --session-id ...`, the launcher
+      #     would invoke `claude env -u CLAUDECODE claude --session-id`
+      #     and claude rejects `-u` as an unknown option. CLAUDECODE
+      #     handling is delegated to the launcher (nohup-spawned bash -c
+      #     subshells generally don't inherit it anyway).
+      if [[ ${#AGENT_LAUNCHER_ARGV[@]} -gt 0 ]]; then
+        _run_with_timeout "${claude_args[@]}"
+      else
+        _run_with_timeout env -u CLAUDECODE "$AGENT_CMD" "${claude_args[@]}"
+      fi
       ;;
     codex)
       # Codex CLI: headless invocation is `codex exec [PROMPT]` (positional
@@ -361,13 +397,21 @@ resume_agent() {
 
   case "$AGENT_CMD" in
     claude)
-      # Unset CLAUDECODE to allow launching from within an existing session
-      # --name is omitted: the session retains the name set at creation.
-      _run_with_timeout env -u CLAUDECODE "$AGENT_CMD" --resume "$session_id" \
-        --permission-mode "$AGENT_PERMISSION_MODE" \
-        ${model:+--model "$model"} \
-        -p "$prompt" \
+      # See run_agent above for the (A) direct vs. (B) launcher rationale.
+      # --name is omitted on resume — the session retains the name set
+      # at creation.
+      local claude_args=(
+        --resume "$session_id"
+        --permission-mode "$AGENT_PERMISSION_MODE"
+        ${model:+--model "$model"}
+        -p "$prompt"
         --output-format json
+      )
+      if [[ ${#AGENT_LAUNCHER_ARGV[@]} -gt 0 ]]; then
+        _run_with_timeout "${claude_args[@]}"
+      else
+        _run_with_timeout env -u CLAUDECODE "$AGENT_CMD" "${claude_args[@]}"
+      fi
       ;;
     codex)
       # Codex `exec resume <thread_id> [PROMPT]` resumes the conversation.

--- a/tests/unit/test-autonomous-launcher-verdict-fresh.sh
+++ b/tests/unit/test-autonomous-launcher-verdict-fresh.sh
@@ -206,24 +206,46 @@ run_agent_capture() {
   cat "$out" 2>/dev/null
 }
 
-# TC-LCH-001: launcher unset → claude shim is invoked directly with the
-# wrapper's standard argv (--session-id, --output-format json, etc).
+# Contract: when AGENT_LAUNCHER is set, the launcher script is
+# responsible for invoking claude itself (it ends with something like
+# `exec claude "$@"`, or the cc shell function's `$CLAUDE_CMD "$@"`).
+# The wrapper passes flags + prompt only — NOT the binary name and NOT
+# `env -u CLAUDECODE`. This lets cc's own `$CLAUDE_CMD "$@"` work
+# without args getting rewritten as `claude env -u CLAUDECODE claude
+# --resume ...` (the bug this PR fixes).
+
+# TC-LCH-001: launcher unset → wrapper drives claude directly with
+# `env -u CLAUDECODE claude args...`. Shim sees standard claude argv.
 OUT1=$(run_agent_capture "")
 ARGV1=$(echo "$OUT1" | grep '^argv:')
 assert_contains "TC-LCH-001 launcher unset: claude shim invoked (--session-id present)" "--session-id" "$ARGV1"
 # Sanity: launcher-injected env should be UNSET when no launcher is set.
 assert_contains "TC-LCH-001 launcher unset: LAUNCHER_FOO env is <unset>" "LAUNCHER_FOO=<unset>" "$OUT1"
 
-# TC-LCH-002: launcher = `env LAUNCHER_FOO=bar` → env reaches claude shim.
-OUT2=$(run_agent_capture "env LAUNCHER_FOO=bar")
+# TC-LCH-002: launcher injects env then invokes claude itself (mimics
+# the real cc shell function which ends with `$CLAUDE_CMD "$@"`).
+LAUNCHER2='bash -c '\''LAUNCHER_FOO=bar exec claude "$@"'\'' --'
+OUT2=$(run_agent_capture "$LAUNCHER2")
 ARGV2=$(echo "$OUT2" | grep '^argv:')
 assert_contains "TC-LCH-002 launcher set: LAUNCHER_FOO reaches claude env" "LAUNCHER_FOO=bar" "$OUT2"
 assert_contains "TC-LCH-002 launcher set: claude still receives --session-id" "--session-id" "$ARGV2"
+# Anti-regression: claude must NOT see `env -u` or `claude` as positional
+# args. Pre-fix the wrapper passed `env -u CLAUDECODE claude --session-id`
+# through to the launcher; cc's `$CLAUDE_CMD "$@"` then invoked
+# `claude env -u CLAUDECODE claude --session-id ...` and claude rejected
+# `-u` as unknown.
+if [[ "$ARGV2" == *"-u"* || "$ARGV2" == *"argv: claude"* ]]; then
+  echo -e "  ${RED}FAIL${NC}: TC-LCH-002 anti-regression — argv leaked binary name or -u: $ARGV2"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}PASS${NC}: TC-LCH-002 anti-regression — no leaked binary name / -u in argv"
+  PASS=$((PASS + 1))
+fi
 
-# TC-LCH-003: launcher with single-quoted bash -c form (the canonical cc shape).
-LAUNCHER='bash -c '\''LAUNCHER_FOO=quoted exec "$@"'\'' --'
-ARGV3=$(run_agent_capture "$LAUNCHER")
-assert_contains "TC-LCH-003 quoted launcher: env propagates through bash -c" "LAUNCHER_FOO=quoted" "$ARGV3"
+# TC-LCH-003: canonical "source rc + invoke binary" launcher form.
+LAUNCHER3='bash -c '\''LAUNCHER_FOO=quoted exec claude "$@"'\'' --'
+OUT3=$(run_agent_capture "$LAUNCHER3")
+assert_contains "TC-LCH-003 quoted launcher: env propagates through bash -c" "LAUNCHER_FOO=quoted" "$OUT3"
 
 # TC-LCH-007: autonomous-dev.sh exports CC_USER/CC_ROLE_KIND.
 DEV_LINE=$(grep -E '^export CC_USER=' "$SCRIPTS_DIR/autonomous-dev.sh" | head -1)


### PR DESCRIPTION
## Summary

Follow-up to #101 (AGENT_LAUNCHER feature) fixing two production bugs surfaced on a downstream consumer's dispatch path. Both bugs caused autonomous wrappers to crash 5 seconds into every dispatch and exhaust retries → `stalled`.

### Bug 1 — `exec cc` resolves to GCC

`autonomous.conf.example` documented:
```
AGENT_LAUNCHER='bash -c '\''source ~/.bash_aliases && exec cc \"$@\"'\'' --'
```

`exec` only runs external binaries; it doesn't see shell functions defined in the sourced rc file. Bash falls through to PATH lookup → `/usr/bin/cc` (GNU C compiler) eats the claude flags:

```
cc: error: unrecognized command-line option '--resume'; did you mean '--ree'?
cc: error: unrecognized command-line option '--permission-mode'
cc: error: unrecognized command-line option '--model'
cc: error: unrecognized command-line option '--output-format'
```

### Bug 2 — `env -u CLAUDECODE` leaks through to launcher's $@

After dropping `exec`, claude itself launched but rejected its own argv:

```
error: unknown option '-u'
```

Root cause: `lib-agent.sh`'s claude branches passed `env -u CLAUDECODE claude --session-id ...` to `_run_with_timeout`. With `AGENT_LAUNCHER` set, the launcher's `bash -c '... cc \"$@\"'` received those tokens as `$@`, and cc's terminal `$CLAUDE_CMD \"$@\"` invoked `claude env -u CLAUDECODE claude --session-id ...` — claude saw `env`, `-u`, and a duplicate `claude` as positional args before the real flags.

PR #101's tests passed because they used a synthetic launcher shape (`env LAUNCHER_FOO=bar`) that didn't end with `$CLAUDE_CMD \"$@\"`. The contract assumption (\"launcher is a transparent env-injecting prefix\") didn't match how the canonical `cc` launcher actually works.

## Fix

- **lib-agent.sh** — claude branches in `run_agent` / `resume_agent` now check `${#AGENT_LAUNCHER_ARGV[@]}` and split into:
  - **(A) launcher unset** → wrapper drives claude directly with `env -u CLAUDECODE claude args...` (existing behavior)
  - **(B) launcher set** → wrapper passes flags only; launcher invokes claude itself
  - Flag list extracted into a local `claude_args` array via simplifier feedback (same flags both paths, only prefix differs).
- **lib-agent.sh** — hard-fail at config load if `AGENT_LAUNCHER` is set with `AGENT_CMD!=claude`. The canonical launcher form is claude-specific.
- **autonomous.conf.example** — `exec`→`cc`, `AGENT_LAUNCHER` commented out by default, added shell-function-vs-alias note (bash non-interactive shells don't expand aliases, so a `cc` alias would also fall through to GCC).

## Tests

- **TC-LCH-002/003 rewritten** to use canonical `bash -c 'exec claude \"$@\"' --` launcher shape (mirrors real cc function).
- **TC-LCH-002 anti-regression** assertion added: argv must NOT contain `-u` or the literal `claude` token under launcher mode — would have caught Bug 2 in CI.

44/44 unit tests pass (37 in `test-autonomous-launcher-verdict-fresh.sh`).

## Test plan

- [x] `bash tests/unit/test-autonomous-launcher-verdict-fresh.sh` — 37/37
- [x] Full unit suite — 44/44
- [ ] Post-merge: a real run on a project with AGENT_LAUNCHER configured produces JSONL `modelUsage` showing the configured Bedrock model id (not the silent-fallback Haiku fingerprint)
- [ ] Post-merge: stuck-on-launcher-bug issue (downstream consumer's dispatch on a stalled issue) converges to a successful dev session after re-syncing skills

## Rollout note for operators

After merge, downstream projects must re-run `npx skills update autonomous-dispatcher` to pick up the new `lib-agent.sh`. The deployed copies under each project's `.agents/skills/` are vendored, not symlinked to upstream. Operators on the affected box may also need to clear any `stalled` labels on issues that hit Bug 1 or Bug 2 — `count_agent_failures` keys off the most-recent \"Marking as stalled\" comment so the prior failed attempts are excluded from the new retry budget once the label is cleared.