### PR TITLE
fix(dispatcher): stop mislabeling long-running review wrappers as crashed (#111)

### DIFF
--- a/docs/designs/dispatcher-review-near-success.md
+++ b/docs/designs/dispatcher-review-near-success.md
@@ -1,0 +1,96 @@
+# Design: Stop mislabeling long-running review wrappers as "crashed"
+
+Issue: #111
+
+## Problem
+
+`dispatcher-tick.sh` Step 5b review-DEAD branch (lines 452-456) declares a
+review wrapper "crashed" purely on a `pid_alive` miss after the cold-start
+grace period (default 600s). Real review wrappers routinely run 15-30 min
+(E2E + multi-bot rounds + line-by-line review). On a transient `pid_alive`
+race, or just after the wrapper has reached the merge-step but before its
+trap clears state, the dispatcher posts a misleading "crashed" comment and
+flips `reviewing` → `pending-dev` while review is still actively running.
+
+The wrapper's own success path eventually merges the PR, but the issue is
+left with stale `pending-dev` label residue and noisy "crashed" comments.
+
+## Two-part fix (delivered together)
+
+### Part A — PR-state cross-check (Step 5b review branch)
+
+Before declaring the review wrapper crashed, check four PR-state signals.
+If ANY signal is positive within `REVIEW_NEAR_SUCCESS_WINDOW_SECONDS`
+(default 300s), short-circuit the crash path and leave `reviewing` alone:
+
+1. **PR just merged** — `mergedAt` younger than the window.
+2. **PR just approved** — most recent APPROVED review event younger than
+   the window.
+3. **Verdict comment posted** — review-agent identity (or any GitHub user
+   matching the review-bot login pattern) posted a comment matching
+   `^Review (PASSED|findings)` in the window.
+4. **Defensive PID re-check** — `kill -0 <pid>` against the current
+   PID-file content. If it now returns 0, the original `pid_alive`
+   miss was a race; defer to next tick. (Mirrors Step 5a's re-verify
+   pattern at dispatcher-tick.sh:404-407.)
+
+Only when **all four are negative** does the existing crash + label-swap
+fire.
+
+### Part B — Wrapper heartbeat
+
+Both wrappers (`autonomous-dev.sh`, `autonomous-review.sh`) install a
+shared `install_agent_heartbeat` helper (in `lib-agent.sh`, parity with
+`install_agent_sigterm_trap`). The helper spawns a background loop that
+`touch`es `AGENT_PID_FILE` every `HEARTBEAT_INTERVAL_SECONDS` (default
+120s). The loop exits when the wrapper exits (parent-pid watchdog).
+
+`pid_alive` in `lib-dispatch.sh` becomes a two-tier check:
+
+- `kill -0 <pid>` → ALIVE.
+- `kill -0 <pid>` fails → check PID-file mtime. If mtime is within
+  `HEARTBEAT_INTERVAL_SECONDS * 3` (default 360s), still treat as ALIVE
+  (process may be transitioning groups, exec'ing, or in a transient
+  race). Otherwise DEAD.
+
+The two parts complement:
+- (A) handles the cleanup-merge-exit tail — wrapper *did* finish, but
+  PR-state evidence is the authoritative success signal.
+- (B) handles the long mid-review window where no PR-state changes are
+  visible yet — heartbeat gives the dispatcher a positive "still working"
+  signal.
+
+## INV-24
+
+> Review wrapper DEAD detection requires both `pid_alive` miss AND no
+> near-success PR signal AND no recent PID-file heartbeat. A `pid_alive`
+> miss alone is NOT sufficient.
+
+Cross-references from `dispatcher-flow.md` Step 5b.
+
+## Risk / non-goals
+
+- **Dev-side wrappers** (`in-progress` / Step 5a) are NOT touched by
+  Part A. Step 5a already has its own re-verify pattern + 5-min idle
+  gate; the false-alarm class described in #111 is review-specific.
+- Heartbeat (Part B) IS installed for both wrappers — costs near zero
+  and benefits both.
+- `HEARTBEAT_INTERVAL_SECONDS=0` disables heartbeat entirely (regression
+  safety).
+- `REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=0` disables Part A short-circuits
+  (preserves legacy strict behavior for ops that prefer it).
+
+## File-level changes
+
+| File | Change |
+|------|--------|
+| `skills/autonomous-dispatcher/scripts/lib-agent.sh` | + `install_agent_heartbeat` helper |
+| `skills/autonomous-dispatcher/scripts/lib-dispatch.sh` | + `pid_alive` mtime fallback, + `review_near_success` helper |
+| `skills/autonomous-dispatcher/scripts/dispatcher-tick.sh` | Step 5b review branch gates on `review_near_success` |
+| `skills/autonomous-dispatcher/scripts/autonomous-dev.sh` | call `install_agent_heartbeat` after PID-file write |
+| `skills/autonomous-dispatcher/scripts/autonomous-review.sh` | call `install_agent_heartbeat` after PID-file write |
+| `scripts/autonomous.conf.example` | document `HEARTBEAT_INTERVAL_SECONDS`, `REVIEW_NEAR_SUCCESS_WINDOW_SECONDS` |
+| `docs/pipeline/invariants.md` | add INV-24 |
+| `docs/pipeline/dispatcher-flow.md` | reference INV-24 in Step 5b |
+| `tests/unit/test-dispatcher-review-near-success.sh` | new |
+| `tests/unit/test-wrapper-heartbeat.sh` | new |

--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -285,10 +285,14 @@ The wording in the "PR found" branches deliberately avoids the keywords `crashed
 
 #### DEAD + `reviewing`
 
+Before posting "crashed" or swapping labels, the dispatcher consults `review_near_success` ([INV-24](invariants.md#inv-24-review-wrapper-dead-detection-requires-both-pid_alive-miss-and-no-near-success-pr-signal)). If ANY of the four PR-state signals (recent merge, recent APPROVED review, recent verdict comment, defensive `kill -0` re-check) is positive within `REVIEW_NEAR_SUCCESS_WINDOW_SECONDS` (default 300s), the branch logs and short-circuits — the wrapper has either already finished successfully or is in its post-verdict / merge tail.
+
+Only when ALL four signals are negative does the crash path fire:
+
 Comment: "Review process appears to have crashed. Moving to pending-dev for retry."
 Labels: `−reviewing +pending-dev`.
 
-(No SHA-comparison shortcut here — the review wrapper's own trap should have already done this transition for genuine crashes; this 5b branch is the safety net for the case where the wrapper died so abruptly that even its trap didn't fire.)
+This branch is the safety net for the case where the wrapper died so abruptly that even its trap didn't fire. The `pid_alive` check that gates entry to this branch ALSO honors a heartbeat-based mtime fallback ([INV-24](invariants.md#inv-24-review-wrapper-dead-detection-requires-both-pid_alive-miss-and-no-near-success-pr-signal)): a fresh PID-file mtime (within `HEARTBEAT_INTERVAL_SECONDS * 3`) keeps the wrapper in the ALIVE bucket, eliminating false alarms from transient races.
 
 ## Failure modes by step
 

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -387,6 +387,37 @@ The `Mode: startup-failure` exclusion matters: `autonomous-dev.sh`'s startup-fai
 - `tests/unit/test-pid-guard-pgid.sh` (18 cases) — TC-PGID-001 (new session under setsid), TC-PGID-002+004 (group-kill reaps grandchildren), TC-PGID-005 (pgrep fallback), TC-PGID-008/009 (`AGENT_PID_FILE` write contract), plus TC-STATIC-001..006 for source-of-truth.
 - `tests/unit/test-sigterm-trap.sh` updated to accept either inline `on_sigterm` or `install_agent_sigterm_trap` factoring.
 
+## INV-24: Review wrapper DEAD detection requires both pid_alive miss AND no near-success PR signal
+
+**Rule**: The dispatcher's Step 5b review-DEAD branch MUST NOT post a "Review process appears to have crashed" comment or flip `reviewing` → `pending-dev` on a bare `pid_alive` miss. It must additionally consult `review_near_success` (in `lib-dispatch.sh`), which returns 0 (skip) when ANY of these PR-state signals are positive within `REVIEW_NEAR_SUCCESS_WINDOW_SECONDS` (default 300s):
+
+1. `PR.mergedAt` within the window — wrapper is finishing the merge step.
+2. Most recent `APPROVED` review event within the window — wrapper has reached approve step.
+3. Most recent `^Review (PASSED|findings)` comment within the window — wrapper completed verdict, may be merging or just exiting normally.
+4. Defensive `kill -0 <pid>` against the current PID-file content now succeeds — the original `pid_alive` miss raced with the wrapper's normal scheduling.
+
+Only when ALL four signals are negative does the existing crash + label-swap fire.
+
+Complementary, `pid_alive` itself MUST honor a heartbeat-based mtime fallback: when `kill -0 <pid>` fails but the PID file's mtime is within `HEARTBEAT_INTERVAL_SECONDS * 3` (default 360s), still treat as ALIVE. The wrapper's `install_agent_heartbeat` helper (in `lib-agent.sh`) refreshes the mtime every `HEARTBEAT_INTERVAL_SECONDS` (default 120s) for its lifetime, so a stale mtime is strong evidence the process is genuinely dead.
+
+**Why**: Real review wrappers routinely run 15-30 min (E2E browser automation + multiple bot rounds + line-by-line review). The cold-start grace period (`DISPATCH_GRACE_PERIOD_SECONDS=600`) is sized for dev-side hangs, not review duration; cranking it to 1800 globally would make legitimate dev hangs take 30 min to detect. The right fix is to make the DEAD-branch decision smarter, not the grace longer (#111).
+
+Pre-fix, a transient `pid_alive` miss (race or short-lived sub-shell exit) within the 21-min review window made the dispatcher post a misleading "crashed" comment and flip the label, even though the wrapper subsequently posted PASSED + auto-merged the PR. The user-visible result was correct, but the timeline was noisy and the label remained stuck on `pending-dev` after the issue closed.
+
+**Producer**: `lib-dispatch.sh::review_near_success` + `lib-dispatch.sh::pid_alive` (mtime tier) + `lib-agent.sh::install_agent_heartbeat`.
+
+**Consumer**: `dispatcher-tick.sh` Step 5b review branch — guards the crash comment + label swap behind `review_near_success`.
+
+**Disable knobs**:
+- `REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=0` — restores legacy strict behavior (every `pid_alive` miss declares crashed). Useful for ops who hit edge cases with the four-signal cross-check.
+- `HEARTBEAT_INTERVAL_SECONDS=0` — disables both the wrapper-side heartbeat spawn and the dispatcher-side mtime fallback. Useful for hosts where the background loop is undesired.
+
+**Status**: **ENFORCED** in this PR (closes #111).
+
+**Test**:
+- `tests/unit/test-dispatcher-review-near-success.sh` (6 cases) — TC-RNS-001..004 cover each signal positive; TC-RNS-005 covers all signals negative (crash path still fires); TC-RNS-006 covers the `=0` legacy strict knob.
+- `tests/unit/test-wrapper-heartbeat.sh` (7 cases) — TC-HB-001..004 cover `pid_alive` decision matrix; TC-HB-005..007 cover heartbeat lifecycle (touches mtime, exits with parent, `=0` no-op).
+
 ## Adding a new invariant
 
 When fixing a pipeline bug, after locating the bug on the state machine + flow docs:

--- a/docs/test-cases/dispatcher-review-near-success.md
+++ b/docs/test-cases/dispatcher-review-near-success.md
@@ -1,0 +1,87 @@
+# Test Cases: dispatcher-review-near-success (#111)
+
+## TC-RNS-001: PR-state cross-check — recent merge
+
+**Setup**: Step 5b review branch, `pid_alive` returns 1, PR `mergedAt`
+within `REVIEW_NEAR_SUCCESS_WINDOW_SECONDS`.
+
+**Expected**: `review_near_success` returns 0 (skip). No "crashed" comment
+posted, no label swap.
+
+## TC-RNS-002: PR-state cross-check — recent APPROVED review
+
+**Setup**: `pid_alive` miss, PR has no `mergedAt`, but most recent review
+event is APPROVED within window.
+
+**Expected**: `review_near_success` returns 0. No "crashed" comment.
+
+## TC-RNS-003: PR-state cross-check — recent verdict comment
+
+**Setup**: `pid_alive` miss, no merge, no approval, but issue has a
+recent comment matching `^Review (PASSED|findings)` within window.
+
+**Expected**: `review_near_success` returns 0. No "crashed" comment.
+
+## TC-RNS-004: PR-state cross-check — defensive PID re-check
+
+**Setup**: `pid_alive` miss on first call, but `kill -0` against the
+PID-file content now succeeds (race recovered).
+
+**Expected**: `review_near_success` returns 0 (defer to next cycle).
+
+## TC-RNS-005: PR-state cross-check — all signals negative
+
+**Setup**: `pid_alive` miss, no merge, no approval, no recent verdict
+comment, defensive PID re-check fails.
+
+**Expected**: `review_near_success` returns 1. The existing crash path
+fires (caller posts "crashed" comment + label swap).
+
+## TC-RNS-006: REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=0
+
+**Setup**: `pid_alive` miss; even though merge / approval signals exist,
+the operator has set the window to 0.
+
+**Expected**: `review_near_success` returns 1 (legacy strict behavior
+preserved).
+
+## TC-HB-001: pid_alive — kill -0 success
+
+**Setup**: PID file points at a live process.
+
+**Expected**: `pid_alive` returns 0 immediately (no mtime check needed).
+
+## TC-HB-002: pid_alive — kill -0 fails, mtime fresh
+
+**Setup**: PID file content points at a non-existent PID, but file mtime
+is within `HEARTBEAT_INTERVAL_SECONDS * 3`.
+
+**Expected**: `pid_alive` returns 0 (treat as ALIVE, race / transition).
+
+## TC-HB-003: pid_alive — kill -0 fails, mtime stale
+
+**Setup**: PID file content points at a non-existent PID, file mtime is
+older than `HEARTBEAT_INTERVAL_SECONDS * 3`.
+
+**Expected**: `pid_alive` returns 1 (DEAD).
+
+## TC-HB-004: heartbeat lifecycle — touches PID file
+
+**Setup**: `install_agent_heartbeat` is called with a PID file path,
+`HEARTBEAT_INTERVAL_SECONDS=1`. Wait > 1s.
+
+**Expected**: PID file mtime advances (recently touched).
+
+## TC-HB-005: heartbeat exits when wrapper exits
+
+**Setup**: Spawn a subshell, install heartbeat, then exit subshell.
+
+**Expected**: No orphan heartbeat process — the heartbeat exits within
+2s of its parent.
+
+## TC-HB-006: HEARTBEAT_INTERVAL_SECONDS=0 disables heartbeat
+
+**Setup**: `HEARTBEAT_INTERVAL_SECONDS=0`, install heartbeat.
+
+**Expected**: No background process spawned (the `install` is a no-op).
+PID file mtime does NOT advance.

--- a/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
@@ -130,6 +130,12 @@ install_agent_sigterm_trap
 acquire_pid_guard "$PID_FILE" "autonomous-dev" "$ISSUE_NUMBER"
 export AGENT_PID_FILE="$PID_FILE"
 
+# Heartbeat: refresh PID-file mtime on a timer so the dispatcher's
+# pid_alive mtime fallback (#111 Part B) can distinguish a transient
+# `kill -0` race from a genuinely dead wrapper. Disabled when
+# HEARTBEAT_INTERVAL_SECONDS=0.
+install_agent_heartbeat
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -138,6 +144,14 @@ log() { echo "[autonomous-dev] $(date -u +%H:%M:%S) $*"; }
 # Ensure labels are updated on exit (trap)
 cleanup() {
   local exit_code=$?
+
+  # Tear down the heartbeat loop fast (parent-pid watchdog would also
+  # take it down within HEARTBEAT_INTERVAL_SECONDS, but explicit is
+  # cheaper). The kill is allowed to fail — the loop may already have
+  # exited on its own.
+  if [[ -n "${_AGENT_HEARTBEAT_PID:-}" ]]; then
+    command kill "$_AGENT_HEARTBEAT_PID" 2>/dev/null || true
+  fi
 
   # Cleanup PID file always
   rm -f "$PID_FILE" 2>/dev/null || true

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -111,6 +111,12 @@ install_agent_sigterm_trap
 acquire_pid_guard "$PID_FILE" "autonomous-review" "$ISSUE_NUMBER"
 export AGENT_PID_FILE="$PID_FILE"
 
+# Heartbeat: refresh PID-file mtime on a timer so the dispatcher's
+# pid_alive mtime fallback (#111 Part B) can distinguish a transient
+# `kill -0` race from a genuinely dead wrapper. Disabled when
+# HEARTBEAT_INTERVAL_SECONDS=0.
+install_agent_heartbeat
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -121,6 +127,14 @@ RESULT_PARSED=false
 
 cleanup() {
   local exit_code=$?
+
+  # Tear down the heartbeat loop fast (parent-pid watchdog would also
+  # take it down within HEARTBEAT_INTERVAL_SECONDS, but explicit is
+  # cheaper). The kill is allowed to fail — the loop may already have
+  # exited on its own.
+  if [[ -n "${_AGENT_HEARTBEAT_PID:-}" ]]; then
+    command kill "$_AGENT_HEARTBEAT_PID" 2>/dev/null || true
+  fi
 
   # Cleanup PID file always
   rm -f "$PID_FILE" 2>/dev/null || true

--- a/skills/autonomous-dispatcher/scripts/autonomous.conf.example
+++ b/skills/autonomous-dispatcher/scripts/autonomous.conf.example
@@ -166,6 +166,30 @@ MAX_RETRIES=3
 # positive crash detection is the failure mode this knob exists to prevent).
 DISPATCH_GRACE_PERIOD_SECONDS=600
 
+# Wrapper heartbeat interval ([INV-24], #111 Part B).
+# autonomous-dev.sh / autonomous-review.sh spawn a background loop that
+# touches their PID file every HEARTBEAT_INTERVAL_SECONDS while they're
+# running. The dispatcher's pid_alive check then honors a mtime-based
+# fallback: a stale `kill -0` is upgraded to ALIVE if the PID-file mtime
+# is within HEARTBEAT_INTERVAL_SECONDS * 3 (default 360s).
+#
+# Why: long-running review wrappers (15-30 min E2E + multi-bot rounds)
+# routinely race with the dispatcher's pid_alive probe. A positive
+# heartbeat signal lets the dispatcher distinguish "wrapper still
+# working" from "wrapper truly hung". Set to 0 to disable both the
+# wrapper-side spawn and the dispatcher-side mtime fallback.
+HEARTBEAT_INTERVAL_SECONDS=120
+
+# Review near-success window ([INV-24], #111 Part A).
+# In Step 5b's review-DEAD branch, before declaring "crashed" the
+# dispatcher cross-checks four PR-state signals — recent merge, recent
+# APPROVED review, recent "Review PASSED|findings" comment, defensive
+# kill -0 retry. If any is positive within this window, the crash path
+# is skipped; the wrapper is either finishing or in its post-verdict
+# tail. Set to 0 to restore legacy strict behavior (every pid_alive
+# miss declares crashed).
+REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=300
+
 # === Dev Agent ===
 DEV_SKILL_CMD="/autonomous-dev"
 

--- a/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
@@ -450,7 +450,24 @@ for i in $(seq 0 $((cand_count - 1))); do
         label_swap "$issue_num" "in-progress" "pending-review"
       fi
     else
-      # DEAD + reviewing: review wrapper crashed without its own trap firing.
+      # DEAD + reviewing: review wrapper appears to have crashed.
+      #
+      # #111 Part A: cross-check PR-state signals before declaring
+      # crashed. Long-running review wrappers (15-30 min E2E + multi-bot
+      # rounds) routinely hit transient pid_alive races, and the
+      # near-success window covers the wrapper's post-verdict / merge
+      # tail. review_near_success returns 0 when ANY of these are true
+      # within REVIEW_NEAR_SUCCESS_WINDOW_SECONDS:
+      #   - PR.mergedAt within window
+      #   - most recent APPROVED review within window
+      #   - "Review PASSED|findings" comment within window
+      #   - defensive `kill -0 <pid>` re-check now succeeds (race)
+      # When any signal fires, leave `reviewing` alone and defer to next
+      # tick — the wrapper either already finished or is mid-merge.
+      if review_near_success "$issue_num"; then
+        echo "INFO: issue ${issue_num} review wrapper pid_alive miss but PR-state signal positive; deferring crash declaration (#111 INV-24)" >&2
+        continue
+      fi
       gh issue comment "$issue_num" --repo "$REPO" \
         --body "Review process appears to have crashed. Moving to pending-dev for retry."
       label_swap "$issue_num" "reviewing" "pending-dev"

--- a/skills/autonomous-dispatcher/scripts/lib-agent.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-agent.sh
@@ -173,6 +173,45 @@ install_agent_sigterm_trap() {
   ' TERM
 }
 
+# install_agent_heartbeat — spawn a background loop that touches
+# AGENT_PID_FILE every HEARTBEAT_INTERVAL_SECONDS (#111 Part B). The loop
+# is parent-pid-watched: when the wrapper shell exits, `kill -0 <parent>`
+# fails and the loop terminates. No orphan heartbeats after wrapper exit.
+#
+# Sets _AGENT_HEARTBEAT_PID so the wrapper's cleanup() trap can SIGTERM
+# the heartbeat at exit (defense in depth — the parent-pid watchdog is
+# the primary lifecycle gate, but explicit teardown is faster).
+#
+# HEARTBEAT_INTERVAL_SECONDS=0 disables heartbeat entirely (no spawn) —
+# the regression-safety knob for ops who hit edge cases.
+#
+# AGENT_PID_FILE must exist before calling this helper. The loop is
+# tolerant of a missing or symlinked file (skips touch silently); the
+# wrapper's acquire_pid_guard / spawn path remains the authoritative
+# writer.
+install_agent_heartbeat() {
+  local interval="${HEARTBEAT_INTERVAL_SECONDS:-120}"
+  # Defensive numeric guard: a typo'd config would otherwise raise an
+  # arithmetic error under set -e. Treat non-numeric as "disabled".
+  [[ "$interval" =~ ^[0-9]+$ ]] || return 0
+  [[ "$interval" -gt 0 ]] || return 0
+  [[ -n "${AGENT_PID_FILE:-}" ]] || return 0
+
+  local parent_pid=$$
+  local pid_file="$AGENT_PID_FILE"
+
+  (
+    while command kill -0 "$parent_pid" 2>/dev/null; do
+      if [[ -f "$pid_file" && ! -L "$pid_file" ]]; then
+        touch "$pid_file" 2>/dev/null || true
+      fi
+      sleep "$interval"
+    done
+  ) &
+  _AGENT_HEARTBEAT_PID=$!
+  disown "$_AGENT_HEARTBEAT_PID" 2>/dev/null || true
+}
+
 # Codex thread-id capture/recall.
 #
 # Codex `exec` mints its own thread (UUID) per invocation and does NOT accept

--- a/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
@@ -429,13 +429,42 @@ _pid_file_for() {
 
 # Returns 0 if the wrapper PID for this issue+kind is alive, 1 otherwise.
 # `kind` is "issue" (dev wrapper) or "review".
+#
+# Two-tier check (#111 Part B):
+#   1. `kill -0 <pid>` succeeds → ALIVE.
+#   2. `kill -0 <pid>` fails → check PID-file mtime. If it was touched
+#      within HEARTBEAT_INTERVAL_SECONDS * 3 (default 360s), still treat
+#      as ALIVE — the wrapper may be transitioning groups, exec'ing, or
+#      racing with us. The wrapper's install_agent_heartbeat helper
+#      (lib-agent.sh) keeps the mtime fresh while it's running, so a
+#      stale mtime is strong evidence the process is genuinely dead.
+#
+# HEARTBEAT_INTERVAL_SECONDS=0 disables the mtime fallback entirely
+# (legacy strict behavior).
 pid_alive() {
   local kind="$1" issue_num="$2"
   local pid_file pid
   pid_file=$(_pid_file_for "$kind" "$issue_num")
   [ -n "$pid_file" ] || return 1
   pid=$(cat "$pid_file" 2>/dev/null || echo "")
-  [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
+  [ -n "$pid" ] || return 1
+  if kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+
+  local hb_interval="${HEARTBEAT_INTERVAL_SECONDS:-120}"
+  # Defensive numeric guard: a typo here would silently flip ALIVE → DEAD,
+  # the exact failure mode #111 fixes. Treat non-numeric / negative as
+  # "fallback disabled" (legacy strict).
+  [[ "$hb_interval" =~ ^[0-9]+$ ]] || return 1
+  [ "$hb_interval" -gt 0 ] || return 1
+  [ -f "$pid_file" ] || return 1
+  local now mtime threshold
+  now=$(date -u +%s)
+  mtime=$(stat -c %Y "$pid_file" 2>/dev/null || stat -f %m "$pid_file" 2>/dev/null || echo "")
+  [ -n "$mtime" ] || return 1
+  threshold=$(( hb_interval * 3 ))
+  [ $(( now - mtime )) -lt "$threshold" ]
 }
 
 # Echoes the current PID for the issue+kind, or empty if none.
@@ -491,6 +520,86 @@ last_reviewed_head() {
   local issue_num="$1"
   gh issue view "$issue_num" --repo "$REPO" --json comments \
     -q '[.comments[].body | capture("Reviewed HEAD: `(?<sha>[0-9a-f]{7,40})`"; "g") | .sha] | last // empty'
+}
+
+# Step 5b: echoes seconds since the most recent review-agent verdict
+# comment on the issue. The verdict comment is matched on a leading
+# "Review PASSED" or "Review findings" — same prefix the wrapper writes
+# in autonomous-review.sh. Empty on parse failure / no match (caller
+# treats as "no recent verdict").
+latest_review_verdict_age_seconds() {
+  local issue_num="$1"
+  local latest_iso
+  latest_iso=$(gh issue view "$issue_num" --repo "$REPO" --json comments \
+    -q '[.comments[] | select(.body | test("^Review (PASSED|findings)"))] | last | .createdAt // empty')
+  [ -n "$latest_iso" ] || { echo ""; return; }
+  _iso_age_seconds "$latest_iso"
+}
+
+# Step 5b: review_near_success <issue_num>
+#
+# Returns 0 (skip the "crashed" path) if ANY of these PR-state signals are
+# positive within REVIEW_NEAR_SUCCESS_WINDOW_SECONDS (default 300s):
+#
+#   1. PR.mergedAt within window — wrapper finished merging.
+#   2. Most recent APPROVED review event within window — wrapper reached
+#      approve step.
+#   3. Most recent "Review PASSED|findings" comment within window —
+#      wrapper completed verdict.
+#   4. Defensive `kill -0 <pid>` against the current PID-file content
+#      now succeeds — the original pid_alive miss raced with the
+#      wrapper's normal scheduling.
+#
+# REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=0 disables the short-circuit (legacy
+# strict behavior — every pid_alive miss declares crashed).
+#
+# Returns 1 if all four signals are negative — caller proceeds with the
+# existing crashed-comment + label-swap.
+review_near_success() {
+  local issue_num="$1"
+  local window="${REVIEW_NEAR_SUCCESS_WINDOW_SECONDS:-300}"
+  # Defensive numeric guard: non-numeric / negative falls back to legacy
+  # strict (every pid_alive miss declares crashed) instead of silently
+  # short-circuiting on a malformed config.
+  [[ "$window" =~ ^[0-9]+$ ]] || return 1
+  [ "$window" -gt 0 ] || return 1
+
+  # Signals 1 + 2: PR.mergedAt and reviews[].
+  local pr_info merged_at approved_at age
+  pr_info=$(fetch_pr_for_issue "$issue_num" "number,mergedAt,reviews")
+  if [ -n "$pr_info" ]; then
+    merged_at=$(jq -r '.mergedAt // empty' <<<"$pr_info" 2>/dev/null)
+    if [ -n "$merged_at" ] && [ "$merged_at" != "null" ]; then
+      age=$(_iso_age_seconds "$merged_at")
+      if [ -n "$age" ] && [ "$age" -lt "$window" ]; then
+        return 0
+      fi
+    fi
+
+    approved_at=$(jq -r '[.reviews[]? | select(.state == "APPROVED") | .submittedAt] | sort | last // empty' <<<"$pr_info" 2>/dev/null)
+    if [ -n "$approved_at" ] && [ "$approved_at" != "null" ]; then
+      age=$(_iso_age_seconds "$approved_at")
+      if [ -n "$age" ] && [ "$age" -lt "$window" ]; then
+        return 0
+      fi
+    fi
+  fi
+
+  # Signal 3: review-agent verdict comment.
+  local verdict_age
+  verdict_age=$(latest_review_verdict_age_seconds "$issue_num")
+  if [ -n "$verdict_age" ] && [ "$verdict_age" -lt "$window" ]; then
+    return 0
+  fi
+
+  # Signal 4: defensive PID re-check.
+  local pid
+  pid=$(get_pid review "$issue_num")
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+
+  return 1
 }
 
 # Step 4a.5: PR-exists short-circuit on the pending-dev scan. Mirrors

--- a/tests/unit/test-dispatcher-review-near-success.sh
+++ b/tests/unit/test-dispatcher-review-near-success.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# test-dispatcher-review-near-success.sh — Unit tests for issue #111.
+#
+# Step 5b review branch must NOT declare a wrapper "crashed" on a bare
+# `pid_alive` miss when any of these PR-state signals are positive within
+# REVIEW_NEAR_SUCCESS_WINDOW_SECONDS:
+#
+#   1. PR.mergedAt within window
+#   2. Most recent APPROVED review event within window
+#   3. Most recent "Review PASSED|findings" verdict comment within window
+#   4. Defensive `kill -0 <pid>` re-check now succeeds (pid_alive race)
+#
+# The cross-check logic is extracted into a new lib-dispatch.sh helper
+# `review_near_success` so it can be unit tested in isolation.
+#
+# Run: bash tests/unit/test-dispatcher-review-near-success.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-dispatch.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Required env (lib-dispatch.sh enforces these via : "${VAR:?...}")
+export REPO=zxkane/autonomous-dev-team
+export REPO_OWNER=zxkane
+export PROJECT_ID=test-proj
+export MAX_RETRIES=3
+export MAX_CONCURRENT=5
+export REVIEW_NEAR_SUCCESS_WINDOW_SECONDS="${REVIEW_NEAR_SUCCESS_WINDOW_SECONDS:-300}"
+
+# ---------------------------------------------------------------------------
+# Mocks — overridden per test case.
+# ---------------------------------------------------------------------------
+_MOCK_PR_INFO=""        # JSON returned by fetch_pr_for_issue_with_reviews
+_MOCK_VERDICT_AGE=""    # seconds since most recent verdict comment ("" = none)
+_MOCK_PID=""            # PID stored "in" the PID file
+_MOCK_KILL0_RC="1"      # rc returned by defensive kill -0 (0 = alive)
+
+# Override fetch helper used by review_near_success.
+fetch_pr_for_issue() {
+  printf '%s' "$_MOCK_PR_INFO"
+}
+
+# review_near_success uses this helper to read seconds since the most
+# recent review-agent verdict comment.
+latest_review_verdict_age_seconds() {
+  printf '%s' "$_MOCK_VERDICT_AGE"
+}
+
+# get_pid is overridden to return a deterministic PID.
+get_pid() {
+  printf '%s' "$_MOCK_PID"
+}
+
+# Override kill so the defensive re-check is deterministic.
+# kill -0 <pid> is the only invocation we care about here.
+kill() {
+  if [ "${1:-}" = "-0" ]; then
+    return "$_MOCK_KILL0_RC"
+  fi
+  command kill "$@"
+}
+
+# Source the lib AFTER the mocks so the helpers can be redefined.
+# shellcheck disable=SC1090
+source "$LIB"
+# lib-dispatch.sh sets -e; turn it off so the assertion harness can
+# capture failing return codes without aborting the test process.
+set +e
+
+# Re-export overrides (sourcing the lib re-defines fetch_pr_for_issue /
+# get_pid; we need our mocks to win).
+fetch_pr_for_issue() {
+  printf '%s' "$_MOCK_PR_INFO"
+}
+get_pid() {
+  printf '%s' "$_MOCK_PID"
+}
+latest_review_verdict_age_seconds() {
+  printf '%s' "$_MOCK_VERDICT_AGE"
+}
+
+reset_mocks() {
+  _MOCK_PR_INFO=""
+  _MOCK_VERDICT_AGE=""
+  _MOCK_PID=""
+  _MOCK_KILL0_RC="1"
+}
+
+assert() {
+  local label="$1" rc="$2" expected_rc="$3"
+  if [ "$rc" = "$expected_rc" ]; then
+    echo -e "  ${GREEN}PASS${NC}: $label (rc=$rc)"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $label (got rc=$rc, expected rc=$expected_rc)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+echo
+echo "=== TC-RNS-001: PR mergedAt within window → returns 0 (skip crash) ==="
+reset_mocks
+recent_iso=$(date -u -d "@$(( $(date -u +%s) - 60 ))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+  || date -u -v-60S +"%Y-%m-%dT%H:%M:%SZ")
+_MOCK_PR_INFO=$(printf '{"number":42,"mergedAt":"%s","reviews":[]}' "$recent_iso")
+REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=300 review_near_success 42
+assert "recent merge → near-success" "$?" "0"
+
+echo
+echo "=== TC-RNS-002: most recent APPROVED review within window → 0 ==="
+reset_mocks
+recent_iso=$(date -u -d "@$(( $(date -u +%s) - 60 ))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+  || date -u -v-60S +"%Y-%m-%dT%H:%M:%SZ")
+_MOCK_PR_INFO=$(printf '{"number":42,"mergedAt":null,"reviews":[{"state":"APPROVED","submittedAt":"%s"}]}' "$recent_iso")
+REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=300 review_near_success 42
+assert "recent APPROVED review → near-success" "$?" "0"
+
+echo
+echo "=== TC-RNS-003: recent verdict comment within window → 0 ==="
+reset_mocks
+_MOCK_PR_INFO='{"number":42,"mergedAt":null,"reviews":[]}'
+_MOCK_VERDICT_AGE="60"
+REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=300 review_near_success 42
+assert "recent verdict comment → near-success" "$?" "0"
+
+echo
+echo "=== TC-RNS-004: defensive kill -0 re-check succeeds → 0 ==="
+reset_mocks
+_MOCK_PR_INFO='{"number":42,"mergedAt":null,"reviews":[]}'
+_MOCK_PID="99999"
+_MOCK_KILL0_RC="0"
+REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=300 review_near_success 42
+assert "defensive PID re-check alive → near-success" "$?" "0"
+
+echo
+echo "=== TC-RNS-005: all signals negative → returns 1 (caller proceeds) ==="
+reset_mocks
+old_iso=$(date -u -d "@$(( $(date -u +%s) - 99999 ))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+  || date -u -v-99999S +"%Y-%m-%dT%H:%M:%SZ")
+_MOCK_PR_INFO=$(printf '{"number":42,"mergedAt":"%s","reviews":[{"state":"COMMENTED","submittedAt":"%s"}]}' "$old_iso" "$old_iso")
+_MOCK_VERDICT_AGE=""
+_MOCK_PID="99999"
+_MOCK_KILL0_RC="1"
+REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=300 review_near_success 42
+assert "all negative → declare crashed" "$?" "1"
+
+echo
+echo "=== TC-RNS-006: REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=0 disables short-circuit ==="
+reset_mocks
+recent_iso=$(date -u -d "@$(( $(date -u +%s) - 60 ))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+  || date -u -v-60S +"%Y-%m-%dT%H:%M:%SZ")
+_MOCK_PR_INFO=$(printf '{"number":42,"mergedAt":"%s","reviews":[]}' "$recent_iso")
+REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=0 review_near_success 42
+assert "window=0 → legacy strict (return 1)" "$?" "1"
+
+echo
+echo "==============================================="
+echo -e "Total: $((PASS + FAIL)) tests, ${GREEN}${PASS} pass${NC}, ${RED}${FAIL} fail${NC}"
+echo "==============================================="
+
+[ "$FAIL" -eq 0 ]

--- a/tests/unit/test-wrapper-heartbeat.sh
+++ b/tests/unit/test-wrapper-heartbeat.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# test-wrapper-heartbeat.sh — Unit tests for issue #111 Part B.
+#
+# Tests:
+#   - pid_alive returns 0 when PID is alive (kill -0 path).
+#   - pid_alive returns 0 when PID is dead but PID-file mtime is fresh
+#     (within HEARTBEAT_INTERVAL_SECONDS * 3).
+#   - pid_alive returns 1 when PID is dead AND mtime is stale.
+#   - install_agent_heartbeat touches the PID file at least once during
+#     its interval.
+#   - install_agent_heartbeat exits cleanly when its parent shell exits
+#     (no orphan loop).
+#   - HEARTBEAT_INTERVAL_SECONDS=0 disables heartbeat (no spawn).
+#
+# Run: bash tests/unit/test-wrapper-heartbeat.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPTS_DIR="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Required env (sourced libs enforce these via : "${VAR:?...}")
+export REPO=zxkane/autonomous-dev-team
+export REPO_OWNER=zxkane
+export PROJECT_ID=test-proj-heartbeat
+export MAX_RETRIES=3
+export MAX_CONCURRENT=5
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"; jobs -p | xargs -r kill 2>/dev/null || true' EXIT
+
+PIDFILE="$TMPDIR/issue-1.pid"
+
+assert_rc() {
+  local label="$1" rc="$2" expected="$3"
+  if [ "$rc" = "$expected" ]; then
+    echo -e "  ${GREEN}PASS${NC}: $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $label (rc=$rc, expected $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_true() {
+  local label="$1" cond="$2"
+  if [ "$cond" = "1" ]; then
+    echo -e "  ${GREEN}PASS${NC}: $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $label"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# pid_alive tests — invoke the helper directly via a stubbed _pid_file_for.
+# ---------------------------------------------------------------------------
+
+# shellcheck disable=SC1091
+source "$SCRIPTS_DIR/lib-dispatch.sh"
+# lib-dispatch.sh sets -e; turn it off so a returning-1 helper doesn't
+# abort the test process before the assertion harness can read $?.
+set +e
+
+# Override _pid_file_for so pid_alive picks up our test PIDFILE.
+_pid_file_for() { echo "$PIDFILE"; }
+
+echo
+echo "=== TC-HB-001: pid_alive — live PID returns 0 ==="
+# Use the current shell's PID — it's guaranteed alive.
+echo $$ >"$PIDFILE"
+pid_alive issue 1
+assert_rc "live PID → alive" "$?" "0"
+
+echo
+echo "=== TC-HB-002: pid_alive — dead PID, fresh mtime → 0 ==="
+echo "999999" >"$PIDFILE"
+HEARTBEAT_INTERVAL_SECONDS=10 pid_alive issue 1
+assert_rc "dead PID + fresh mtime → alive" "$?" "0"
+
+echo
+echo "=== TC-HB-003: pid_alive — dead PID, stale mtime → 1 ==="
+echo "999999" >"$PIDFILE"
+# Set mtime to 1000s ago. HEARTBEAT_INTERVAL_SECONDS=10 → threshold 30s.
+old_t=$(date -u -d "@$(( $(date +%s) - 1000 ))" +"%Y%m%d%H%M.%S" 2>/dev/null \
+  || date -u -v-1000S +"%Y%m%d%H%M.%S")
+touch -t "$old_t" "$PIDFILE"
+HEARTBEAT_INTERVAL_SECONDS=10 pid_alive issue 1
+assert_rc "dead PID + stale mtime → dead" "$?" "1"
+
+echo
+echo "=== TC-HB-004: pid_alive — HEARTBEAT_INTERVAL_SECONDS=0 falls back to legacy ==="
+# With heartbeat disabled, the mtime fallback should NOT save a dead PID.
+echo "999999" >"$PIDFILE"
+touch "$PIDFILE"
+HEARTBEAT_INTERVAL_SECONDS=0 pid_alive issue 1
+assert_rc "heartbeat=0 + dead PID → dead (legacy)" "$?" "1"
+
+# ---------------------------------------------------------------------------
+# install_agent_heartbeat tests — must source lib-agent.sh, which has its
+# own deps. We isolate by exporting AGENT_PID_FILE and calling the helper
+# directly in a subshell.
+# ---------------------------------------------------------------------------
+
+# Avoid lib-agent.sh's heavy dependencies by stubbing what we need and
+# then sourcing only the helper. Since lib-agent.sh sources lib-config.sh,
+# we need PROJECT_ID set (already exported above).
+
+# Some functions in lib-agent.sh need lib-config.sh helpers; sourcing the
+# whole file is safe under set +u (we don't trigger run_agent here).
+set +u
+# shellcheck disable=SC1091
+source "$SCRIPTS_DIR/lib-agent.sh" 2>/dev/null || true
+set -u
+
+if ! type install_agent_heartbeat >/dev/null 2>&1; then
+  echo -e "  ${RED}FAIL${NC}: install_agent_heartbeat is not defined in lib-agent.sh"
+  FAIL=$((FAIL + 1))
+else
+  echo
+  echo "=== TC-HB-005: heartbeat touches PID file ==="
+  HB_PIDFILE="$TMPDIR/hb-touch.pid"
+  echo "$$" >"$HB_PIDFILE"
+  # Set mtime far in the past so an advance is unmistakable.
+  old_t=$(date -u -d "@$(( $(date +%s) - 1000 ))" +"%Y%m%d%H%M.%S" 2>/dev/null \
+    || date -u -v-1000S +"%Y%m%d%H%M.%S")
+  touch -t "$old_t" "$HB_PIDFILE"
+  before_mtime=$(stat -c %Y "$HB_PIDFILE" 2>/dev/null || stat -f %m "$HB_PIDFILE")
+
+  AGENT_PID_FILE="$HB_PIDFILE" HEARTBEAT_INTERVAL_SECONDS=1 \
+    install_agent_heartbeat
+  hb_pid="${_AGENT_HEARTBEAT_PID:-}"
+  sleep 2
+  after_mtime=$(stat -c %Y "$HB_PIDFILE" 2>/dev/null || stat -f %m "$HB_PIDFILE")
+  # Tear down the heartbeat we spawned.
+  [ -n "$hb_pid" ] && command kill "$hb_pid" 2>/dev/null || true
+
+  if [ "$after_mtime" -gt "$before_mtime" ]; then
+    assert_true "heartbeat advanced mtime ($before_mtime → $after_mtime)" "1"
+  else
+    assert_true "heartbeat advanced mtime ($before_mtime → $after_mtime)" "0"
+  fi
+
+  echo
+  echo "=== TC-HB-006: HEARTBEAT_INTERVAL_SECONDS=0 disables heartbeat ==="
+  HB_PIDFILE2="$TMPDIR/hb-disabled.pid"
+  echo "$$" >"$HB_PIDFILE2"
+  old_t=$(date -u -d "@$(( $(date +%s) - 1000 ))" +"%Y%m%d%H%M.%S" 2>/dev/null \
+    || date -u -v-1000S +"%Y%m%d%H%M.%S")
+  touch -t "$old_t" "$HB_PIDFILE2"
+  before_mtime=$(stat -c %Y "$HB_PIDFILE2" 2>/dev/null || stat -f %m "$HB_PIDFILE2")
+  unset _AGENT_HEARTBEAT_PID
+  AGENT_PID_FILE="$HB_PIDFILE2" HEARTBEAT_INTERVAL_SECONDS=0 \
+    install_agent_heartbeat
+  sleep 2
+  after_mtime=$(stat -c %Y "$HB_PIDFILE2" 2>/dev/null || stat -f %m "$HB_PIDFILE2")
+  if [ "$after_mtime" = "$before_mtime" ] && [ -z "${_AGENT_HEARTBEAT_PID:-}" ]; then
+    assert_true "interval=0 → no spawn, no mtime advance" "1"
+  else
+    assert_true "interval=0 → no spawn, no mtime advance (got hb_pid='${_AGENT_HEARTBEAT_PID:-}', mtime $before_mtime → $after_mtime)" "0"
+  fi
+
+  echo
+  echo "=== TC-HB-007: heartbeat exits when parent exits ==="
+  HB_PIDFILE3="$TMPDIR/hb-orphan.pid"
+  echo "$$" >"$HB_PIDFILE3"
+  # Spawn a subshell that installs heartbeat then exits. The heartbeat's
+  # parent-pid watchdog should make it exit promptly.
+  hb_child_pid=$(
+    bash -c "
+      set +u
+      source '$SCRIPTS_DIR/lib-agent.sh' 2>/dev/null || true
+      set -u
+      AGENT_PID_FILE='$HB_PIDFILE3' HEARTBEAT_INTERVAL_SECONDS=1 install_agent_heartbeat
+      echo \"\${_AGENT_HEARTBEAT_PID:-}\"
+    "
+  )
+  # Give the watchdog up to 4s to react to the parent exit.
+  for _ in 1 2 3 4 5 6 7 8; do
+    if [ -n "$hb_child_pid" ] && command kill -0 "$hb_child_pid" 2>/dev/null; then
+      sleep 1
+    else
+      break
+    fi
+  done
+  if [ -z "$hb_child_pid" ] || ! command kill -0 "$hb_child_pid" 2>/dev/null; then
+    assert_true "heartbeat process exited with parent" "1"
+  else
+    assert_true "heartbeat process exited with parent (still running pid=$hb_child_pid)" "0"
+    command kill -9 "$hb_child_pid" 2>/dev/null || true
+  fi
+fi
+
+echo
+echo "==============================================="
+echo -e "Total: $((PASS + FAIL)) tests, ${GREEN}${PASS} pass${NC}, ${RED}${FAIL} fail${NC}"
+echo "==============================================="
+
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Closes #111.

The dispatcher's Step 5b review-DEAD branch posted "Review process appears
to have crashed" purely on a `pid_alive` miss after the cold-start grace
period. Real review wrappers run 15-30 min (E2E + multi-bot rounds +
line-by-line review) and routinely race transient `pid_alive` probes,
producing misleading "crashed" comments and `pending-dev` label residue
even though the wrapper went on to PASS + auto-merge.

Two complementary fixes, delivered together:

**Part A — PR-state cross-check** (`lib-dispatch.sh::review_near_success`)
Before declaring crashed, consult four signals within
`REVIEW_NEAR_SUCCESS_WINDOW_SECONDS` (default 300s):
1. `PR.mergedAt`
2. most recent APPROVED review event
3. most recent `^Review (PASSED|findings)` comment
4. defensive `kill -0` re-check (race recovery)

If any is positive, defer to next tick. Set to 0 to restore legacy strict
behavior.

**Part B — Wrapper heartbeat** (`lib-agent.sh::install_agent_heartbeat`)
Both wrappers spawn a background loop that touches `AGENT_PID_FILE` every
`HEARTBEAT_INTERVAL_SECONDS` (default 120s, parent-pid watched).
`pid_alive` upgrades a `kill -0` miss to ALIVE if mtime is within
`HEARTBEAT_INTERVAL_SECONDS * 3`. Set interval to 0 to disable.

Documents [INV-24](docs/pipeline/invariants.md) and cross-references it
from `dispatcher-flow.md` Step 5b. New env vars documented in
`autonomous.conf.example`.

## Design

- [x] Design canvas created (`docs/designs/dispatcher-review-near-success.md`)
- [x] Design approved (issue describes the approach in detail; this PR
  follows it byte-for-byte)

## Test Plan

- [x] Test cases documented (`docs/test-cases/dispatcher-review-near-success.md`)
- [x] Build passes (no build step; bash scripts)
- [x] Unit tests pass (`bash tests/unit/test-dispatcher-review-near-success.sh` — 6/6)
- [x] Unit tests pass (`bash tests/unit/test-wrapper-heartbeat.sh` — 7/7)
- [x] Regression: `tests/unit/test-dispatcher-step4-stale-verdict.sh` — 23/23
- [x] Regression: `tests/unit/test-pid-guard-pgid.sh` — 18/18
- [x] Regression: `tests/unit/test-kill-before-spawn.sh` — 24/24
- [ ] CI checks pass
- [x] Code simplification review passed
- [x] PR review agent review passed (LGTM, no blocking findings)
- [ ] Reviewer bot findings addressed (no new findings)
- [ ] E2E tests pass (N/A — no E2E surface for shell library changes)

## Checklist

- [x] New unit tests written for new functionality (13 cases total
  covering each signal positive, all-negative crash path, legacy-strict
  knob, heartbeat lifecycle, and `=0` disable paths)
- [x] Documentation updated (INV-24 in `invariants.md`, Step 5b reference
  in `dispatcher-flow.md`, env vars in `autonomous.conf.example`)
- [x] No regression to #109 PGID-tracking contract (PID-file semantics
  unchanged: leader PID == PGID; heartbeat only refreshes mtime, never
  rewrites the PID)