### PR TITLE
fix(dispatcher): exclude SIGTERM from agent failures + defer stall on live wrappers (#121 Fix A + Fix C)

### DIFF
--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -178,7 +178,7 @@ This is the most subtle gate in the dispatcher. Two failure events count toward 
 
 Failure events:
 
-- **`Agent Session Report (Dev)` comments with non-zero exit code.** Posted by the dev wrapper trap on agent failure ([INV-03](invariants.md#inv-03-dev-session-report-comment-format)). Always count.
+- **`Agent Session Report (Dev)` comments with non-zero exit code, EXCLUDING SIGTERM (143) and SIGKILL (137).** Posted by the dev wrapper trap on agent failure ([INV-03](invariants.md#inv-03-dev-session-report-comment-format)). Exits 143 / 137 are excluded ([INV-26](invariants.md#inv-26-stall-decision-excludes-dispatcher-induced-terminations-and-defers-on-live-wrappers)) because they are almost exclusively caused by `dispatch-local.sh::kill_stale_wrapper` — counting the dispatcher's own kill as an agent failure consumes retry budget the agent never spent. Wall-clock-timeout exit 124 still counts (catches genuine hangs).
 - **Dispatcher-detected crash comments matching the regex `Task appears to have crashed \(no PR found\)|process not found`.** This regex anchors only on Step 5b-DEAD-no-PR comments and explicit "process not found" wording. It MUST NOT match the forward-progress phrases — see [INV-06](invariants.md#inv-06-crashed--process-not-found-keyword-contract). **Only counts when the agent has confirmed startup** in this retry cycle (a `Dev Session ID:` comment exists post-cutoff) — see [INV-19](invariants.md#inv-19-retry-counter-requires-confirmed-agent-startup).
 
 Pseudocode:
@@ -191,10 +191,17 @@ SESSION_SEEN = count of "Dev Session ID: ..." comments AFTER LAST_STALLED_AT (IN
 RETRY_COUNT = AGENT_FAILURES + (SESSION_SEEN > 0 ? DISPATCHER_CRASHES : 0)
 
 if RETRY_COUNT >= MAX_RETRIES (default 3):
-  remove pending-dev, add stalled
-  comment "Marking as stalled. <counter breakdown including suppressed false positives> @owner please investigate manually."
-  skip
+  if pid_alive(issue, issue_num):                  # INV-26 liveness deferral
+    if no INV-26-stall-deferral marker for this PID:
+      comment "Stall decision deferred: dev wrapper PID <N> is still alive..."
+    skip                                            # let the live wrapper finish
+  else:
+    remove pending-dev, add stalled
+    comment "Marking as stalled. <counter breakdown including suppressed false positives> @owner please investigate manually."
+    skip
 ```
+
+Both gates ([INV-26](invariants.md#inv-26-stall-decision-excludes-dispatcher-induced-terminations-and-defers-on-live-wrappers)) protect the `stalled` signal: the counter only sees genuine failures, and the transition only fires when the wrapper has actually exited. Without (1), `kill_stale_wrapper`-induced SIGTERMs let the counter overcount; without (2), the transition lies about a wrapper that's still making progress and produces the `approved + stalled` co-existence wedge documented in #121's reproduction.
 
 ### Step 4a.5: PR-exists short-circuit (#99 Bug 3, #106)
 

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -435,11 +435,39 @@ Step 0 runs UNCONDITIONALLY — even when concurrency is saturated. Hygiene is p
 **Cross-references**:
 - [INV-15] documents the SIGTERM race that is one *producer* of the residue this invariant heals. The race itself is convergent (PR-6); the residue this heals is from earlier-or-different races and from manual reconciliation, not from the SIGTERM path under normal conditions.
 - All four `list_*` selectors in `lib-dispatch.sh` (`list_new_issues`, `list_pending_review`, `list_pending_dev`, `list_stale_candidates`) inline their own `approved` AND `stalled` subtraction. `list_new_issues` was correct from inception (it explicitly excludes every state label); `list_stale_candidates` was fixed in PR #116 (Bug A); `list_pending_review` and `list_pending_dev` were fixed by the Bug C post-investigation PR — pre-fix, `list_pending_review` only excluded `reviewing` and `list_pending_dev` had no inline filter at all. INV-25 makes those inline subtractions defense-in-depth rather than the only line of defense — Step 0 hygiene heals the residue at tick start regardless of which selector would have misclassified. Future selectors should call `_has_terminal_label()` for symmetry; a missed call is no longer a Bug-A-class infinite-loop bug, just a wasted query.
+- [INV-26] (stall-decision correctness) reduces one of the producers of the `stalled + transitional` residue this invariant heals: pre-INV-26, `mark_stalled` could fire against a still-live wrapper, the wrapper trap then writing `+pending-review` onto the resulting `+stalled` issue. With INV-26, that producer is closed at the upstream side — the live wrapper finishes first, the trap correctly transitions to `+pending-review` (no `stalled`), and INV-25 only has to heal residue from genuinely-stalled-but-late-trap edge cases.
 
 **Status**: **ENFORCED** in this PR (closes #115 Bug B).
 
 **Test**:
 - `tests/unit/test-step0-hygiene.sh` (23 cases) — TC-HAS-TERM-001..005 cover the predicate, TC-HYG-001..006 cover per-issue strip logic, TC-COMMENT-001..003 cover audit-comment idempotency, TC-STEP0-INT-001..003 statically pin Step 0 placement (before Step 1, not gated by concurrency).
+
+## INV-26: Stall decision excludes dispatcher-induced terminations and defers on live wrappers
+
+**Rule**: Two conjunct conditions must hold before the dispatcher can mark an issue `+stalled`:
+
+1. **Failure counter accuracy**: `count_agent_failures` (`lib-dispatch.sh`) MUST exclude Session Reports whose `Exit code` is 0 (success), 143 (SIGTERM), or 137 (SIGKILL) from the agent-failure tally. Exits 143 and 137 are almost exclusively caused by `dispatch-local.sh::kill_stale_wrapper` — the dispatcher's own kill of a stale wrapper to spawn a fresh one. Counting the dispatcher's kill as an "agent failure" silently consumes retry budget the agent never spent.
+2. **Liveness deferral**: `mark_stalled` MUST query `pid_alive issue <issue_num>` before any `gh issue edit` or stall comment. If the dev wrapper is alive, the stall decision is deferred — `mark_stalled` returns 0 without changing labels, posts a one-shot deferral comment (idempotency-keyed on the wrapper PID via marker `INV-26-stall-deferral:pid=<pid>`), and lets the next tick re-evaluate. The stall path proceeds only when no live wrapper holds the PID file.
+
+**Why**: Without (1), `kill_stale_wrapper`-induced SIGTERMs accumulate against the retry budget; combined with `pid_alive` misjudgements producing "Task crashed" comments, MAX_RETRIES is hit prematurely. Without (2), `mark_stalled` then transitions to `+stalled` while the wrapper is still alive — and the wrapper subsequently completes work, the trap writes `+pending-review` onto a `+stalled` issue, the next tick's Step 3 picks it up (pre-#118: with no `stalled` filter; post-#118: blocked by Step 0 hygiene but only after a tick lag), and the issue ends in inconsistent label state. Reproduced on a downstream consumer's `#204`-class wedge on 2026-05-14: 2 dispatcher-misjudgement crashes + 1 SIGTERM-from-dispatcher → false stall while the real wrapper finished and PR auto-merged. See #121.
+
+**Producer**:
+- (1) `lib-dispatch.sh::count_agent_failures` — jq predicate excludes exit codes 0, 143, 137. Anchors on `\b` word boundary so 144 / 1430 don't false-match.
+- (2) `lib-dispatch.sh::mark_stalled` — calls `pid_alive issue $issue_num` first; defers (post one-shot comment, return 0) if alive.
+
+**Consumer**: `dispatcher-tick.sh` Step 4 retry-counter branch — calls `mark_stalled` when `count_retries >= MAX_RETRIES`. With both rules in place, a wrapper that's making real progress can never be `+stalled` until it has actually exited.
+
+**Cross-references**:
+- [INV-15] (SIGTERM race) is one *producer* of the residue [INV-25] heals; this invariant prevents the *upstream* false stall that creates the residue in the first place.
+- [INV-19] (retry counter requires confirmed agent startup) gates dispatcher-detected crashes; this invariant adds a parallel gate on agent-side Session Reports for terminations the dispatcher itself caused.
+- [INV-23] (PID_FILE death reaps subtree) gives `pid_alive` its truth: a wrapper still holding the PID file means the agent subtree is reachable. The liveness deferral relies on that contract.
+- [INV-24] (review wrapper DEAD detection requires near-success short-circuit) is the review-side analog. The dev-side near-success short-circuit (`dev_near_success`) is tracked separately as a follow-up to this PR; once landed, it complements the deferral here by preventing the upstream "Task crashed" comments that drove the false stall in the first place.
+
+**Status**: **ENFORCED** in this PR (closes #121 Fix A + Fix C; Fix B / `dev_near_success` is a separate follow-up PR).
+
+**Tests**:
+- `tests/unit/test-count-agent-failures-sigterm.sh` (7 cases): TC-CAF-001/006/007 cover regression bounds (0/1/124/144 still scored correctly), TC-CAF-002/003 cover genuine failures, TC-CAF-004/005 cover the new SIGTERM/SIGKILL exclusions, TC-CAF-007 covers a mixed-bag fixture.
+- `tests/unit/test-mark-stalled-liveness.sh` (5 cases): TC-MSL-001/004/005 cover the alive-wrapper deferral path, TC-MSL-002/003 cover the dead-PID and missing-PID paths (existing behavior preserved). Uses a real spawned `sleep` for the alive case to avoid mocking `kill -0`.
 
 ## Adding a new invariant
 

--- a/docs/test-cases/dispatcher-stall-correctness-a-c.md
+++ b/docs/test-cases/dispatcher-stall-correctness-a-c.md
@@ -1,0 +1,43 @@
+# Test Cases — Stall-decision correctness (Fix A + Fix C)
+
+Tracks: issue #121 (Fix A and Fix C; Fix B in a follow-up PR).
+
+## Scenario
+
+Two of the three failure modes documented in #121:
+
+- **Fix A**: `count_agent_failures` (lib-dispatch.sh) counts every Session Report whose `Exit code` is non-zero as an agent failure — including SIGTERM (143) and SIGKILL (137) caused by the dispatcher's own `kill_stale_wrapper`. The dispatcher is essentially scoring its own kills against the wrapper.
+- **Fix C**: `mark_stalled` (lib-dispatch.sh) transitions an issue to `+stalled` without checking whether a wrapper is still alive. Once the retry counter is wrong (e.g. via Fix A), `mark_stalled` lies about a healthy wrapper that's making progress.
+
+Together they produce the panoptes-class wedge: 2 dispatcher-misjudgement crashes + 1 SIGTERM-from-dispatcher → 3 strikes → false stall while the real wrapper finishes the work.
+
+## Test Cases
+
+### Fix A — `count_agent_failures` exit-code filter
+
+| ID | Session Report exit code | Expected: counted as agent failure? |
+|----|---|---|
+| TC-CAF-001 | `Exit code: 0` | NO (pre-existing behavior) |
+| TC-CAF-002 | `Exit code: 1` (real crash) | YES (pre-existing behavior preserved) |
+| TC-CAF-003 | `Exit code: 124` (timeout) | YES (genuine hang must still count) |
+| TC-CAF-004 | `Exit code: 143` (SIGTERM) | NO (dispatcher-induced, not agent failure) |
+| TC-CAF-005 | `Exit code: 137` (SIGKILL) | NO (dispatcher-induced escalation) |
+| TC-CAF-006 | `Exit code: 144` (must NOT collide with 143) | YES (only 143 is excluded; 144 is a genuine crash) |
+| TC-CAF-007 | Mixed bag of exit codes | counts only the genuine failures |
+
+### Fix C — `mark_stalled` liveness check
+
+| ID | PID file state | Expected: stall fires? |
+|----|---|---|
+| TC-MSL-001 | PID file present, process alive (real `kill -0` succeeds) | NO — defer with diagnostic comment |
+| TC-MSL-002 | PID file present, process dead | YES — existing behavior preserved |
+| TC-MSL-003 | PID file absent | YES — existing behavior preserved |
+| TC-MSL-004 | PID file present, process alive — verify the deferral comment is posted | comment posted, no label edit |
+| TC-MSL-005 | PID file present, process alive — verify NO `gh issue edit ... --add-label stalled` call | edit call absent |
+
+## Acceptance
+
+- All TC-CAF-001..007 pass after Fix A; TC-CAF-001/002/003/006/007 pass on both sides of Fix A (no regression on genuine failures); TC-CAF-004/005 fail before Fix A (SIGTERM counts) and pass after.
+- All TC-MSL-001..005 pass after Fix C; TC-MSL-002/003 pass on both sides of Fix C (no regression on dead/missing PID); TC-MSL-001/004/005 fail before (mark_stalled fires regardless of liveness) and pass after.
+- Pre-existing 378-test unit suite stays green.
+- `mark_stalled` deferral path posts an idempotency-keyed comment (per future tick re-evaluations) so the issue timeline doesn't fill with one-comment-per-tick when the wrapper is genuinely making progress over many ticks.

--- a/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
@@ -379,8 +379,26 @@ count_agent_failures() {
   local last_stalled_at
   last_stalled_at=$(gh issue view "$issue_num" --repo "$REPO" --json comments \
     -q '[.comments[] | select(.body | test("Marking as stalled"))] | last | .createdAt // "1970-01-01T00:00:00Z"')
+  # Exit code exclusions:
+  #   0   → success (pre-existing exclusion).
+  #   143 → SIGTERM. Almost always caused by `dispatch-local.sh::kill_stale_wrapper`
+  #         when the dispatcher decides to kick a stale wrapper to spawn a fresh
+  #         one. Counting the dispatcher's own kill as an "agent failure"
+  #         consumed retry budget the agent never spent (see #121 Fix A).
+  #   137 → SIGKILL. The escalation path when SIGTERM is ignored, again driven
+  #         by kill_stale_wrapper. Same reasoning as 143.
+  # Genuine hangs are still bounded by `lib-agent.sh::_run_with_timeout`'s
+  # exit code 124 (kept counting) and any non-listed non-zero exit (real
+  # agent crashes). The regex anchors on word boundaries (`Exit code:
+  # 143\b`-equivalent via `\\b`) so 144 / 1430 / etc. don't false-match.
   gh issue view "$issue_num" --repo "$REPO" --json comments \
-    -q "[.comments[] | select((.createdAt > \"${last_stalled_at}\") and (.body | test(\"Agent Session Report \\\\(Dev\\\\)\")) and (.body | test(\"Exit code: 0\") | not))] | length"
+    -q "[.comments[] | select(
+         (.createdAt > \"${last_stalled_at}\")
+         and (.body | test(\"Agent Session Report \\\\(Dev\\\\)\"))
+         and (.body | test(\"Exit code: 0\\\\b\") | not)
+         and (.body | test(\"Exit code: 143\\\\b\") | not)
+         and (.body | test(\"Exit code: 137\\\\b\") | not)
+       )] | length"
 }
 
 count_dispatcher_crashes() {
@@ -396,6 +414,33 @@ count_dispatcher_crashes() {
 # stalled" comment that the next stalled-cutoff calculation will key off.
 mark_stalled() {
   local issue_num="$1"
+
+  # Liveness defer (#121 Fix C): if a dev wrapper is still alive on this
+  # issue, the retry counter is almost certainly wrong (the wrapper is
+  # making real progress; the dispatcher's "crash" detection or its own
+  # kill_stale_wrapper SIGTERMs are scoring a healthy wrapper). Posting
+  # `+stalled` here would lie about a working wrapper — and worse, the
+  # wrapper trap will then write `pending-review` onto a stalled issue,
+  # producing the `approved + stalled` co-existence wedge documented in
+  # #121's reproduction (podcast-curation#204 / 2026-05-14).
+  #
+  # Defense: defer the decision when `pid_alive` reports ALIVE. Post a
+  # one-shot deferral comment (idempotency-keyed on the agent's current
+  # session id pulled from the wrapper PID file path, so re-ticks against
+  # the same alive wrapper don't fill the timeline).
+  if pid_alive issue "$issue_num"; then
+    local pid current_session_marker
+    pid=$(get_pid issue "$issue_num")
+    current_session_marker="INV-26-stall-deferral:pid=${pid}"
+    if gh issue view "$issue_num" --repo "$REPO" --json comments \
+        -q "[.comments[].body | select(contains(\"${current_session_marker}\"))] | length" \
+        2>/dev/null | grep -q '^0$'; then
+      gh issue comment "$issue_num" --repo "$REPO" \
+        --body "Stall decision deferred: dev wrapper PID ${pid} is still alive — counter says ${MAX_RETRIES} but a wrapper is making progress. Re-evaluating next tick. (\`${current_session_marker}\`)"
+    fi
+    return 0
+  fi
+
   local agent_failures dispatcher_crashes false_positives
   agent_failures=$(count_agent_failures "$issue_num")
   dispatcher_crashes=$(count_dispatcher_crashes "$issue_num")

--- a/tests/unit/test-count-agent-failures-sigterm.sh
+++ b/tests/unit/test-count-agent-failures-sigterm.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# test-count-agent-failures-sigterm.sh — Regression for issue #121 Fix A.
+#
+# `count_agent_failures` previously counted every Session Report whose
+# `Exit code` is non-zero. That includes SIGTERM (143) and SIGKILL (137)
+# from `dispatch-local.sh::kill_stale_wrapper` — i.e. the dispatcher's
+# own kills were scored as agent failures, fueling premature
+# `mark_stalled` calls.
+#
+# Fix A: exclude exit codes 143 and 137 from the agent-failure count.
+# Genuine failures (1, 2, 124-timeout, custom non-143/137 exits) still
+# count. The wall-clock timeout exit 124 is the catch-all for genuine
+# hangs and remains counted.
+#
+# Run: bash tests/unit/test-count-agent-failures-sigterm.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-dispatch.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+export REPO=zxkane/autonomous-dev-team
+export REPO_OWNER=zxkane
+export PROJECT_ID=test-caf
+export MAX_RETRIES=3
+export MAX_CONCURRENT=5
+
+# `gh` stub: feeds _MOCK_COMMENTS_JSON through jq with the requested -q
+# expression. Same pattern as test-lib-dispatch.sh / test-step0-hygiene.sh.
+_MOCK_COMMENTS_JSON=""
+gh() {
+  local q_expr=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -q) q_expr="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [[ -n "$q_expr" && -n "$_MOCK_COMMENTS_JSON" ]]; then
+    jq -r "$q_expr" <<<"$_MOCK_COMMENTS_JSON"
+  fi
+}
+export -f gh
+
+# shellcheck source=../../skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+source "$LIB"
+set +e
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected: $expected"
+    echo "      actual:   $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Build a comments JSON wrapper around an array of {createdAt, body} objects.
+# Each Session Report is a comment whose body matches the regex used by
+# count_agent_failures: 'Agent Session Report \(Dev\)' AND a specific
+# 'Exit code: <N>' line.
+mk_session_report() {
+  # mk_session_report "<iso-ts>" <exit-code>
+  local ts="$1" code="$2"
+  jq -n --arg ts "$ts" --arg code "$code" \
+    '{createdAt: $ts, body: ("**Agent Session Report (Dev)**\n- Dev Session ID: `abc-\($code)`\n- Exit code: \($code)\n- Mode: new\n- Timestamp: \($ts)")}'
+}
+
+mk_comments_json() {
+  # mk_comments_json <comment1> <comment2> ...
+  jq -n --argjson arr "$(printf '%s\n' "$@" | jq -s '.')" \
+    '{comments: $arr}'
+}
+
+# ===================================================================
+echo "=== TC-CAF-001..007: count_agent_failures excludes SIGTERM/SIGKILL ==="
+
+# TC-CAF-001 — exit 0 → 0 (pre-existing, no regression)
+_MOCK_COMMENTS_JSON=$(mk_comments_json \
+  "$(mk_session_report '2026-05-14T07:00:00Z' '0')")
+out=$(count_agent_failures 1)
+assert_eq "TC-CAF-001 exit 0 → not counted" "0" "$out"
+
+# TC-CAF-002 — exit 1 → 1 (genuine crash, must still count)
+_MOCK_COMMENTS_JSON=$(mk_comments_json \
+  "$(mk_session_report '2026-05-14T07:00:00Z' '1')")
+out=$(count_agent_failures 2)
+assert_eq "TC-CAF-002 exit 1 (genuine crash) → counted" "1" "$out"
+
+# TC-CAF-003 — exit 124 (wall-clock timeout) → 1 (must count: genuine hang)
+_MOCK_COMMENTS_JSON=$(mk_comments_json \
+  "$(mk_session_report '2026-05-14T07:00:00Z' '124')")
+out=$(count_agent_failures 3)
+assert_eq "TC-CAF-003 exit 124 (timeout) → counted" "1" "$out"
+
+# TC-CAF-004 — exit 143 (SIGTERM) → 0 (dispatcher-induced, must NOT count)
+_MOCK_COMMENTS_JSON=$(mk_comments_json \
+  "$(mk_session_report '2026-05-14T07:00:00Z' '143')")
+out=$(count_agent_failures 4)
+assert_eq "TC-CAF-004 exit 143 (SIGTERM from kill_stale_wrapper) → not counted" "0" "$out"
+
+# TC-CAF-005 — exit 137 (SIGKILL) → 0 (dispatcher-escalation kill)
+_MOCK_COMMENTS_JSON=$(mk_comments_json \
+  "$(mk_session_report '2026-05-14T07:00:00Z' '137')")
+out=$(count_agent_failures 5)
+assert_eq "TC-CAF-005 exit 137 (SIGKILL escalation) → not counted" "0" "$out"
+
+# TC-CAF-006 — exit 144 (custom; must NOT collide with 143 prefix-match)
+_MOCK_COMMENTS_JSON=$(mk_comments_json \
+  "$(mk_session_report '2026-05-14T07:00:00Z' '144')")
+out=$(count_agent_failures 6)
+assert_eq "TC-CAF-006 exit 144 (genuine — must NOT match 143 by prefix)" "1" "$out"
+
+# TC-CAF-007 — mixed bag: counts only genuine failures
+_MOCK_COMMENTS_JSON=$(mk_comments_json \
+  "$(mk_session_report '2026-05-14T07:00:00Z' '0')" \
+  "$(mk_session_report '2026-05-14T07:05:00Z' '1')" \
+  "$(mk_session_report '2026-05-14T07:10:00Z' '143')" \
+  "$(mk_session_report '2026-05-14T07:15:00Z' '137')" \
+  "$(mk_session_report '2026-05-14T07:20:00Z' '124')" \
+  "$(mk_session_report '2026-05-14T07:25:00Z' '2')" \
+  "$(mk_session_report '2026-05-14T07:30:00Z' '144')")
+# Genuine: 1, 124, 2, 144 = 4
+# Excluded: 0, 143, 137 = 3
+out=$(count_agent_failures 7)
+assert_eq "TC-CAF-007 mixed bag → only genuine failures counted (4)" "4" "$out"
+
+echo
+echo "=== Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/tests/unit/test-mark-stalled-liveness.sh
+++ b/tests/unit/test-mark-stalled-liveness.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# test-mark-stalled-liveness.sh — Regression for issue #121 Fix C.
+#
+# `mark_stalled` previously did `gh issue edit --remove-label pending-dev
+# --add-label stalled` + post comment WITHOUT checking whether a wrapper
+# was still alive. Once the retry counter was wrong (Fix A), `mark_stalled`
+# fired against a healthy wrapper that was making real progress — the
+# wrapper subsequently completed work but the issue was already labeled
+# stalled, leaving an `approved + stalled` (or similar) inconsistent end
+# state.
+#
+# Fix C: `mark_stalled` queries the dev-wrapper PID file for this issue;
+# if `pid_alive` returns ALIVE, defer the stall decision (no label edit,
+# post a one-shot deferral comment). Next tick re-evaluates. Existing
+# behavior (PID file absent or process dead) preserved.
+#
+# Run: bash tests/unit/test-mark-stalled-liveness.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-dispatch.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+export REPO=zxkane/autonomous-dev-team
+export REPO_OWNER=zxkane
+export PROJECT_ID=test-msl
+export MAX_RETRIES=3
+export MAX_CONCURRENT=5
+
+# Capture every gh call (and its args) so we can assert on what mark_stalled
+# tried to do. Stub returns canned outputs based on verb.
+_GH_CALLS=()
+_MOCK_COMMENTS_JSON=""
+gh() {
+  _GH_CALLS+=("$*")
+  case "$1" in
+    issue)
+      case "$2" in
+        view)
+          # mark_stalled doesn't call `issue view`; count_* helpers do.
+          # Default to empty comments array so the counters return 0.
+          local q=""
+          local i=3
+          while [[ $i -le $# ]]; do
+            if [[ "${!i}" == "-q" ]]; then
+              local j=$((i + 1))
+              q="${!j}"
+              break
+            fi
+            i=$((i + 1))
+          done
+          if [[ -n "$q" ]]; then
+            jq -r "$q" <<<"${_MOCK_COMMENTS_JSON:-{\"comments\":[]\}}"
+          fi
+          ;;
+        edit|comment)
+          # Side-effect verbs — silent success.
+          ;;
+      esac
+      ;;
+  esac
+}
+export -f gh
+
+# Override pid_dir_for_project so mark_stalled and pid_alive look in our
+# sandbox dir rather than the user's runtime dir. lib-config.sh defines it
+# in scope; we just redefine the function after sourcing.
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# shellcheck source=../../skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+source "$LIB"
+
+# Override pid_dir_for_project AFTER source so our sandbox wins. This is
+# the same hook autonomous-dev.sh::cleanup uses to find the wrapper PID.
+pid_dir_for_project() {
+  echo "$TMPDIR"
+}
+export -f pid_dir_for_project
+
+set +e
+
+assert_match() {
+  local desc="$1" pattern="$2" haystack="$3"
+  if grep -qE "$pattern" <<<"$haystack"; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (pattern: $pattern)"
+    echo "      haystack:"
+    echo "$haystack" | sed 's/^/        /'
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_no_match() {
+  local desc="$1" pattern="$2" haystack="$3"
+  if ! grep -qE "$pattern" <<<"$haystack"; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (pattern '$pattern' should NOT match)"
+    echo "      haystack:"
+    echo "$haystack" | sed 's/^/        /'
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ===================================================================
+echo "=== TC-MSL-001..005: mark_stalled liveness check ==="
+
+# TC-MSL-001 & TC-MSL-004 & TC-MSL-005 — wrapper alive: defer
+_GH_CALLS=()
+# Spawn a real long-lived process and write its PID into the file
+# pid_alive will read.
+sleep 60 &
+LIVE_PID=$!
+echo "$LIVE_PID" > "$TMPDIR/issue-101.pid"
+mark_stalled 101 >/dev/null
+edit_calls=$(printf '%s\n' "${_GH_CALLS[@]}" | grep -E '^issue edit' || true)
+comment_calls=$(printf '%s\n' "${_GH_CALLS[@]}" | grep -E '^issue comment' || true)
+assert_no_match "TC-MSL-001/005 alive wrapper → no 'issue edit ... stalled' label call" "issue edit.*stalled" "$edit_calls"
+assert_match "TC-MSL-004 alive wrapper → deferral comment posted" "issue comment 101" "$comment_calls"
+# Make sure the comment text says "deferred" so operators know it's not a stall.
+deferral_text=$(printf '%s\n' "${_GH_CALLS[@]}" | grep -E '^issue comment 101' || true)
+assert_match "TC-MSL-004 deferral comment mentions 'defer'" "[Dd]efer" "$deferral_text"
+# Cleanup the spawned process before next test
+kill "$LIVE_PID" 2>/dev/null || true
+wait "$LIVE_PID" 2>/dev/null || true
+rm -f "$TMPDIR/issue-101.pid"
+
+# TC-MSL-002 — PID file present but process dead: stall fires (existing behavior)
+_GH_CALLS=()
+# Use a PID that almost certainly doesn't exist (max valid PID + 1 territory).
+# `kill -0 999999` will fail on most Linux systems where pid_max is 32768 or
+# 4194304. Even if it does happen to exist, the heartbeat-mtime fallback
+# requires the file to be recently mtime'd — which a real spawned-then-dead
+# wrapper would have but our test setup won't.
+echo "999999" > "$TMPDIR/issue-102.pid"
+# Backdate the mtime so heartbeat fallback doesn't kick in.
+touch -t 200001010000.00 "$TMPDIR/issue-102.pid"
+mark_stalled 102 >/dev/null
+edit_calls=$(printf '%s\n' "${_GH_CALLS[@]}" | grep -E '^issue edit' || true)
+assert_match "TC-MSL-002 dead wrapper → stall label edit fires" "issue edit 102.*stalled" "$edit_calls"
+rm -f "$TMPDIR/issue-102.pid"
+
+# TC-MSL-003 — PID file absent: stall fires (existing behavior)
+_GH_CALLS=()
+# No PID file for issue 103.
+mark_stalled 103 >/dev/null
+edit_calls=$(printf '%s\n' "${_GH_CALLS[@]}" | grep -E '^issue edit' || true)
+assert_match "TC-MSL-003 missing PID file → stall label edit fires" "issue edit 103.*stalled" "$edit_calls"
+
+echo
+echo "=== Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary
- Implements Fix A and Fix C from #121. Fix B (`dev_near_success` / INV-27) is a separate follow-up PR per #121's three-PR phased plan.
- **Fix A**: `count_agent_failures` excludes SIGTERM (143) and SIGKILL (137) — they're almost exclusively caused by `dispatch-local.sh::kill_stale_wrapper`, so counting them as "agent failures" makes the dispatcher score its own kills against the wrapper.
- **Fix C**: `mark_stalled` checks `pid_alive issue $issue_num` first; if ALIVE, defers with a one-shot deferral comment (idempotency-keyed on the wrapper PID via `INV-26-stall-deferral:pid=<N>` marker) instead of transitioning to `+stalled` while the wrapper is still making real progress.

## Refs
Refs: #121. Note: deliberate `Refs:` (not `Closes:`) — this PR closes 2 of the 3 axes; Fix B remains open. Per project memory: never use `Closes #N` on partial-axis PRs.

## Background
Reproduced on a downstream consumer's #204-class wedge on 2026-05-14:

```
07:10  dev-new dispatched
07:20  dispatcher: "Task crashed (no PR)" ← strike 1 (likely transient pid_alive miss)
07:25  dev-resume dispatched (kill_stale_wrapper SIGTERMs old wrapper)
07:25  Session Report Exit code: 143 ← strike 2 (counted as agent failure;
       actually the dispatcher's own kill)
07:40  dispatcher: "Task crashed (no PR)" ← strike 3
07:45  Marking as stalled (false stall)
08:58  ...wrapper actually completes, posts PR ← issue is `+stalled` but
       pending-review trap fires, ending in `approved + stalled` mess
```

INV-26 closes both producers of the false stall: counter accuracy (Fix A) + transition liveness (Fix C). Step 0 hygiene (PR #117) heals the residue downstream; this PR shrinks the producer surface upstream.

## Doc updates (Pipeline Documentation Authority compliance)
- `docs/pipeline/invariants.md` — adds **INV-26** binding both rules; INV-25 cross-reference updated to note INV-26 reduces a producer of the `stalled + transitional` residue INV-25 heals.
- `docs/pipeline/dispatcher-flow.md::Step 4a` — failure-event description spells out the SIGTERM/SIGKILL exclusion; pseudocode updated to show the liveness-deferral branch; cross-refs INV-26.

## Test Plan
- [x] Test cases: `docs/test-cases/dispatcher-stall-correctness-a-c.md` (12 cases)
- [x] Regression test 1: `tests/unit/test-count-agent-failures-sigterm.sh` (7 cases, 4 fail pre-fix, all pass post-fix)
- [x] Regression test 2: `tests/unit/test-mark-stalled-liveness.sh` (5 cases, 3 fail pre-fix, all pass post-fix). Uses a real `sleep 60` background process for the alive-wrapper case.
- [x] Full unit suite: **390/390 pass** (was 378 + 12 new)
- [x] Code simplification: predicates kept symmetric with PR #116/#117/#118 idiom; helper code minimal
- [x] PR review agent: verdict "no issues at confidence ≥ 80, approve"
- [ ] CI checks pass (will watch)
- [ ] Reviewer bot findings (Amazon Q runs automatically)
- [ ] E2E (no E2E surface for dispatcher; covered by unit regression)

## Checklist
- [x] New unit tests
- [x] Pipeline docs updated in lockstep (invariants.md + dispatcher-flow.md)
- [x] No regression in genuine-failure detection (TC-CAF-002/003/006 confirm exits 1/124/144 still count)
- [x] No regression in dead/missing-PID stall paths (TC-MSL-002/003)

## Out of scope
- Fix B (`dev_near_success` / INV-27): tracked separately in #121, will land as a follow-up PR after this one.