### PR TITLE
fix(create-issue): tighten Dependencies guidance to prevent dispatcher false-positives (#120)

### DIFF
--- a/docs/test-cases/create-issue-dependencies-guidance.md
+++ b/docs/test-cases/create-issue-dependencies-guidance.md
@@ -1,0 +1,38 @@
+# Test Cases — `create-issue` Dependencies guidance
+
+Tracks: issue #120.
+
+## Scenario
+
+The `create-issue` skill's pre-fix Dependencies guidance was too
+permissive. LLMs filled the section with parent-epic references,
+forward-references ("must merge before #N-B / #N-C"), and meta-tracker
+context — anything that contained `#NNN`. The autonomous dispatcher's
+`check_deps_resolved` parses the section literally with a regex that
+extracts every `#NNN`, so any OPEN issue number found there silently
+blocks the issue forever (no error, just skipped on every tick).
+
+The fix tightens three doc sites: the placeholder in
+`references/issue-templates.md`, the Writing Guidelines bullet in
+`SKILL.md`, and the Multi-Issue Creation step 2 in `SKILL.md`. This
+test pins the new wording so future drift trips a regression alarm.
+
+## Test Cases
+
+| ID | Site | Expected text fragment present |
+|----|---|---|
+| TC-DEPS-001 | `references/issue-templates.md` Dependencies block | HTML comment with `IMPORTANT: List ONLY` |
+| TC-DEPS-002 | `references/issue-templates.md` Dependencies block | `parses this section literally` |
+| TC-DEPS-003 | `references/issue-templates.md` Dependencies block | `silently skipped` |
+| TC-DEPS-004 | `references/issue-templates.md` Dependencies block | explicit `Do NOT list:` enumeration with parent epics, unblocked-by issues, context references |
+| TC-DEPS-005 | `references/issue-templates.md` Dependencies block | `If there are no blocking prerequisites, write exactly: None` |
+| TC-DEPS-006 | `SKILL.md` Writing Guidelines Dependencies bullet | `parses this section literally` |
+| TC-DEPS-007 | `SKILL.md` Writing Guidelines Dependencies bullet | `silently skipped` |
+| TC-DEPS-008 | `SKILL.md` Writing Guidelines Dependencies bullet | `Do NOT include` (with the three categories: parent epics, issues this one unblocks, non-blocker references) |
+| TC-DEPS-009 | `SKILL.md` Multi-Issue Creation step 2 | `directly blocking` |
+| TC-DEPS-010 | `SKILL.md` Multi-Issue Creation step 2 | warning that every `#NNN` is treated as a hard blocker |
+
+## Acceptance
+
+- All TC-DEPS-001..010 pass after the fix
+- All fail before the fix (the new strings don't exist on `main` yet)

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -131,7 +131,7 @@ Frame the question as:
 - **Acceptance criteria**: Must be objectively verifiable, not subjective
 - **Scope**: Prefer smaller, focused issues over large multi-part ones
 - **References**: Link to related issues, PRD sections, or code paths when relevant
-- **Dependencies**: When creating multiple related issues, populate the `## Dependencies` section with links to blocking issues. Create issues in dependency order so earlier issue numbers are available for later ones. The dispatcher will skip issues whose dependencies are still open.
+- **Dependencies**: The `## Dependencies` section must contain **only** issues that must be closed/merged before this issue can be started. Do NOT include: parent epics referenced for context, issues this one unblocks, or any `#NNN` reference that isn't a true blocker. The autonomous dispatcher parses this section literally — any open `#NNN` here causes the issue to be silently skipped forever. If there are no blockers, write exactly `None`. Create issues in dependency order so earlier issue numbers are known when writing later ones.
 - **Testing Requirements**: ALWAYS include the "Testing Requirements" section. The dev agent follows the project's TDD workflow but has been observed to skip E2E tests or test-case docs when the issue doesn't explicitly call them out. Be specific about:
   - Key scenarios each test type must cover (2-4 bullet points)
   - For bugs: the regression test must fail before the fix and pass after
@@ -141,7 +141,7 @@ Frame the question as:
 When breaking a large feature into multiple issues:
 
 1. **Create issues in dependency order** — issues with no dependencies first, then issues that depend on them. This ensures issue numbers are known when writing dependency references.
-2. **Populate the `## Dependencies` section** in each issue body with `#N` links to blocking issues.
+2. **Populate the `## Dependencies` section** in each issue body with `#N` links to **directly blocking** issues only. Do not reference parent epics, context issues, or issues this one unblocks — the dispatcher treats every `#NNN` in that section as a hard blocker.
 3. **Use a consistent naming scheme** — prefix titles with the project/feature name for easy filtering (e.g., "MyProject: Add DynamoDB infrastructure").
 4. **Cross-reference the plan** — if an implementation plan exists, link each issue to the relevant plan tasks/chunks.
 5. **The dispatcher skips blocked issues** — issues with open dependencies in the `## Dependencies` section are ignored by the autonomous dispatcher until all dependencies are resolved (closed/merged).

--- a/skills/create-issue/references/issue-templates.md
+++ b/skills/create-issue/references/issue-templates.md
@@ -50,7 +50,7 @@
 
   Pick exactly ONE of the two shapes below (delete the other):
     - If there are no blocking prerequisites, write exactly: None
-    - Otherwise, list each blocker on its own line:           - #N (must be merged first because <specific reason>)
+    - Otherwise, list each blocker on its own line: - #N (must be merged first because <specific reason>)
 -->
 - None
 

--- a/skills/create-issue/references/issue-templates.md
+++ b/skills/create-issue/references/issue-templates.md
@@ -39,8 +39,17 @@
 - [ ] <Criterion 2>
 
 ## Dependencies
-<List issues that must be completed before this issue can begin. Use GitHub issue links.>
-- None | Depends on #N (<brief reason>)
+<!--
+  IMPORTANT: List ONLY issues that must be closed/merged before this issue can be started.
+  Do NOT list:
+    - Issues that this issue unblocks (i.e., issues that depend on THIS one)
+    - Parent epics or meta-trackers referenced for context
+    - Issues mentioned elsewhere in the body
+  The autonomous dispatcher parses this section literally — any #NNN here that is still
+  OPEN will cause this issue to be silently skipped until that issue is closed.
+  If there are no blocking prerequisites, write exactly: None
+-->
+- None | #N (must be merged first because <specific reason>)
 
 ## Design Considerations
 <Architecture notes, API changes, data model impact -- if applicable>

--- a/skills/create-issue/references/issue-templates.md
+++ b/skills/create-issue/references/issue-templates.md
@@ -47,9 +47,12 @@
     - Issues mentioned elsewhere in the body
   The autonomous dispatcher parses this section literally — any #NNN here that is still
   OPEN will cause this issue to be silently skipped until that issue is closed.
-  If there are no blocking prerequisites, write exactly: None
+
+  Pick exactly ONE of the two shapes below (delete the other):
+    - If there are no blocking prerequisites, write exactly: None
+    - Otherwise, list each blocker on its own line:           - #N (must be merged first because <specific reason>)
 -->
-- None | #N (must be merged first because <specific reason>)
+- None
 
 ## Design Considerations
 <Architecture notes, API changes, data model impact -- if applicable>

--- a/tests/unit/test-create-issue-dependencies-guidance.sh
+++ b/tests/unit/test-create-issue-dependencies-guidance.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# test-create-issue-dependencies-guidance.sh — Regression for issue #120.
+#
+# Pins the tightened Dependencies guidance in the create-issue skill so
+# future doc rewrites must preserve the warnings the dispatcher's
+# check_deps_resolved depends on. Future authors will see the test fail
+# if they relax the warning language back to the pre-fix state.
+#
+# Static-grep test: verifies expected strings exist in three places —
+# the issue template placeholder, the SKILL.md Writing Guidelines
+# bullet, and the SKILL.md Multi-Issue Creation step 2.
+#
+# Run: bash tests/unit/test-create-issue-dependencies-guidance.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SKILL_MD="$PROJECT_ROOT/skills/create-issue/SKILL.md"
+TEMPLATES_MD="$PROJECT_ROOT/skills/create-issue/references/issue-templates.md"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Extract the Dependencies section from the feature template.
+# The section starts with `## Dependencies` and ends at the next `## ` header.
+extract_section() {
+  local file="$1" start_marker="$2" end_marker_re="$3"
+  awk -v start="$start_marker" -v end_re="$end_marker_re" '
+    $0 == start { in_block=1; next }
+    in_block && $0 ~ end_re { exit }
+    in_block { print }
+  ' "$file"
+}
+
+assert_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      needle: $needle"
+    echo "      first 200 chars of haystack:"
+    echo "      $(echo "$haystack" | head -c 200)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ===================================================================
+# issue-templates.md Dependencies section
+# ===================================================================
+echo "=== TC-DEPS-001..005: issue-templates.md Dependencies block ==="
+
+deps_block=$(extract_section "$TEMPLATES_MD" "## Dependencies" "^## ")
+
+assert_contains "TC-DEPS-001 HTML comment opens with 'IMPORTANT: List ONLY'" \
+  "$deps_block" "IMPORTANT: List ONLY"
+
+assert_contains "TC-DEPS-002 mentions 'parses this section literally'" \
+  "$deps_block" "parses this section literally"
+
+assert_contains "TC-DEPS-003 mentions 'silently skipped'" \
+  "$deps_block" "silently skipped"
+
+assert_contains "TC-DEPS-004 explicit 'Do NOT list' anti-pattern enumeration" \
+  "$deps_block" "Do NOT list"
+
+assert_contains "TC-DEPS-005 'write exactly: None' fallback instruction" \
+  "$deps_block" "write exactly: None"
+
+# ===================================================================
+# SKILL.md Writing Guidelines — Dependencies bullet
+# ===================================================================
+echo
+echo "=== TC-DEPS-006..008: SKILL.md Writing Guidelines Dependencies bullet ==="
+
+# Extract Writing Guidelines section
+wg_block=$(extract_section "$SKILL_MD" "## Writing Guidelines" "^## ")
+
+assert_contains "TC-DEPS-006 Writing Guidelines mentions 'parses this section literally'" \
+  "$wg_block" "parses this section literally"
+
+assert_contains "TC-DEPS-007 Writing Guidelines mentions 'silently skipped'" \
+  "$wg_block" "silently skipped"
+
+assert_contains "TC-DEPS-008 Writing Guidelines has explicit 'Do NOT include' enumeration" \
+  "$wg_block" "Do NOT include"
+
+# ===================================================================
+# SKILL.md Multi-Issue Creation — step 2
+# ===================================================================
+echo
+echo "=== TC-DEPS-009..010: SKILL.md Multi-Issue Creation step 2 ==="
+
+mi_block=$(extract_section "$SKILL_MD" "## Multi-Issue Creation" "^## ")
+
+assert_contains "TC-DEPS-009 Multi-Issue Creation step 2 says 'directly blocking'" \
+  "$mi_block" "directly blocking"
+
+assert_contains "TC-DEPS-010 Multi-Issue Creation step 2 warns every '#NNN' is a hard blocker" \
+  "$mi_block" "hard blocker"
+
+echo
+echo "=== Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary
- Closes #120. Tightens the `create-issue` skill's Dependencies guidance so LLMs filling the template stop including parent-epic / forward-reference / meta-tracker `#NNN` references that the dispatcher's `check_deps_resolved` then treats as hard blockers.
- Three doc sites updated:
  1. `references/issue-templates.md` Dependencies placeholder — replaced vague placeholder with an HTML comment naming four anti-patterns + literal-parse warning + "Pick exactly ONE of the two shapes" instruction.
  2. `SKILL.md::Writing Guidelines` Dependencies bullet — explicit "Do NOT include" enumeration + `silently skipped` warning.
  3. `SKILL.md::Multi-Issue Creation` step 2 — "**directly blocking**" + "every `#NNN` is a hard blocker".

## Background
The `check_deps_resolved` parser (`lib-dispatch.sh:289-295`) literally extracts every `#NNN` from the Dependencies section via `sed | grep -oE '#[0-9]+'`. Pre-fix, LLMs filled the section with parent-epic context, forward-references ("must merge before #N-B / #N-C / #N-D"), and meta-tracker mentions; any of those that were OPEN issues silently blocked the new issue forever, with no error message. Documented victims include podcast-curation#205 (forward-ref `#13-B,C,D` extracted as `#13` → blocked on parent epic) and #204 (meta-tracker `#166` shadowed real deps).

This PR is the **authoring-side** fix; #119 tracks the complementary **parser-side** fix (LLM-based semantic parsing of the Dependencies section). Both ship independently.

## Reviewer-driven fix (commit 44e4324)
The pr-review-toolkit:code-reviewer flagged a confidence-82 ambiguity: the original example line `- None | #N (must be merged first because <specific reason>)` used `|` as a "pick one" separator, but a literal pipe could be left in the rendered body — producing `- None | #205 (...)` that the dispatcher would parse as blocked-on-#205, defeating the entire fix. Commit 44e4324 splits the example into two adjacent shapes inside an "Pick exactly ONE of the two shapes (delete the other)" instruction in the HTML comment, and renders only `- None` as the visible default. Imperative `write exactly: None` preserved (load-bearing — the test pins on it).

## Design
- [x] No design canvas — pure docs change

## Test Plan
- [x] Test cases: `docs/test-cases/create-issue-dependencies-guidance.md` (10 cases)
- [x] Static-grep regression test: `tests/unit/test-create-issue-dependencies-guidance.sh` verifies the warning fragments at all three sites
- [x] All 10 cases fail before the fix; all 10 pass after
- [x] Full unit suite: **378/378 pass** (was 368 + 10 new)
- [x] Code simplification: nothing further (pure prose)
- [x] PR review agent: 2 rounds — round 1 caught the `|` separator ambiguity (fixed in 44e4324); round 2 verdict "no high-confidence issues, code meets standards"
- [ ] CI checks pass (will watch)
- [ ] Reviewer bot findings (none configured)
- [ ] E2E (no E2E surface — pure docs change)

## Checklist
- [x] New regression test (`tests/unit/test-create-issue-dependencies-guidance.sh`)
- [x] No code changes — pure docs/skill update
- [x] No pipeline doc lockstep needed (no changes to `docs/pipeline/*.md` since the change is to `skills/create-issue/`, not the dispatcher/wrapper subsystem)

## Out of scope
- Adding a `## Dependencies` section to the bug template (the bug template currently has none; flagged by the reviewer but explicitly out of scope per the issue body)
- Parser-side LLM-based dependency parsing (tracked in #119)