### PR TITLE
fix(dispatcher): Step 4 stale-verdict loop + empty-session stall (#106, #107)

### DIFF
--- a/docs/designs/issue-106-107-step4-correctness.md
+++ b/docs/designs/issue-106-107-step4-correctness.md
@@ -1,0 +1,231 @@
+# Design: Step 4 correctness — fixes for #106 + #107
+
+Two related but independent bugs in `dispatcher-tick.sh` Step 4 (the
+`pending-dev` scan) and `dispatch-local.sh`'s `dev-resume` validation,
+bundled into a single PR because they share the same code region and the
+same failure surface (silent stalls in Step 4).
+
+## Goal
+
+- Stop the stale-verdict re-review loop on PRs whose HEAD has not changed
+  since the last FAILED review (#106).
+- Stop the silent first-tick stall when an issue lands in `pending-dev`
+  with no prior `Dev Session ID:` (#107).
+
+Non-goals: restructuring Step 4 control flow beyond the two specific
+defects; modifying Step 5b (its symmetric `last_reviewed_head` logic is
+the model we mirror).
+
+---
+
+## Bug 1 (#106) — Step 4a.5 PR-exists short-circuit ignores `last_reviewed_head`
+
+### Current (broken) behavior
+
+`dispatcher-tick.sh:236-247`:
+
+```bash
+pr_for_issue=$(fetch_pr_for_issue "$issue_num" "number")
+if [ -n "$pr_for_issue" ]; then
+  pr_num=$(jq -r '.number // empty' <<<"$pr_for_issue")
+  pr_ref="${pr_num:+#${pr_num}}"
+  log "  issue #${issue_num} has PR ${pr_ref} — transitioning to pending-review (Bug 3 fix)"
+  gh issue comment "$issue_num" --repo "$REPO" \
+    --body "PR ${pr_ref} exists for this issue; transitioning to pending-review instead of retrying dev (#99 Bug 3)."
+  label_swap "$issue_num" "pending-dev" "pending-review"
+  JUST_DISPATCHED+=("$issue_num")
+  continue
+fi
+```
+
+Problem: every tick, if a PR exists for the issue, route to
+`pending-review` regardless of whether the current PR HEAD has already
+been reviewed. After a legitimate FAILED verdict against
+`<sha-A>`, the dev agent hasn't (yet) pushed new commits, so HEAD remains
+`<sha-A>`. The re-route to `pending-review` makes the review wrapper run
+Sonnet against the same code and produce the same FAILED verdict, looping
+every ~5 minutes.
+
+### Fix (mirrors Step 5b's `last_reviewed_head` check)
+
+```bash
+pr_info=$(fetch_pr_for_issue "$issue_num" "number,headRefOid")
+if [ -n "$pr_info" ]; then
+  pr_num=$(jq -r '.number // empty' <<<"$pr_info")
+  current_head=$(jq -r '.headRefOid // empty' <<<"$pr_info")
+  pr_ref="${pr_num:+#${pr_num}}"
+  pr_ref="${pr_ref:-(number unknown)}"
+  last_head=$(last_reviewed_head "$issue_num")
+
+  if [ -n "$last_head" ] && [ -n "$current_head" ] && [ "$current_head" = "$last_head" ]; then
+    # Same HEAD already reviewed — verdict was FAILED (otherwise we
+    # wouldn't be in pending-dev). Don't redo review; surface the stale
+    # verdict and keep pending-dev so the dev agent can act on feedback.
+    notice_marker="stale-verdict:${current_head}"
+    if gh issue view "$issue_num" --repo "$REPO" --json comments \
+        -q "[.comments[].body | select(contains(\"${notice_marker}\"))] | length" \
+        2>/dev/null | grep -q '^0$'; then
+      gh issue comment "$issue_num" --repo "$REPO" \
+        --body "PR ${pr_ref} HEAD \`${current_head}\` already reviewed with FAILED verdict; awaiting new commits before re-review. (\`${notice_marker}\`)"
+    fi
+    JUST_DISPATCHED+=("$issue_num")
+    continue
+  fi
+
+  # New HEAD or first review — keep existing Bug 3 behavior.
+  log "  issue #${issue_num} has PR ${pr_ref} — transitioning to pending-review (Bug 3 fix)"
+  gh issue comment "$issue_num" --repo "$REPO" \
+    --body "PR ${pr_ref} exists for this issue; transitioning to pending-review instead of retrying dev (#99 Bug 3)."
+  label_swap "$issue_num" "pending-dev" "pending-review"
+  JUST_DISPATCHED+=("$issue_num")
+  continue
+fi
+```
+
+Idempotency marker `stale-verdict:<sha>` follows the existing
+`INV-12-completed:${session_id}` pattern. Same HEAD on subsequent ticks
+finds the marker and skips posting again.
+
+### State-machine summary
+
+| State | Action |
+|---|---|
+| pending-dev + PR exists + HEAD == last_reviewed_head | stay pending-dev, post idempotent stale-verdict notice |
+| pending-dev + PR exists + HEAD != last_reviewed_head | flip to pending-review (existing Bug 3 behavior) |
+| pending-dev + PR exists + no last_reviewed_head | flip to pending-review (first review on fresh PR) |
+| pending-dev + PR exists + last_reviewed_head matches + notice already present | no-op (idempotency) |
+
+---
+
+## Bug 2 (#107) — `dispatch-local.sh:155` rejects empty session_id
+
+### Current (broken) behavior
+
+`dispatch-local.sh:154-158`:
+
+```bash
+dev-resume)
+  if [[ -z "$SESSION_ID" ]]; then
+    echo "ERROR: session_id required for dev-resume" >&2
+    exit 1
+  fi
+```
+
+Problem: `dispatcher-tick.sh:314` always calls
+`dispatch dev-resume "$issue_num" "$session_id"` from Step 4, even when
+`$session_id` is empty (first-time pickup of a `pending-dev` issue with
+no prior `Dev Session ID:` comment). The hard rejection here prevents the
+wrapper — which has its own session-empty fallback at
+`autonomous-dev.sh:257-260` — from ever running.
+
+### Fix (Option A from issue body — drop the rejection)
+
+Tolerate empty `SESSION_ID` in the `dev-resume` branch of BOTH transport
+drivers (`dispatch-local.sh` and `dispatch-remote-aws-ssm.sh`). The
+wrapper already falls back to `MODE=new` when invoked with `--mode
+resume` and no `--session`, so passing empty session through is safe
+and idempotent with the wrapper's own contract. Both backends must
+honor the same contract — `dispatcher-tick.sh:314` calls
+`dispatch dev-resume "$issue_num" "$session_id"` regardless of
+`EXECUTION_BACKEND`, so a one-sided fix would leave SSM users still
+hitting the original silent stall.
+
+```bash
+dev-resume)
+  # Empty SESSION_ID is tolerated: dispatcher-tick.sh:314 dispatches
+  # dev-resume on every Step 4 pending-dev pass, including first-time
+  # pickup with no prior Dev Session ID. autonomous-dev.sh:257-260
+  # falls back to MODE=new when --mode resume is invoked without
+  # --session, so omitting the flag here is the canonical handoff.
+  if [[ -n "$SESSION_ID" ]]; then
+    nohup "${PROJECT_DIR}/scripts/autonomous-dev.sh" \
+      --issue "$ISSUE_NUM" --mode resume --session "$SESSION_ID" \
+      >> "/tmp/agent-${PROJECT_ID}-issue-${ISSUE_NUM}.log" 2>&1 &
+  else
+    nohup "${PROJECT_DIR}/scripts/autonomous-dev.sh" \
+      --issue "$ISSUE_NUM" --mode resume \
+      >> "/tmp/agent-${PROJECT_ID}-issue-${ISSUE_NUM}.log" 2>&1 &
+  fi
+  CHILD_PID=$!
+  ;;
+```
+
+Why Option A and not Option B (`dispatcher-tick.sh:314` routes
+`dev-new` when session empty)? Option A is a one-line behavioral change
+in a single script; Option B requires touching two scripts and adds
+branching logic to the dispatch path. Both work; Option A is the smaller
+patch with less surface area, and it makes `dispatch-local.sh` a more
+forgiving boundary: any future caller that legitimately needs empty
+session resume (debugging, manual operator dispatch) gets the same
+fallback for free.
+
+---
+
+## Tests
+
+TDD: write tests first, watch them fail, then apply fixes.
+
+### #107 — `dispatch-local.sh` + `dispatch-remote-aws-ssm.sh` empty session
+
+New test file `tests/unit/test-dispatch-local-empty-session.sh`:
+
+- TC-EMPTY-RESUME-1: `dispatch-local.sh dev-resume 99 ""` (empty session)
+  spawns the wrapper without `exit 1` (post-fix expectation; pre-fix
+  fails with stderr containing "session_id required").
+- TC-EMPTY-RESUME-2: `dispatch-local.sh dev-resume 99 abc-123` still
+  passes `--session abc-123` to the wrapper (regression).
+- TC-EMPTY-RESUME-3: `dispatch-local.sh dev-new 99` unchanged.
+
+Updated `tests/unit/test-dispatch-remote-aws-ssm.sh` (TC-EB-007b):
+- Replaces the prior "rejects empty session_id" assertion with a
+  positive assertion that empty session is tolerated. Validates the
+  inner SSM command shape contains `dev-resume 99` (3-arg form).
+- Regression: real session_id still gets forwarded as the 4th arg.
+
+Strategy: stub `autonomous-dev.sh` in a sandboxed `$PROJECT_DIR/scripts/`
+that records its argv to a file; invoke `dispatch-local.sh` with the
+appropriate args; assert on the recorded argv.
+
+### #106 — Step 4a.5 stale-verdict logic
+
+Extend `tests/unit/test-dispatcher-reliability-99.sh` (it already
+exercises lib-dispatch.sh helpers with mocked `gh`; the new tests reuse
+that pattern but call a Step-4a.5 function we extract):
+
+- TC-STALE-VERDICT-1: PR exists + last_reviewed_head matches current →
+  stale-verdict notice posted, label NOT swapped.
+- TC-STALE-VERDICT-2: PR exists + last_reviewed_head differs → label
+  swapped to pending-review (existing Bug 3 behavior preserved).
+- TC-STALE-VERDICT-3: PR exists + no Reviewed HEAD trailer → label
+  swapped to pending-review (first review).
+- TC-STALE-VERDICT-4: PR exists + matches + notice already present →
+  no duplicate notice (idempotency).
+
+Strategy: extract the Step 4a.5 block into a helper function, mock
+`fetch_pr_for_issue`, `last_reviewed_head`, `label_swap`, `gh issue
+view`, `gh issue comment`. Either expose this as a separate function in
+`lib-dispatch.sh` or test it via awk-extraction harness like
+`test-dispatcher-tick-router.sh`.
+
+After review: extracting to a function in `lib-dispatch.sh` is cleaner
+(testable surface, named, documented) and lets the dispatcher stay
+readable. Function name: `handle_pending_dev_pr_exists`. Returns 0 if
+the caller should `continue`, 1 otherwise (no PR, fall through to
+session/dispatch logic).
+
+---
+
+## Acceptance Criteria
+
+- [ ] `dispatch-local.sh dev-resume <N> ""` no longer exits 1; spawns
+  wrapper which falls back to `--mode new` (#107)
+- [ ] An issue labeled `autonomous` + `pending-dev` simultaneously
+  progresses through one full dev cycle within one tick (#107)
+- [ ] Step 4a.5 PR-exists path uses `last_reviewed_head` to decide
+  between pending-review and stale-verdict-keep-pending-dev (#106)
+- [ ] Stale-verdict path posts a one-time idempotent notice keyed on
+  `stale-verdict:<sha>` (#106)
+- [ ] Existing Step 5b "DEAD + in-progress + PR exists" branch unchanged
+- [ ] All 44+ existing unit tests still pass
+- [ ] New tests added for both fixes
+- [ ] PR closes both #106 and #107

--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -173,23 +173,27 @@ if RETRY_COUNT >= MAX_RETRIES (default 3):
   skip
 ```
 
-### Step 4a.5: PR-exists short-circuit (#99 Bug 3)
+### Step 4a.5: PR-exists short-circuit (#99 Bug 3, #106)
 
-Before extracting the session-id and dispatching a resume, check `fetch_pr_for_issue`. If a PR is already open and references this issue, the agent had finished publishing — any subsequent crash that landed it in `pending-dev` (e.g. cleanup-trap fired with non-zero exit after `gh pr create` succeeded) does not warrant re-developing.
+Before extracting the session-id and dispatching a resume, the helper `handle_pending_dev_pr_exists` (in `lib-dispatch.sh`) checks `fetch_pr_for_issue` for a PR referencing this issue. If a PR is already open, the agent had finished publishing — any subsequent crash that landed it in `pending-dev` (e.g. cleanup-trap fired with non-zero exit after `gh pr create` succeeded) does not warrant re-developing.
 
-Action when a PR exists:
+The helper consults `last_reviewed_head` to distinguish "first review (or new commits)" from "stale verdict on unchanged HEAD" (#106):
 
-1. Comment: "PR #N exists for this issue; transitioning to pending-review instead of retrying dev (#99 Bug 3)."
-2. `gh issue edit --remove-label pending-dev --add-label pending-review`.
-3. Append the issue to `JUST_DISPATCHED` so Step 5 doesn't reprobe it on the same tick.
+| State | Action |
+|---|---|
+| PR exists, `current_head == last_reviewed_head` (FAILED verdict against unchanged HEAD) | Post idempotent `stale-verdict:<sha>` notice (fail-closed via `grep -q '^0$'`), keep `pending-dev`, append to `JUST_DISPATCHED`. |
+| PR exists, `current_head != last_reviewed_head` (new commits to assess) | Post Bug 3 transition comment, `label_swap pending-dev → pending-review`, append to `JUST_DISPATCHED`. |
+| PR exists, no prior `Reviewed HEAD:` trailer (first review) | Same as the new-commits branch. |
+| Empty `current_head` from PR JSON (schema drift / partial response) | Defensive: treat as new-commits branch, transition to `pending-review`. |
+| No PR | Helper returns 1; caller falls through to session-id extraction (Step 4b). |
 
-This is the Step 4 mirror of Step 5b's "DEAD + in-progress + PR exists" branch — it covers the case where the cleanup trap got there first and the issue is already on `pending-dev` when the next tick arrives.
+This is the Step 4 mirror of Step 5b's "DEAD + in-progress + PR exists" branch — it covers the case where the cleanup trap got there first and the issue is already on `pending-dev` when the next tick arrives. The `last_reviewed_head` check prevents the prior-review-FAILED-on-unchanged-HEAD loop where every tick would otherwise re-dispatch review against identical code.
 
 ### Step 4b: extract session-id
 
 Find the most recent comment matching `Dev Session ID: \`<id>\`` (note: `Review Session ID: ...` is a separate trailer and MUST NOT match — they share the word "Session" so the regex anchors on `Dev Session ID:` specifically, see [INV-03](invariants.md#inv-03-dev-session-report-comment-format)).
 
-If no session-id can be extracted, the resume cannot proceed. Today, the dispatcher dispatches a new dev session anyway (the wrapper's `--mode resume` path falls back to `--mode new` when `SESSION_ID` is empty — see [`dev-agent-flow.md`](dev-agent-flow.md#mode-normalization)).
+If no session-id can be extracted, the resume cannot proceed at the wrapper level — but the wrapper's `--mode resume` path falls back to `--mode new` when `SESSION_ID` is empty (see [`dev-agent-flow.md`](dev-agent-flow.md#mode-normalization)). Both transport drivers (`dispatch-local.sh` and `dispatch-remote-aws-ssm.sh`) tolerate empty `SESSION_ID` in the `dev-resume` branch and forward the call without `--session`, so the wrapper-side fallback is reachable for first-time `pending-dev` pickup (#107). Prior to this fix, both drivers rejected empty session with `exit 1`, leaving the issue stuck in `in-progress` until Step 5 stale-detection swapped it back one tick later.
 
 ### Step 4b.5: terminal-state gate ([INV-12](invariants.md#inv-12-resume-only-against-unfinished-sessions))
 

--- a/docs/test-cases/issue-106-107-step4-correctness.md
+++ b/docs/test-cases/issue-106-107-step4-correctness.md
@@ -1,0 +1,138 @@
+# Test Cases: Step 4 correctness — fixes for #106 + #107
+
+## #107 — `dispatch-local.sh` empty session_id tolerance
+
+File: `tests/unit/test-dispatch-local-empty-session.sh`
+
+### TC-EMPTY-RESUME-1: empty session_id → wrapper invoked without --session
+
+**Setup**: sandboxed `$PROJECT_DIR/scripts/` with a stubbed
+`autonomous-dev.sh` that records its argv. Sandboxed
+`autonomous.conf` so `dispatch-local.sh` config-load passes.
+
+**Action**: `bash dispatch-local.sh dev-resume 99 ""` (empty third arg).
+
+**Expected (post-fix)**:
+- exit code 0
+- stub argv recorded contains `--issue 99 --mode resume`
+- argv does NOT contain `--session`
+- no "session_id required" message in stderr
+
+**Pre-fix behavior** (proves the test is meaningful):
+- exit code 1
+- stderr contains `session_id required for dev-resume`
+
+### TC-EMPTY-RESUME-2: real session_id → --session flag forwarded (regression)
+
+**Setup**: same as TC-EMPTY-RESUME-1.
+
+**Action**: `bash dispatch-local.sh dev-resume 99 abc-session-id-123`.
+
+**Expected**:
+- exit code 0
+- stub argv contains `--issue 99 --mode resume --session abc-session-id-123`
+
+### TC-EMPTY-RESUME-3: dev-new path unaffected
+
+**Setup**: same as TC-EMPTY-RESUME-1.
+
+**Action**: `bash dispatch-local.sh dev-new 99`.
+
+**Expected**:
+- exit code 0
+- stub argv contains `--issue 99 --mode new`
+- argv does NOT contain `--session`
+
+---
+
+## #106 — Step 4a.5 stale-verdict / `last_reviewed_head` check
+
+File: `tests/unit/test-dispatcher-step4-stale-verdict.sh` (or extend
+existing `test-dispatcher-reliability-99.sh`).
+
+The Step 4a.5 logic is being extracted into a `lib-dispatch.sh` helper
+function `handle_pending_dev_pr_exists` that takes an issue number,
+returns 0 if the caller should `continue`, and produces the appropriate
+side effects via `label_swap` and `gh issue comment`. Tests stub
+`fetch_pr_for_issue`, `last_reviewed_head`, `label_swap`, and `gh`.
+
+### TC-STALE-VERDICT-1: same HEAD already reviewed → keep pending-dev, post notice once
+
+**Setup**:
+- `fetch_pr_for_issue` returns `{"number":42,"headRefOid":"sha-A"}`
+- `last_reviewed_head` returns `sha-A`
+- mocked `gh issue view -q '...stale-verdict:sha-A...' | length` returns `0` (no prior notice)
+
+**Action**: call `handle_pending_dev_pr_exists 99`.
+
+**Expected**:
+- function returns 0 (caller continues)
+- `label_swap` NOT called
+- `gh issue comment` called once with body containing
+  `stale-verdict:sha-A` and `HEAD \`sha-A\` already reviewed`
+
+### TC-STALE-VERDICT-2: HEAD differs from last review → flip to pending-review
+
+**Setup**:
+- `fetch_pr_for_issue` returns `{"number":42,"headRefOid":"sha-B"}`
+- `last_reviewed_head` returns `sha-A`
+
+**Action**: call `handle_pending_dev_pr_exists 99`.
+
+**Expected**:
+- function returns 0
+- `label_swap 99 pending-dev pending-review` called
+- `gh issue comment` body contains `transitioning to pending-review`
+  (existing Bug 3 message)
+
+### TC-STALE-VERDICT-3: no last_reviewed_head trailer → flip to pending-review
+
+**Setup**:
+- `fetch_pr_for_issue` returns `{"number":42,"headRefOid":"sha-A"}`
+- `last_reviewed_head` returns `""` (no prior review)
+
+**Action**: call `handle_pending_dev_pr_exists 99`.
+
+**Expected**:
+- function returns 0
+- `label_swap 99 pending-dev pending-review` called
+- `gh issue comment` body contains `transitioning to pending-review`
+
+### TC-STALE-VERDICT-4: idempotency — notice already present → no duplicate
+
+**Setup**:
+- `fetch_pr_for_issue` returns `{"number":42,"headRefOid":"sha-A"}`
+- `last_reviewed_head` returns `sha-A`
+- mocked `gh issue view -q '...stale-verdict:sha-A...' | length` returns `1`
+
+**Action**: call `handle_pending_dev_pr_exists 99`.
+
+**Expected**:
+- function returns 0
+- `label_swap` NOT called
+- `gh issue comment` NOT called
+
+### TC-STALE-VERDICT-5: no PR → function returns 1 (fall through)
+
+**Setup**:
+- `fetch_pr_for_issue` returns `""` (no PR)
+
+**Action**: call `handle_pending_dev_pr_exists 99`.
+
+**Expected**:
+- function returns 1 (caller does NOT continue, falls through to
+  session-id / dispatch path)
+- `label_swap` NOT called
+- `gh issue comment` NOT called
+
+---
+
+## Regression coverage (must still pass after these changes)
+
+- All 44+ tests in `tests/unit/*.sh` pre-existing pass
+- `test-dispatcher-reliability-99.sh` — Bug 3 PR-exists short-circuit
+  semantics preserved when HEAD differs / first review
+- `test-dispatcher-tick-router.sh` — dispatch() router unchanged
+- `test-symlink-resolution.sh` — dispatch-local.sh INV-14 chain unchanged
+- `test-stale-alive-with-pr.sh` — Step 5b's `last_reviewed_head` check
+  unchanged (we only mirror it, not modify it)

--- a/skills/autonomous-dispatcher/scripts/dispatch-local.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatch-local.sh
@@ -152,12 +152,14 @@ case "$TYPE" in
     CHILD_PID=$!
     ;;
   dev-resume)
-    if [[ -z "$SESSION_ID" ]]; then
-      echo "ERROR: session_id required for dev-resume" >&2
-      exit 1
-    fi
-    nohup "${PROJECT_DIR}/scripts/autonomous-dev.sh" \
-      --issue "$ISSUE_NUM" --mode resume --session "$SESSION_ID" \
+    # Empty SESSION_ID is tolerated: dispatcher-tick.sh Step 4 dispatches
+    # dev-resume on every pending-dev pass, including first-time pickup
+    # with no prior `Dev Session ID:` comment. autonomous-dev.sh:257-260
+    # falls back to MODE=new when --mode resume is invoked without
+    # --session, so omitting the flag here is the canonical handoff. (#107)
+    resume_args=(--issue "$ISSUE_NUM" --mode resume)
+    [[ -n "$SESSION_ID" ]] && resume_args+=(--session "$SESSION_ID")
+    nohup "${PROJECT_DIR}/scripts/autonomous-dev.sh" "${resume_args[@]}" \
       >> "/tmp/agent-${PROJECT_ID}-issue-${ISSUE_NUM}.log" 2>&1 &
     CHILD_PID=$!
     ;;

--- a/skills/autonomous-dispatcher/scripts/dispatch-remote-aws-ssm.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatch-remote-aws-ssm.sh
@@ -139,11 +139,17 @@ case "$TYPE" in
     COMMENT="${SSM_REMOTE_PROJECT_ID}: new dev task for issue #${ISSUE_NUM}"
     ;;
   dev-resume)
-    if [[ -z "$SESSION_ID" ]]; then
-      echo "ERROR: session_id required for dev-resume" >&2
-      exit 1
+    # Empty SESSION_ID is tolerated: dispatcher-tick.sh Step 4 dispatches
+    # dev-resume on every pending-dev pass, including first-time pickup
+    # with no prior `Dev Session ID:` comment. The remote dispatch-local.sh
+    # handles empty session by spawning the wrapper without --session,
+    # and autonomous-dev.sh:257-260 falls back to MODE=new. Mirrors the
+    # local-backend tolerance so SSM users see the same Step 4 fix. (#107)
+    if [[ -n "$SESSION_ID" ]]; then
+      INNER_CMD="${prefix}PROJECT_DIR=${SSM_REMOTE_PROJECT_DIR} PROJECT_ID=${SSM_REMOTE_PROJECT_ID} bash ${DISPATCH_LOCAL} dev-resume ${ISSUE_NUM} ${SESSION_ID}"
+    else
+      INNER_CMD="${prefix}PROJECT_DIR=${SSM_REMOTE_PROJECT_DIR} PROJECT_ID=${SSM_REMOTE_PROJECT_ID} bash ${DISPATCH_LOCAL} dev-resume ${ISSUE_NUM}"
     fi
-    INNER_CMD="${prefix}PROJECT_DIR=${SSM_REMOTE_PROJECT_DIR} PROJECT_ID=${SSM_REMOTE_PROJECT_ID} bash ${DISPATCH_LOCAL} dev-resume ${ISSUE_NUM} ${SESSION_ID}"
     COMMENT="${SSM_REMOTE_PROJECT_ID}: resume dev for issue #${ISSUE_NUM}"
     ;;
   review)

--- a/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
@@ -233,15 +233,14 @@ for i in $(seq 0 $((pd_count - 1))); do
   # finished development — any subsequent crash (e.g. cleanup-time exit
   # non-zero after gh pr create) routed us to pending-dev, but re-developing
   # would just re-do work. Hand off to review instead.
-  pr_for_issue=$(fetch_pr_for_issue "$issue_num" "number")
-  if [ -n "$pr_for_issue" ]; then
-    pr_num=$(jq -r '.number // empty' <<<"$pr_for_issue")
-    pr_ref="${pr_num:+#${pr_num}}"
-    pr_ref="${pr_ref:-(number unknown)}"
-    log "  issue #${issue_num} has PR ${pr_ref} — transitioning to pending-review (Bug 3 fix)"
-    gh issue comment "$issue_num" --repo "$REPO" \
-      --body "PR ${pr_ref} exists for this issue; transitioning to pending-review instead of retrying dev (#99 Bug 3)."
-    label_swap "$issue_num" "pending-dev" "pending-review"
+  #
+  # #106: when the PR's HEAD already matches the most recent
+  # `Reviewed HEAD:` trailer, the prior verdict was FAILED and the dev
+  # agent hasn't pushed new commits yet. Re-routing to pending-review
+  # would loop the same review against the same code every tick. The
+  # helper keeps such issues in pending-dev with an idempotent
+  # stale-verdict notice; only NEW commits or first-review issues flip.
+  if handle_pending_dev_pr_exists "$issue_num"; then
     JUST_DISPATCHED+=("$issue_num")
     continue
   fi

--- a/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
@@ -493,6 +493,60 @@ last_reviewed_head() {
     -q '[.comments[].body | capture("Reviewed HEAD: `(?<sha>[0-9a-f]{7,40})`"; "g") | .sha] | last // empty'
 }
 
+# Step 4a.5: PR-exists short-circuit on the pending-dev scan. Mirrors
+# Step 5b's `last_reviewed_head` check so a stale FAILED verdict against
+# an unchanged PR HEAD doesn't drive an infinite re-review loop (#106).
+#
+# Returns:
+#   0 — handled (caller should `continue` to next issue)
+#   1 — no PR for this issue (caller falls through to session/dispatch logic)
+#
+# Side effects (only when returning 0):
+#   - Same HEAD already reviewed → idempotent stale-verdict notice;
+#     label stays pending-dev.
+#   - HEAD differs OR no prior review → flips pending-dev → pending-review
+#     and posts the Bug 3 transition comment.
+handle_pending_dev_pr_exists() {
+  local issue_num="$1"
+  local pr_info pr_num current_head pr_ref last_head notice_marker
+  pr_info=$(fetch_pr_for_issue "$issue_num" "number,headRefOid")
+  if [ -z "$pr_info" ]; then
+    return 1
+  fi
+
+  pr_num=$(jq -r '.number // empty' <<<"$pr_info")
+  current_head=$(jq -r '.headRefOid // empty' <<<"$pr_info")
+  pr_ref="${pr_num:+#${pr_num}}"
+  pr_ref="${pr_ref:-(number unknown)}"
+  last_head=$(last_reviewed_head "$issue_num")
+
+  if [ -n "$last_head" ] && [ -n "$current_head" ] && [ "$current_head" = "$last_head" ]; then
+    # Same HEAD already reviewed — verdict was FAILED (otherwise the issue
+    # wouldn't be in pending-dev). Don't redo review; surface the stale
+    # verdict and keep pending-dev so the dev agent can act on feedback.
+    #
+    # Idempotency check uses `grep -q '^0$'` (fail-closed): a transient
+    # `gh issue view` error yields empty output, grep returns 1, and we
+    # skip the post — preventing duplicate notices on rate-limit / auth
+    # refresh blips. Mirrors the existing INV-12-completed marker pattern
+    # in dispatcher-tick.sh:267-269.
+    notice_marker="stale-verdict:${current_head}"
+    if gh issue view "$issue_num" --repo "$REPO" --json comments \
+        -q "[.comments[].body | select(contains(\"${notice_marker}\"))] | length" \
+        2>/dev/null | grep -q '^0$'; then
+      gh issue comment "$issue_num" --repo "$REPO" \
+        --body "PR ${pr_ref} HEAD \`${current_head}\` already reviewed with FAILED verdict; awaiting new commits before re-review. (\`${notice_marker}\`)"
+    fi
+    return 0
+  fi
+
+  # New HEAD or first review — keep existing Bug 3 (#99) behavior.
+  gh issue comment "$issue_num" --repo "$REPO" \
+    --body "PR ${pr_ref} exists for this issue; transitioning to pending-review instead of retrying dev (#99 Bug 3)."
+  label_swap "$issue_num" "pending-dev" "pending-review"
+  return 0
+}
+
 # ---------------------------------------------------------------------------
 # Label transitions (atomic per-edit, see [INV-08])
 # ---------------------------------------------------------------------------

--- a/tests/unit/test-dispatch-local-empty-session.sh
+++ b/tests/unit/test-dispatch-local-empty-session.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# test-dispatch-local-empty-session.sh — Unit tests for issue #107.
+#
+# dispatch-local.sh's dev-resume branch must tolerate an empty session_id.
+# dispatcher-tick.sh:314 unconditionally calls
+#   dispatch dev-resume "$issue_num" "$session_id"
+# from Step 4 (pending-dev scan), and "$session_id" is empty on first-time
+# pickup of a pending-dev issue with no prior `Dev Session ID:` comment.
+# autonomous-dev.sh:257-260 already falls back to MODE=new when --mode
+# resume is invoked without --session, so dispatch-local.sh must forward
+# the call (without --session) instead of exiting 1.
+#
+# Run: bash tests/unit/test-dispatch-local-empty-session.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DISPATCHER_SCRIPTS="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts"
+DISPATCH_LOCAL="$DISPATCHER_SCRIPTS/dispatch-local.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected='$expected'"
+    echo "      actual=  '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      needle='$needle'"
+    echo "      haystack='$haystack'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      needle='$needle' (should NOT appear)"
+    echo "      haystack='$haystack'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Sandbox: replicate the project-side scripts/ layout that dispatch-local.sh
+# expects (autonomous.conf + autonomous-dev.sh stub that records its argv).
+# ---------------------------------------------------------------------------
+
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+PROJ="$TMPROOT/proj"
+mkdir -p "$PROJ/scripts" "$PROJ/.pids"
+
+# Stub autonomous-dev.sh: record argv to a deterministic file and exit 0
+# quickly so dispatch-local.sh's `kill -0 $CHILD_PID` post-spawn check can
+# see the process is alive (we sleep briefly before exiting).
+ARGV_FILE="$TMPROOT/argv.log"
+cat > "$PROJ/scripts/autonomous-dev.sh" <<STUB
+#!/bin/bash
+# Test stub — records argv to capture how dispatch-local.sh forwarded the call.
+echo "argv: \$*" >> "$ARGV_FILE"
+# Stay alive briefly so the post-spawn kill -0 check in dispatch-local.sh
+# (sleep 1 + kill -0) sees a live PID.
+sleep 2
+exit 0
+STUB
+chmod +x "$PROJ/scripts/autonomous-dev.sh"
+
+cat > "$PROJ/scripts/autonomous.conf" <<CONF
+PROJECT_ID="empty-session-test"
+REPO="test/test"
+REPO_OWNER="test"
+REPO_NAME="test"
+PROJECT_DIR="$PROJ"
+AGENT_CMD="claude"
+GH_AUTH_MODE="token"
+PID_DIR="$PROJ/.pids"
+CONF
+
+# Symlink dispatch-local.sh + lib chain into the project's scripts/. This is
+# the production "shared-install" topology (PR #105) where the project side
+# only holds symlinks pointing at the upstream skill checkout.
+LIB_FILES=(
+  dispatch-local.sh lib-config.sh lib-agent.sh lib-auth.sh
+  lib-dispatch.sh lib-review-bots.sh
+  gh-app-token.sh gh-with-token-refresh.sh gh-token-refresh-daemon.sh
+)
+for f in "${LIB_FILES[@]}"; do
+  if [[ -f "$DISPATCHER_SCRIPTS/$f" ]]; then
+    ln -sf "$DISPATCHER_SCRIPTS/$f" "$PROJ/scripts/$f"
+  fi
+done
+
+DISPATCH_ENTRY="$PROJ/scripts/dispatch-local.sh"
+
+# Helper: invoke dispatch-local.sh and wait for the stub's argv to land.
+# Captures stderr from dispatch-local.sh itself so we can assert on it
+# (the pre-fix "session_id required" error message lives there).
+run_dispatch() {
+  : > "$ARGV_FILE"
+  rm -f "$PROJ/.pids/"*.pid 2>/dev/null
+  local stderr_capture="$TMPROOT/stderr.log"
+  : > "$stderr_capture"
+  local rc=0
+  ( cd "$PROJ" && bash "$DISPATCH_ENTRY" "$@" >/dev/null 2>"$stderr_capture" ) || rc=$?
+  # Wait briefly for the stub to write argv (dispatch-local nohup'd it).
+  local _i found=""
+  for _i in 1 2 3 4 5 6 7 8 9 10; do
+    if [[ -s "$ARGV_FILE" ]]; then
+      found=1
+      break
+    fi
+    sleep 0.2
+  done
+  echo "rc=$rc"
+  echo "---argv---"
+  cat "$ARGV_FILE" 2>/dev/null
+  echo "---stderr---"
+  cat "$stderr_capture" 2>/dev/null
+  echo "---end---"
+}
+
+# ---------------------------------------------------------------------------
+echo "=== TC-EMPTY-RESUME-1: dev-resume + empty session → wrapper invoked w/o --session ==="
+# ---------------------------------------------------------------------------
+
+OUTPUT=$(run_dispatch dev-resume 99 "")
+
+# Expected post-fix:
+#   - exit 0 (no rejection)
+#   - argv logged with --mode resume (no --session)
+#   - stderr does not contain "session_id required"
+assert_contains "exit code 0" "rc=0" "$OUTPUT"
+assert_contains "argv contains --mode resume" "--mode resume" "$OUTPUT"
+assert_contains "argv contains --issue 99" "--issue 99" "$OUTPUT"
+assert_not_contains "argv does NOT contain --session" "--session" "$OUTPUT"
+assert_not_contains "stderr does NOT say 'session_id required'" "session_id required" "$OUTPUT"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EMPTY-RESUME-2: dev-resume + real session → --session forwarded (regression) ==="
+# ---------------------------------------------------------------------------
+
+OUTPUT=$(run_dispatch dev-resume 99 abc-session-id-123)
+
+assert_contains "exit code 0" "rc=0" "$OUTPUT"
+assert_contains "argv contains --mode resume" "--mode resume" "$OUTPUT"
+assert_contains "argv contains --session abc-session-id-123" "--session abc-session-id-123" "$OUTPUT"
+assert_contains "argv contains --issue 99" "--issue 99" "$OUTPUT"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-EMPTY-RESUME-3: dev-new path unaffected (regression) ==="
+# ---------------------------------------------------------------------------
+
+OUTPUT=$(run_dispatch dev-new 99)
+
+assert_contains "exit code 0" "rc=0" "$OUTPUT"
+assert_contains "argv contains --mode new" "--mode new" "$OUTPUT"
+assert_contains "argv contains --issue 99" "--issue 99" "$OUTPUT"
+assert_not_contains "argv does NOT contain --session" "--session" "$OUTPUT"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "==============================================="
+echo -e "Total: $((PASS + FAIL)) tests, ${GREEN}${PASS} pass${NC}, ${RED}${FAIL} fail${NC}"
+echo "==============================================="
+
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1

--- a/tests/unit/test-dispatch-remote-aws-ssm.sh
+++ b/tests/unit/test-dispatch-remote-aws-ssm.sh
@@ -239,11 +239,36 @@ assert_contains "stderr names instance ID" "$SSM_INSTANCE_ID" "$err"
 
 # ---------------------------------------------------------------------------
 echo ""
-echo "=== TC-EB-007b: dev-resume requires session_id (run before PATH test) ==="
+echo "=== TC-EB-007b: dev-resume tolerates empty session_id (#107) ==="
 # ---------------------------------------------------------------------------
+# dispatcher-tick.sh Step 4 dispatches dev-resume on every pending-dev pass,
+# including first-time pickup with no prior `Dev Session ID:` comment. The
+# remote driver must forward the call (without --session) so the wrapper
+# can fall back to MODE=new — symmetric with the local backend's tolerance.
+: > "$TMPROOT/aws-record"
 err=$(run_driver dev-resume 99 2>&1 >/dev/null)
-assert_rc "dev-resume without session_id → rc=1" 1 "$?"
-assert_contains "stderr names session_id" "session_id" "$err"
+rc=$?
+assert_rc "dev-resume without session_id succeeds" 0 "$rc"
+[[ -s "$TMPROOT/aws-record" ]] && {
+  echo -e "  ${GREEN}PASS${NC}: aws send-command was invoked"
+  PASS=$((PASS + 1))
+} || {
+  echo -e "  ${RED}FAIL${NC}: aws send-command NOT invoked when session empty"
+  FAIL=$((FAIL + 1))
+}
+# The constructed inner command must include `dev-resume 99` (3-arg form,
+# no trailing session id).
+record=$(cat "$TMPROOT/aws-record")
+assert_contains "inner command contains dev-resume 99" "dev-resume 99" "$record"
+assert_not_contains "stderr does NOT say 'session_id required'" "session_id required" "$err"
+
+# Regression: real session_id still gets forwarded as the 4th arg.
+: > "$TMPROOT/aws-record"
+err=$(run_driver dev-resume 99 abc-session-id-123 2>&1 >/dev/null)
+rc=$?
+assert_rc "dev-resume with session_id succeeds" 0 "$rc"
+record=$(cat "$TMPROOT/aws-record")
+assert_contains "inner command contains session id" "abc-session-id-123" "$record"
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/unit/test-dispatcher-step4-stale-verdict.sh
+++ b/tests/unit/test-dispatcher-step4-stale-verdict.sh
@@ -1,0 +1,274 @@
+#!/bin/bash
+# test-dispatcher-step4-stale-verdict.sh — Unit tests for issue #106.
+#
+# Step 4a.5 PR-exists short-circuit must consult last_reviewed_head before
+# routing to pending-review. If the current PR HEAD has already been
+# reviewed (so the prior verdict was FAILED — otherwise the issue wouldn't
+# be in pending-dev), keep the issue in pending-dev and surface a one-time
+# idempotent stale-verdict notice. Only flip to pending-review when the
+# HEAD has changed (new commits to assess) or no prior `Reviewed HEAD:`
+# trailer exists (first review).
+#
+# The Step 4a.5 logic is extracted from dispatcher-tick.sh into a new
+# lib-dispatch.sh helper `handle_pending_dev_pr_exists` so it can be unit
+# tested in isolation.
+#
+# Run: bash tests/unit/test-dispatcher-step4-stale-verdict.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-dispatch.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Required env (lib-dispatch.sh enforces these via : "${VAR:?...}")
+export REPO=zxkane/autonomous-dev-team
+export REPO_OWNER=zxkane
+export PROJECT_ID=test-proj
+export MAX_RETRIES=3
+export MAX_CONCURRENT=5
+
+# ---------------------------------------------------------------------------
+# Mocks — overridden per test case.
+#
+# We intercept gh/fetch_pr_for_issue/last_reviewed_head/label_swap and
+# track which side effects fire so each assertion can verify exactly the
+# expected behavior (notice posted exactly once / label swapped / both /
+# neither).
+# ---------------------------------------------------------------------------
+_MOCK_PR_INFO=""           # JSON returned by fetch_pr_for_issue, or "" for no PR
+_MOCK_LAST_REVIEWED=""     # last_reviewed_head return value
+_MOCK_NOTICE_PRESENT="0"   # "0" (no prior notice) or "1" (already present)
+_MOCK_LAST_COMMENT_BODY="" # last gh issue comment --body argument
+_MOCK_COMMENT_COUNT=0      # how many gh issue comment calls fired
+_MOCK_LABEL_SWAPS=""       # space-separated list of "issue:remove:add" tuples
+
+fetch_pr_for_issue() {
+  printf '%s' "$_MOCK_PR_INFO"
+}
+
+last_reviewed_head() {
+  printf '%s' "$_MOCK_LAST_REVIEWED"
+}
+
+label_swap() {
+  local issue_num="$1" remove="$2" add="$3"
+  _MOCK_LABEL_SWAPS+="${issue_num}:${remove}:${add} "
+}
+
+# Mocked gh: handles `gh issue view ... --json comments -q ...` (returns
+# the count of contains() matches based on _MOCK_NOTICE_PRESENT) and
+# `gh issue comment ... --body ...` (records body / increments counter).
+gh() {
+  local cmd="${1:-}"
+  local sub="${2:-}"
+  if [[ "$cmd" == "issue" && "$sub" == "comment" ]]; then
+    while [[ $# -gt 0 ]]; do
+      if [[ "$1" == "--body" ]]; then
+        _MOCK_LAST_COMMENT_BODY="$2"
+        _MOCK_COMMENT_COUNT=$((_MOCK_COMMENT_COUNT + 1))
+        return 0
+      fi
+      shift
+    done
+    return 0
+  fi
+  if [[ "$cmd" == "issue" && "$sub" == "view" ]]; then
+    # The handler uses this to count prior stale-verdict notices.
+    # Return _MOCK_NOTICE_PRESENT directly — caller pipes through grep '^0$'.
+    printf '%s\n' "$_MOCK_NOTICE_PRESENT"
+    return 0
+  fi
+  return 0
+}
+# shellcheck source=../../skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+source "$LIB"
+set +e
+
+# Re-define mocks AFTER sourcing the lib so they shadow lib's real
+# implementations of fetch_pr_for_issue/last_reviewed_head/label_swap.
+fetch_pr_for_issue() {
+  printf '%s' "$_MOCK_PR_INFO"
+}
+
+last_reviewed_head() {
+  printf '%s' "$_MOCK_LAST_REVIEWED"
+}
+
+label_swap() {
+  local issue_num="$1" remove="$2" add="$3"
+  _MOCK_LABEL_SWAPS+="${issue_num}:${remove}:${add} "
+}
+
+reset_mocks() {
+  _MOCK_PR_INFO=""
+  _MOCK_LAST_REVIEWED=""
+  _MOCK_NOTICE_PRESENT="0"
+  _MOCK_LAST_COMMENT_BODY=""
+  _MOCK_COMMENT_COUNT=0
+  _MOCK_LABEL_SWAPS=""
+}
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected='$expected'"
+    echo "      actual=  '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      needle='$needle'"
+    echo "      haystack='$haystack'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+echo "=== TC-STALE-VERDICT-1: same HEAD reviewed → keep pending-dev, post notice ==="
+# ---------------------------------------------------------------------------
+
+reset_mocks
+_MOCK_PR_INFO='{"number":42,"headRefOid":"sha-A"}'
+_MOCK_LAST_REVIEWED="sha-A"
+_MOCK_NOTICE_PRESENT="0"
+
+handle_pending_dev_pr_exists 99
+rc=$?
+
+assert_eq "function returns 0 (caller continues)" "0" "$rc"
+assert_eq "label_swap NOT called" "" "$_MOCK_LABEL_SWAPS"
+assert_eq "exactly one comment posted" "1" "$_MOCK_COMMENT_COUNT"
+assert_contains "comment body contains marker" "stale-verdict:sha-A" "$_MOCK_LAST_COMMENT_BODY"
+assert_contains "comment body mentions HEAD reviewed" "already reviewed" "$_MOCK_LAST_COMMENT_BODY"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-STALE-VERDICT-2: HEAD differs → flip to pending-review ==="
+# ---------------------------------------------------------------------------
+
+reset_mocks
+_MOCK_PR_INFO='{"number":42,"headRefOid":"sha-B"}'
+_MOCK_LAST_REVIEWED="sha-A"
+_MOCK_NOTICE_PRESENT="0"
+
+handle_pending_dev_pr_exists 99
+rc=$?
+
+assert_eq "function returns 0" "0" "$rc"
+assert_contains "label swapped pending-dev → pending-review" "99:pending-dev:pending-review" "$_MOCK_LABEL_SWAPS"
+assert_eq "exactly one comment posted (Bug 3 transition message)" "1" "$_MOCK_COMMENT_COUNT"
+assert_contains "comment body says transitioning to pending-review" "transitioning to pending-review" "$_MOCK_LAST_COMMENT_BODY"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-STALE-VERDICT-3: no prior Reviewed HEAD trailer → flip to pending-review ==="
+# ---------------------------------------------------------------------------
+
+reset_mocks
+_MOCK_PR_INFO='{"number":42,"headRefOid":"sha-A"}'
+_MOCK_LAST_REVIEWED=""    # no prior review
+_MOCK_NOTICE_PRESENT="0"
+
+handle_pending_dev_pr_exists 99
+rc=$?
+
+assert_eq "function returns 0" "0" "$rc"
+assert_contains "label swapped pending-dev → pending-review" "99:pending-dev:pending-review" "$_MOCK_LABEL_SWAPS"
+assert_contains "comment body says transitioning to pending-review" "transitioning to pending-review" "$_MOCK_LAST_COMMENT_BODY"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-STALE-VERDICT-4: idempotency — notice already present → no duplicate ==="
+# ---------------------------------------------------------------------------
+
+reset_mocks
+_MOCK_PR_INFO='{"number":42,"headRefOid":"sha-A"}'
+_MOCK_LAST_REVIEWED="sha-A"
+_MOCK_NOTICE_PRESENT="1"   # marker already in comments
+
+handle_pending_dev_pr_exists 99
+rc=$?
+
+assert_eq "function returns 0" "0" "$rc"
+assert_eq "label_swap NOT called" "" "$_MOCK_LABEL_SWAPS"
+assert_eq "no duplicate comment posted" "0" "$_MOCK_COMMENT_COUNT"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-STALE-VERDICT-4b: HEAD moved + stale marker still present → flip ==="
+# ---------------------------------------------------------------------------
+# Recovery scenario: prior tick posted a stale-verdict marker for sha-A,
+# but the dev agent has since pushed sha-B. We must NOT let the stale
+# marker gate the flip — last_head!=current_head dominates.
+
+reset_mocks
+_MOCK_PR_INFO='{"number":42,"headRefOid":"sha-B"}'
+_MOCK_LAST_REVIEWED="sha-A"
+_MOCK_NOTICE_PRESENT="1"   # prior stale-verdict:sha-A marker still present
+
+handle_pending_dev_pr_exists 99
+rc=$?
+
+assert_eq "function returns 0" "0" "$rc"
+assert_contains "label swapped pending-dev → pending-review (HEAD wins)" "99:pending-dev:pending-review" "$_MOCK_LABEL_SWAPS"
+assert_contains "transition message posted" "transitioning to pending-review" "$_MOCK_LAST_COMMENT_BODY"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-STALE-VERDICT-4c: empty current_head from PR JSON → flip (defensive) ==="
+# ---------------------------------------------------------------------------
+# If fetch_pr_for_issue returns a PR with empty headRefOid (API schema
+# drift / partial JSON), the same-HEAD comparison's `[ -n "$current_head" ]`
+# guard must reject the match and route to pending-review (the existing
+# Bug 3 path) rather than silently posting a marker for an empty SHA.
+
+reset_mocks
+_MOCK_PR_INFO='{"number":42,"headRefOid":""}'
+_MOCK_LAST_REVIEWED="sha-A"
+
+handle_pending_dev_pr_exists 99
+rc=$?
+
+assert_eq "function returns 0" "0" "$rc"
+assert_contains "label swapped pending-dev → pending-review" "99:pending-dev:pending-review" "$_MOCK_LABEL_SWAPS"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-STALE-VERDICT-5: no PR → function returns 1 (caller falls through) ==="
+# ---------------------------------------------------------------------------
+
+reset_mocks
+_MOCK_PR_INFO=""           # no PR for this issue
+
+handle_pending_dev_pr_exists 99
+rc=$?
+
+assert_eq "function returns 1 (caller does NOT continue)" "1" "$rc"
+assert_eq "label_swap NOT called" "" "$_MOCK_LABEL_SWAPS"
+assert_eq "no comment posted" "0" "$_MOCK_COMMENT_COUNT"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "==============================================="
+echo -e "Total: $((PASS + FAIL)) tests, ${GREEN}${PASS} pass${NC}, ${RED}${FAIL} fail${NC}"
+echo "==============================================="
+
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- **#106 fix**: Step 4a.5 PR-exists short-circuit now consults `last_reviewed_head` (mirrors Step 5b). When PR HEAD matches the most recent `Reviewed HEAD:` trailer, the dispatcher keeps the issue in `pending-dev` with an idempotent `stale-verdict:<sha>` notice instead of looping the same FAILED review every tick (~$1, ~10 min wall-clock per loop).
- **#107 fix**: Both transport drivers (`dispatch-local.sh` + `dispatch-remote-aws-ssm.sh`) now tolerate empty `SESSION_ID` in `dev-resume`. The wrapper already falls back to `MODE=new` (`autonomous-dev.sh:257-260`); only the dispatch-layer rejection was blocking first-time `pending-dev` pickup.
- Step 4a.5 logic extracted to `handle_pending_dev_pr_exists()` in `lib-dispatch.sh` for unit-testability.

## Design
- [x] Design canvas created: `docs/designs/issue-106-107-step4-correctness.md`
- [x] Design approved (single PR per user request)

## Test Plan
- [x] Test cases documented: `docs/test-cases/issue-106-107-step4-correctness.md`
- [x] Build/syntax: bash scripts, no build step
- [x] Unit tests: 46/46 pass
  - 23 new in `test-dispatcher-step4-stale-verdict.sh` (TC-STALE-VERDICT-1..5 + 4b recovery + 4c empty-headRefOid)
  - 13 new in `test-dispatch-local-empty-session.sh` (TC-EMPTY-RESUME-1..3)
  - TC-EB-007b in `test-dispatch-remote-aws-ssm.sh` inverted to assert SSM-side empty-session tolerance
- [ ] CI checks pass
- [x] Code simplification review (args-array form for dispatch-local.sh)
- [x] PR review agent review passed (1 critical + 2 important findings from initial pass, all addressed in final commit)
- [ ] Reviewer bot findings addressed (no new findings)
- [ ] E2E tests pass (N/A — pure dispatcher-side bash logic; live verification will happen on next downstream pickup)

## Checklist
- [x] TDD: tests written first (RED), then fixes (GREEN) — verified empty-session test failed pre-fix with `ERROR: session_id required for dev-resume` from stderr; stale-verdict tests failed pre-fix with `command not found` for the helper
- [x] Symmetry preserved with Step 5b's `last_reviewed_head` check (the model)
- [x] Idempotency uses `grep -q '^0$'` (fail-closed, matching existing INV-12 pattern)
- [x] Both backends fixed (`local` and `remote-aws-ssm`)
- [x] No private repo references in any artifact
- [x] Closes #106 (stale-verdict loop)
- [x] Closes #107 (silent first-tick stall)

Closes #106
Closes #107