### PR TITLE
fix(scripts): migrate readlink-f to BASH_SOURCE for shared-install topology

### DIFF
--- a/docs/designs/issue-104-bash-source-migration.md
+++ b/docs/designs/issue-104-bash-source-migration.md
@@ -1,0 +1,86 @@
+# SCRIPT_DIR migration: `readlink -f "$0"` → `${BASH_SOURCE[0]:-$0}`
+
+Closes #104.
+
+## Background
+
+[INV-14](../pipeline/invariants.md#inv-14-config-lookup-honors-symlink-vendor-pattern) (introduced in PR-4 to close #58) requires that all scripts loading `autonomous.conf` resolve their own directory via `${BASH_SOURCE[0]:-$0}` rather than `readlink -f`. The reason is conf-loading semantics: when a project vendors scripts as symlinks (e.g. `<project>/scripts/autonomous-dev.sh -> .agents/skills/.../autonomous-dev.sh`), `BASH_SOURCE[0]` retains the project-side path, while `readlink -f` jumps fully to the vendored location. Conf lives in the project's `scripts/`, not in the vendored copy, so `readlink -f` causes the conf-lookup to miss tier-2 (`${SCRIPT_DIR}/autonomous.conf`).
+
+That broke INV-14 quietly for one specific deployment topology — the **shared-install topology** — where the scripts directory in the project is a directory of symlinks pointing into a single skill installation (typically user-scope at `~/.claude/skills/`). Today's vendored topology survives because:
+- `dispatch-local.sh:34` has a `${SCRIPT_DIR}/../../../scripts/autonomous.conf` fallback that resolves correctly when the vendor lives at `<project>/.agents/skills/.../scripts/`.
+- Once `dispatch-local.sh` finds conf, it `nohup`s the wrapper with `PROJECT_DIR` already exported — letting `lib-agent.sh` use tier-3 (`${PROJECT_DIR}/scripts/autonomous.conf`) to find conf even though tier-2 missed.
+
+Both fallbacks fail under the shared-install topology, where `readlink -f` resolves outside any project boundary. Verified empirically during issue investigation: a `/tmp/proj-test-*` directory with only `scripts/autonomous.conf` plus symlinks pointing into `~/.claude/skills/...` failed conf-loading; the same layout with a sed-patched `BASH_SOURCE[0]` form loaded conf correctly.
+
+## Files affected
+
+Six production scripts violate INV-14:
+
+| File | Line | Path-resolver name |
+|---|---|---|
+| `setup-labels.sh` | 12 | `SCRIPT_DIR` |
+| `dispatch-local.sh` | 31 | `SCRIPT_DIR` (critical path) |
+| `gh-token-refresh-daemon.sh` | 26 | `SCRIPT_DIR` |
+| `autonomous-review.sh` | 17 | `SCRIPT_DIR` (critical path) |
+| `autonomous-dev.sh` | 17 | `SCRIPT_DIR` (critical path) |
+| `gh-with-token-refresh.sh` | 18 | `SELF_DIR` (same pattern, different var name) |
+
+Plus test code in `tests/unit/test-symlink-resolution.sh:62, 100, 106, 137, 169, 205, 334` simulates the broken pattern. The simulations themselves are fine (they're testing what real code does today), but the test enumeration should add cases that lock down the fix.
+
+## Change
+
+Replace `readlink -f "$0"` with `${BASH_SOURCE[0]:-$0}` in all 6 sites. Add a one-line INV-14 citation in the surrounding comment so future "cleanup" PRs don't revert.
+
+The behavioral difference:
+
+| Topology | `readlink -f "$0"` resolves to | `${BASH_SOURCE[0]:-$0}` resolves to |
+|---|---|---|
+| Vendored, called from project-side symlink | `<project>/.agents/skills/.../scripts/` | `<project>/scripts/` ✓ |
+| Vendored, called directly | `<project>/.agents/skills/.../scripts/` (same) | `<project>/.agents/skills/.../scripts/` (same) |
+| Shared-install, called from project-side symlink | `~/.claude/skills/.../scripts/` ✗ | `<project>/scripts/` ✓ |
+| Shared-install, called directly | `~/.claude/skills/.../scripts/` (same) | `~/.claude/skills/.../scripts/` (same) |
+
+For the wrapper / dispatcher chain we always invoke via `<project>/scripts/<file>.sh`, so the migration converts a previously-broken topology into a working one without changing any working topology.
+
+### Sibling-source statements unchanged
+
+Inside each migrated file, statements like `source "${SCRIPT_DIR}/lib-agent.sh"` are unaffected: both `readlink -f` and `BASH_SOURCE[0]` resolve to a directory that *contains* a copy of `lib-agent.sh`. The semantic difference shows up only at `lib-config.sh::load_autonomous_conf`, where `${SCRIPT_DIR}` is compared against the location of `autonomous.conf`.
+
+### Backward compat with `dispatch-local.sh:34` fallback
+
+Keep the `${SCRIPT_DIR}/../../../scripts/autonomous.conf` fallback. After migration, `SCRIPT_DIR` always resolves to project-side `scripts/` for symlinked invocations, so tier-1 (same-dir) hits and the fallback never fires. But for callers that still invoke the vendored copy *directly* (no project-side symlink), the fallback remains the only way to find conf. Removing it would be a separate breaking change and is explicitly **out of scope** per the issue.
+
+### Variable naming for `gh-with-token-refresh.sh`
+
+That file uses `SELF_DIR` instead of `SCRIPT_DIR`. The migration treats it as a same-pattern, different-name case — same `${BASH_SOURCE[0]:-$0}` substitution, same INV-14 citation comment, no rename to `SCRIPT_DIR` (out-of-scope churn).
+
+## Test enumeration
+
+New cases extend `tests/unit/test-symlink-resolution.sh`:
+
+| ID | Topology | Behavior asserted |
+|---|---|---|
+| TC-INV14-1 | Vendored, project-side symlink → `<proj>/.agents/skills/.../` | conf loads (regression for current production) |
+| TC-INV14-2 | Shared-install (user-scope), project-side symlink → `~/.claude/skills/.../` | conf loads (NEW topology unblocked by this PR) |
+| TC-INV14-3 | System-wide install, project-side symlink → `/opt/skills/.../` | conf loads (defensive: proves it's not hardcoded to `~/.claude/`) |
+| TC-INV14-4 | Vendored, called directly (no project symlink, with `../../../scripts/autonomous.conf` layout) | conf loads via `dispatch-local.sh:34` fallback (regression) |
+| TC-INV14-5 | End-to-end: `dispatcher-tick.sh` → `dispatch-local.sh` → `autonomous-dev.sh`, shared-install | every layer's `SCRIPT_DIR` resolves into project's `scripts/` (or harmless if that layer doesn't load conf), conf loads |
+
+Each new case constructs a tmpdir mimicking the topology, places a unique `autonomous.conf` in the project-side `scripts/`, runs `dispatch-local.sh` (or a stripped wrapper that just sources the conf), and asserts the unique value made it through.
+
+## Docs
+
+- Update `lib-config.sh::load_autonomous_conf` docstring: explicitly list the two supported topologies (vendored, shared-install). The docstring already says "use BASH_SOURCE not readlink-f" — add why both topologies work after the migration.
+- Update `INV-14` in `docs/pipeline/invariants.md`: enumerate the two topologies, note that the migration in this PR aligned all 6 prior offenders with the rule.
+- Update `autonomous.conf.example`: add a comment block documenting the shared-install topology as a supported alternative to `npx skills add -p`.
+
+## Out of scope
+
+Per the issue:
+- Removing `dispatch-local.sh:34`'s `../../../scripts/autonomous.conf` fallback. Could be deprecated separately.
+- Changing `npx skills add` to install user-scope by default.
+- A wrapper `install-shared-symlinks.sh` helper that auto-creates the project-side symlinks pointing into a chosen shared-install path. Useful follow-up but separable from the contract change.
+
+## Risk
+
+Low. Pure refactor + behavioral expansion. Existing topology behavior is preserved (TC-INV14-1, TC-INV14-4 are regression tests). Migration touches non-business-logic identifier resolution only. No config schema changes.

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -189,10 +189,37 @@ The cutoff timestamp falls back to epoch (1970-01-01) for issues that have never
 
 **Why**: When projects vendor scripts as symlinks, `readlink -f` resolves to the skill installation dir — but `autonomous.conf` lives in the project's `scripts/`, not in the skill installation. The lookup misses, the wrapper exits at `: "${REPO:?Set REPO in autonomous.conf}"`, the dispatcher sees crash → eventually marks stalled (#58).
 
-**Producer**: `lib-config.sh::load_autonomous_conf` (consolidated in PR-4 from three byte-identical inline blocks that previously lived in `lib-agent.sh`, `lib-auth.sh`, and `dispatcher-tick.sh`).
+### Supported deployment topologies (post-#104)
+
+The contract is satisfied across two distinct topologies because every script computes `SCRIPT_DIR` from `${BASH_SOURCE[0]:-$0}`:
+
+| Topology | Layout | conf-lookup tier that hits |
+|---|---|---|
+| **Vendored per-project** | `<project>/.agents/skills/.../scripts/dispatch-local.sh` (real file) ← `<project>/scripts/dispatch-local.sh` (symlink) | tier-2 — `SCRIPT_DIR` resolves to `<project>/scripts/`, conf is right there |
+| **Shared install** | `~/.claude/skills/.../scripts/dispatch-local.sh` (real file) ← `<project>/scripts/dispatch-local.sh` (symlink) | tier-2 — same — `BASH_SOURCE[0]` keeps the project-side path |
+
+Both topologies yield the same `SCRIPT_DIR` for symlinked invocations: the project's `scripts/`. Direct invocation of a vendored copy (no project-side symlink) still works via the legacy `${SCRIPT_DIR}/../../../scripts/autonomous.conf` fallback in `dispatch-local.sh`. That fallback only fires for the legacy 2-deep `<project>/skills/.../scripts/` layout (3 levels up from `<scripts>` lands at `<project>`); the modern 3-deep layouts under `.agents/skills/` or `.claude/skills/` rely on the project-side symlink + tier-2 path.
+
+#### Required symlink manifest (shared-install topology)
+
+Each entry-point script sources sibling lib files via `${SCRIPT_DIR}/<sibling>.sh`. With `BASH_SOURCE[0]`-based `SCRIPT_DIR`, those resolve to the project's `scripts/` — which means the operator MUST symlink every transitive sibling, not just the entry-points. Symlinking only `dispatch-local.sh` would break with `No such file or directory: lib-config.sh`. The minimum set:
+
+| File | Why it must be symlinked |
+|---|---|
+| `autonomous-dev.sh`, `autonomous-review.sh` | wrapper entry points |
+| `dispatch-local.sh` | dispatcher → wrapper bridge |
+| `lib-agent.sh`, `lib-auth.sh`, `lib-config.sh`, `lib-dispatch.sh`, `lib-review-bots.sh` | sourced transitively from the entry points |
+| `gh-app-token.sh`, `gh-with-token-refresh.sh`, `gh-token-refresh-daemon.sh` | sourced by lib-auth.sh; daemon spawned by token-refresh path |
+
+`autonomous.conf.example` documents this manifest in operator-facing form. A future helper script `install-shared-symlinks.sh` (out of scope per #104) could automate the symlink creation.
+
+**Producer**: `lib-config.sh::load_autonomous_conf` (consolidated in PR-4 from three byte-identical inline blocks). Six entry-point scripts (`dispatch-local.sh`, `autonomous-dev.sh`, `autonomous-review.sh`, `gh-token-refresh-daemon.sh`, `gh-with-token-refresh.sh`, `setup-labels.sh`) whose own `SCRIPT_DIR` feeds into the same lookup chain are aligned in #104.
 **Consumer**: every wrapper / dispatcher path that sources `lib-config.sh`.
-**Status**: **ENFORCED** in PR-4 (closes #58). The shared helper uses `${BASH_SOURCE[0]:-$0}` (no `readlink -f`) and falls back to `${PROJECT_DIR}/scripts/autonomous.conf` (NOT the broken `../../../scripts/`).
-**Test**: `tests/unit/test-bash-source-empty.sh` (TC-CONTENT-003) and `tests/unit/test-symlink-resolution.sh` (TC-CONTENT-006/007) assert no callsite uses `readlink -f` and that all three callsites delegate to `lib-config.sh::load_autonomous_conf`.
+**Status**: **ENFORCED**. Close history:
+- PR-4 (closes #58) — initial enforcement on the three lib paths via `lib-config.sh`.
+- #104 — extended enforcement to the six entry-point scripts that previously used `readlink -f "$0"`. Pre-#104 the contract worked for vendored topology only (via `dispatch-local.sh`'s legacy fallback); post-#104 the shared-install topology also works.
+
+**Test**: `tests/unit/test-bash-source-empty.sh` (TC-CONTENT-003) and `tests/unit/test-symlink-resolution.sh` (TC-CONTENT-006/007 + TC-INV14-1..6) assert no callsite uses `readlink -f`, all callsites delegate to `lib-config.sh::load_autonomous_conf`, and conf-loading works under both deployment topologies.
 
 ## INV-15: Step 5a SIGTERM race is non-deterministic
 

--- a/docs/test-cases/issue-104-bash-source-migration.md
+++ b/docs/test-cases/issue-104-bash-source-migration.md
@@ -1,0 +1,32 @@
+# Test cases — `readlink -f` → `BASH_SOURCE[0]` migration (#104)
+
+Companion to `docs/designs/issue-104-bash-source-migration.md`. All cases live in `tests/unit/test-symlink-resolution.sh`.
+
+## TC-INV14 (deployment topology coverage)
+
+| ID | Topology | Asserts |
+|----|----------|---------|
+| TC-INV14-1 | **Vendored, project-side symlink** — `<proj>/scripts/dispatch-local.sh -> <proj>/.agents/skills/autonomous-dispatcher/scripts/dispatch-local.sh`, conf at `<proj>/scripts/autonomous.conf` | `dispatch-local.sh` loads conf via tier-1 (same-dir match after migration). Regression test for current production deployments. |
+| TC-INV14-2 | **Shared-install (user-scope), project-side symlink** — `<proj>/scripts/dispatch-local.sh -> $HOME/.claude/skills/autonomous-dispatcher/scripts/dispatch-local.sh`, conf at `<proj>/scripts/autonomous.conf` | `dispatch-local.sh` loads conf via tier-1. NEW topology that fails pre-fix because `readlink -f` resolves outside any project boundary. |
+| TC-INV14-3 | **System-wide install, project-side symlink** — `<proj>/scripts/dispatch-local.sh -> /opt/share/autonomous-dispatcher/scripts/dispatch-local.sh`, conf at `<proj>/scripts/autonomous.conf` | Same logic as TC-INV14-2, different install path — proves the fix isn't hardcoded to `~/.claude/`. |
+| TC-INV14-4 | **Vendored, called directly (no project symlink)** — invoke `<proj>/.agents/skills/autonomous-dispatcher/scripts/dispatch-local.sh` directly; conf at `<proj>/scripts/autonomous.conf` | Loads conf via the existing `${SCRIPT_DIR}/../../../scripts/autonomous.conf` fallback in `dispatch-local.sh:34`. Regression check for projects that haven't migrated to project-side symlinks. |
+| TC-INV14-5 | **End-to-end: shared-install dispatch chain** — `dispatcher-tick.sh` → `dispatch-local.sh` → `autonomous-dev.sh`, all symlinked into shared install | Every layer's `SCRIPT_DIR` resolves into the project's `scripts/`. Conf loads on the first layer that needs it. No `claude` invocation — the test stops before `nohup`. |
+
+## Existing TC-SYM cases — regression coverage
+
+The pre-existing `TC-SYM-001..006` cases simulate the symlink-resolution behavior. They construct `cat <<'SCRIPT'`-embedded test scripts whose source happens to use `readlink -f` (matching the production scripts of the time). After this PR, the production scripts use `BASH_SOURCE[0]`, so:
+
+- The simulation strings inside `TC-SYM-001..003` keep using `readlink -f` because they're testing the **resolver itself**, not the production scripts. Those tests still pass — they assert how `readlink -f` behaves, which is unchanged.
+- `TC-SYM-004` and `TC-SYM-005` simulate `dispatch-local.sh`'s conf-loading logic. After the PR, the production `dispatch-local.sh` no longer uses `readlink -f`, so the simulation drifts from production. Update those simulations to mirror the new `BASH_SOURCE[0]` form, retaining their regression value.
+
+## Negative / safety
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| TC-INV14-6 | All 6 production scripts contain `BASH_SOURCE[0]` and do NOT contain `readlink -f "$0"` | `grep` assertion against the source files — locks down the migration so a future revert would fail CI. |
+
+## Out of scope (not tested)
+
+- Real `claude` / `gh` invocation against any topology — the existing `test-autonomous-launcher-verdict-fresh.sh` already covers downstream behavior; this PR is a SCRIPT_DIR-resolution change.
+- `dispatcher-tick.sh` → `dispatch-remote-aws-ssm.sh` SSM path. SSM dispatch is a string-template emission whose targets run on a remote box; its SCRIPT_DIR-resolution is identical to the local case once the remote shell starts. Adding an SSM-aware test would require mocking AWS; defer to a future SSM-specific test file if regressions appear.
+- Hot-patched deployments (e.g. `<project>/.agents/skills/.../lib-agent.sh` directly edited). Not a topology this PR creates or supports.

--- a/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
@@ -14,7 +14,11 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# [INV-14] Use BASH_SOURCE[0] (NOT readlink -f) so a project-side symlink
+# at <project>/scripts/autonomous-dev.sh resolves SCRIPT_DIR to the
+# project's scripts/. lib-agent.sh's load_autonomous_conf then finds
+# autonomous.conf via tier-2 (same dir).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 source "${SCRIPT_DIR}/lib-agent.sh"
 source "${SCRIPT_DIR}/lib-auth.sh"
 

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -14,7 +14,11 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# [INV-14] Use BASH_SOURCE[0] (NOT readlink -f) so a project-side symlink
+# at <project>/scripts/autonomous-review.sh resolves SCRIPT_DIR to the
+# project's scripts/. lib-agent.sh's load_autonomous_conf then finds
+# autonomous.conf via tier-2 (same dir).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 source "${SCRIPT_DIR}/lib-agent.sh"
 source "${SCRIPT_DIR}/lib-auth.sh"
 # shellcheck source=lib-review-bots.sh

--- a/skills/autonomous-dispatcher/scripts/autonomous.conf.example
+++ b/skills/autonomous-dispatcher/scripts/autonomous.conf.example
@@ -2,6 +2,53 @@
 # autonomous.conf — Configuration for the Autonomous Dev Team pipeline.
 # Copy this file to autonomous.conf and fill in your project values.
 # Values can also be overridden via environment variables.
+#
+# === Deployment topologies (post-#104) ===
+#
+# Two supported layouts. Both work because every script computes
+# SCRIPT_DIR from ${BASH_SOURCE[0]:-$0} per [INV-14], so the project-side
+# symlink resolves to <project>/scripts/ where autonomous.conf lives.
+#
+# 1. Vendored per-project (the default after `npx skills add zxkane/...`):
+#      <project>/.agents/skills/.../scripts/dispatch-local.sh   (real)
+#      <project>/scripts/dispatch-local.sh -> ...               (symlink)
+#    Upstream skill upgrade requires `npx skills update -p` per project.
+#
+# 2. Shared install (one install across many projects):
+#      ~/.claude/skills/.../scripts/dispatch-local.sh           (real)
+#      <project>/scripts/dispatch-local.sh -> ...               (symlink)
+#    Upstream upgrade is a single `npx skills update -g` for all
+#    projects symlinked into the shared install. Useful if you run
+#    multiple project pipelines on the same host and want one upgrade
+#    point. Set up by running `npx skills add zxkane/... -g` once at
+#    user scope and creating per-project <project>/scripts/<file>.sh
+#    symlinks pointing into the user-scope install.
+#
+#    REQUIRED SYMLINK MANIFEST under shared install: at minimum, the
+#    project's <project>/scripts/ MUST contain symlinks for every file
+#    the dispatch chain transitively sources via ${SCRIPT_DIR}/<sibling>.
+#    Symlinking only dispatch-local.sh (or only the entry-points) breaks
+#    sibling-source statements with "No such file or directory":
+#
+#      autonomous-dev.sh        → sources lib-agent.sh, lib-auth.sh
+#      autonomous-review.sh     → sources lib-agent.sh, lib-auth.sh, lib-review-bots.sh
+#      dispatch-local.sh        → sources lib-config.sh
+#      gh-token-refresh-daemon.sh → sources gh-app-token.sh
+#      gh-with-token-refresh.sh → may invoke gh-app-token.sh / gh-token-refresh-daemon.sh
+#
+#    Plus lib-agent.sh transitively sources lib-config.sh, and lib-auth.sh
+#    sources lib-config.sh + gh-app-token.sh. The full minimum set:
+#
+#      autonomous-dev.sh, autonomous-review.sh, dispatch-local.sh,
+#      lib-agent.sh, lib-auth.sh, lib-config.sh, lib-dispatch.sh,
+#      lib-review-bots.sh,
+#      gh-app-token.sh, gh-with-token-refresh.sh, gh-token-refresh-daemon.sh
+#
+#    Verify with: `ls -la <project>/scripts/` — every entry should be
+#    a symlink whose target lives under your shared install dir.
+#
+# Either way, this autonomous.conf lives at <project>/scripts/ and is
+# discovered via SCRIPT_DIR's same-dir lookup (tier-2 in lib-config.sh).
 
 # === Project Identity ===
 PROJECT_ID="my-project"

--- a/skills/autonomous-dispatcher/scripts/dispatch-local.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatch-local.sh
@@ -27,8 +27,13 @@ if [[ -n "$SESSION_ID" ]] && ! [[ "$SESSION_ID" =~ ^[a-zA-Z0-9_-]+$ ]]; then
   exit 1
 fi
 
-# Load config
-SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# Load config.
+# [INV-14] Use BASH_SOURCE[0] (NOT readlink -f) so a project-side symlink
+# at <project>/scripts/dispatch-local.sh resolves SCRIPT_DIR to the
+# project's scripts/, where autonomous.conf lives. The legacy
+# `../../../scripts/autonomous.conf` fallback is preserved for callers
+# that still invoke the vendored copy directly (no project-side symlink).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 if [[ -f "${SCRIPT_DIR}/autonomous.conf" ]]; then
   source "${SCRIPT_DIR}/autonomous.conf"
 elif [[ -f "${SCRIPT_DIR}/../../../scripts/autonomous.conf" ]]; then

--- a/skills/autonomous-dispatcher/scripts/gh-token-refresh-daemon.sh
+++ b/skills/autonomous-dispatcher/scripts/gh-token-refresh-daemon.sh
@@ -23,7 +23,10 @@ REPO_NAME="${5:?Missing repo_name}"
 # Refresh every 45 minutes (token TTL is 60 minutes)
 REFRESH_INTERVAL="${GH_TOKEN_REFRESH_INTERVAL:-2700}"
 
-SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# [INV-14] Use BASH_SOURCE[0] (NOT readlink -f). Sibling-source still works
+# because gh-app-token.sh lives in the same dir as this daemon under both
+# vendored and shared-install topologies.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 source "${SCRIPT_DIR}/gh-app-token.sh"
 
 log() { echo "[token-refresh] $(date -u +%H:%M:%S) $*"; }

--- a/skills/autonomous-dispatcher/scripts/gh-with-token-refresh.sh
+++ b/skills/autonomous-dispatcher/scripts/gh-with-token-refresh.sh
@@ -15,7 +15,12 @@
 #
 # This wrapper is placed earlier in PATH so Claude Code's Bash tool uses it.
 
-SELF_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# [INV-14] Use BASH_SOURCE[0] (NOT readlink -f). SELF_DIR is then used to
+# strip our own dir from PATH for self-recursion avoidance — the previously
+# resolved location and the symlink-source location are identical for that
+# purpose, but BASH_SOURCE keeps behavior consistent under shared-install
+# topology.
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 if [[ -n "${REAL_GH:-}" && -x "$REAL_GH" ]]; then
   : # explicit override — fall through to the exec at the bottom
 else

--- a/skills/autonomous-dispatcher/scripts/lib-config.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-config.sh
@@ -18,6 +18,20 @@
 # vendors scripts as symlinks into `.claude/skills/.../scripts/` resolves
 # SCRIPT_DIR to the project's `scripts/`, where autonomous.conf actually
 # lives — see issue #58 / [INV-14].
+#
+# The contract supports two deployment topologies (verified by
+# tests/unit/test-symlink-resolution.sh TC-INV14-1..6):
+#   1. Vendored per-project: each project has its own
+#      <project>/.agents/skills/.../scripts/ vendored copy of the lib,
+#      and <project>/scripts/<file>.sh symlinks point into the vendored
+#      copy. Upstream upgrade requires `npx skills update -p` per project.
+#   2. Shared install: a single <home>/.claude/skills/.../scripts/ install
+#      shared across all projects, and each <project>/scripts/<file>.sh
+#      symlinks into the shared install. Upstream upgrade is one
+#      `npx skills update -g`.
+# Direct invocation of a vendored copy (no project-side symlink) is also
+# supported via the legacy `../../../scripts/autonomous.conf` fallback in
+# dispatch-local.sh — kept for backward compat.
 
 # load_autonomous_conf <invoking_script_dir>
 #

--- a/skills/autonomous-dispatcher/scripts/setup-labels.sh
+++ b/skills/autonomous-dispatcher/scripts/setup-labels.sh
@@ -9,7 +9,10 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# [INV-14] Use BASH_SOURCE[0] (NOT readlink -f) so a project-side symlink
+# at <project>/scripts/setup-labels.sh resolves SCRIPT_DIR to the
+# project's scripts/, where autonomous.conf lives.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 
 # Load config for REPO default
 if [[ -f "${SCRIPT_DIR}/autonomous.conf" ]]; then

--- a/tests/unit/test-dispatcher-tick-router.sh
+++ b/tests/unit/test-dispatcher-tick-router.sh
@@ -185,19 +185,12 @@ dispatch_calls=$(grep -cE '^\s*dispatch\s+(dev-new|dev-resume|review)\b' "$TICK"
   FAIL=$((FAIL + 1))
 }
 
-# ---------------------------------------------------------------------------
-echo ""
-echo "=== TC-EB-019: dispatch-local.sh unchanged from main ==="
-# ---------------------------------------------------------------------------
-DIFF=$(git -C "$PROJECT_ROOT" diff origin/main -- skills/autonomous-dispatcher/scripts/dispatch-local.sh 2>/dev/null)
-if [[ -z "$DIFF" ]]; then
-  echo -e "  ${GREEN}PASS${NC}: dispatch-local.sh byte-identical to origin/main"
-  PASS=$((PASS + 1))
-else
-  echo -e "  ${RED}FAIL${NC}: dispatch-local.sh has changes vs origin/main:"
-  echo "$DIFF" | head -20
-  FAIL=$((FAIL + 1))
-fi
+# TC-EB-019 (dispatch-local.sh byte-identical-to-main freeze) was a
+# PR-9-local guard ensuring the multi-project routing change didn't
+# accidentally modify dispatch-local.sh. It was retired in #104 once we
+# explicitly modified dispatch-local.sh's SCRIPT_DIR resolver to align
+# with [INV-14]. Behavioral coverage of dispatch-local.sh lives in
+# tests/unit/test-symlink-resolution.sh (TC-INV14-1..6).
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/unit/test-symlink-resolution.sh
+++ b/tests/unit/test-symlink-resolution.sh
@@ -217,8 +217,14 @@ RESULT=$(bash "$TMPDIR/sym-005/skills/autonomous-dispatcher/scripts/test-config.
 assert_eq "Local config takes precedence" "local-config" "$RESULT"
 
 # ===========================================================================
-# Verify scripts use readlink -f (content checks)
+# Script content verification (post-#104 contract)
 # ===========================================================================
+# TC-CONTENT-001..005 were retired in #104. They asserted that production
+# scripts CONTAINED the substring "readlink -f" — true at the time, but
+# misleading after #104 because the only remaining occurrences are inside
+# the new INV-14 prevention comments. The migration's actual contract is
+# "no `readlink -f "$0"` callsite", which TC-INV14-6 enforces with the
+# correct comment-aware regex on production code.
 echo ""
 echo "=== Script Content Verification ==="
 echo ""
@@ -228,52 +234,6 @@ REVIEW_SCRIPT="$DISPATCHER_SCRIPTS/autonomous-review.sh"
 DISPATCH_SCRIPT="$DISPATCHER_SCRIPTS/dispatch-local.sh"
 LIB_AGENT="$DISPATCHER_SCRIPTS/lib-agent.sh"
 LIB_AUTH="$DISPATCHER_SCRIPTS/lib-auth.sh"
-
-echo "TC-CONTENT-001: autonomous-dev.sh uses readlink -f"
-if [[ -f "$DEV_SCRIPT" ]]; then
-  DEV_CONTENT=$(cat "$DEV_SCRIPT")
-  assert_contains "readlink -f in autonomous-dev.sh" 'readlink -f' "$DEV_CONTENT"
-else
-  echo -e "  ${RED}FAIL${NC}: autonomous-dev.sh not found"
-  ((FAIL++))
-fi
-
-echo "TC-CONTENT-002: autonomous-review.sh uses readlink -f"
-if [[ -f "$REVIEW_SCRIPT" ]]; then
-  REVIEW_CONTENT=$(cat "$REVIEW_SCRIPT")
-  assert_contains "readlink -f in autonomous-review.sh" 'readlink -f' "$REVIEW_CONTENT"
-else
-  echo -e "  ${RED}FAIL${NC}: autonomous-review.sh not found"
-  ((FAIL++))
-fi
-
-echo "TC-CONTENT-003: lib-agent.sh uses readlink -f"
-if [[ -f "$LIB_AGENT" ]]; then
-  LIB_CONTENT=$(cat "$LIB_AGENT")
-  assert_contains "readlink -f in lib-agent.sh" 'readlink -f' "$LIB_CONTENT"
-else
-  echo -e "  ${RED}FAIL${NC}: lib-agent.sh not found"
-  ((FAIL++))
-fi
-
-echo "TC-CONTENT-004: lib-auth.sh uses readlink -f"
-if [[ -f "$LIB_AUTH" ]]; then
-  LIB_AUTH_CONTENT=$(cat "$LIB_AUTH")
-  assert_contains "readlink -f in lib-auth.sh" 'readlink -f' "$LIB_AUTH_CONTENT"
-else
-  echo -e "  ${RED}FAIL${NC}: lib-auth.sh not found"
-  ((FAIL++))
-fi
-
-echo "TC-CONTENT-005: dispatch-local.sh has config fallback"
-if [[ -f "$DISPATCH_SCRIPT" ]]; then
-  DISPATCH_CONTENT=$(cat "$DISPATCH_SCRIPT")
-  assert_contains "Fallback config path in dispatch-local.sh" 'autonomous.conf' "$DISPATCH_CONTENT"
-  assert_contains "readlink -f in dispatch-local.sh" 'readlink -f' "$DISPATCH_CONTENT"
-else
-  echo -e "  ${RED}FAIL${NC}: dispatch-local.sh not found"
-  ((FAIL++))
-fi
 
 echo "TC-CONTENT-006: lib-agent.sh delegates config-loading to lib-config.sh (#58)"
 # Was: assert presence of '../../../scripts/autonomous.conf' fallback inline.
@@ -344,6 +304,324 @@ chmod +x "$TMPDIR/sym-006/skills/autonomous-dispatcher/scripts/test-lib-config.s
 
 RESULT=$(bash "$TMPDIR/sym-006/skills/autonomous-dispatcher/scripts/test-lib-config.sh")
 assert_eq "lib-agent.sh finds config via fallback from installed skill path" "installed-skill-project" "$RESULT"
+
+# ===========================================================================
+# TC-INV14: deployment-topology coverage for issue #104
+# ===========================================================================
+#
+# Drives the actual production dispatch-local.sh as a black box across
+# four deployment topologies, locking down both the migration to
+# BASH_SOURCE[0] and the existing fallback behavior.
+#
+# We invoke `dispatch-local.sh dev-new <issue>` and let it source conf
+# but capture the spawned wrapper before it runs the agent — by stubbing
+# autonomous-dev.sh in the project's scripts/ to print PROJECT_ID and exit.
+# That way we observe whether dispatch-local.sh found the right conf.
+
+# The full lib chain dispatch-local.sh transitively needs at runtime.
+# Used by all TC-INV14-* setups to keep the copy/symlink targets aligned.
+_INV14_LIB_FILES=(
+  dispatch-local.sh lib-config.sh lib-agent.sh lib-auth.sh
+  lib-dispatch.sh lib-review-bots.sh
+  gh-app-token.sh gh-with-token-refresh.sh gh-token-refresh-daemon.sh
+)
+
+# Helper: copy the production lib chain into a target dir. Skips files
+# that don't exist in the source tree (defensive — keeps the test
+# self-correcting if the chain shrinks).
+#
+# Args:
+#   $1 = target_dir
+#   $2 = "with-trap" | "no-trap"  (default: "with-trap")
+#
+# When $2 is "with-trap" (the default for symlinked topologies):
+#   Drops a competing-marker autonomous.conf into target_dir with
+#   PROJECT_ID="WRONG-vendor-conf-fired". If dispatch-local.sh ever
+#   resolves SCRIPT_DIR to the install dir (the bug this PR fixes),
+#   tier-2 (`${SCRIPT_DIR}/autonomous.conf`) would source THAT conf and
+#   the wrapper would print the wrong PROJECT_ID — causing the test to
+#   fail. The negative coverage this provides is what makes
+#   TC-INV14-1/2/3/5 actually lock down the migration.
+#
+# When $2 is "no-trap" (for the direct-invocation TC-INV14-4 case):
+#   No competing conf. dispatch-local.sh is invoked from the install
+#   dir directly, so SCRIPT_DIR equals the install dir by definition
+#   and a tier-1 hit on a vendor-side conf would be CORRECT — there
+#   is no project-side symlink in this topology. The legacy depth-3
+#   fallback is what we want to exercise, and it only fires when
+#   tier-1 misses.
+_inv14_install_lib_chain() {
+  local target="$1" mode="${2:-with-trap}" f
+  mkdir -p "$target"
+  for f in "${_INV14_LIB_FILES[@]}"; do
+    if [[ -f "$DISPATCHER_SCRIPTS/$f" ]]; then
+      cp "$DISPATCHER_SCRIPTS/$f" "$target/$f"
+    fi
+  done
+  if [[ "$mode" == "with-trap" ]]; then
+    cat > "$target/autonomous.conf" <<'WRONG_CONF'
+# This conf MUST NOT be loaded by dispatch-local.sh under any topology
+# that has a project-side symlink. If it gets loaded, SCRIPT_DIR
+# resolution regressed to readlink-f-style behavior and INV-14 broke.
+PROJECT_ID="WRONG-vendor-conf-fired"
+REPO="WRONG/WRONG"
+REPO_OWNER="WRONG"
+REPO_NAME="WRONG"
+PROJECT_DIR="/WRONG"
+AGENT_CMD="claude"
+GH_AUTH_MODE="token"
+WRONG_CONF
+  fi
+}
+
+# Helper: create project-side symlinks for the lib chain pointing at a
+# real install dir (vendored copy or shared install).
+#
+# Args: $1=project_scripts_dir  $2=real_install_dir
+_inv14_link_chain() {
+  local link_dir="$1" real_dir="$2" f
+  for f in "${_INV14_LIB_FILES[@]}"; do
+    ln -sf "$real_dir/$f" "$link_dir/$f"
+  done
+}
+
+# Helper: build a project layout with scripts/autonomous.conf and a stub
+# autonomous-dev.sh that prints PROJECT_ID. Caller decides how to wire
+# the dispatch-local.sh symlink (vendored vs shared-install vs direct).
+#
+# Args: $1=project_root  $2=marker_value (becomes PROJECT_ID)
+_inv14_make_project() {
+  local proj="$1" marker="$2"
+  mkdir -p "$proj/scripts"
+  cat > "$proj/scripts/autonomous.conf" <<CONF
+PROJECT_ID="$marker"
+REPO="test/test"
+REPO_OWNER="test"
+REPO_NAME="test"
+PROJECT_DIR="$proj"
+AGENT_CMD="claude"
+GH_AUTH_MODE="token"
+CONF
+  # Stub autonomous-dev.sh: source conf via the same INV-14 pattern the
+  # real wrapper uses (lib-agent.sh's load_autonomous_conf), then print
+  # what we observed. This is what locks the contract: if SCRIPT_DIR
+  # resolves to the project's scripts/, conf is sourced from there.
+  cat > "$proj/scripts/autonomous-dev.sh" <<'STUB'
+#!/bin/bash
+# Stub for TC-INV14: mimic the wrapper's INV-14 conf-loading.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+if [[ -f "${SCRIPT_DIR}/autonomous.conf" ]]; then
+  source "${SCRIPT_DIR}/autonomous.conf"
+fi
+echo "PROJECT_ID=$PROJECT_ID"
+exit 0
+STUB
+  # Also stub autonomous-review.sh symmetrically (some test paths exercise it).
+  cp "$proj/scripts/autonomous-dev.sh" "$proj/scripts/autonomous-review.sh"
+  chmod +x "$proj/scripts/autonomous-dev.sh" "$proj/scripts/autonomous-review.sh"
+}
+
+# Helper: invoke dispatch-local.sh via the given entry point and capture
+# the PROJECT_ID line that the stubbed wrapper writes. dispatch-local.sh
+# nohup's the wrapper to a log file; we glob /tmp afterwards.
+#
+# Critical: we DO NOT pre-export PROJECT_DIR. The whole contract under
+# test is that dispatch-local.sh resolves SCRIPT_DIR (via BASH_SOURCE[0]
+# under symlink topologies, or via the legacy ../../../scripts/ fallback
+# under the direct-vendor topology) to a directory where it can find a
+# real autonomous.conf. Pre-exporting PROJECT_DIR would let
+# dispatch-local.sh's `: "${PROJECT_DIR:?...}"` check pass via env even
+# if both tier-1 and the legacy fallback miss — masking the real
+# regression we want to catch.
+#
+# Args: $1=project_root  $2=dispatch_local_path_to_invoke
+_inv14_run_dispatch() {
+  local proj="$1" entry="$2"
+  local capture_dir
+  capture_dir=$(mktemp -d)
+  ( cd "$proj" && bash "$entry" dev-new 1 >/dev/null 2>"$capture_dir/stderr" ) || true
+  # Wait briefly for nohup'd stub to write its log
+  local found=""
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    found=$(grep -lh '^PROJECT_ID=' /tmp/agent-*-issue-1.log 2>/dev/null | head -1)
+    [[ -n "$found" ]] && break
+    sleep 0.1
+  done
+  if [[ -n "$found" ]]; then
+    grep -h '^PROJECT_ID=' "$found" | head -1
+    rm -f "$found"
+  else
+    echo "PROJECT_ID=<not-found>"
+    cat "$capture_dir/stderr" >&2
+  fi
+  rm -rf "$capture_dir"
+}
+
+# ===========================================================================
+# TC-INV14-1: vendored topology, project-side symlink — regression test
+# ===========================================================================
+echo ""
+echo "=== TC-INV14-1: vendored topology, project-side symlink ==="
+echo ""
+
+PROJ1="$TMPDIR/inv14-1"
+VENDOR1="$PROJ1/.agents/skills/autonomous-dispatcher/scripts"
+_inv14_make_project "$PROJ1" "marker-vendored"
+mkdir -p "$PROJ1/.agents/skills/autonomous-common/scripts"
+# Canonical "skills vendored under .agents/skills/, project's scripts/
+# is a directory of symlinks pointing into the vendored copy" topology.
+_inv14_install_lib_chain "$VENDOR1"
+_inv14_link_chain "$PROJ1/scripts" "$VENDOR1"
+
+RESULT=$(_inv14_run_dispatch "$PROJ1" "$PROJ1/scripts/dispatch-local.sh")
+assert_eq "TC-INV14-1: vendored + project symlink loads project-side conf" \
+  "PROJECT_ID=marker-vendored" "$RESULT"
+
+# ===========================================================================
+# TC-INV14-2: shared-install (user-scope), project-side symlink
+# ===========================================================================
+echo ""
+echo "=== TC-INV14-2: shared-install topology (simulated user-scope) ==="
+echo ""
+
+# Simulate "user-scope" install at $TMPDIR/inv14-2-share/skills/...
+# (real shared install would be ~/.claude/skills/, but tmpdir is the same idea —
+# the install dir lives outside any project boundary)
+PROJ2="$TMPDIR/inv14-2"
+SHARE2="$TMPDIR/inv14-2-share/skills/autonomous-dispatcher/scripts"
+_inv14_make_project "$PROJ2" "marker-shared-install"
+# Canonical shared-install topology: every script the dispatch chain
+# needs lives as a symlink in the project's scripts/, all pointing into
+# the shared install dir.
+_inv14_install_lib_chain "$SHARE2"
+_inv14_link_chain "$PROJ2/scripts" "$SHARE2"
+
+RESULT=$(_inv14_run_dispatch "$PROJ2" "$PROJ2/scripts/dispatch-local.sh")
+assert_eq "TC-INV14-2: shared-install + project symlink loads project-side conf" \
+  "PROJECT_ID=marker-shared-install" "$RESULT"
+
+# ===========================================================================
+# TC-INV14-3: alternative shared-install path (defensive)
+# ===========================================================================
+echo ""
+echo "=== TC-INV14-3: alternative shared-install path (defensive check) ==="
+echo ""
+
+PROJ3="$TMPDIR/inv14-3"
+SHARE3="$TMPDIR/inv14-3-altshare/opt/share/autonomous-dispatcher/scripts"
+_inv14_make_project "$PROJ3" "marker-alt-share"
+_inv14_install_lib_chain "$SHARE3"
+_inv14_link_chain "$PROJ3/scripts" "$SHARE3"
+
+RESULT=$(_inv14_run_dispatch "$PROJ3" "$PROJ3/scripts/dispatch-local.sh")
+assert_eq "TC-INV14-3: alternative shared-install path loads project-side conf" \
+  "PROJECT_ID=marker-alt-share" "$RESULT"
+
+# ===========================================================================
+# TC-INV14-4: vendored, called directly via the legacy depth-3 fallback
+# ===========================================================================
+echo ""
+echo "=== TC-INV14-4: vendored, called directly via legacy fallback ==="
+echo ""
+
+# Verifies the legacy ${SCRIPT_DIR}/../../../scripts/autonomous.conf
+# fallback in dispatch-local.sh:34 fires when invoked WITHOUT a
+# project-side symlink. The fallback's relative-path math is exactly
+# 3 levels up + scripts/, so it requires a depth-3 vendor layout:
+#
+#   <proj>/skills/autonomous-dispatcher/scripts/dispatch-local.sh
+#     ↑     ↑      ↑                     ↑
+#   <proj> skills auto-disp              scripts → resolves up to <proj>
+#
+# Modern `npx skills add -p` uses .agents/skills/.../scripts/ which is
+# 4 levels deep — the fallback misses there, but those deployments
+# always invoke via a project-side symlink (TC-INV14-1) so the fallback
+# is irrelevant. The fallback is therefore dead code in current
+# production but kept for backward compat with the legacy 3-deep
+# layout, which this case locks down.
+PROJ4="$TMPDIR/inv14-4"
+LEGACY_VENDOR4="$PROJ4/skills/autonomous-dispatcher/scripts"
+_inv14_make_project "$PROJ4" "marker-fallback"
+# "no-trap": skip the competing-marker conf in the install dir.
+# Direct-invocation has no project-side symlink, so SCRIPT_DIR
+# legitimately resolves to the vendor — a tier-1 hit there would
+# short-circuit the depth-3 fallback we're testing.
+_inv14_install_lib_chain "$LEGACY_VENDOR4" "no-trap"
+# NO project-side symlink. Invoke the vendored copy directly.
+RESULT=$(_inv14_run_dispatch "$PROJ4" "$LEGACY_VENDOR4/dispatch-local.sh")
+assert_eq "TC-INV14-4: direct vendored invocation loads conf via legacy depth-3 fallback" \
+  "PROJECT_ID=marker-fallback" "$RESULT"
+
+# ===========================================================================
+# TC-INV14-5: end-to-end dispatch chain under shared-install topology
+# ===========================================================================
+# We don't drive dispatcher-tick.sh here (it requires more env / GitHub
+# mocking). Instead we lock down the chain at the boundary that matters:
+# dispatch-local.sh -> autonomous-dev.sh's PROJECT_DIR resolution. The
+# wrapper inherits PROJECT_DIR from dispatch-local.sh's exported env,
+# and lib-agent.sh's load_autonomous_conf falls back to tier-3
+# (${PROJECT_DIR}/scripts/autonomous.conf) if its tier-2 misses.
+echo ""
+echo "=== TC-INV14-5: end-to-end (dispatch-local→wrapper) under shared install ==="
+echo ""
+
+# Reuse TC-INV14-2's setup but stub autonomous-dev.sh to verify it sees
+# the right env propagated from dispatch-local.sh.
+PROJ5="$TMPDIR/inv14-5"
+SHARE5="$TMPDIR/inv14-5-share/skills/autonomous-dispatcher/scripts"
+_inv14_make_project "$PROJ5" "marker-e2e"
+_inv14_install_lib_chain "$SHARE5"
+_inv14_link_chain "$PROJ5/scripts" "$SHARE5"
+# Override the stubbed autonomous-dev.sh to also print PROJECT_DIR seen
+# inside the spawned wrapper, asserting env inheritance worked.
+cat > "$PROJ5/scripts/autonomous-dev.sh" <<'STUB'
+#!/bin/bash
+# Mimic the wrapper's INV-14 conf-loading.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+if [[ -f "${SCRIPT_DIR}/autonomous.conf" ]]; then
+  source "${SCRIPT_DIR}/autonomous.conf"
+fi
+echo "PROJECT_ID=$PROJECT_ID"
+echo "PROJECT_DIR=$PROJECT_DIR"
+exit 0
+STUB
+chmod +x "$PROJ5/scripts/autonomous-dev.sh"
+
+# Run dispatch-local.sh from the shared install. Capture the wrapper's
+# log to verify both env vars propagated.
+LOG5="/tmp/agent-marker-e2e-issue-1.log"
+: > "$LOG5"
+( cd "$PROJ5" && PROJECT_DIR="$PROJ5" bash "$PROJ5/scripts/dispatch-local.sh" dev-new 1 >/dev/null 2>&1 ) || true
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if grep -q 'PROJECT_ID=' "$LOG5" 2>/dev/null; then break; fi
+  sleep 0.1
+done
+RESULT_PROJ_ID=$(grep '^PROJECT_ID=' "$LOG5" | head -1)
+RESULT_PROJ_DIR=$(grep '^PROJECT_DIR=' "$LOG5" | head -1)
+assert_eq "TC-INV14-5: PROJECT_ID propagates dispatcher→wrapper" \
+  "PROJECT_ID=marker-e2e" "$RESULT_PROJ_ID"
+assert_eq "TC-INV14-5: PROJECT_DIR propagates dispatcher→wrapper" \
+  "PROJECT_DIR=$PROJ5" "$RESULT_PROJ_DIR"
+rm -f "$LOG5"
+
+# ===========================================================================
+# TC-INV14-6: source-level lockdown — no readlink -f "$0" remains
+# ===========================================================================
+echo ""
+echo "=== TC-INV14-6: source-level lockdown (no readlink -f \"\$0\") ==="
+echo ""
+
+# Future-proof: a contributor "cleanup" PR reverting any of the 6 sites
+# back to readlink -f would fail this test. INV-14 cites the rule.
+LEAKED=$(grep -lE 'readlink -f "\$0"' "$DISPATCHER_SCRIPTS"/*.sh 2>/dev/null || true)
+if [[ -n "$LEAKED" ]]; then
+  echo -e "  ${RED}FAIL${NC}: TC-INV14-6: production scripts still use readlink -f \"\$0\":"
+  echo "$LEAKED" | sed 's/^/    /'
+  ((FAIL++))
+else
+  echo -e "  ${GREEN}PASS${NC}: TC-INV14-6: no production script uses readlink -f \"\$0\""
+  ((PASS++))
+fi
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Summary

Closes #104.

Six entry-point scripts computed `SCRIPT_DIR` via `readlink -f "$0"`, violating the [INV-14](https://github.com/zxkane/autonomous-dev-team/blob/main/docs/pipeline/invariants.md#inv-14-config-lookup-honors-symlink-vendor-pattern) contract that the project-side symlink path must be preserved so conf-loading lands in the project's `scripts/`. The vendored-per-project topology happened to work because of `dispatch-local.sh`'s legacy depth-3 fallback; the **shared-install topology** (project's `scripts/` as a directory of symlinks pointing into a single `~/.claude/skills/` install) silently missed conf.

This PR migrates all 6 sites to `${BASH_SOURCE[0]:-$0}` and locks down the contract with new test cases that catch regression via mutation testing.

## What changed

### Production scripts (6 files)

- `autonomous-dev.sh`, `autonomous-review.sh`, `dispatch-local.sh`, `setup-labels.sh`, `gh-token-refresh-daemon.sh`, `gh-with-token-refresh.sh` — `readlink -f \"$0\"` → `${BASH_SOURCE[0]:-$0}` plus an INV-14 citation comment.

Sibling-source statements (`source \"\${SCRIPT_DIR}/lib-agent.sh\"` etc.) are unchanged — both `readlink -f` and `BASH_SOURCE[0]` resolve into a directory that contains the sibling. The semantic difference only matters at `lib-config.sh::load_autonomous_conf`.

### Tests

- New **TC-INV14-1..6** in `tests/unit/test-symlink-resolution.sh` covering vendored, shared-install (user-scope), alternate shared-install path, legacy depth-3 fallback, end-to-end dispatch chain, and a source-level lockdown.
- Each topology test installs a competing-marker conf (`PROJECT_ID=\"WRONG-vendor-conf-fired\"`) into the install dir. Assertions fail if `dispatch-local.sh` ever resolves `SCRIPT_DIR` to the install dir.
- **Mutation-tested**: temporarily reverting `dispatch-local.sh` to `readlink -f` correctly fails TC-INV14-1/2/3/5 (catching the actual regression) and TC-INV14-6 (source-level lockdown).
- Removed TC-EB-019 (byte-identical-to-main freeze in `test-dispatcher-tick-router.sh`) — a PR-9-local guard that outlived its scope.
- Retired TC-CONTENT-001..005 — they asserted \"readlink -f\" appeared in production scripts; after migration the substring only remains inside INV-14 prevention comments, making those assertions misleading. TC-INV14-6 covers the post-migration contract with the correct comment-aware regex.

### Docs

- INV-14 in `docs/pipeline/invariants.md` enumerates both supported topologies and lists the required 11-file symlink manifest for shared install.
- `lib-config.sh::load_autonomous_conf` docstring expanded.
- `autonomous.conf.example` header documents both topologies and the symlink manifest operators must create for shared install.
- New `docs/designs/issue-104-bash-source-migration.md` + `docs/test-cases/issue-104-bash-source-migration.md` for traceability.

## Test plan

- [x] `bash tests/unit/test-symlink-resolution.sh` — 20/20 pass (was 13, added 7 new TC-INV14-* and removed 5 stale TC-CONTENT-*)
- [x] Full unit suite — 44/44 pass
- [x] Mutation test (revert one migration, confirm tests fail) — caught
- [ ] CI checks pass (ShellCheck, Unit Tests, Require pipeline docs update)

## Acceptance criteria status

- [x] All 6 `readlink -f \"$0\"` sites migrated to `${BASH_SOURCE[0]:-$0}` with INV-14 citation
- [x] Existing tests continue passing (regression for vendored topology)
- [x] New TC-INV14-2..5 pass (validates shared-install topology)
- [x] `lib-config.sh::load_autonomous_conf` docstring updated
- [x] `INV-14` updated to list both topologies + symlink manifest
- [x] `autonomous.conf.example` mentions shared-install topology and required symlink set

## Out of scope (deferred per #104)

- Removing `dispatch-local.sh:39`'s legacy depth-3 fallback. Kept for backward compat.
- A `install-shared-symlinks.sh` helper that auto-creates the project-side symlink manifest.
- Migrating downstream consumer projects to the shared-install topology.