### PR TITLE
fix(dispatcher): scope kill_stale_wrapper pgrep fallback by project + type (#126, INV-28)

### DIFF
--- a/docs/designs/dispatch-local-pgrep-type-scope.md
+++ b/docs/designs/dispatch-local-pgrep-type-scope.md
@@ -1,0 +1,227 @@
+# Design — Type-scoped pgrep fallback in `dispatch-local.sh::kill_stale_wrapper`
+
+**Issue**: #126
+**Status**: Proposed
+**Author**: zxkane (autonomous-dev session)
+
+## Problem
+
+`dispatch-local.sh::kill_stale_wrapper` falls back to a `pgrep -f` matcher that
+selects orphan agent processes by `--issue <N>` argv only. Both
+`autonomous-dev.sh` and `autonomous-review.sh` are launched with the same
+argv shape, so the fallback **does not distinguish wrapper type**. It also
+does **not** distinguish between projects on a multi-project box: dispatching
+project A's `dev-resume` for issue 100 group-kills any project-B wrapper
+also running with `--issue 100` on the same host.
+
+Concrete failure mode (from #126 reproduction):
+
+1. `review` wrapper for issue N is alive and mid-work (>5 min CLI run).
+2. A `pid_alive review` miss (race or normal slow review) leads
+   `dispatcher-tick.sh` to post "Review process appears to have crashed" and
+   flip `reviewing` → `pending-dev`. The review wrapper is still alive.
+3. The next tick dispatches `dev-resume`. `dispatch-local.sh` invokes
+   `kill_stale_wrapper` against `issue-<N>.pid` (the dev PID file). The PID
+   file is clean, but the pgrep fallback regex `[-]-issue ${ISSUE_NUM}\b`
+   matches the live review wrapper by argv and SIGTERMs (then SIGKILLs) its
+   process group.
+4. The review agent exits 143 in the verdict-posting window, producing zero
+   actionable output; ~$1 of sonnet-1M time wasted.
+
+This is a second loop, distinct from the FAILED-verdict / same-HEAD loop,
+and reproduces on clean PRs with no FAILED verdict.
+
+**Multi-project amplification.** On the dispatcher box that runs multiple
+autonomous projects in parallel (the operator's actual topology — see
+`CLAUDE.local.md` for the OpenClaw cloud-station running 5+ projects against
+the same EC2 instance), the bug is even worse: any two projects whose issue
+numbering overlaps (e.g. project A issue 200, project B issue 200) cross-kill
+each other on every dispatch. Even after type-scoping by wrapper script, the
+`autonomous-dev.sh` script-name is **not** unique across projects — every
+project has its own copy. Type-scope alone is necessary but not sufficient.
+
+## Constraints / invariants we must preserve
+
+- **#109 (PID file vs `$$` reparenting)**: the pgrep fallback exists because
+  PID-file-based reaping misses subtrees from pre-fix wrappers, races between
+  `acquire_pid_guard` and `_run_with_timeout`, and rotational kills. The
+  fallback must continue to find genuine same-type orphans.
+- **Word boundary on `--issue N`**: prevents issue 9 from matching issue 99.
+- **`KILL_STALE_PGREP_FALLBACK=false`** must remain a complete bypass.
+- **No new argv** on the wrapper scripts (additive surface invites compat
+  bugs and we don't need it). The wrapper script *path* is already on the
+  argv via `nohup "<path>/autonomous-dev.sh" ...`.
+- **Pipeline doc parity**: the existing pgrep-fallback rule is documented in
+  `INV-23` ("Defence in depth (option C)") and worded as type-agnostic. That
+  wording is now incorrect, and a new INV-NN must capture the type-scoping
+  rule explicitly so future code can't regress.
+
+## Design
+
+### Approach: scope by project's wrapper *path* + wrapper script name
+
+Compose a regex from two pieces of information **already present on argv**:
+
+1. **`PROJECT_DIR`** — the project's root directory, sourced from
+   `autonomous.conf`. Every wrapper invocation in `dispatch-local.sh:199-220`
+   runs `nohup "${PROJECT_DIR}/scripts/autonomous-(dev|review).sh" ...`, so
+   `pgrep -f` sees the absolute path on argv0.
+2. **`TYPE`** — selects which of the two wrapper scripts (`autonomous-dev.sh`
+   or `autonomous-review.sh`) is the legal kill target.
+
+```bash
+# Regex-quote PROJECT_DIR so any '.' / '+' / etc. in the path are literal.
+project_re=$(printf '%s' "${PROJECT_DIR}/scripts/" | sed 's|[][\\.*^$+?(){}|]|\\&|g')
+case "$TYPE" in
+  dev-new|dev-resume) script_re="${project_re}autonomous-dev\\.sh" ;;
+  review)             script_re="${project_re}autonomous-review\\.sh" ;;
+  *)                  script_re="${project_re}autonomous-(dev|review)\\.sh" ;;
+esac
+orphan_pids=$(pgrep -f "${script_re}.*[-]-issue ${ISSUE_NUM}\b" 2>/dev/null \
+  | grep -vw "$$" || true)
+```
+
+Why path-anchored *and* type-anchored:
+
+- **Multi-project safety**. The dispatcher box typically runs 5+ projects;
+  per `CLAUDE.local.md`, `vidsyllabus`, `quant-scorer`, `podcast-curation`,
+  `panoptes`, and `llm-wiki` all live on the same cloud station and overlap
+  on issue numbers regularly. Anchoring on `${PROJECT_DIR}/scripts/` ensures
+  project A's dispatch never even *sees* project B's wrappers in its match
+  set.
+- **Zero ABI change**. `nohup` already invokes wrappers by absolute path
+  (the path is on argv[0]); we don't need to add `--project` or `--type`.
+- The wrappers use disjoint script names (`autonomous-dev.sh` vs
+  `autonomous-review.sh`); combined with the project path anchor, the match
+  set is bounded to *exactly* "this project's wrapper of this type for this
+  issue".
+- `dispatch-local.sh:188-192` *already* maps `TYPE` to wrapper-script-keyed
+  PID files (`issue-N.pid` vs `review-N.pid`). Extending the same mapping to
+  the pgrep fallback is the smallest change consistent with the existing
+  architecture.
+
+### Why regex-quote `PROJECT_DIR`
+
+`PROJECT_DIR` is operator-supplied via `autonomous.conf`. Most paths are
+plain `/data/git/<project>` and don't need quoting, but defense in depth
+matters here: a path containing `.` (e.g. `/home/ops/.local/share/...`)
+would otherwise let one project match another by a wildcarded char, and a
+path containing `[` or `(` would syntax-error the pgrep regex. The
+`sed`-based escape is local to the function (no helper proliferation).
+
+### Why not `--type <kind>` argv (rejected alternative)
+
+The issue mentions a more invasive option: add `--type <kind>` to both
+wrappers and match `--type ${TYPE}.*--issue ${N}\b`. Rejected because:
+
+- Both wrapper scripts and every caller (dispatcher's `dispatch-local.sh`,
+  remote-AWS-SSM `dispatch-remote-aws-ssm.sh`, manual operator invocations,
+  any in-tree tests that exec the wrappers) would need to pass the new flag.
+- Forward-compat hazard: a future remote-only dispatch path that doesn't yet
+  pass `--type` would silently regress to the broken matcher.
+- The script-name approach gives the same selectivity at zero compat cost
+  because the script path is already on argv.
+
+### Default-case fallthrough
+
+If `TYPE` is anything other than `dev-new|dev-resume|review` (which the
+case statement at `dispatch-local.sh:197` already rejects with exit 1),
+the function would already not be reached — but to be defensive against a
+future call site refactor, the catch-all `*)` branch keeps the project
+path anchor and a *type-agnostic* script-name matcher
+(`autonomous-(dev|review)\.sh`) so we don't silently let escaped wrappers
+of *this project* run forever. This is strictly safer than "match any
+process", because it still requires the wrapper script name to be
+`autonomous-(dev|review).sh` AND the path to be under
+`${PROJECT_DIR}/scripts/`.
+
+### Logging
+
+The "Found orphan agent process(es) for issue #N" message gains a `type=`
+prefix so operator log-spelunking can see why a kill was chosen:
+
+```
+Found orphan dev-resume agent process(es) for issue #126: 12345 — group-killing
+```
+
+This aids debugging the next regression class without changing the
+machine-readable parts of the dispatcher protocol.
+
+## Test plan
+
+**Test cases doc**: `docs/test-cases/dispatcher-stale-wrapper-cross-type.md`
+captures TC-A through TC-D from the issue, plus TC-E for the multi-project
+case:
+
+- **TC-A**: `review` wrapper alive (PID file present + responsive),
+  `dispatch-local.sh dev-resume <N>` is invoked. Expect: review wrapper
+  still alive after `kill_stale_wrapper` returns; new dev wrapper spawns
+  clean.
+- **TC-B**: Mirror — `autonomous-dev.sh` alive, dispatch `review`. Expect:
+  dev wrapper untouched, review wrapper spawns.
+- **TC-C**: Same-type orphan — real escaped `autonomous-dev.sh --issue N`
+  subtree from a prior crash, no PID file, dispatch `dev-resume`. Expect:
+  pgrep fallback still finds and group-kills the orphan.
+- **TC-D**: Negative — issue 9 vs issue 99. Dispatch `--issue 9`. Expect:
+  a live wrapper for `--issue 99` is not matched (existing word-boundary
+  preserved).
+- **TC-E (new, multi-project)**: project A's `dev-resume` for issue N must
+  not kill project B's wrapper for the same issue N (different
+  `PROJECT_DIR`). Mirrors the operator's actual topology where 5+ projects
+  share a host and overlap on issue numbers.
+
+**Unit tests** (new file
+`tests/unit/test-dispatch-local-pgrep-type-scope.sh` following the existing
+plain-bash harness pattern of e.g. `tests/unit/test-pid-guard.sh`):
+
+- **TC-REGEX-001..004**: extract the regex-selection code into a testable
+  function (in-test eval against the source file by `sed`-pattern, no
+  source modification needed for testability) and assert each `TYPE` maps
+  to the documented `script_re`.
+- **TC-PGREP-001..004**: spawn fixture `sleep 60` processes whose `argv0`
+  matches each wrapper-script pattern, run a stripped-down version of
+  `kill_stale_wrapper`'s pgrep-fallback block (sourced into the test
+  process), and assert the kill set per `TYPE`. Notably TC-PGREP-002 is
+  the regression for #126: dispatch `dev-resume`, decoy is
+  `autonomous-review.sh --issue N`, decoy must remain alive.
+- **TC-DISABLE-001**: `KILL_STALE_PGREP_FALLBACK=false` short-circuits the
+  fallback regardless of decoys.
+- **TC-STATIC-001..002** (grep-asserted): `dispatch-local.sh` must compute
+  `script_re` per `TYPE`, and the case branches must match what this
+  design canvas declares. Pins the implementation against silent
+  regression to the type-agnostic regex.
+
+## Pipeline doc updates (in same PR)
+
+- `docs/pipeline/invariants.md`: append **INV-28** — "pgrep fallback in
+  `kill_stale_wrapper` MUST scope by `${PROJECT_DIR}/scripts/` path AND
+  wrapper script name". Cross-references INV-23, INV-26.
+- `docs/pipeline/invariants.md::INV-23`: amend the "Defence in depth (option
+  C)" paragraph to call out the type-scoping requirement and link forward
+  to INV-28. The previous wording is no longer authoritative on its own.
+- `docs/pipeline/dispatcher-flow.md`: no structural change required — the
+  doc references `kill_stale_wrapper` as a black box; the regex-scope is
+  an INV-level rule, not a flow-step change.
+
+## Acceptance criteria mapping (from #126)
+
+| AC | Verification |
+|---|---|
+| `kill_stale_wrapper` from `dev-*` never SIGTERMs `autonomous-review.sh`, and vice versa, even with same issue N | TC-PGREP-001/002 |
+| Same-type orphan still group-killed | TC-PGREP-003 |
+| No regression of #109 PID-vs-$$ reparenting | INV-23 unchanged for PID-file path; pgrep fallback only narrows match set |
+| `KILL_STALE_PGREP_FALLBACK=false` unchanged | TC-DISABLE-001 |
+| `dispatcher-tick.sh:483-503` classification unchanged | This fix is upstream of the classifier; not touched |
+| Cross-project isolation (different `PROJECT_DIR`, same issue N) | TC-PGREP-005 |
+
+## Out of scope
+
+- Fixing the `pid_alive review` race that misclassifies a slow live review
+  as crashed (root cause of step 2 in the failure narrative). That's a
+  separate dispatcher-side correctness issue with its own design surface
+  (intersection of INV-24 and `pid_alive` debounce). The fix here only
+  prevents the cross-type kill that #126 documents.
+- Any change to `autonomous-dev.sh` or `autonomous-review.sh` argv.
+- Remote-AWS-SSM dispatch path: the SSM-side dispatcher invokes the same
+  `dispatch-local.sh`-equivalent code on the cloud station, so the fix is
+  inherited unchanged.

