### PR TITLE
fix(dispatcher): list_stale_candidates excludes approved (#115 Bug A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,14 @@ This project enforces a strict TDD development workflow through agent hooks. The
 
 > Hooks are supported in Claude Code and Kiro CLI. For agents without hook support (Cursor, Windsurf, Gemini CLI), follow each step manually — the discipline is the same.
 
+### Pipeline Documentation Authority
+
+`docs/pipeline/*.md` (`state-machine.md`, `invariants.md`, `dispatcher-flow.md`, `dev-agent-flow.md`, `review-agent-flow.md`, `handoffs.md`) is the **spec** for the dispatcher / dev wrapper / review wrapper subsystem. Any code change to those wrappers MUST update the corresponding pipeline doc in the **same PR**.
+
+When code and docs disagree, the **docs are authoritative** — code that diverges from a documented invariant is a bug, not the doc. New invariants get a new `INV-NN` entry in `invariants.md`; new label transitions update the `state-machine.md` mermaid diagram and the "Invalid combinations" section. PR reviewers reject pipeline-touching PRs that ship without the matching doc update.
+
+This rule is scoped to the dispatcher/wrapper subsystem; the rest of the repo follows ordinary docs-keep-up-to-date hygiene.
+
 ### Workflow Summary
 
 ```
@@ -84,6 +92,7 @@ Before merging any PR, confirm:
 - [ ] E2E tests pass
 - [ ] Peer review complete
 - [ ] Worktree cleaned up after merge
+- [ ] If the PR touches dispatcher / dev / review wrappers, the corresponding `docs/pipeline/*.md` (state-machine, invariants, *-flow, handoffs) is updated in the same PR — see [Pipeline Documentation Authority](#pipeline-documentation-authority)
 
 ---
 

--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -219,7 +219,7 @@ This is a conservative gate: it only fires when the helper is certain the prior 
 
 Implementation: `lib-dispatch.sh::list_stale_candidates`, `was_just_dispatched`, `pid_alive`, `get_pid`, `fetch_pr_for_issue`, `ci_is_green`, `pr_idle_seconds`, `last_reviewed_head`, `label_swap`.
 
-Find issues labeled `in-progress` OR `reviewing`.
+Find issues labeled `in-progress` OR `reviewing` **and not also `approved`**. The `approved` exclusion is critical: an issue in the `approved` terminal state that still carries a transitional label (residue from a wrapper crash between two label edits, or from the [INV-15](invariants.md#inv-15-step-5a-sigterm-race-is-non-deterministic) SIGTERM race) must not be treated as stale. Without the exclusion, Step 5 would swap the active label to `pending-dev`, which re-arms Step 4 on the next tick — an infinite loop burning tokens on a terminally-decided issue (issue #115 Bug A).
 
 For each match:
 

--- a/docs/test-cases/dispatcher-stale-candidates-approved.md
+++ b/docs/test-cases/dispatcher-stale-candidates-approved.md
@@ -1,0 +1,30 @@
+# Test Cases — `list_stale_candidates` excludes `approved`
+
+Tracks: issue #115 (Bug A).
+
+## Scenario
+
+`skills/autonomous-dispatcher/scripts/lib-dispatch.sh::list_stale_candidates`
+is the Step 5 stale-detection selector. Before this fix it returned every
+issue with the `autonomous` label whose label set contained `in-progress`
+or `reviewing`, without subtracting `approved`. When an `approved` issue
+also still carried a transitional label (residue from a wrapper crash
+between two label transitions, or from the [INV-15] SIGTERM race), Step 5
+re-classified it as stale and swapped the active label to `pending-dev`,
+which then re-armed Step 4 on the next tick — an infinite token-burning
+loop.
+
+## Test Cases
+
+| ID | Labels on fixture | `list_stale_candidates` returns | Why |
+|----|---|---|---|
+| TC-STALE-APPROVED-001 | `autonomous`, `in-progress`, `approved` | `[]` | Approved issues are terminal; Step 5 must not touch them |
+| TC-STALE-APPROVED-002 | `autonomous`, `reviewing`, `approved` | `[]` | Same rule, other transitional label |
+| TC-STALE-APPROVED-003 | `autonomous`, `in-progress` | one entry | Pre-existing behavior: actual stale candidates still detected |
+| TC-STALE-APPROVED-004 | `autonomous`, `reviewing` | one entry | Pre-existing behavior preserved |
+
+## Acceptance
+
+- TC-001 and TC-002 fail against current `main` (regression coverage)
+- TC-003 and TC-004 pass against current `main` AND after the fix
+- All four pass after the fix

--- a/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
@@ -77,10 +77,20 @@ list_pending_dev() {
 # Step 5: issues currently in active state (in-progress OR reviewing) — same
 # query as count_active but returning {number, labels} so callers can branch on
 # which active label is set.
+#
+# `approved` is subtracted: an issue in the `approved` terminal state that
+# still carries a transitional label (residue from a wrapper crash between
+# two label edits, or from the [INV-15] SIGTERM race) must NOT be treated
+# as stale. Issue #115 Bug A: without this exclusion, Step 5 swaps the
+# active label to `pending-dev`, which re-arms Step 4 on the next tick —
+# infinite loop burning tokens on a terminally-decided issue.
 list_stale_candidates() {
   gh issue list --repo "$REPO" --state open --limit 100 \
     --label "autonomous" --json number,labels \
-    -q '[.[] | select(.labels[].name | IN("in-progress","reviewing"))]'
+    -q '[.[] | select(
+      (.labels[].name | IN("in-progress","reviewing")) and
+      ([.labels[].name] | contains(["approved"]) | not)
+    )]'
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test-list-stale-candidates-approved.sh
+++ b/tests/unit/test-list-stale-candidates-approved.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# test-list-stale-candidates-approved.sh — Regression for issue #115 Bug A.
+#
+# `list_stale_candidates` (Step 5 stale-detection in lib-dispatch.sh)
+# previously selected every issue with `in-progress` or `reviewing`
+# without subtracting `approved`. When an `approved` issue still carried
+# a transitional label, Step 5 misclassified it as stale and swapped to
+# `pending-dev`, re-arming Step 4 on the next tick — infinite token-burn
+# loop.
+#
+# Mirrors the fixture-and-stub pattern from test-lib-dispatch.sh: stub
+# `gh issue list` to emit a controlled JSON array, then run the
+# `list_stale_candidates` jq pipeline against it.
+#
+# Run: bash tests/unit/test-list-stale-candidates-approved.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-dispatch.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+export REPO=zxkane/autonomous-dev-team
+export REPO_OWNER=zxkane
+export PROJECT_ID=test-stale-approved
+export MAX_RETRIES=3
+export MAX_CONCURRENT=5
+
+# Stub `gh issue list ... --json number,labels -q '...'`. The real call
+# emits a JSON array of {number, labels:[{name,...}]}. Tests set
+# _MOCK_ISSUE_LIST to the JSON array; the stub feeds it through jq with
+# whatever -q expression `list_stale_candidates` passes.
+_MOCK_ISSUE_LIST=""
+gh() {
+  local q_expr=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -q) q_expr="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [[ -n "$q_expr" ]]; then
+    jq "$q_expr" <<<"${_MOCK_ISSUE_LIST:-[]}"
+  else
+    printf '%s' "${_MOCK_ISSUE_LIST:-[]}"
+  fi
+}
+export -f gh
+
+# shellcheck source=../../skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+source "$LIB"
+set +e
+
+assert_count() {
+  local desc="$1" expected="$2" json="$3"
+  local actual
+  actual=$(jq 'length' <<<"$json")
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc (count=$actual)"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected count=$expected"
+    echo "      actual count=  $actual"
+    echo "      json=          $json"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+mklabels() {
+  # mklabels foo bar baz -> [{"name":"foo"},{"name":"bar"},{"name":"baz"}]
+  local out="["
+  local first=1
+  for n in "$@"; do
+    if [[ $first -eq 1 ]]; then first=0; else out+=","; fi
+    out+="{\"name\":\"$n\"}"
+  done
+  out+="]"
+  printf '%s' "$out"
+}
+
+mkissue() {
+  # mkissue NUMBER label1 label2 ... -> {"number":NUMBER,"labels":[...]}
+  local num="$1"; shift
+  printf '{"number":%s,"labels":%s}' "$num" "$(mklabels "$@")"
+}
+
+echo "=== TC-STALE-APPROVED-001..004: list_stale_candidates approved exclusion ==="
+
+# TC-001: in-progress + approved → MUST be excluded
+_MOCK_ISSUE_LIST="[$(mkissue 101 autonomous in-progress approved)]"
+out=$(list_stale_candidates)
+assert_count "TC-001 in-progress+approved excluded" 0 "$out"
+
+# TC-002: reviewing + approved → MUST be excluded
+_MOCK_ISSUE_LIST="[$(mkissue 102 autonomous reviewing approved)]"
+out=$(list_stale_candidates)
+assert_count "TC-002 reviewing+approved excluded" 0 "$out"
+
+# TC-003: in-progress alone → MUST still be detected (pre-existing behavior)
+_MOCK_ISSUE_LIST="[$(mkissue 103 autonomous in-progress)]"
+out=$(list_stale_candidates)
+assert_count "TC-003 in-progress alone detected" 1 "$out"
+
+# TC-004: reviewing alone → MUST still be detected
+_MOCK_ISSUE_LIST="[$(mkissue 104 autonomous reviewing)]"
+out=$(list_stale_candidates)
+assert_count "TC-004 reviewing alone detected" 1 "$out"
+
+# Mixed bag — partial defense + partial detection in one query
+_MOCK_ISSUE_LIST="[$(mkissue 201 autonomous in-progress approved),$(mkissue 202 autonomous in-progress),$(mkissue 203 autonomous reviewing approved),$(mkissue 204 autonomous reviewing)]"
+out=$(list_stale_candidates)
+assert_count "TC-mixed: only the two non-approved are returned" 2 "$out"
+
+echo
+echo "=== Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Fix issue #115 Bug A: Step 5 `list_stale_candidates` now subtracts `approved`, matching the other four `list_*` selectors. This stops the infinite re-dispatch loop on terminally-decided issues that still carry a residual transitional label.
- Same PR lands two cross-cutting hardening pieces from the issue: `CLAUDE.md` "Pipeline Documentation Authority" rule (codifies what was missing — the docs are spec, code that diverges from `docs/pipeline/*.md` is a bug) + matching Acceptance Checklist line, and `dispatcher-flow.md` Step 5 description spelling out the exclusion.
- Bug B (hygiene pass + INV-25 + state-machine.md mermaid) and Bug C (suspected dev-wrapper label-flip — investigation only) are explicitly deferred to follow-up PRs per the issue's phased plan.

## Why CLAUDE.md is in this PR (not a separate doc PR)
The new "Pipeline Documentation Authority" rule is the rule whose absence let this bug ship in the first place — `docs/pipeline/state-machine.md:90` already documented "approved + any active state is invalid", but the code didn't enforce it. Landing the rule alongside the first instance of its enforcement keeps the lesson and the code change coupled. Out of scope for a typical bug fix; in scope for #115 because the issue explicitly calls for it.

## Design
- [x] Test case doc: `docs/test-cases/dispatcher-stale-candidates-approved.md`
- [x] No design canvas — 1-line jq predicate change

## Test Plan
- [x] Test cases documented (`docs/test-cases/dispatcher-stale-candidates-approved.md`)
- [x] New regression test fails pre-fix (TC-001, TC-002, TC-mixed) and passes post-fix
- [x] Full unit suite: 325/325 pass, 0 fail
- [x] Code simplification review: no further simplification possible (single jq predicate)
- [x] PR review agent: verdict "meets standards, safe to merge" — no blocking findings
- [ ] CI checks pass (will watch)
- [ ] Reviewer bot findings addressed (no new findings)
- [ ] E2E tests pass (this repo doesn't have an E2E surface for the dispatcher; covered by unit regression)

## Checklist
- [x] New unit test written for new behavior (`tests/unit/test-list-stale-candidates-approved.sh`)
- [x] Documentation updated in lockstep (`dispatcher-flow.md` Step 5 text)
- [x] CLAUDE.md updated with the new authority rule + checklist entry
- [x] Bugs B and C deferred to follow-up issues, called out above

Refs: #115