### PR TITLE
fix(dev-wrapper): anchor REVIEW_COMMENTS filter on review-agent prefixes (#113)

### DIFF
--- a/docs/pipeline/dev-agent-flow.md
+++ b/docs/pipeline/dev-agent-flow.md
@@ -86,7 +86,7 @@ The `AUTONOMOUS_CONF` env var bypass takes precedence over filesystem detection 
 
 ## Mode = resume
 
-1. **Fetch review feedback** from issue comments — most recent comment containing `Review findings` or `review`.
+1. **Fetch review feedback** from issue comments — most recent comment whose body **starts with** `Review findings` or `Review PASSED`. Both are wrapper-side prefixes the review agent emits; dispatcher status comments (e.g. `Dispatching autonomous review`, `Moving to pending-review for assessment`, `no new commits since last review at <sha>`) never start with either prefix and are correctly excluded. Pre-fix (#113) the second clause was a substring match on `review`, which let dispatcher chatter shadow real review findings whenever a status comment landed after the verdict — the resumed dev session would then see dispatcher noise as its `## Review Feedback` and make zero progress.
 2. **Fetch PR inline review comments** — find the PR linked to the issue, then `gh api repos/.../pulls/N/comments` for each line-anchored comment.
 3. Construct resume prompt with both feedback streams, again wrapped in `<user-issue-content>` tags.
 4. `resume_agent SESSION_ID PROMPT MODEL`. For claude: `claude --resume ID --permission-mode auto -p PROMPT --output-format json`. The `--name` flag is omitted on resume (claude doesn't update display name on resume).

--- a/docs/test-cases/dev-resume-review-comments-filter.md
+++ b/docs/test-cases/dev-resume-review-comments-filter.md
@@ -1,0 +1,47 @@
+# Test Cases — `REVIEW_COMMENTS` filter (resume-mode prompt)
+
+Tracks: issue #113.
+
+## Scenario
+
+`autonomous-dev.sh::resume` constructs a prompt that includes the most
+recent review feedback. The pre-fix selector
+
+```bash
+[.comments[] | select(.body | contains("Review findings") or contains("review"))] | last // empty
+```
+
+substring-matches the literal `review` against every comment body. Many
+dispatcher status comments contain that substring (`Dispatching
+autonomous review`, `Moving to pending-review for retry`,
+`no new commits since last review at <sha>`). When the most recent
+matching comment is a dispatcher status, `last` returns it instead of
+the actual review-findings body — the resume prompt then carries
+dispatcher chatter as `## Review Feedback`. Verified producer of stuck
+issues that resume forever without making progress.
+
+## Test Cases
+
+The fix tightens the filter to `startswith("Review findings") or
+startswith("Review PASSED")`. These tests pin the new behavior against
+fixtures crafted from real-world dispatcher comment bodies.
+
+| ID | Comments fixture (in chronological order) | Expected match |
+|----|---|---|
+| TC-RFB-001 | One real `Review findings: ... [BLOCKING] ...` comment | the real comment |
+| TC-RFB-002 | Real `Review findings` AT T0, then dispatcher `Moving to pending-review for retry` AT T1 | the real comment (dispatcher status SKIPPED) |
+| TC-RFB-003 | Real `Review findings` AT T0, then dispatcher `Dispatching autonomous review...` AT T1 | the real comment |
+| TC-RFB-004 | Real `Review findings` AT T0, then dispatcher `Dev process exited (no new commits since last review at <sha>)` AT T1 | the real comment |
+| TC-RFB-005 | Only `Review PASSED — All checklist items verified` (no findings yet) | the PASSED comment |
+| TC-RFB-006 | No matching comment (fresh issue, no review yet) | empty |
+| TC-RFB-007 | Multiple real review comments — `Review findings (round 1)` then `Review findings (round 2)` | round 2 (`last` semantics preserved) |
+| TC-RFB-008 | Real `Review findings`, then a comment whose body merely **mentions** "review" mid-sentence (e.g. `Owner: please re-trigger review`) | the real comment (mid-sentence "review" no longer matches) |
+
+## Acceptance
+
+- TC-RFB-002, 003, 004, 008 fail against current `main` (substring
+  match picks the dispatcher status / mention) and pass after the fix
+- TC-RFB-001, 005, 006, 007 pass on both sides of the fix (the new
+  filter does not regress these cases)
+- Test must use real dispatcher comment bodies copied verbatim from
+  the wild

--- a/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
@@ -318,9 +318,25 @@ EOF
   set -e
 
 elif [[ "$MODE" = "resume" ]]; then
-  # Fetch review feedback from issue comments
+  # Fetch review feedback from issue comments.
+  #
+  # The selector must match ONLY review-agent output, never dispatcher
+  # status comments. Pre-fix (#113) the second clause was
+  # `contains("review")`, which substring-matched literal `review`
+  # against every comment body — including dispatcher messages like
+  # `Dispatching autonomous review`, `Moving to pending-review for
+  # assessment`, and `no new commits since last review at <sha>`.
+  # When such a status landed AFTER a real `Review findings:` comment,
+  # `| last` returned the dispatcher chatter and the dev agent's
+  # resume prompt carried it as its "Review Feedback" — making real
+  # blocking findings invisible to the resumed session. See #113.
+  #
+  # Anchor on the literal prefixes the review wrapper writes: `Review
+  # findings` (verdict FAIL) and `Review PASSED` (verdict PASS). Both
+  # are wrapper-side strings; dispatcher status comments never start
+  # with either.
   REVIEW_COMMENTS=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json comments \
-    -q '[.comments[] | select(.body | contains("Review findings") or contains("review"))] | last // empty')
+    -q '[.comments[] | select(.body | startswith("Review findings") or startswith("Review PASSED"))] | last // empty')
 
   # Fetch PR number linked to this issue for inline review comments
   PR_NUM=$(gh pr list --repo "$REPO" --state open --json number,body \

--- a/tests/unit/test-resume-review-comments-filter.sh
+++ b/tests/unit/test-resume-review-comments-filter.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# test-resume-review-comments-filter.sh — Regression for issue #113.
+#
+# autonomous-dev.sh::resume builds a `REVIEW_COMMENTS` shell variable from
+# the most recent issue comment matching a jq filter; the prior filter
+# `contains("Review findings") or contains("review")` substring-matched
+# the literal `review` against every comment body, including dispatcher
+# status comments like "Dispatching autonomous review" / "Moving to
+# pending-review for retry" / "no new commits since last review at
+# <sha>". When such a status comment landed AFTER a real
+# review-findings comment, `| last` returned the status — the dev agent
+# then resumed with dispatcher chatter as its `## Review Feedback`.
+#
+# This test extracts the jq selector body and runs it against synthetic
+# `comments` fixtures that mirror real dispatcher message shapes.
+#
+# Run: bash tests/unit/test-resume-review-comments-filter.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DEV_WRAPPER="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous-dev.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Extract the jq filter expression from the wrapper. The wrapper
+# constructs REVIEW_COMMENTS via:
+#
+#   REVIEW_COMMENTS=$(gh issue view ... --json comments -q '<EXPR>')
+#
+# We pull the EXPR literal and run it against synthetic fixtures. This
+# couples the test to the wrapper's chosen filter, which is exactly
+# what we want — the test breaks if the filter regresses.
+extract_filter() {
+  awk '
+    /REVIEW_COMMENTS=\$\(gh issue view/ { in_block=1 }
+    in_block && /-q / {
+      # Capture the single-quoted jq expression on the -q line.
+      match($0, /-q '\''([^'\'']+)'\''/, a)
+      if (a[1] != "") { print a[1]; exit }
+    }
+  ' "$DEV_WRAPPER"
+}
+
+JQ_FILTER=$(extract_filter)
+if [[ -z "$JQ_FILTER" ]]; then
+  echo -e "${RED}FATAL${NC}: could not extract REVIEW_COMMENTS jq filter from $DEV_WRAPPER"
+  exit 2
+fi
+
+echo "Extracted filter: $JQ_FILTER"
+echo
+
+assert_body_match() {
+  local desc="$1" expected_substring="$2" actual_body="$3"
+  if [[ -z "$actual_body" ]]; then
+    if [[ "$expected_substring" == "<EMPTY>" ]]; then
+      echo -e "  ${GREEN}PASS${NC}: $desc (got empty as expected)"
+      PASS=$((PASS + 1))
+    else
+      echo -e "  ${RED}FAIL${NC}: $desc"
+      echo "      expected to contain: '$expected_substring'"
+      echo "      got: <EMPTY>"
+      FAIL=$((FAIL + 1))
+    fi
+    return
+  fi
+  if [[ "$actual_body" == *"$expected_substring"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected to contain: '$expected_substring'"
+    echo "      got: $(echo "$actual_body" | head -c 160)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Run the filter against a comments JSON array, return the body of the
+# selected comment (or "" if empty).
+run_filter() {
+  local comments_json="$1"
+  local result
+  # Wrap result through .body if jq returned an object.
+  result=$(jq -r "$JQ_FILTER | if type == \"object\" then .body else . end // \"\"" \
+    <<<"$comments_json" 2>/dev/null)
+  printf '%s' "$result"
+}
+
+# Fixture builders — using real dispatcher comment bodies from the wild.
+mk_comment() {
+  # mk_comment "<iso-timestamp>" "<body-with-quotes-escaped>"
+  local ts="$1" body="$2"
+  jq -n --arg ts "$ts" --arg body "$body" \
+    '{createdAt: $ts, body: $body}'
+}
+
+# Real dispatcher comment templates copied from #204 / #37 timelines.
+DISPATCH_REVIEW_TOKEN="<!-- dispatcher-token: abc123 at 2026-05-14T01:23:45Z mode=review -->
+Dispatching autonomous review..."
+# Real dev-wrapper trap message for the "exit 0 + PR present" path —
+# contains literal lowercase 'pending-review' which substring-matches
+# the buggy 'or contains(\"review\")' clause.
+MOVING_PENDING_REVIEW="Dev process exited (PR found). Moving to pending-review for assessment."
+DEV_NO_COMMITS="Dev process exited (no new commits since last review at \`abc1234\`). Moving to pending-dev for retry."
+REAL_FINDINGS_R1='Review findings:
+
+[BLOCKING] Missing input validation in `submitFeed`.
+[BLOCKING] DynamoDB TTL not configured on the new artifacts table.
+
+session: 11111111-1111-1111-1111-111111111111'
+REAL_FINDINGS_R2='Review findings:
+
+[BLOCKING] Round 2: regression on the cancel endpoint.
+
+session: 22222222-2222-2222-2222-222222222222'
+REAL_PASSED='Review PASSED - All checklist items verified, code quality good.
+
+session: 33333333-3333-3333-3333-333333333333'
+
+# ===================================================================
+echo "=== TC-RFB-001..008: REVIEW_COMMENTS filter regression ==="
+
+# TC-RFB-001 — only real review findings present, must pick it
+fixture=$(jq -n --argjson c1 "$(mk_comment '2026-05-14T01:00:00Z' "$REAL_FINDINGS_R1")" \
+  '{comments: [$c1]}')
+out=$(run_filter "$fixture")
+assert_body_match "TC-RFB-001 only real findings → picked" "[BLOCKING] Missing input validation" "$out"
+
+# TC-RFB-002 — real findings, then "Moving to pending-review for retry" later
+fixture=$(jq -n \
+  --argjson c1 "$(mk_comment '2026-05-14T01:00:00Z' "$REAL_FINDINGS_R1")" \
+  --argjson c2 "$(mk_comment '2026-05-14T01:30:00Z' "$MOVING_PENDING_REVIEW")" \
+  '{comments: [$c1, $c2]}')
+out=$(run_filter "$fixture")
+assert_body_match "TC-RFB-002 real findings preferred over 'Moving to pending-review' status" "[BLOCKING] Missing input validation" "$out"
+
+# TC-RFB-003 — real findings, then "Dispatching autonomous review..." later
+fixture=$(jq -n \
+  --argjson c1 "$(mk_comment '2026-05-14T01:00:00Z' "$REAL_FINDINGS_R1")" \
+  --argjson c2 "$(mk_comment '2026-05-14T01:30:00Z' "$DISPATCH_REVIEW_TOKEN")" \
+  '{comments: [$c1, $c2]}')
+out=$(run_filter "$fixture")
+assert_body_match "TC-RFB-003 real findings preferred over 'Dispatching autonomous review' status" "[BLOCKING] Missing input validation" "$out"
+
+# TC-RFB-004 — real findings, then "no new commits since last review at <sha>" later
+fixture=$(jq -n \
+  --argjson c1 "$(mk_comment '2026-05-14T01:00:00Z' "$REAL_FINDINGS_R1")" \
+  --argjson c2 "$(mk_comment '2026-05-14T01:30:00Z' "$DEV_NO_COMMITS")" \
+  '{comments: [$c1, $c2]}')
+out=$(run_filter "$fixture")
+assert_body_match "TC-RFB-004 real findings preferred over 'no new commits since last review' status" "[BLOCKING] Missing input validation" "$out"
+
+# TC-RFB-005 — only Review PASSED present, must pick it
+fixture=$(jq -n --argjson c1 "$(mk_comment '2026-05-14T01:00:00Z' "$REAL_PASSED")" \
+  '{comments: [$c1]}')
+out=$(run_filter "$fixture")
+assert_body_match "TC-RFB-005 'Review PASSED' picked when no findings exist" "Review PASSED" "$out"
+
+# TC-RFB-006 — no review comment at all (fresh issue, only dispatcher chatter)
+fixture=$(jq -n \
+  --argjson c1 "$(mk_comment '2026-05-14T00:30:00Z' "Dispatching autonomous development...")" \
+  --argjson c2 "$(mk_comment '2026-05-14T00:35:00Z' "Resuming autonomous development...")" \
+  '{comments: [$c1, $c2]}')
+out=$(run_filter "$fixture")
+assert_body_match "TC-RFB-006 no review comment → empty" "<EMPTY>" "$out"
+
+# TC-RFB-007 — multiple real review rounds, last wins
+fixture=$(jq -n \
+  --argjson c1 "$(mk_comment '2026-05-14T01:00:00Z' "$REAL_FINDINGS_R1")" \
+  --argjson c2 "$(mk_comment '2026-05-14T02:00:00Z' "$REAL_FINDINGS_R2")" \
+  '{comments: [$c1, $c2]}')
+out=$(run_filter "$fixture")
+assert_body_match "TC-RFB-007 multiple findings rounds → last wins" "Round 2: regression" "$out"
+
+# TC-RFB-008 — real findings, then a comment that merely MENTIONS "review" mid-sentence
+fixture=$(jq -n \
+  --argjson c1 "$(mk_comment '2026-05-14T01:00:00Z' "$REAL_FINDINGS_R1")" \
+  --argjson c2 "$(mk_comment '2026-05-14T01:30:00Z' "Owner: please re-trigger review on this PR when ready")" \
+  '{comments: [$c1, $c2]}')
+out=$(run_filter "$fixture")
+assert_body_match "TC-RFB-008 mid-sentence 'review' mention does not shadow real findings" "[BLOCKING] Missing input validation" "$out"
+
+echo
+echo "=== Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary
- Closes #113. Fixes the resume-mode `REVIEW_COMMENTS` selector in `autonomous-dev.sh` so dispatcher status comments can no longer shadow real review-agent feedback in the dev-resume prompt.
- 1-line jq predicate change (`contains("review")` → `startswith("Review findings") or startswith("Review PASSED")`). Same `REVIEW_COMMENTS` shell variable feeds both the RESUME_PROMPT and the resume-fallback FULL_PROMPT, so a single change covers both prompt paths.
- Producer side verified: review wrapper writes `Review findings:` / `Review PASSED` as the literal first characters of the verdict comment (autonomous-review.sh:494-509 + verdict-poll classifier at lines 626-628). Tighter contract is sound — no false negatives.

## Refs
Refs: #113. Note the deliberate `Refs:` (not `Closes:`) — only one issue is being closed and the close-keyword would auto-close on merge regardless. Using `Refs` keeps the link without surprising auto-closures.

## Background
Pre-fix, the substring `review` in the second clause matched every dispatcher message that mentioned the word — `Dispatching autonomous review`, `Moving to pending-review for assessment`, `no new commits since last review at <sha>`, owner-typed re-trigger mentions. Such status messages typically land AFTER the verdict (the wrapper trap and Step 4 flip labels with status comments after each round), so `| last` returned dispatcher chatter and the resumed dev session saw it as `## Review Feedback`. Real BLOCKING items disappeared from the prompt; sessions exited without progress; dispatcher saw "no new commits" and looped — feedback loop that locks an issue at HEAD forever, burning Claude budget per tick.

## Design
- [x] No design canvas — 1-line filter change, full rationale in the in-code comment block

## Test Plan
- [x] Test cases: `docs/test-cases/dev-resume-review-comments-filter.md` (8 cases)
- [x] Regression test: `tests/unit/test-resume-review-comments-filter.sh` self-extracts the live filter from the wrapper via awk so future regressions on the filter trip the test
- [x] TC-RFB-002/003/004/005/008 fail before the fix; all 8 pass after
- [x] TC-RFB-001/006/007 pass on both sides (no regression on legitimate cases)
- [x] Full unit suite: **368/368 pass** (was 360 + 8 new)
- [x] Code simplification: nothing further (single jq predicate)
- [x] PR review agent: verdict "approve, no issues at confidence ≥ 80, code meets project standards"
- [ ] CI checks pass (will watch)
- [ ] Reviewer bot findings (none configured for this repo's REVIEW_BOTS)
- [ ] E2E (no E2E surface for the dev wrapper; covered by unit regression)

## Checklist
- [x] New unit test (`tests/unit/test-resume-review-comments-filter.sh`)
- [x] Documentation updated in lockstep (`docs/pipeline/dev-agent-flow.md::Mode = resume` step 1)
- [x] Pipeline Documentation Authority rule followed (dev-wrapper change paired with dev-agent-flow.md update)
- [x] No regression on the legitimate cases (TC-RFB-001/006/007)