--- a/docs/pipeline/handoffs.md
+++ b/docs/pipeline/handoffs.md
@@ -35,7 +35,7 @@ flowchart LR
 
 - Atomic `+in-progress` label set BEFORE `nohup` spawn. Otherwise Step 5 in the same tick could probe a non-existent PID file and falsely diagnose DEAD ([INV-09](invariants.md#inv-09-just_dispatched-skip-rule) is the safety net for this; `JUST_DISPATCHED` only protects against the same-tick race, the label ordering protects against an immediately-following tick).
 - `JUST_DISPATCHED` includes the issue.
-- Dispatch goes through `dispatch-local.sh dev-new`, never directly invokes `autonomous-dev.sh`. The dispatch script is the only place that does `kill_stale_wrapper` (#57), input validation, and pre-creates the log file with 0600.
+- Dispatch goes through `dispatch-local.sh dev-new`, never directly invokes `autonomous-dev.sh`. The dispatch script is the only place that does `kill_stale_wrapper` (#57), input validation, and pre-creates the log file with 0600. The `kill_stale_wrapper` pgrep fallback is scoped to `${PROJECT_DIR}/scripts/autonomous-dev.sh` for `dev-*` dispatches (and the review variant for `review` dispatches) per [INV-28](invariants.md#inv-28-pgrep-fallback-must-be-scoped-by-project-and-wrapper-type) — without project + type scoping, multi-project boxes would cross-kill wrappers between projects, and same-project / different-type dispatches would kill each other (#126).
 
 **Consumer-side invariants** (dev wrapper must tolerate):
 

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -379,7 +379,7 @@ The `Mode: startup-failure` exclusion matters: `autonomous-dev.sh`'s startup-fai
 - `dispatch-local.sh::kill_stale_wrapper` issues `kill -TERM -- -<old_pid>` AND a leader-only kill, on both TERM and KILL escalation paths. The leader-only kill is a fallback for mid-rollout PID files that still hold a pre-fix `$$`.
 - `autonomous-dev.sh` and `autonomous-review.sh`, via `lib-agent.sh::install_agent_sigterm_trap`, forward dispatcher SIGTERM to the group via `kill -TERM -- -${_AGENT_RUN_PID}`.
 
-**Defence in depth (option C)**: `kill_stale_wrapper` additionally runs `pgrep -f -- '--issue ${ISSUE_NUM}\b'` and group-kills any matches not reachable through PID_FILE. Catches escaped trees from pre-fix wrappers and races between `acquire_pid_guard` and `_run_with_timeout` overwriting PID_FILE. Operators can disable via `KILL_STALE_PGREP_FALLBACK=false` if the heuristic over-matches.
+**Defence in depth (option C)**: `kill_stale_wrapper` additionally runs `pgrep -f` against a regex anchored on `${PROJECT_DIR}/scripts/autonomous-(dev|review)\.sh.*--issue ${ISSUE_NUM}\b` (per [INV-28](#inv-28-pgrep-fallback-must-be-scoped-by-project-and-wrapper-type)) and group-kills any matches not reachable through PID_FILE. Catches escaped trees from pre-fix wrappers and races between `acquire_pid_guard` and `_run_with_timeout` overwriting PID_FILE. Operators can disable via `KILL_STALE_PGREP_FALLBACK=false` if the heuristic over-matches.
 
 **Fallback when setsid is missing**: `_run_with_timeout` falls back to a non-setsid background spawn (defensive: the dispatcher fleet is Linux/Ubuntu and util-linux is universal there; macOS operators get setsid via Homebrew). In that mode the agent runs in the wrapper's process group; `kill_stale_wrapper`'s pgrep fallback still picks up orphans, with degraded — but not broken — atomicity.
 
@@ -499,6 +499,38 @@ Only when ALL three signals are negative does the existing crashed-comment + lab
 
 **Test**:
 - `tests/unit/test-dev-near-success.sh` (12 cases): TC-DNS-001..006 cover each signal independently (positive within window / stale / negative); TC-DNS-007/008 cover the disable knob and non-numeric fallback; TC-DNS-009 covers mixed-bag (any-signal-wins); TC-DNS-INT-001..003 statically pin the dispatcher-tick.sh placement before the crash comment with an INV-27 reference.
+
+## INV-28: pgrep fallback must be scoped by project AND wrapper type
+
+**Rule**: `dispatch-local.sh::kill_stale_wrapper`'s `pgrep -f` defence-in-depth (the [INV-23] "option C" fallback) MUST scope its match on three independent axes:
+
+1. **Project**: anchor on `${PROJECT_DIR}/scripts/`. Multiple autonomous projects can run on the same host with overlapping issue numbers; a regex without this anchor cross-kills wrappers across projects.
+2. **Wrapper type**: `dev-new` / `dev-resume` dispatch only matches `autonomous-dev.sh`; `review` only matches `autonomous-review.sh`. The two wrapper scripts have disjoint names and disjoint PID-file paths (`issue-N.pid` vs `review-N.pid`); the pgrep fallback must respect the same separation.
+3. **Issue**: `--issue <N>` with a `\b` word boundary so issue 9 doesn't match issue 99.
+
+`PROJECT_DIR` MUST be regex-quoted before composition into the pattern (e.g. via `sed 's|[][\\.*^$+?(){}|]|\\&|g'`), so an operator path containing `.`, `+`, `(`, etc. doesn't silently widen the match set.
+
+**Why**: Pre-fix the matcher was `[-]-issue ${ISSUE_NUM}\b` only — type-agnostic and project-agnostic. Two distinct loops resulted:
+
+- **Cross-type loop (#126)**: a live `autonomous-review.sh` wrapper (>5 min CLI run) racing a transient `pid_alive review` miss caused `dispatcher-tick.sh` to flip `reviewing` → `pending-dev`. The next tick dispatched `dev-resume`, whose `kill_stale_wrapper` then SIGTERMed the still-alive review wrapper in its verdict-posting window. Net effect: ~$1 of sonnet-1M time per cycle wasted with zero actionable output. The `review_near_success` defence ([INV-24]) was upstream of this kill — it gates the `pid_alive` *miss interpretation*, not the cross-type kill that follows the label flip.
+- **Cross-project amplification**: on a multi-project dispatcher box (the operator's actual topology runs 5+ projects against the same host), any two projects whose issue numbers happen to overlap cross-killed each other on every dispatch. Type-scope alone is necessary but not sufficient — every project has its own `autonomous-dev.sh` copy.
+
+**Producer**: `dispatch-local.sh::kill_stale_wrapper` (the only consumer of the regex).
+
+**Consumer**: same — the regex is private to the function. Other actors (`acquire_pid_guard`, the wrappers' SIGTERM trap) reach orphans through PID_FILE per [INV-23]'s primary path; the pgrep fallback is reached only when PID_FILE misses.
+
+**Operator override**: `KILL_STALE_PGREP_FALLBACK=false` still bypasses the entire fallback block — INV-28 narrows the *match set* when the fallback runs, not its on/off semantics.
+
+**Status**: **ENFORCED** in this PR (closes #126).
+
+**Test**:
+- `tests/unit/test-dispatch-local-pgrep-type-scope.sh` (21 cases): TC-REGEX-001..005 pin the script_re shape per TYPE plus PROJECT_DIR regex-quoting; TC-PGREP-001/002 are the cross-type regression for #126 (dev-resume must not kill live review wrapper, and vice versa); TC-PGREP-003 confirms same-type/same-project orphans are still group-killed (no regression of #109's [INV-23]); TC-PGREP-004 preserves the issue-9-vs-99 word boundary; TC-PGREP-005 is the cross-project regression (proj-A dispatch must not kill proj-B wrapper); TC-DISABLE-001 confirms `KILL_STALE_PGREP_FALLBACK=false` still fully bypasses; TC-STATIC-001/002 grep-pin the regex shape and `INV-28` reference in source.
+- `tests/unit/test-pid-guard-pgid.sh::TC-PGID-005` updated: the fake escaped tree is now placed under `${PROJECT_DIR}/scripts/autonomous-dev.sh` and `TYPE=dev-resume` is set so the project-anchored regex matches it.
+
+**Cross-references**:
+- [INV-23] (PID_FILE reaps subtree) is the primary path; INV-28 narrows the option-C fallback's match set.
+- [INV-24] (review-side near-success short-circuit) and [INV-27] (dev-side near-success) sit upstream of the label flip that triggers the cross-type kill described in #126's reproduction. They reduce frequency; INV-28 closes the cross-kill bug regardless of how the label flip was reached.
+- [INV-26] (stall decision excludes dispatcher-induced terminations + defers on live wrappers) reduces the residue created when `kill_stale_wrapper` itself fires. INV-28 prevents the *wrong* kills that caused the residue in the first place.
 
 ## Adding a new invariant
 

--- a/docs/test-cases/dispatcher-stale-wrapper-cross-type.md
+++ b/docs/test-cases/dispatcher-stale-wrapper-cross-type.md
@@ -1,0 +1,162 @@
+# Test Cases — Cross-type stale-wrapper kill (issue #126)
+
+**Feature**: Type-scoped pgrep fallback in `dispatch-local.sh::kill_stale_wrapper`
+**Issue**: #126
+**Design**: `docs/designs/dispatch-local-pgrep-type-scope.md`
+**Invariant**: INV-28 (added in this PR)
+**Test file**: `tests/unit/test-dispatch-local-pgrep-type-scope.sh`
+
+## Acceptance criteria coverage
+
+| AC (from #126) | Test cases |
+|---|---|
+| `dev-*` dispatch never SIGTERMs `autonomous-review.sh`, and vice versa | TC-PGREP-001, TC-PGREP-002 |
+| Same-type orphan still group-killed | TC-PGREP-003 |
+| No regression of #109 (PID file vs `$$` reparenting) | TC-PGREP-003 (orphan w/ no PID file still reaped); INV-23 PID-file path is unchanged in code |
+| `KILL_STALE_PGREP_FALLBACK=false` unchanged | TC-DISABLE-001 |
+| Word-boundary preserved (issue 9 vs 99) | TC-PGREP-004 |
+| Cross-project isolation (multiple autonomous projects on same host, overlapping issue N) | TC-PGREP-005 |
+| `dispatcher-tick.sh:483-503` classifier unchanged | Out of scope; covered by existing INV-26/INV-27 tests |
+
+## Test scenarios
+
+### TC-PGREP-001 — dev-resume must NOT kill live review wrapper (regression for #126)
+
+**Given**:
+- A live decoy process whose argv0 path ends in `autonomous-review.sh` and whose
+  argv contains `--issue 998877`.
+- No PID file at `${PID_DIR}/issue-998877.pid` (so the PID-file path of
+  `kill_stale_wrapper` is a no-op and the pgrep fallback runs).
+
+**When**: `kill_stale_wrapper` runs in `TYPE=dev-resume` context for issue 998877.
+
+**Expect**:
+- `kill_stale_wrapper` exits 0.
+- The decoy `autonomous-review.sh --issue 998877` process is **still alive**.
+
+### TC-PGREP-002 — review must NOT kill live dev wrapper (mirror of TC-PGREP-001)
+
+**Given**:
+- A live decoy `autonomous-dev.sh --issue 998877`.
+- No `${PID_DIR}/review-998877.pid`.
+
+**When**: `kill_stale_wrapper` runs in `TYPE=review` context for issue 998877.
+
+**Expect**:
+- `kill_stale_wrapper` exits 0.
+- The decoy `autonomous-dev.sh --issue 998877` is **still alive**.
+
+### TC-PGREP-003 — same-type orphan IS group-killed (no regression of #109 fallback)
+
+**Given**:
+- A live decoy `autonomous-dev.sh --issue 998877` (orphan; no PID file).
+
+**When**: `kill_stale_wrapper` runs in `TYPE=dev-resume` context for issue 998877.
+
+**Expect**:
+- `kill_stale_wrapper` exits 0.
+- The decoy is **dead** within 5 s (fallback successfully reaped it).
+
+### TC-PGREP-004 — word boundary preserved (issue 9 vs issue 99)
+
+**Given**:
+- A live decoy `autonomous-dev.sh --issue 99` (note: NOT 9).
+
+**When**: `kill_stale_wrapper` runs in `TYPE=dev-resume` context for issue 9.
+
+**Expect**:
+- `kill_stale_wrapper` exits 0.
+- The decoy for issue 99 is **still alive** (word-boundary stops the
+  numerically-prefix match).
+
+### TC-PGREP-005 — cross-project isolation (multi-project box)
+
+**Given**:
+- Two distinct `PROJECT_DIR` paths (e.g. `/tmp/.../proj-a/` and
+  `/tmp/.../proj-b/`), each with its own `scripts/autonomous-dev.sh` copy.
+- A live decoy at `${PROJ_B}/scripts/autonomous-dev.sh --issue 998877`
+  (project B's wrapper).
+
+**When**: `kill_stale_wrapper` runs with `PROJECT_DIR=${PROJ_A}` and
+`TYPE=dev-resume` for issue 998877.
+
+**Expect**:
+- `kill_stale_wrapper` exits 0.
+- The project-B decoy is **still alive** (project A's pgrep regex
+  anchors on `${PROJ_A}/scripts/`, so project B's wrapper is not in the
+  match set).
+
+This is the multi-project case the dispatcher box hits in production: per
+`CLAUDE.local.md`, the cloud station (Singapore `i-0c87da4b7346b86d6`)
+runs `vidsyllabus`, `quant-scorer`, `podcast-curation`, `panoptes`, and
+`llm-wiki` simultaneously. Issue numbers are per-repo and overlap
+constantly, so without project-path anchoring, every dispatch is a
+potential cross-kill.
+
+### TC-DISABLE-001 — KILL_STALE_PGREP_FALLBACK=false short-circuits
+
+**Given**:
+- A live decoy `autonomous-dev.sh --issue 998877`.
+- `KILL_STALE_PGREP_FALLBACK=false` in the environment.
+
+**When**: `kill_stale_wrapper` runs in `TYPE=dev-resume` context for issue 998877.
+
+**Expect**:
+- `kill_stale_wrapper` exits 0.
+- The decoy is **still alive** (the entire fallback block is skipped).
+
+### TC-REGEX-001 — `TYPE=dev-new` selects `${PROJECT_DIR}/scripts/autonomous-dev\.sh`
+
+Static-behavioral assertion: `script_re` for `TYPE=dev-new` must contain
+the regex-quoted `${PROJECT_DIR}/scripts/` AND `autonomous-dev\.sh`, and
+must NOT match the review wrapper.
+
+### TC-REGEX-002 — `TYPE=dev-resume` selects dev wrapper under project path
+
+Same as TC-REGEX-001 for `dev-resume`.
+
+### TC-REGEX-003 — `TYPE=review` selects review wrapper under project path
+
+Static-behavioral assertion: `script_re` for `TYPE=review` must contain the
+regex-quoted `${PROJECT_DIR}/scripts/` AND `autonomous-review\.sh`, and
+must NOT match the dev wrapper.
+
+### TC-REGEX-004 — Default fallthrough preserves project anchor + both wrappers
+
+Static-behavioral assertion: the `*)` catch-all branch's `script_re`
+matches `${PROJECT_DIR}/scripts/autonomous-(dev|review)\.sh`. The project
+path anchor is preserved even in the catch-all so a future refactor that
+calls the function with an unexpected `TYPE` cannot accidentally cross
+project boundaries.
+
+### TC-REGEX-005 — `PROJECT_DIR` is regex-quoted
+
+Static-behavioral assertion: a `PROJECT_DIR` containing `.` (e.g.
+`/home/x/.local/foo`) must be literalized in the regex — i.e. the `script_re`
+must contain `\\.` not `.` for that character. Guards against operator
+PROJECT_DIR paths with dots, brackets, or parens silently widening the
+match set.
+
+### TC-STATIC-001 — pgrep regex ANDs project + script + issue
+
+Static grep against `dispatch-local.sh`: the `pgrep -f` invocation must use
+a single regex string that contains `${script_re}` (which itself contains
+the project path anchor) AND `--issue ${ISSUE_NUM}\\b`. Pins the
+implementation against regression to the type-agnostic / project-agnostic
+regex.
+
+### TC-STATIC-002 — INV-28 referenced from `dispatch-local.sh` comment
+
+Static grep: the comment block above the pgrep fallback references
+`INV-28` so future maintainers find the invariants doc.
+
+## How tests run
+
+```bash
+bash tests/unit/test-dispatch-local-pgrep-type-scope.sh
+```
+
+The test file is plain bash and follows the existing harness pattern of
+`tests/unit/test-pid-guard.sh` (PASS/FAIL counters, `assert_eq` /
+`assert_contains` helpers, `mktemp -d` per-test scratch dir, fixture
+processes via `bash -c 'exec -a <argv0> sleep 60'`). No bats dependency.

--- a/skills/autonomous-dispatcher/scripts/dispatch-local.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatch-local.sh
@@ -144,7 +144,7 @@ kill_stale_wrapper() {
     rm -f "$pid_file"
   fi
 
-  # Defensive pgrep fallback (closes #109 — option C).
+  # Defensive pgrep fallback (closes #109 — option C; INV-23, INV-28).
   #
   # Catches escaped agent trees that PID_FILE never reaches:
   #   - pre-fix wrappers whose PID_FILE held `$$` and got reparented to PID 1
@@ -154,18 +154,42 @@ kill_stale_wrapper() {
   #   - rotational kills where a previous tick removed PID_FILE but the
   #     subtree was still unwinding
   #
-  # Match by `--issue <N>` argv (highly specific to the wrappers; the word
-  # boundary stops issue 9 from matching issue 99). Disabled via
-  # KILL_STALE_PGREP_FALLBACK=false for operators running their own kill
-  # choreography.
+  # The match must be scoped on three axes (INV-28):
+  #   1. project — anchor on `${PROJECT_DIR}/scripts/`. Multiple autonomous
+  #      projects can run on the same host with overlapping issue numbers
+  #      (e.g. project A issue 200, project B issue 200); a global match
+  #      would cross-kill across projects.
+  #   2. wrapper type — `dev-*` dispatches must only target
+  #      `autonomous-dev.sh` orphans, `review` only `autonomous-review.sh`
+  #      (closes #126). Pre-fix the matcher was type-agnostic and a
+  #      `dev-resume` for issue N would SIGTERM a live `autonomous-review.sh
+  #      --issue N` wrapper, killing the review in its verdict-posting
+  #      window.
+  #   3. issue — `--issue <N>` with a `\b` word boundary so issue 9 doesn't
+  #      match issue 99.
+  #
+  # Disabled via KILL_STALE_PGREP_FALLBACK=false for operators running
+  # their own kill choreography.
   if [[ "${KILL_STALE_PGREP_FALLBACK:-true}" == "true" ]]; then
-    local orphan_pids
+    local orphan_pids project_re script_re
+    # `:-` defaults so unit tests sourcing this function in isolation don't
+    # trip `set -u`. In production, both vars are validated at the top of
+    # dispatch-local.sh.
+    # Defensive *) branch: TYPE is validated up-top, so it's unreachable
+    # in normal flow; keeping the project anchor in the catch-all means a
+    # future refactor cannot silently widen the match across projects.
+    project_re=$(printf '%s' "${PROJECT_DIR:-}/scripts/" | sed 's|[][\\.*^$+?(){}|]|\\&|g')
+    case "${TYPE:-}" in
+      dev-new|dev-resume) script_re="${project_re}autonomous-dev\\.sh" ;;
+      review)             script_re="${project_re}autonomous-review\\.sh" ;;
+      *)                  script_re="${project_re}autonomous-(dev|review)\\.sh" ;;
+    esac
     # `pgrep -f` matches against the full command line (argv[0] + args).
     # The `[-]-` trick keeps the matcher itself off the result list.
-    orphan_pids=$(pgrep -f "[-]-issue ${ISSUE_NUM}\b" 2>/dev/null \
+    orphan_pids=$(pgrep -f "${script_re}.*[-]-issue ${ISSUE_NUM}\b" 2>/dev/null \
       | grep -vw "$$" || true)
     if [[ -n "$orphan_pids" ]]; then
-      echo "Found orphan agent process(es) for issue #${ISSUE_NUM}: $(tr '\n' ' ' <<<"$orphan_pids")— group-killing" >&2
+      echo "Found orphan ${TYPE:-?} agent process(es) for issue #${ISSUE_NUM} (project ${PROJECT_ID:-?}): $(tr '\n' ' ' <<<"$orphan_pids")— group-killing" >&2
       local op
       while IFS= read -r op; do
         [[ -z "$op" ]] && continue

--- a/tests/unit/test-dispatch-local-pgrep-type-scope.sh
+++ b/tests/unit/test-dispatch-local-pgrep-type-scope.sh
@@ -1,0 +1,357 @@
+#!/bin/bash
+# test-dispatch-local-pgrep-type-scope.sh — Unit tests for issue #126.
+#
+# `dispatch-local.sh::kill_stale_wrapper`'s pgrep fallback must scope its
+# match to `${PROJECT_DIR}/scripts/autonomous-<type>.sh --issue <N>` so that:
+#   1. dev-resume for issue N never SIGTERMs autonomous-review.sh for N
+#      (and vice versa) — issue #126's primary bug.
+#   2. project A's dispatch never touches project B's wrappers, even when
+#      both projects share an issue number — multi-project amplification
+#      flagged by the operator (TC-PGREP-005).
+#
+# Test plan: docs/test-cases/dispatcher-stale-wrapper-cross-type.md
+# Design:    docs/designs/dispatch-local-pgrep-type-scope.md
+# Invariant: INV-28
+#
+# Run: bash tests/unit/test-dispatch-local-pgrep-type-scope.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DISPATCH_LOCAL="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/dispatch-local.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected='$expected', actual='$actual')"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (expected to contain '$needle')"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+# Spawn a sleep with a wrapper-shaped argv0. The trampoline lives at
+# ${proj_dir}/scripts/<script_name> so /proc/<pid>/cmdline (which pgrep -f
+# reads) shows the path mirrored from production.
+spawn_decoy() {
+  local proj_dir="$1"; shift
+  local script_name="$1"; shift
+  local issue_num="$1"; shift
+  local extra_args=("$@")
+
+  mkdir -p "${proj_dir}/scripts"
+  local trampoline="${proj_dir}/scripts/${script_name}"
+  # NB: do NOT `exec sleep` — exec replaces argv on /proc/<pid>/cmdline
+  # with bare `sleep`, defeating pgrep -f. Sleep in-process so the
+  # wrapper-shaped argv stays visible.
+  cat >"$trampoline" <<'EOF'
+#!/bin/bash
+sleep 30
+EOF
+  chmod +x "$trampoline"
+  # Use setsid so the decoy is its own session/PG leader (mirrors how the
+  # real wrapper runs under setsid in lib-agent.sh::_run_with_timeout —
+  # group-kill semantics depend on this).
+  setsid "$trampoline" --issue "$issue_num" "${extra_args[@]}" >/dev/null 2>&1 &
+  local pid=$!
+  # Tiny settle so /proc/<pid>/cmdline is populated before pgrep runs.
+  sleep 0.1
+  printf '%s' "$pid"
+}
+
+_DECOY_PIDS=()
+_track_decoy() { _DECOY_PIDS+=("$1"); }
+_reap_decoys() {
+  local p
+  for p in "${_DECOY_PIDS[@]:-}"; do
+    [[ -z "$p" ]] && continue
+    kill -9 -- "-${p}" 2>/dev/null || true
+    kill -9 "$p" 2>/dev/null || true
+  done
+  _DECOY_PIDS=()
+}
+
+TMPDIR_T=$(mktemp -d)
+PROJ_A="${TMPDIR_T}/proj-a"
+PROJ_B="${TMPDIR_T}/proj-b"
+PID_DIR_A="${TMPDIR_T}/pidfiles-a"
+mkdir -p "$PROJ_A" "$PROJ_B" "$PID_DIR_A"
+trap '_reap_decoys; rm -rf "$TMPDIR_T"' EXIT
+
+# ---------------------------------------------------------------------------
+# Source `kill_stale_wrapper` from dispatch-local.sh into a sub-test shell.
+# ---------------------------------------------------------------------------
+
+extract_kill_stale_wrapper() {
+  awk '
+    /^kill_stale_wrapper\(\) \{$/ { flag=1 }
+    flag { print }
+    flag && /^\}$/ { flag=0 }
+  ' "$DISPATCH_LOCAL"
+}
+
+# Driver shim: sets PROJECT_DIR/TYPE/ISSUE_NUM/KILL_STALE_PGREP_FALLBACK,
+# computes script_re per the implementation contract, then invokes
+# kill_stale_wrapper. Uses the regex-escape sed pattern from the design canvas.
+run_kill_stale() {
+  local proj_dir="$1" type_val="$2" issue_num="$3" pid_file="$4"
+  local fallback_env="${5:-true}"
+
+  PROJECT_DIR="$proj_dir" \
+  ISSUE_NUM="$issue_num" \
+  TYPE="$type_val" \
+  KILL_STALE_PGREP_FALLBACK="$fallback_env" \
+  bash -c '
+    set -uo pipefail
+    project_re=$(printf "%s" "${PROJECT_DIR}/scripts/" | sed "s|[][\\.*^\$+?(){}|]|\\\\&|g")
+    case "$TYPE" in
+      dev-new|dev-resume) script_re="${project_re}autonomous-dev\\.sh" ;;
+      review)             script_re="${project_re}autonomous-review\\.sh" ;;
+      *)                  script_re="${project_re}autonomous-(dev|review)\\.sh" ;;
+    esac
+    '"$(extract_kill_stale_wrapper)"'
+    kill_stale_wrapper "$1"
+  ' _ "$pid_file"
+}
+
+# Helper: emit script_re for a given (PROJECT_DIR, TYPE) — used by TC-REGEX-*.
+emit_script_re() {
+  local proj_dir="$1" type_val="$2"
+  PROJECT_DIR="$proj_dir" TYPE="$type_val" bash -c '
+    project_re=$(printf "%s" "${PROJECT_DIR}/scripts/" | sed "s|[][\\.*^\$+?(){}|]|\\\\&|g")
+    case "$TYPE" in
+      dev-new|dev-resume) script_re="${project_re}autonomous-dev\\.sh" ;;
+      review)             script_re="${project_re}autonomous-review\\.sh" ;;
+      *)                  script_re="${project_re}autonomous-(dev|review)\\.sh" ;;
+    esac
+    printf "%s" "$script_re"
+  '
+}
+
+# ---------------------------------------------------------------------------
+# Static / regex-shape assertions
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Regex-shape assertions ==="
+
+src=$(extract_kill_stale_wrapper)
+
+# TC-REGEX-001..004: regex shape per TYPE.
+re_dev_new=$(emit_script_re "/var/lib/proj-a" dev-new)
+re_dev_resume=$(emit_script_re "/var/lib/proj-a" dev-resume)
+re_review=$(emit_script_re "/var/lib/proj-a" review)
+re_default=$(emit_script_re "/var/lib/proj-a" _unused_)
+
+assert_contains "TC-REGEX-001 dev-new contains project path anchor" \
+  '/var/lib/proj-a/scripts/' "$re_dev_new"
+assert_contains "TC-REGEX-001 dev-new contains autonomous-dev.sh" \
+  'autonomous-dev\.sh' "$re_dev_new"
+[[ "$re_dev_new" != *autonomous-review* ]] \
+  && { echo -e "  ${GREEN}PASS${NC}: TC-REGEX-001 dev-new excludes review wrapper"; PASS=$((PASS+1)); } \
+  || { echo -e "  ${RED}FAIL${NC}: TC-REGEX-001 dev-new should not include 'autonomous-review'"; FAIL=$((FAIL+1)); }
+
+assert_contains "TC-REGEX-002 dev-resume contains autonomous-dev.sh" \
+  'autonomous-dev\.sh' "$re_dev_resume"
+assert_contains "TC-REGEX-003 review contains autonomous-review.sh" \
+  'autonomous-review\.sh' "$re_review"
+[[ "$re_review" != *autonomous-dev\\.sh* ]] \
+  && { echo -e "  ${GREEN}PASS${NC}: TC-REGEX-003 review excludes dev wrapper"; PASS=$((PASS+1)); } \
+  || { echo -e "  ${RED}FAIL${NC}: TC-REGEX-003 review should not include 'autonomous-dev.sh'"; FAIL=$((FAIL+1)); }
+assert_contains "TC-REGEX-004 default catch-all matches both wrappers under project" \
+  'autonomous-(dev|review)\.sh' "$re_default"
+assert_contains "TC-REGEX-004 default still anchors on project path" \
+  '/var/lib/proj-a/scripts/' "$re_default"
+
+# TC-REGEX-005: regex-quoting for dotted PROJECT_DIR.
+re_dotted=$(emit_script_re "/home/x/.local/foo" dev-new)
+assert_contains "TC-REGEX-005 dotted PROJECT_DIR is regex-escaped (\\.local)" \
+  '\.local' "$re_dotted"
+# A path-traversal sanity check: the dotted regex MUST NOT also match the
+# undotted variant (which it would if '.' stayed unescaped).
+[[ "/home/xX.local/foo/scripts/autonomous-dev.sh" =~ ^${re_dotted}$ ]] \
+  && { echo -e "  ${RED}FAIL${NC}: TC-REGEX-005 unescaped dot wildcards across paths"; FAIL=$((FAIL+1)); } \
+  || { echo -e "  ${GREEN}PASS${NC}: TC-REGEX-005 escaped dot does not wildcard"; PASS=$((PASS+1)); }
+
+# TC-STATIC-001: dispatch-local.sh source declares the same shape.
+assert_contains "TC-STATIC-001 source declares script_re= for dev-new|dev-resume" \
+  'dev-new|dev-resume) script_re=' "$src"
+assert_contains "TC-STATIC-001 source declares script_re= for review" \
+  'review)             script_re=' "$src"
+assert_contains "TC-STATIC-001 pgrep regex ANDs script_re with --issue matcher" \
+  'pgrep -f "${script_re}.*[-]-issue ${ISSUE_NUM}\b"' "$src"
+assert_contains "TC-STATIC-001 source includes project path anchor (PROJECT_DIR/scripts/)" \
+  '${PROJECT_DIR}/scripts/' "$src"
+
+# TC-STATIC-002: INV-28 reference in source comment.
+assert_contains "TC-STATIC-002 source references INV-28" \
+  'INV-28' "$src"
+
+# ---------------------------------------------------------------------------
+# Behavioral assertions — fixture processes vs the live function body.
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Behavioral pgrep-fallback assertions ==="
+
+# TC-PGREP-001 — dev-resume must NOT kill autonomous-review.sh decoy of same project.
+echo ""
+echo "--- TC-PGREP-001 dev-resume MUST NOT kill review wrapper for same issue/project ---"
+review_pid=$(spawn_decoy "$PROJ_A" "autonomous-review.sh" 998877 --some-flag x)
+_track_decoy "$review_pid"
+if ! kill -0 "$review_pid" 2>/dev/null; then
+  echo -e "  ${RED}FAIL${NC}: TC-PGREP-001 setup — decoy did not start"
+  FAIL=$((FAIL+1))
+else
+  run_kill_stale "$PROJ_A" dev-resume 998877 "$PID_DIR_A/issue-998877.pid" >/dev/null 2>&1 || true
+  if kill -0 "$review_pid" 2>/dev/null; then
+    echo -e "  ${GREEN}PASS${NC}: TC-PGREP-001 review decoy survived dev-resume kill_stale_wrapper"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: TC-PGREP-001 review decoy was killed by dev-resume (regression for #126)"
+    FAIL=$((FAIL+1))
+  fi
+fi
+_reap_decoys
+
+# TC-PGREP-002 — review must NOT kill autonomous-dev.sh decoy of same project.
+echo ""
+echo "--- TC-PGREP-002 review MUST NOT kill dev wrapper for same issue/project ---"
+dev_pid=$(spawn_decoy "$PROJ_A" "autonomous-dev.sh" 998877 --mode resume)
+_track_decoy "$dev_pid"
+if ! kill -0 "$dev_pid" 2>/dev/null; then
+  echo -e "  ${RED}FAIL${NC}: TC-PGREP-002 setup — decoy did not start"
+  FAIL=$((FAIL+1))
+else
+  run_kill_stale "$PROJ_A" review 998877 "$PID_DIR_A/review-998877.pid" >/dev/null 2>&1 || true
+  if kill -0 "$dev_pid" 2>/dev/null; then
+    echo -e "  ${GREEN}PASS${NC}: TC-PGREP-002 dev decoy survived review kill_stale_wrapper"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: TC-PGREP-002 dev decoy was killed by review (regression for #126)"
+    FAIL=$((FAIL+1))
+  fi
+fi
+_reap_decoys
+
+# TC-PGREP-003 — same-type orphan in same project IS group-killed.
+echo ""
+echo "--- TC-PGREP-003 dev-resume DOES kill autonomous-dev.sh orphan for same issue/project ---"
+dev_pid=$(spawn_decoy "$PROJ_A" "autonomous-dev.sh" 998877 --mode resume)
+_track_decoy "$dev_pid"
+if ! kill -0 "$dev_pid" 2>/dev/null; then
+  echo -e "  ${RED}FAIL${NC}: TC-PGREP-003 setup — decoy did not start"
+  FAIL=$((FAIL+1))
+else
+  run_kill_stale "$PROJ_A" dev-resume 998877 "$PID_DIR_A/issue-998877.pid" >/dev/null 2>&1 || true
+  for _ in 1 2 3 4 5; do
+    kill -0 "$dev_pid" 2>/dev/null || break
+    sleep 1
+  done
+  if kill -0 "$dev_pid" 2>/dev/null; then
+    echo -e "  ${RED}FAIL${NC}: TC-PGREP-003 same-type same-project orphan survived (fallback regression)"
+    FAIL=$((FAIL+1))
+  else
+    echo -e "  ${GREEN}PASS${NC}: TC-PGREP-003 same-type same-project orphan was reaped"
+    PASS=$((PASS+1))
+  fi
+fi
+_reap_decoys
+
+# TC-PGREP-004 — issue 9 dispatch must NOT kill issue 99 wrapper (word boundary).
+echo ""
+echo "--- TC-PGREP-004 word-boundary preserved (issue 9 vs 99) ---"
+dev_pid=$(spawn_decoy "$PROJ_A" "autonomous-dev.sh" 99 --mode resume)
+_track_decoy "$dev_pid"
+if ! kill -0 "$dev_pid" 2>/dev/null; then
+  echo -e "  ${RED}FAIL${NC}: TC-PGREP-004 setup — decoy did not start"
+  FAIL=$((FAIL+1))
+else
+  run_kill_stale "$PROJ_A" dev-resume 9 "$PID_DIR_A/issue-9.pid" >/dev/null 2>&1 || true
+  if kill -0 "$dev_pid" 2>/dev/null; then
+    echo -e "  ${GREEN}PASS${NC}: TC-PGREP-004 issue 99 decoy survived issue 9 dispatch"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: TC-PGREP-004 issue 99 decoy killed by issue 9 dispatch (word-boundary regression)"
+    FAIL=$((FAIL+1))
+  fi
+fi
+_reap_decoys
+
+# TC-PGREP-005 — cross-project isolation. The decoy is in PROJ_B; dispatch
+# is for PROJ_A, same issue number. Decoy must survive.
+echo ""
+echo "--- TC-PGREP-005 cross-project isolation (proj-A dispatch must NOT kill proj-B wrapper) ---"
+projb_pid=$(spawn_decoy "$PROJ_B" "autonomous-dev.sh" 998877 --mode resume)
+_track_decoy "$projb_pid"
+if ! kill -0 "$projb_pid" 2>/dev/null; then
+  echo -e "  ${RED}FAIL${NC}: TC-PGREP-005 setup — decoy did not start"
+  FAIL=$((FAIL+1))
+else
+  run_kill_stale "$PROJ_A" dev-resume 998877 "$PID_DIR_A/issue-998877.pid" >/dev/null 2>&1 || true
+  if kill -0 "$projb_pid" 2>/dev/null; then
+    echo -e "  ${GREEN}PASS${NC}: TC-PGREP-005 proj-B decoy survived proj-A dispatch"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: TC-PGREP-005 proj-B decoy was killed by proj-A dispatch (cross-project regression)"
+    FAIL=$((FAIL+1))
+  fi
+fi
+_reap_decoys
+
+# TC-DISABLE-001 — KILL_STALE_PGREP_FALLBACK=false short-circuits.
+echo ""
+echo "--- TC-DISABLE-001 KILL_STALE_PGREP_FALLBACK=false skips fallback ---"
+dev_pid=$(spawn_decoy "$PROJ_A" "autonomous-dev.sh" 998877 --mode resume)
+_track_decoy "$dev_pid"
+if ! kill -0 "$dev_pid" 2>/dev/null; then
+  echo -e "  ${RED}FAIL${NC}: TC-DISABLE-001 setup — decoy did not start"
+  FAIL=$((FAIL+1))
+else
+  run_kill_stale "$PROJ_A" dev-resume 998877 "$PID_DIR_A/issue-998877.pid" false >/dev/null 2>&1 || true
+  if kill -0 "$dev_pid" 2>/dev/null; then
+    echo -e "  ${GREEN}PASS${NC}: TC-DISABLE-001 fallback was skipped, decoy alive"
+    PASS=$((PASS+1))
+  else
+    echo -e "  ${RED}FAIL${NC}: TC-DISABLE-001 decoy was killed (disable knob ignored)"
+    FAIL=$((FAIL+1))
+  fi
+fi
+_reap_decoys
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+if [[ $FAIL -eq 0 ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/tests/unit/test-pid-guard-pgid.sh
+++ b/tests/unit/test-pid-guard-pgid.sh
@@ -406,14 +406,20 @@ fi
 
 ISSUE_NUM=987654  # used by log messages and the pgrep pattern
 KILL_STALE_PGREP_FALLBACK=true
+# Per INV-28 the pgrep fallback is scoped to ${PROJECT_DIR}/scripts/ so
+# multi-project boxes don't cross-kill. Place the fake tree under a
+# fixture PROJECT_DIR/scripts/ and export it for the function. TYPE
+# selects the dev wrapper since the fake tree is named autonomous-dev.sh.
+PROJECT_DIR="$TMPDIR/proj"
+TYPE=dev-resume
+mkdir -p "$PROJECT_DIR/scripts"
 # shellcheck source=/dev/null
 source "$EXTRACT_FILE"
 
 # Spawn a fake "escaped tree" with `--issue <N>` in its argv so the
-# pgrep fallback can match it. We pass --issue as a real argument (not
-# argv[0] override) so it lands in /proc/PID/cmdline verbatim. The
-# script reads it via "$@" but ignores the value.
-FAKE_TREE_SCRIPT="$TMPDIR/fake-autonomous-dev.sh"
+# pgrep fallback can match it. The trampoline lives under
+# ${PROJECT_DIR}/scripts/ — the path anchor INV-28 requires.
+FAKE_TREE_SCRIPT="$PROJECT_DIR/scripts/autonomous-dev.sh"
 cat > "$FAKE_TREE_SCRIPT" <<'EOS'
 #!/bin/bash
 # Block on a sleep child so SIGTERM cleanup is responsive. Args are not


### PR DESCRIPTION
## Summary

- Tighten `dispatch-local.sh::kill_stale_wrapper` pgrep fallback regex to anchor on `${PROJECT_DIR}/scripts/` AND `autonomous-(dev|review)\.sh` (per `TYPE`) AND `--issue N\b`.
- Closes the cross-type kill (`dev-resume` group-killing a live `autonomous-review.sh` for the same issue, #126's primary loop) and the cross-project kill (project A dispatch killing project B wrapper for an overlapping issue number on multi-project hosts).
- New invariant `INV-28` documents the three-axis scoping rule; `INV-23` amended to forward-reference it; `handoffs.md::H1` updated.

## Why

`pgrep -f "[-]-issue ${ISSUE_NUM}\b"` was type-agnostic and project-agnostic. On the production multi-project dispatcher box this caused two distinct loops:

1. **Cross-type (#126)**: a slow live review wrapper + a transient `pid_alive` miss → label flip `reviewing` → `pending-dev` → next tick dispatches `dev-resume` → `kill_stale_wrapper`'s pgrep matches the live review wrapper by argv only and SIGTERMs it in its verdict-posting window. ~$1 of sonnet-1M time per cycle wasted with zero actionable output.
2. **Cross-project**: any two projects whose issue numbers overlapped cross-killed each other on every dispatch. The operator's actual topology runs 5+ projects on the same host.

`PROJECT_DIR` is regex-quoted (`sed 's|[][\\.*^$+?(){}|]|\\&|g'`) so operator paths with `.`, `+`, `(` are literal. The `:-` defaults on `PROJECT_DIR`/`TYPE` keep unit tests sourcing the function in isolation deterministic. The `KILL_STALE_PGREP_FALLBACK=false` operator override is unchanged.

## Design

- [x] Design canvas: `docs/designs/dispatch-local-pgrep-type-scope.md`
- [x] Test cases doc: `docs/test-cases/dispatcher-stale-wrapper-cross-type.md`
- [x] Pipeline docs updated (`invariants.md` INV-28 + INV-23 amendment, `handoffs.md` H1)

## Test Plan

- [x] Build / lint: `shellcheck` clean (only pre-existing SC1091 informationals on `source` lines)
- [x] Unit tests: 59/59 pass (`tests/unit/test-*.sh`)
  - New `tests/unit/test-dispatch-local-pgrep-type-scope.sh` (21 cases):
    - TC-PGREP-001/002 — cross-type regression (#126); fail before fix, pass after
    - TC-PGREP-005 — cross-project regression (multi-project box)
    - TC-PGREP-003/004 — no regression of #109 (option-C orphan reap) and word-boundary
    - TC-DISABLE-001 — operator override unchanged
    - TC-REGEX-001..005 — regex shape per TYPE + `PROJECT_DIR` regex-quoting
    - TC-STATIC-001/002 — pin source shape and `INV-28` reference
  - Updated `tests/unit/test-pid-guard-pgid.sh::TC-PGID-005` — fake escaped tree placed under `${PROJECT_DIR}/scripts/` so the project-anchored regex matches it (the existing test was implicitly relying on the now-deleted type-agnostic regex)
- [x] Code simplification review passed
- [x] PR review agent review passed
- [ ] CI checks pass
- [ ] E2E tests pass

## Acceptance criteria mapping (from #126)

| AC | Verification |
|---|---|
| `dev-*` dispatch never SIGTERMs `autonomous-review.sh`, vice versa, even with same issue N | TC-PGREP-001, TC-PGREP-002 |
| Same-type orphan still group-killed | TC-PGREP-003 |
| No regression of #109 PID-vs-`$$` reparenting | INV-23 PID-file path unchanged; pgrep fallback only *narrows* match set |
| `KILL_STALE_PGREP_FALLBACK=false` unchanged | TC-DISABLE-001 |
| `dispatcher-tick.sh:483-503` classifier unchanged | This fix is upstream of the classifier; not touched |
| Cross-project isolation (multi-project box) | TC-PGREP-005 |

Closes #126.