### PR TITLE
fix(dispatcher): pid_alive long-running false-DEAD + heartbeat sibling (#129, INV-29)

### DIFF
--- a/docs/designs/dispatcher-pid-alive-long-running.md
+++ b/docs/designs/dispatcher-pid-alive-long-running.md
@@ -1,0 +1,62 @@
+# Design: long-running healthy wrappers must not be misclassified as DEAD (#129)
+
+## Problem
+
+A long-running healthy `autonomous-dev` wrapper (~70+ min, single Claude session, real progress, eventual successful PR) is repeatedly classified as crashed by the dispatcher's `pid_alive` check, exhausting `MAX_RETRIES` and triggering `mark_stalled` despite continuous progress. See issue #129 for the full timeline.
+
+Existing defences each individually fail in this scenario:
+
+- `dev_near_success` ([INV-27]) needs a `Dev Session ID:` / `Exit code: 0` / live `kill -0 <pid>` signal within 300s. None hold for a long mid-session run.
+- `mark_stalled` ([INV-26]) defers only when `pid_alive` reports ALIVE — same false-negative re-rolls.
+- `pid_alive` mtime fallback (#111 Part B) needs the PID file's mtime to be fresh. The heartbeat loop *should* keep it fresh, but doesn't, because:
+  - At T0+15m the dev-resume's `kill_stale_wrapper` runs. `kill -0 $old_pid` fails (the agent-tree session leader's PID has drifted out of `kill -0` reachability via the `AGENT_LAUNCHER='bash -c "source ~/.bash_aliases && cc \"$@\"' --'` indirection). Nothing is actually killed — but `rm -f "$pid_file"` runs **unconditionally** (line 144 of `dispatch-local.sh`).
+  - The heartbeat loop's `touch` is guarded by `[[ -f "$pid_file" && ! -L "$pid_file" ]]`, so after the deletion the next iteration silently no-ops. The PID file is gone; there is nothing to keep fresh.
+  - Next tick: `pid_alive` finds no PID file → DEAD → "Task appears to have crashed (no PR found)" → cycle repeats until `MAX_RETRIES`.
+
+## Fix
+
+Two complementary fixes — both land in this PR.
+
+### Fix A: `kill_stale_wrapper` preserves the PID file when nothing was killed
+
+In `skills/autonomous-dispatcher/scripts/dispatch-local.sh::kill_stale_wrapper`, the `rm -f "$pid_file"` at the bottom of the function runs even when the inner `kill -0 "$old_pid"` returned failure (i.e. nothing was actually killed). This is the bug the inline comment "Remove PID file regardless" identifies — "regardless" is precisely wrong.
+
+Change: track whether we successfully signalled the old PID. If we did not (the `kill -0` miss path), leave the PID file in place. The heartbeat loop in the (still-alive) wrapper then continues touching it, the `pid_alive` mtime fallback gets the data it needs, and the dispatcher correctly classifies the wrapper as ALIVE on subsequent ticks.
+
+If we *did* successfully kill (or the file is empty / unreadable / contains a non-numeric PID), keep the existing behaviour and `rm -f` the PID file — leaving stale data behind would leak into the next acquire.
+
+### Fix B: sibling `*.heartbeat` file owned only by the wrapper
+
+Defence in depth against future regressions of Fix A and against any other code path that might delete the PID file out from under a live wrapper:
+
+- `install_agent_heartbeat` (`lib-agent.sh`) writes a sibling file alongside `AGENT_PID_FILE`: `${AGENT_PID_FILE%.pid}.heartbeat`. The same `touch` cadence applies — the loop touches BOTH the PID file (back-compat: existing pid_alive mtime fallback still works on hosts running mixed wrapper/dispatcher versions) AND the heartbeat file.
+- The wrapper's `cleanup` trap removes both files at exit — so the heartbeat file does not outlive the wrapper.
+- `kill_stale_wrapper` does NOT touch the heartbeat file. Its responsibility is the PID file (which is keyed on the PID it kills); the heartbeat file's mtime is owned exclusively by the still-alive wrapper.
+- `pid_alive` extends the existing mtime fallback to also consult the heartbeat file's mtime: ALIVE if EITHER file's mtime is fresh within `HEARTBEAT_INTERVAL_SECONDS * 3`.
+
+This means: even if a future change re-introduces the unconditional `rm -f` (or some other path nukes the PID file), the heartbeat file survives, the wrapper keeps refreshing its mtime, and `pid_alive` stays accurate.
+
+## Out of scope
+
+Fix (c) from the issue — replacing `kill -0 <leader>` with a process-group probe — is more invasive and not required to close #129. The mtime-based fallback (Fix B) already covers the failure mode without changing the kill semantics. Filed as a future option if a downstream consumer hits a different escape.
+
+The proposed `dev_near_success` window stretch is also not adopted: it widens the false-positive window for long runs but does not fix the root cause and would over-extend the legitimate-crash detection budget.
+
+## Invariant
+
+New invariant **INV-29**: the dispatcher's `pid_alive` mtime tier MUST consult a heartbeat sibling file whose lifecycle is owned exclusively by the wrapper, NOT the PID file alone. `kill_stale_wrapper` MUST NOT delete a PID file when its `kill -0` liveness check returned failure (no actual kill happened).
+
+Added to `docs/pipeline/invariants.md` with cross-references to [INV-23] (PID_FILE reaps subtree, primary path), [INV-24] / [INV-27] (near-success short-circuits, upstream gates), and [INV-26] (stall-decision liveness deferral, downstream gate).
+
+## Test plan
+
+See `docs/test-cases/dispatcher-pid-alive-long-running.md`. The unit tests simulate the exact failure mode from #129 in seconds rather than running real 75-min sessions:
+
+- TC-PALR-001: `kill_stale_wrapper` does not delete the PID file when its `kill -0` miss path is taken (PID is dead but content is non-empty).
+- TC-PALR-002: `kill_stale_wrapper` still deletes the PID file when it successfully killed an alive wrapper.
+- TC-PALR-003: `pid_alive` returns ALIVE when the PID is unreachable but the heartbeat sibling file is fresh.
+- TC-PALR-004: `pid_alive` returns DEAD when both PID file and heartbeat file are stale.
+- TC-PALR-005: `install_agent_heartbeat` creates and refreshes the heartbeat sibling.
+- TC-PALR-006: end-to-end — PID file deleted mid-flight, heartbeat survives, `pid_alive` stays ALIVE.
+
+E2E coverage of the 75-min window is intentionally left to the consumer-project regression tests; replicating it here would 15× the unit test runtime.

--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -322,7 +322,7 @@ Only when ALL four signals are negative does the crash path fire:
 Comment: "Review process appears to have crashed. Moving to pending-dev for retry."
 Labels: `−reviewing +pending-dev`.
 
-This branch is the safety net for the case where the wrapper died so abruptly that even its trap didn't fire. The `pid_alive` check that gates entry to this branch ALSO honors a heartbeat-based mtime fallback ([INV-24](invariants.md#inv-24-review-wrapper-dead-detection-requires-both-pid_alive-miss-and-no-near-success-pr-signal)): a fresh PID-file mtime (within `HEARTBEAT_INTERVAL_SECONDS * 3`) keeps the wrapper in the ALIVE bucket, eliminating false alarms from transient races.
+This branch is the safety net for the case where the wrapper died so abruptly that even its trap didn't fire. The `pid_alive` check that gates entry to this branch ALSO honors a heartbeat-based mtime fallback ([INV-24](invariants.md#inv-24-review-wrapper-dead-detection-requires-both-pid_alive-miss-and-no-near-success-pr-signal), extended by [INV-29](invariants.md#inv-29-pid_alive-heartbeat-is-owned-exclusively-by-the-wrapper-not-by-the-pid-file-alone)): a fresh mtime on EITHER the PID file OR the wrapper-owned `<base>.heartbeat` sibling (within `HEARTBEAT_INTERVAL_SECONDS * 3`) keeps the wrapper in the ALIVE bucket, eliminating false alarms from transient races AND from spurious PID-file deletions against still-alive long-running wrappers.
 
 ## Failure modes by step
 

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -536,7 +536,7 @@ Only when ALL three signals are negative does the existing crashed-comment + lab
 
 **Rule**: Two conjunct sub-rules.
 
-1. **Wrapper-side**: `lib-agent.sh::install_agent_heartbeat` MUST maintain a sibling heartbeat file at `${AGENT_PID_FILE%.pid}.heartbeat`, in addition to touching `AGENT_PID_FILE` itself. The sibling is created if missing and `touch`'d every `HEARTBEAT_INTERVAL_SECONDS` (default 120s). The wrapper's `cleanup` trap removes BOTH files at exit.
+1. **Wrapper-side**: `lib-agent.sh::install_agent_heartbeat` MUST maintain a sibling heartbeat file at `${AGENT_PID_FILE%.pid}.heartbeat`, in addition to touching `AGENT_PID_FILE` itself. The sibling is created if missing and `touch`'d every `HEARTBEAT_INTERVAL_SECONDS` (default 120s). The wrapper's `cleanup` trap removes BOTH files at exit. The heartbeat loop re-checks parent liveness (`kill -0 <parent_pid>`) immediately before each `touch`, so a parent that exited during the loop's `sleep` cannot get either file resurrected after the cleanup trap deleted them — this closes the post-exit ALIVE-window race that would otherwise persist for up to `HEARTBEAT_INTERVAL_SECONDS * 3`.
 2. **Dispatcher-side**: `lib-dispatch.sh::pid_alive` mtime fallback MUST consult EITHER file's mtime — ALIVE if either is fresh within `HEARTBEAT_INTERVAL_SECONDS * 3` (default 360s), DEAD only when both are stale (or both are absent). Symmetrically, `dispatch-local.sh::kill_stale_wrapper` MUST NOT delete the PID file when its `kill -0 <old_pid>` returned failure (i.e. nothing was actually killed) and MUST NEVER touch the heartbeat sibling. The PID file is deleted only when (a) we successfully signalled an alive holder, or (b) the file content is empty / non-numeric.
 
 **Why**: A long-running healthy `autonomous-dev` wrapper (~70+ min real run) was repeatedly classified DEAD by `pid_alive`, exhausting `MAX_RETRIES`, and `mark_stalled` fired despite continuous progress. Reproduced on a downstream consumer's #N-class issue 2026-05-13. The cascade:
@@ -561,7 +561,7 @@ The two sub-rules close the loop independently: rule (1) gives `pid_alive` an ow
 **Status**: **ENFORCED** in this PR (closes #129).
 
 **Test**:
-- `tests/unit/test-pid-alive-long-running.sh` (17 cases): TC-PALR-001 / 002 / 002b cover `kill_stale_wrapper`'s deletion policy (preserve on miss; delete on hit; delete on empty-content); TC-PALR-003 / 003b / 004 / 004b cover `pid_alive`'s three-tier decision matrix including the #129 repro (PID file gone but sibling fresh → ALIVE); TC-PALR-005 / 005b cover heartbeat sibling creation + refresh; TC-PALR-STATIC-001 / 002 pin the INV-29 cross-references and that `kill_stale_wrapper` does not reference `*.heartbeat`.
+- `tests/unit/test-pid-alive-long-running.sh` (18 cases): TC-PALR-001 / 002 / 002b cover `kill_stale_wrapper`'s deletion policy (preserve on miss; delete on hit; delete on empty-content); TC-PALR-003 / 003b / 004 / 004b cover `pid_alive`'s three-tier decision matrix including the #129 repro (PID file gone but sibling fresh → ALIVE); TC-PALR-005 / 005b cover heartbeat sibling creation + refresh; TC-PALR-005c is the resurrection-race regression (heartbeat does NOT recreate the files after the parent's cleanup trap deleted them); TC-PALR-STATIC-001 / 002 pin the INV-29 cross-references and that `kill_stale_wrapper` does not reference `*.heartbeat`.
 - `tests/unit/test-kill-before-spawn.sh::TC-DKBS-003` updated to reflect the new contract: the dead-PID `kill -0` miss path now PRESERVES the PID file rather than deleting it.
 
 **Cross-references**:

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -532,6 +532,45 @@ Only when ALL three signals are negative does the existing crashed-comment + lab
 - [INV-24] (review-side near-success short-circuit) and [INV-27] (dev-side near-success) sit upstream of the label flip that triggers the cross-type kill described in #126's reproduction. They reduce frequency; INV-28 closes the cross-kill bug regardless of how the label flip was reached.
 - [INV-26] (stall decision excludes dispatcher-induced terminations + defers on live wrappers) reduces the residue created when `kill_stale_wrapper` itself fires. INV-28 prevents the *wrong* kills that caused the residue in the first place.
 
+## INV-29: pid_alive heartbeat is owned exclusively by the wrapper, NOT by the PID file alone
+
+**Rule**: Two conjunct sub-rules.
+
+1. **Wrapper-side**: `lib-agent.sh::install_agent_heartbeat` MUST maintain a sibling heartbeat file at `${AGENT_PID_FILE%.pid}.heartbeat`, in addition to touching `AGENT_PID_FILE` itself. The sibling is created if missing and `touch`'d every `HEARTBEAT_INTERVAL_SECONDS` (default 120s). The wrapper's `cleanup` trap removes BOTH files at exit.
+2. **Dispatcher-side**: `lib-dispatch.sh::pid_alive` mtime fallback MUST consult EITHER file's mtime — ALIVE if either is fresh within `HEARTBEAT_INTERVAL_SECONDS * 3` (default 360s), DEAD only when both are stale (or both are absent). Symmetrically, `dispatch-local.sh::kill_stale_wrapper` MUST NOT delete the PID file when its `kill -0 <old_pid>` returned failure (i.e. nothing was actually killed) and MUST NEVER touch the heartbeat sibling. The PID file is deleted only when (a) we successfully signalled an alive holder, or (b) the file content is empty / non-numeric.
+
+**Why**: A long-running healthy `autonomous-dev` wrapper (~70+ min real run) was repeatedly classified DEAD by `pid_alive`, exhausting `MAX_RETRIES`, and `mark_stalled` fired despite continuous progress. Reproduced on a downstream consumer's #N-class issue 2026-05-13. The cascade:
+
+- The agent-tree session leader's PID drifted out of `kill -0` reachability while the underlying process group was still ticking (observed under `AGENT_LAUNCHER='bash -c "source ~/.bash_aliases && cc \"$@\"' --'` indirection, where the launcher's outer `bash -c` exited after the agent had been backgrounded by `_run_with_timeout`).
+- Pre-fix, `kill_stale_wrapper`'s `rm -f "$pid_file"` ran unconditionally — even on the `kill -0` miss path where nothing was actually killed (literal inline comment "Remove PID file regardless" was the bug).
+- The wrapper's heartbeat loop then had no file to refresh (the `[[ -f "$pid_file" ]]` guard at `lib-agent.sh::install_agent_heartbeat` no-op'd), so the dispatcher's `pid_alive` mtime fallback (#111 Part B / [INV-24]) saw nothing to consult.
+- Each subsequent tick re-rolled the false DEAD verdict, accumulating dispatcher-detected crash comments. [INV-26] would have deferred `mark_stalled` had `pid_alive` reported ALIVE — but it didn't, exactly because the heartbeat carrier was gone.
+- After `MAX_RETRIES` ticks the issue was `+stalled` while the real wrapper continued, eventually opened a successful PR, and the trap tried to flip `in-progress` → `pending-review` onto a `+stalled` issue ([INV-25] residue).
+
+The two sub-rules close the loop independently: rule (1) gives `pid_alive` an owner-isolated heartbeat that survives any `kill_stale_wrapper` change; rule (2) prevents the wrong deletion in the first place. Either alone is sufficient to fix the reported scenario; both together are defence-in-depth and protect against future regressions of either side.
+
+**Producer**:
+- (1) `lib-agent.sh::install_agent_heartbeat` (writes the sibling); `autonomous-dev.sh::cleanup` and `autonomous-review.sh::cleanup` (remove both files at exit).
+- (2) `dispatch-local.sh::kill_stale_wrapper` (preserves the PID file on `kill -0` miss; never references the heartbeat sibling).
+
+**Consumer**: `lib-dispatch.sh::pid_alive` (three-tier check: kill -0 → PID-file mtime → heartbeat-sibling mtime). The heartbeat sibling is also implicitly consumed by [INV-26]'s liveness deferral, [INV-24]'s defensive `kill -0` re-check, and [INV-27]'s defensive `kill -0` re-check — each is unaffected when the agent's session-leader PID still answers `kill -0`, and each falls through to `pid_alive` when it doesn't.
+
+**Disable knobs**:
+- `HEARTBEAT_INTERVAL_SECONDS=0` — disables BOTH the wrapper-side heartbeat spawn (no PID-file or sibling refresh) AND the dispatcher-side mtime fallback. Restores the `kill -0`-only legacy behavior.
+
+**Status**: **ENFORCED** in this PR (closes #129).
+
+**Test**:
+- `tests/unit/test-pid-alive-long-running.sh` (17 cases): TC-PALR-001 / 002 / 002b cover `kill_stale_wrapper`'s deletion policy (preserve on miss; delete on hit; delete on empty-content); TC-PALR-003 / 003b / 004 / 004b cover `pid_alive`'s three-tier decision matrix including the #129 repro (PID file gone but sibling fresh → ALIVE); TC-PALR-005 / 005b cover heartbeat sibling creation + refresh; TC-PALR-STATIC-001 / 002 pin the INV-29 cross-references and that `kill_stale_wrapper` does not reference `*.heartbeat`.
+- `tests/unit/test-kill-before-spawn.sh::TC-DKBS-003` updated to reflect the new contract: the dead-PID `kill -0` miss path now PRESERVES the PID file rather than deleting it.
+
+**Cross-references**:
+- [INV-01] (PID file naming) — the heartbeat sibling lives in the same per-user, mode-0700 dir as the PID file. Same CWE-377 protection; the sibling's path is mechanically derived (`%.pid` strip + `.heartbeat` append) so [INV-01]'s naming guarantees transitively cover it.
+- [INV-23] (PID_FILE reaps subtree) — the primary kill path is unchanged; INV-29 only narrows what `kill_stale_wrapper` deletes after that path runs, and adds a parallel liveness-carrier file.
+- [INV-24] / [INV-27] (review / dev near-success short-circuits) — these gate `pid_alive` *miss interpretation*. INV-29 makes `pid_alive` itself correct on the failure mode where the agent is truly alive but `kill -0` misses, so the upstream gates are no longer the only safety net.
+- [INV-26] (stall decision deferral on live wrappers) — relies on `pid_alive` returning ALIVE for genuinely-alive wrappers. INV-29 closes the producer-side gap that pre-fix could feed it a false DEAD.
+- [INV-25] (sticky terminal labels with hygiene at tick start) — heals residue from rare cases where the stall decision still slips through. INV-29 reduces the producer of that residue; [INV-25]'s hygiene pass remains the safety net.
+
 ## Adding a new invariant
 
 When fixing a pipeline bug, after locating the bug on the state machine + flow docs:

--- a/docs/test-cases/dispatcher-pid-alive-long-running.md
+++ b/docs/test-cases/dispatcher-pid-alive-long-running.md
@@ -1,0 +1,96 @@
+# Test cases — long-running pid_alive false-negative (#129)
+
+Covers the two-part fix in `dispatch-local.sh::kill_stale_wrapper` and `lib-agent.sh::install_agent_heartbeat` + `lib-dispatch.sh::pid_alive`.
+
+Located in `tests/unit/test-pid-alive-long-running.sh`. Run via:
+
+```bash
+bash tests/unit/test-pid-alive-long-running.sh
+```
+
+## TC-PALR-001 — `kill_stale_wrapper` does NOT delete the PID file when `kill -0` missed
+
+**Intent**: The bug from #129's "Most likely root cause" section. When `kill_stale_wrapper`'s `kill -0 $old_pid` returns failure (the PID is unreachable), the function used to `rm -f` the PID file regardless. After the fix, the file must survive.
+
+**Setup**:
+- Create a temp PID file containing a known-dead PID (e.g. `999999`).
+- Set `PROJECT_DIR`, `ISSUE_NUM`, `TYPE`, `KILL_STALE_PGREP_FALLBACK=false` so the function takes the `kill -0` miss path without invoking `pgrep`.
+- Source `dispatch-local.sh::kill_stale_wrapper` and call it.
+
+**Expected**:
+- Return code 0.
+- PID file still exists with original content untouched.
+
+## TC-PALR-002 — `kill_stale_wrapper` still deletes the PID file after successfully killing an alive wrapper
+
+**Intent**: Regression-pin that Fix A does not over-correct. When we DO actually kill the holder, removing the file is still the right thing.
+
+**Setup**:
+- Spawn a real `sleep 30` subshell.
+- Write its PID into the PID file.
+- Call `kill_stale_wrapper`.
+
+**Expected**:
+- The sleep subshell is gone (kill -0 fails).
+- PID file is removed.
+
+## TC-PALR-003 — `pid_alive` returns ALIVE when the heartbeat sibling file is fresh, regardless of PID file state
+
+**Intent**: Defence in depth. Even if the PID file has a stale mtime (or is gone), a fresh heartbeat sibling is sufficient evidence the wrapper is alive.
+
+**Setup**:
+- Create the PID file with a dead PID and an old mtime (e.g. 1000s ago).
+- Create the sibling `*.heartbeat` file with `mtime = now`.
+- Call `pid_alive issue <N>` with `HEARTBEAT_INTERVAL_SECONDS=10`.
+
+**Expected**:
+- Return code 0 (ALIVE).
+
+## TC-PALR-004 — `pid_alive` returns DEAD when BOTH PID file and heartbeat file are stale
+
+**Intent**: Don't regress legitimate crash detection (Acceptance Criteria #2 from #129).
+
+**Setup**:
+- Create the PID file with a dead PID and an old mtime (1000s ago).
+- Create the heartbeat file with a matching old mtime.
+- Call `pid_alive issue <N>` with `HEARTBEAT_INTERVAL_SECONDS=10` (threshold = 30s).
+
+**Expected**:
+- Return code 1 (DEAD).
+
+## TC-PALR-005 — `install_agent_heartbeat` creates and refreshes the heartbeat sibling
+
+**Intent**: The heartbeat loop must touch BOTH the PID file (back-compat with pre-#129 dispatcher) AND the new sibling file. Both mtimes advance.
+
+**Setup**:
+- Set the PID file mtime far in the past.
+- Pre-create the sibling file with the same far-past mtime.
+- Call `install_agent_heartbeat` with `HEARTBEAT_INTERVAL_SECONDS=1`, `AGENT_PID_FILE=<path>`.
+- Sleep 2s.
+- Tear down the heartbeat process.
+
+**Expected**:
+- Both mtimes have advanced.
+- Heartbeat process exits when the parent shell exits (re-uses TC-HB-007's coverage).
+
+## TC-PALR-006 — end-to-end: PID file deleted mid-run, heartbeat sibling keeps `pid_alive` ALIVE
+
+**Intent**: Repro of #129's exact failure mode. A spurious deletion of the PID file (e.g. by the buggy pre-fix `kill_stale_wrapper`) must NOT trip `pid_alive` into DEAD as long as the heartbeat is still ticking.
+
+**Setup**:
+- Use the current process PID (guaranteed alive; bypasses the `kill -0` miss).
+- Wait — actually we need the failure mode to *also* cover the `kill -0` miss. Two flavours:
+  - **TC-PALR-006a**: PID file gone, heartbeat sibling fresh → `pid_alive` returns ALIVE.
+  - **TC-PALR-006b**: PID file gone, heartbeat sibling absent → `pid_alive` returns DEAD (regression bound; without Fix B alone there's no escape).
+
+**Expected**:
+- TC-PALR-006a: rc=0 (ALIVE) — Fix B saves us.
+- TC-PALR-006b: rc=1 (DEAD) — without the heartbeat sibling, `pid_alive` correctly fails closed.
+
+## Static-analysis pin (TC-PALR-STATIC-001)
+
+`grep` for the literal "INV-29" string in `dispatch-local.sh` and `lib-agent.sh` so a future refactor can't silently drop the invariant reference. Also pins the `_HEARTBEAT_FILE` derivation pattern in `lib-agent.sh` and that `kill_stale_wrapper` does NOT remove `*.heartbeat`.
+
+## Out-of-scope: 75-min real-time test
+
+The acceptance criterion "75-min healthy wrapper does not stall" is verified at the consumer-project level (downstream regression run). Reproducing it as a unit test would 15× the test suite runtime; the failure-mode-simulating tests above cover the same failure surface in seconds.

--- a/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
@@ -153,8 +153,8 @@ cleanup() {
     command kill "$_AGENT_HEARTBEAT_PID" 2>/dev/null || true
   fi
 
-  # Cleanup PID file always
-  rm -f "$PID_FILE" 2>/dev/null || true
+  # Cleanup PID file and heartbeat sibling (INV-29) always.
+  rm -f "$PID_FILE" "${PID_FILE%.pid}.heartbeat" 2>/dev/null || true
 
   # Wrapper failed before invoking the agent (e.g. gh-with-token-refresh
   # couldn't find a real gh — issue #92, or any future startup-time

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -136,8 +136,8 @@ cleanup() {
     command kill "$_AGENT_HEARTBEAT_PID" 2>/dev/null || true
   fi
 
-  # Cleanup PID file always
-  rm -f "$PID_FILE" 2>/dev/null || true
+  # Cleanup PID file and heartbeat sibling (INV-29) always.
+  rm -f "$PID_FILE" "${PID_FILE%.pid}.heartbeat" 2>/dev/null || true
 
   # If result was already parsed by the main script, labels are handled there
   if [[ "$RESULT_PARSED" == "true" ]]; then

--- a/skills/autonomous-dispatcher/scripts/dispatch-local.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatch-local.sh
@@ -91,7 +91,7 @@ kill_stale_wrapper() {
       echo "ERROR: cannot read PID file $pid_file (permission denied or removed)" >&2
       return 1
     fi
-    local old_pid
+    local old_pid killed=0
     old_pid=$(cat "$pid_file" 2>/dev/null)
 
     if [[ -n "$old_pid" ]] && kill -0 "$old_pid" 2>/dev/null; then
@@ -136,12 +136,28 @@ kill_stale_wrapper() {
           return 1
         fi
       fi
+      killed=1
     fi
 
-    # Remove PID file regardless. If `rm -f` fails (read-only mount, perm),
-    # acquire_pid_guard in the new wrapper re-validates liveness on whatever
-    # PID is in the file — and we just verified that PID is no longer alive.
-    rm -f "$pid_file"
+    # PID-file deletion policy (INV-29, closes #129): only delete when we
+    # either (a) successfully signalled an alive holder (`killed=1`) — the
+    # PID we hold is now stale, leaving the file would leak into the next
+    # acquire_pid_guard, OR (b) the file content is empty / non-numeric —
+    # there's nothing useful to keep fresh.
+    #
+    # If we hit the `kill -0` miss path (PID is non-empty, numeric, but
+    # `kill -0` returned failure), do NOT delete the file. The agent's
+    # session-leader PID can drift out of `kill -0` reachability while the
+    # underlying process group is still ticking (observed under
+    # AGENT_LAUNCHER `bash -c "..."` indirection); the wrapper's
+    # `install_agent_heartbeat` loop relies on the file existing so its
+    # `touch` keeps the mtime fresh. Deleting it strands the dispatcher's
+    # `pid_alive` mtime fallback (#111 Part B) and re-creates the
+    # false-DEAD loop described in #129. The pgrep fallback below remains
+    # the safety net for genuinely-orphaned trees we cannot reach via PID.
+    if [[ "$killed" -eq 1 ]] || [[ -z "$old_pid" ]] || [[ ! "$old_pid" =~ ^[0-9]+$ ]]; then
+      rm -f "$pid_file"
+    fi
   fi
 
   # Defensive pgrep fallback (closes #109 — option C; INV-23, INV-28).

--- a/skills/autonomous-dispatcher/scripts/lib-agent.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-agent.sh
@@ -174,8 +174,9 @@ install_agent_sigterm_trap() {
 }
 
 # install_agent_heartbeat — spawn a background loop that touches
-# AGENT_PID_FILE every HEARTBEAT_INTERVAL_SECONDS (#111 Part B). The loop
-# is parent-pid-watched: when the wrapper shell exits, `kill -0 <parent>`
+# AGENT_PID_FILE and a sibling `<base>.heartbeat` file every
+# HEARTBEAT_INTERVAL_SECONDS (#111 Part B + INV-29). The loop is
+# parent-pid-watched: when the wrapper shell exits, `kill -0 <parent>`
 # fails and the loop terminates. No orphan heartbeats after wrapper exit.
 #
 # Sets _AGENT_HEARTBEAT_PID so the wrapper's cleanup() trap can SIGTERM
@@ -189,6 +190,16 @@ install_agent_sigterm_trap() {
 # tolerant of a missing or symlinked file (skips touch silently); the
 # wrapper's acquire_pid_guard / spawn path remains the authoritative
 # writer.
+#
+# Sibling heartbeat file (INV-29, closes #129): we ALSO maintain
+# `${AGENT_PID_FILE%.pid}.heartbeat`. Its lifecycle is owned by the
+# wrapper alone — the cleanup trap removes it at exit; the dispatcher's
+# `kill_stale_wrapper` does NOT touch it. The dispatcher's `pid_alive`
+# mtime fallback consults EITHER file's mtime, so a spurious deletion of
+# the PID file (e.g. by a buggy stale-cleaner — see #129) cannot strand
+# the liveness probe. We continue to touch the PID file too so a mixed-
+# version dispatcher (older `pid_alive` that only knows about the PID
+# file) still gets accurate readings during a rolling upgrade.
 install_agent_heartbeat() {
   local interval="${HEARTBEAT_INTERVAL_SECONDS:-120}"
   # Defensive numeric guard: a typo'd config would otherwise raise an
@@ -199,11 +210,20 @@ install_agent_heartbeat() {
 
   local parent_pid=$$
   local pid_file="$AGENT_PID_FILE"
+  local hb_file="${pid_file%.pid}.heartbeat"
 
   (
     while command kill -0 "$parent_pid" 2>/dev/null; do
       if [[ -f "$pid_file" && ! -L "$pid_file" ]]; then
         touch "$pid_file" 2>/dev/null || true
+      fi
+      # Heartbeat sibling: create-on-demand and refresh. Same CWE-59
+      # symlink defence as the PID file — if a symlink is planted at the
+      # path, skip silently rather than follow it. `touch` creates the
+      # file when missing, so a single touch covers both first-call and
+      # post-deletion cases.
+      if [[ ! -L "$hb_file" ]]; then
+        touch "$hb_file" 2>/dev/null || true
       fi
       sleep "$interval"
     done

--- a/skills/autonomous-dispatcher/scripts/lib-agent.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-agent.sh
@@ -214,6 +214,15 @@ install_agent_heartbeat() {
 
   (
     while command kill -0 "$parent_pid" 2>/dev/null; do
+      # Re-check parent liveness immediately before each touch. The outer
+      # `while` test fires only once per iteration, but the wrapper can
+      # exit during the `sleep` below and its cleanup trap can delete
+      # both files before this loop wakes. Without the inner kill -0,
+      # the loop's `touch` would resurrect the heartbeat sibling with a
+      # fresh mtime, leaving the dispatcher seeing a fake-ALIVE wrapper
+      # for up to HEARTBEAT_INTERVAL_SECONDS * 3. The check is cheap and
+      # closes the resurrection race documented in #129's review pass.
+      command kill -0 "$parent_pid" 2>/dev/null || break
       if [[ -f "$pid_file" && ! -L "$pid_file" ]]; then
         touch "$pid_file" 2>/dev/null || true
       fi

--- a/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
@@ -663,25 +663,37 @@ _pid_file_for() {
 # Returns 0 if the wrapper PID for this issue+kind is alive, 1 otherwise.
 # `kind` is "issue" (dev wrapper) or "review".
 #
-# Two-tier check (#111 Part B):
+# Three-tier check (#111 Part B + INV-29, closes #129):
 #   1. `kill -0 <pid>` succeeds → ALIVE.
-#   2. `kill -0 <pid>` fails → check PID-file mtime. If it was touched
-#      within HEARTBEAT_INTERVAL_SECONDS * 3 (default 360s), still treat
-#      as ALIVE — the wrapper may be transitioning groups, exec'ing, or
-#      racing with us. The wrapper's install_agent_heartbeat helper
-#      (lib-agent.sh) keeps the mtime fresh while it's running, so a
-#      stale mtime is strong evidence the process is genuinely dead.
+#   2. PID file mtime is fresh (within HEARTBEAT_INTERVAL_SECONDS * 3,
+#      default 360s) → ALIVE. Back-compat path for pre-INV-29 wrappers
+#      that only touch the PID file.
+#   3. Sibling `<base>.heartbeat` file mtime is fresh → ALIVE.
+#   Otherwise → DEAD.
 #
-# HEARTBEAT_INTERVAL_SECONDS=0 disables the mtime fallback entirely
+# Why two files (INV-29): the heartbeat sibling's lifecycle is owned
+# exclusively by the wrapper — created and cleaned up by the wrapper's
+# cleanup trap, NOT by the dispatcher. The dispatcher's
+# `kill_stale_wrapper` may legitimately delete the PID file (after
+# killing its holder); without the sibling, a spurious PID-file
+# deletion against a still-alive wrapper would strand `pid_alive` and
+# false-flag the agent as DEAD on subsequent ticks (the failure mode in
+# #129). The sibling survives such deletions, so the wrapper's
+# still-running heartbeat keeps the mtime fresh and the probe stays
+# accurate. The PID file content (holding the agent-tree session leader
+# PID) is not used here beyond tier 1 — its mtime is a back-compat
+# heartbeat carrier only.
+#
+# HEARTBEAT_INTERVAL_SECONDS=0 disables both mtime tiers entirely
 # (legacy strict behavior).
 pid_alive() {
   local kind="$1" issue_num="$2"
-  local pid_file pid
+  local pid_file pid hb_file
   pid_file=$(_pid_file_for "$kind" "$issue_num")
   [ -n "$pid_file" ] || return 1
+  hb_file="${pid_file%.pid}.heartbeat"
   pid=$(cat "$pid_file" 2>/dev/null || echo "")
-  [ -n "$pid" ] || return 1
-  if kill -0 "$pid" 2>/dev/null; then
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
     return 0
   fi
 
@@ -691,13 +703,30 @@ pid_alive() {
   # "fallback disabled" (legacy strict).
   [[ "$hb_interval" =~ ^[0-9]+$ ]] || return 1
   [ "$hb_interval" -gt 0 ] || return 1
-  [ -f "$pid_file" ] || return 1
-  local now mtime threshold
+
+  local now threshold mtime
   now=$(date -u +%s)
-  mtime=$(stat -c %Y "$pid_file" 2>/dev/null || stat -f %m "$pid_file" 2>/dev/null || echo "")
-  [ -n "$mtime" ] || return 1
   threshold=$(( hb_interval * 3 ))
-  [ $(( now - mtime )) -lt "$threshold" ]
+
+  # Tier 2: PID-file mtime (back-compat with pre-INV-29 wrappers that
+  # only touch the PID file). Symlink-defended (CWE-59).
+  if [ -f "$pid_file" ] && [ ! -L "$pid_file" ]; then
+    mtime=$(stat -c %Y "$pid_file" 2>/dev/null || stat -f %m "$pid_file" 2>/dev/null || echo "")
+    if [ -n "$mtime" ] && [ $(( now - mtime )) -lt "$threshold" ]; then
+      return 0
+    fi
+  fi
+
+  # Tier 3: heartbeat sibling mtime (INV-29). Owned exclusively by the
+  # wrapper — survives spurious PID-file deletion. Same symlink defence.
+  if [ -f "$hb_file" ] && [ ! -L "$hb_file" ]; then
+    mtime=$(stat -c %Y "$hb_file" 2>/dev/null || stat -f %m "$hb_file" 2>/dev/null || echo "")
+    if [ -n "$mtime" ] && [ $(( now - mtime )) -lt "$threshold" ]; then
+      return 0
+    fi
+  fi
+
+  return 1
 }
 
 # Echoes the current PID for the issue+kind, or empty if none.

--- a/tests/unit/test-kill-before-spawn.sh
+++ b/tests/unit/test-kill-before-spawn.sh
@@ -231,10 +231,13 @@ else
 fi
 
 # ============================================================================
-# TC-DKBS-003: Dead PID is handled cleanly
+# TC-DKBS-003: Dead PID (numeric, kill -0 miss) preserves the PID file (INV-29).
+# Pre-#129 the file was deleted unconditionally; post-fix we keep it so
+# the live wrapper's heartbeat loop continues to refresh the mtime — see
+# the rationale in dispatch-local.sh::kill_stale_wrapper.
 # ============================================================================
 echo
-echo "=== TC-DKBS-003: dead PID handled cleanly ==="
+echo "=== TC-DKBS-003: dead-PID path preserves the PID file (INV-29) ==="
 echo
 
 PID_FILE="$TMPDIR/test-003.pid"
@@ -252,11 +255,11 @@ else
   FAIL=$((FAIL+1))
 fi
 if [[ -e "$PID_FILE" ]]; then
-  echo -e "  ${RED}FAIL${NC}: PID file still exists after dead-PID handling"
-  FAIL=$((FAIL+1))
-else
-  echo -e "  ${GREEN}PASS${NC}: PID file removed"
+  echo -e "  ${GREEN}PASS${NC}: PID file preserved on kill -0 miss (INV-29; #129)"
   PASS=$((PASS+1))
+else
+  echo -e "  ${RED}FAIL${NC}: PID file should be preserved on kill -0 miss (INV-29; #129) — got deleted"
+  FAIL=$((FAIL+1))
 fi
 
 # ============================================================================

--- a/tests/unit/test-pid-alive-long-running.sh
+++ b/tests/unit/test-pid-alive-long-running.sh
@@ -1,0 +1,308 @@
+#!/bin/bash
+# test-pid-alive-long-running.sh — Unit tests for issue #129.
+#
+# Two-part regression:
+#   Fix A: kill_stale_wrapper does NOT delete the PID file when its
+#          `kill -0 <old_pid>` miss path is taken (no actual kill happened).
+#   Fix B: install_agent_heartbeat writes a sibling `<base>.heartbeat`
+#          file alongside AGENT_PID_FILE; pid_alive's mtime fallback
+#          consults EITHER file.
+#
+# Run: bash tests/unit/test-pid-alive-long-running.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPTS_DIR="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Required env (the libs enforce these via : "${VAR:?...}")
+export REPO=zxkane/autonomous-dev-team
+export REPO_OWNER=zxkane
+export PROJECT_ID=test-proj-pid-alive-long-running
+export MAX_RETRIES=3
+export MAX_CONCURRENT=5
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"; jobs -p | xargs -r kill 2>/dev/null || true' EXIT
+
+assert_rc() {
+  local label="$1" rc="$2" expected="$3"
+  if [ "$rc" = "$expected" ]; then
+    echo -e "  ${GREEN}PASS${NC}: $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $label (rc=$rc, expected $expected)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_true() {
+  local label="$1" cond="$2"
+  if [ "$cond" = "1" ]; then
+    echo -e "  ${GREEN}PASS${NC}: $label"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $label"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Helper: set a file's mtime to N seconds ago (Linux + macOS).
+touch_age() {
+  local path="$1" age="$2" t
+  t=$(date -u -d "@$(( $(date +%s) - age ))" +"%Y%m%d%H%M.%S" 2>/dev/null \
+    || date -u -v-"${age}"S +"%Y%m%d%H%M.%S")
+  touch -t "$t" "$path"
+}
+
+# ---------------------------------------------------------------------------
+# Source the dispatcher's libraries. lib-dispatch.sh sets `set -e` which
+# would abort the test process on any returning-1 helper, so disable it.
+# lib-agent.sh has `set -u` requirements; isolate with `set +u`.
+# ---------------------------------------------------------------------------
+
+# shellcheck disable=SC1091
+source "$SCRIPTS_DIR/lib-dispatch.sh"
+set +e
+
+set +u
+# shellcheck disable=SC1091
+source "$SCRIPTS_DIR/lib-agent.sh" 2>/dev/null || true
+set -u
+
+# Source kill_stale_wrapper as a function. dispatch-local.sh runs
+# top-level statements when sourced; we need the function only.
+# Extract just the function definition into a temp file and source it.
+KILL_FN_FILE=$(mktemp)
+awk '
+  /^kill_stale_wrapper\(\) \{/ { capturing = 1 }
+  capturing { print }
+  capturing && /^\}/ { capturing = 0; exit }
+' "$SCRIPTS_DIR/dispatch-local.sh" >"$KILL_FN_FILE"
+# shellcheck disable=SC1090
+source "$KILL_FN_FILE"
+rm -f "$KILL_FN_FILE"
+
+# Override _pid_file_for so pid_alive picks up our test paths.
+_pid_file_for() { echo "$PIDFILE"; }
+
+# ---------------------------------------------------------------------------
+# Fix A tests — kill_stale_wrapper PID-file preservation
+# ---------------------------------------------------------------------------
+
+echo
+echo "=== TC-PALR-001: kill_stale_wrapper preserves PID file when kill -0 missed ==="
+PIDFILE="$TMPDIR/issue-1.pid"
+echo "999999" >"$PIDFILE"
+ORIG_CONTENT=$(cat "$PIDFILE")
+# Disable the pgrep fallback so we test the kill -0 miss path in isolation.
+KILL_STALE_PGREP_FALLBACK=false \
+  PROJECT_DIR="$TMPDIR/proj" \
+  PROJECT_ID="$PROJECT_ID" \
+  ISSUE_NUM=1 \
+  TYPE=dev-resume \
+  kill_stale_wrapper "$PIDFILE" >/dev/null 2>&1
+KSW_RC=$?
+assert_rc "kill_stale_wrapper rc=0 on miss" "$KSW_RC" "0"
+if [[ -f "$PIDFILE" ]]; then
+  CONTENT_NOW=$(cat "$PIDFILE")
+  if [[ "$CONTENT_NOW" == "$ORIG_CONTENT" ]]; then
+    assert_true "PID file preserved with original content" "1"
+  else
+    assert_true "PID file content unchanged (got '$CONTENT_NOW', expected '$ORIG_CONTENT')" "0"
+  fi
+else
+  assert_true "PID file still exists after kill_stale_wrapper miss" "0"
+fi
+
+echo
+echo "=== TC-PALR-002: kill_stale_wrapper still removes PID file after a successful kill ==="
+PIDFILE="$TMPDIR/issue-2.pid"
+# Spawn a real sleep so kill -0 succeeds and SIGTERM lands.
+sleep 30 &
+TARGET_PID=$!
+echo "$TARGET_PID" >"$PIDFILE"
+KILL_STALE_PGREP_FALLBACK=false \
+  PROJECT_DIR="$TMPDIR/proj" \
+  PROJECT_ID="$PROJECT_ID" \
+  ISSUE_NUM=2 \
+  TYPE=dev-resume \
+  kill_stale_wrapper "$PIDFILE" >/dev/null 2>&1
+KSW_RC=$?
+# Reap the killed child so it doesn't show as zombie.
+wait "$TARGET_PID" 2>/dev/null || true
+assert_rc "kill_stale_wrapper rc=0 on hit" "$KSW_RC" "0"
+if [[ ! -f "$PIDFILE" ]]; then
+  assert_true "PID file removed after successful kill" "1"
+else
+  assert_true "PID file removed after successful kill (still exists)" "0"
+fi
+
+echo
+echo "=== TC-PALR-002b: kill_stale_wrapper removes empty PID file (treat as garbage) ==="
+PIDFILE="$TMPDIR/issue-3.pid"
+: >"$PIDFILE"  # empty
+KILL_STALE_PGREP_FALLBACK=false \
+  PROJECT_DIR="$TMPDIR/proj" \
+  PROJECT_ID="$PROJECT_ID" \
+  ISSUE_NUM=3 \
+  TYPE=dev-resume \
+  kill_stale_wrapper "$PIDFILE" >/dev/null 2>&1
+KSW_RC=$?
+assert_rc "kill_stale_wrapper rc=0 on empty file" "$KSW_RC" "0"
+if [[ ! -f "$PIDFILE" ]]; then
+  assert_true "empty PID file removed (no useful liveness data)" "1"
+else
+  assert_true "empty PID file removed" "0"
+fi
+
+# ---------------------------------------------------------------------------
+# Fix B tests — heartbeat sibling file
+# ---------------------------------------------------------------------------
+
+echo
+echo "=== TC-PALR-003: pid_alive ALIVE when heartbeat sibling is fresh, PID file is stale ==="
+PIDFILE="$TMPDIR/issue-10.pid"
+HBFILE="${PIDFILE%.pid}.heartbeat"
+echo "999999" >"$PIDFILE"
+touch_age "$PIDFILE" 1000     # stale PID file
+: >"$HBFILE"
+touch "$HBFILE"               # fresh heartbeat
+HEARTBEAT_INTERVAL_SECONDS=10 pid_alive issue 10
+assert_rc "pid_alive ALIVE via fresh heartbeat sibling" "$?" "0"
+
+echo
+echo "=== TC-PALR-003b: pid_alive ALIVE when PID file is gone but heartbeat sibling is fresh ==="
+PIDFILE="$TMPDIR/issue-11.pid"
+HBFILE="${PIDFILE%.pid}.heartbeat"
+# Simulate the #129 mid-flight deletion: PID file gone, heartbeat survives.
+rm -f "$PIDFILE"
+: >"$HBFILE"
+touch "$HBFILE"
+HEARTBEAT_INTERVAL_SECONDS=10 pid_alive issue 11
+assert_rc "pid_alive ALIVE via heartbeat alone (#129 repro)" "$?" "0"
+
+echo
+echo "=== TC-PALR-004: pid_alive DEAD when both PID file and heartbeat sibling are stale ==="
+PIDFILE="$TMPDIR/issue-12.pid"
+HBFILE="${PIDFILE%.pid}.heartbeat"
+echo "999999" >"$PIDFILE"
+touch_age "$PIDFILE" 1000
+: >"$HBFILE"
+touch_age "$HBFILE" 1000
+HEARTBEAT_INTERVAL_SECONDS=10 pid_alive issue 12
+assert_rc "pid_alive DEAD when both files stale" "$?" "1"
+
+echo
+echo "=== TC-PALR-004b: pid_alive DEAD when PID file is gone AND heartbeat absent ==="
+PIDFILE="$TMPDIR/issue-13.pid"
+HBFILE="${PIDFILE%.pid}.heartbeat"
+rm -f "$PIDFILE" "$HBFILE"
+HEARTBEAT_INTERVAL_SECONDS=10 pid_alive issue 13
+assert_rc "pid_alive DEAD when both files absent" "$?" "1"
+
+# ---------------------------------------------------------------------------
+# install_agent_heartbeat must touch the heartbeat sibling
+# ---------------------------------------------------------------------------
+
+if ! type install_agent_heartbeat >/dev/null 2>&1; then
+  echo -e "  ${RED}FAIL${NC}: install_agent_heartbeat is not defined in lib-agent.sh"
+  FAIL=$((FAIL + 1))
+else
+  echo
+  echo "=== TC-PALR-005: heartbeat advances mtime of sibling .heartbeat file ==="
+  PIDFILE="$TMPDIR/issue-20.pid"
+  HBFILE="${PIDFILE%.pid}.heartbeat"
+  echo "$$" >"$PIDFILE"
+  : >"$HBFILE"
+  touch_age "$PIDFILE" 1000
+  touch_age "$HBFILE" 1000
+  before_pid_mtime=$(stat -c %Y "$PIDFILE" 2>/dev/null || stat -f %m "$PIDFILE")
+  before_hb_mtime=$(stat -c %Y "$HBFILE" 2>/dev/null || stat -f %m "$HBFILE")
+
+  AGENT_PID_FILE="$PIDFILE" HEARTBEAT_INTERVAL_SECONDS=1 \
+    install_agent_heartbeat
+  hb_pid="${_AGENT_HEARTBEAT_PID:-}"
+  sleep 2
+  after_pid_mtime=$(stat -c %Y "$PIDFILE" 2>/dev/null || stat -f %m "$PIDFILE")
+  after_hb_mtime=$(stat -c %Y "$HBFILE" 2>/dev/null || stat -f %m "$HBFILE")
+  [ -n "$hb_pid" ] && command kill "$hb_pid" 2>/dev/null || true
+
+  if [ "$after_pid_mtime" -gt "$before_pid_mtime" ]; then
+    assert_true "heartbeat advanced PID-file mtime ($before_pid_mtime → $after_pid_mtime)" "1"
+  else
+    assert_true "heartbeat advanced PID-file mtime ($before_pid_mtime → $after_pid_mtime)" "0"
+  fi
+  if [ "$after_hb_mtime" -gt "$before_hb_mtime" ]; then
+    assert_true "heartbeat advanced sibling mtime ($before_hb_mtime → $after_hb_mtime)" "1"
+  else
+    assert_true "heartbeat advanced sibling mtime ($before_hb_mtime → $after_hb_mtime)" "0"
+  fi
+
+  echo
+  echo "=== TC-PALR-005b: heartbeat creates the sibling file if it does not exist yet ==="
+  PIDFILE="$TMPDIR/issue-21.pid"
+  HBFILE="${PIDFILE%.pid}.heartbeat"
+  echo "$$" >"$PIDFILE"
+  rm -f "$HBFILE"
+
+  unset _AGENT_HEARTBEAT_PID
+  AGENT_PID_FILE="$PIDFILE" HEARTBEAT_INTERVAL_SECONDS=1 \
+    install_agent_heartbeat
+  hb_pid="${_AGENT_HEARTBEAT_PID:-}"
+  sleep 2
+  [ -n "$hb_pid" ] && command kill "$hb_pid" 2>/dev/null || true
+
+  if [ -f "$HBFILE" ]; then
+    assert_true "heartbeat sibling created when missing" "1"
+  else
+    assert_true "heartbeat sibling created when missing (still absent)" "0"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Static-analysis pins so the invariant cross-references can't silently rot
+# ---------------------------------------------------------------------------
+
+echo
+echo "=== TC-PALR-STATIC-001: source files reference INV-29 ==="
+if grep -q "INV-29" "$SCRIPTS_DIR/dispatch-local.sh"; then
+  assert_true "dispatch-local.sh mentions INV-29" "1"
+else
+  assert_true "dispatch-local.sh mentions INV-29" "0"
+fi
+if grep -q "INV-29" "$SCRIPTS_DIR/lib-agent.sh"; then
+  assert_true "lib-agent.sh mentions INV-29" "1"
+else
+  assert_true "lib-agent.sh mentions INV-29" "0"
+fi
+if grep -q "INV-29" "$SCRIPTS_DIR/lib-dispatch.sh"; then
+  assert_true "lib-dispatch.sh mentions INV-29" "1"
+else
+  assert_true "lib-dispatch.sh mentions INV-29" "0"
+fi
+
+echo
+echo "=== TC-PALR-STATIC-002: kill_stale_wrapper does NOT touch *.heartbeat ==="
+# The heartbeat file is owned exclusively by the wrapper; the dispatcher
+# must never delete it. A grep for `.heartbeat` in dispatch-local.sh would
+# only be present if a future change accidentally widened the cleanup.
+if ! grep -E '\.heartbeat' "$SCRIPTS_DIR/dispatch-local.sh" >/dev/null; then
+  assert_true "dispatch-local.sh contains no '.heartbeat' references" "1"
+else
+  assert_true "dispatch-local.sh must not reference '.heartbeat' (would risk deletion)" "0"
+fi
+
+echo
+echo "==============================================="
+echo -e "Total: $((PASS + FAIL)) tests, ${GREEN}${PASS} pass${NC}, ${RED}${FAIL} fail${NC}"
+echo "==============================================="
+
+[ "$FAIL" -eq 0 ]

--- a/tests/unit/test-pid-alive-long-running.sh
+++ b/tests/unit/test-pid-alive-long-running.sh
@@ -265,6 +265,53 @@ else
   else
     assert_true "heartbeat sibling created when missing (still absent)" "0"
   fi
+
+  echo
+  echo "=== TC-PALR-005c: heartbeat does NOT resurrect files after parent exit ==="
+  # Race: cleanup trap deletes both files, then heartbeat loop wakes from
+  # sleep. Without the inner kill -0 re-check, the loop's `touch` would
+  # recreate the heartbeat sibling with a fresh mtime — leaving the
+  # dispatcher to see a fake-ALIVE wrapper for up to 6 minutes after
+  # the wrapper actually exited. This test reproduces that window.
+  HB_PIDFILE_R="$TMPDIR/hb-resurrect.pid"
+  HB_FILE_R="${HB_PIDFILE_R%.pid}.heartbeat"
+
+  # Run the parent in a subshell so we can synchronously wait for it to
+  # exit before checking. The parent installs heartbeat (interval=1),
+  # sleeps long enough for the loop to enter `sleep 1`, then exits.
+  bash -c "
+    set +u
+    source '$SCRIPTS_DIR/lib-agent.sh' 2>/dev/null || true
+    set -u
+    AGENT_PID_FILE='$HB_PIDFILE_R' HEARTBEAT_INTERVAL_SECONDS=1 install_agent_heartbeat
+    # Touch both files first so the loop has something to refresh.
+    echo \$\$ >'$HB_PIDFILE_R'
+    : >'$HB_FILE_R'
+    # Let the loop iterate at least once, then sleep partway into its
+    # next sleep so it's blocked when we exit.
+    sleep 1.5
+  " &
+  parent_pid=$!
+  wait "$parent_pid" 2>/dev/null || true
+
+  # Immediately delete both files (simulating the cleanup trap). The
+  # heartbeat subshell is still asleep at this point.
+  rm -f "$HB_PIDFILE_R" "$HB_FILE_R"
+
+  # Wait long enough for the heartbeat loop to wake from its sleep
+  # (interval=1) AND complete its parent-pid re-check. 3s gives margin.
+  sleep 3
+
+  # Neither file should have been resurrected.
+  if [ ! -e "$HB_PIDFILE_R" ] && [ ! -e "$HB_FILE_R" ]; then
+    assert_true "heartbeat did not resurrect files after parent exit" "1"
+  else
+    resurrected=""
+    [ -e "$HB_PIDFILE_R" ] && resurrected="$resurrected pid_file"
+    [ -e "$HB_FILE_R" ]    && resurrected="$resurrected hb_file"
+    assert_true "heartbeat did not resurrect files after parent exit (resurrected:$resurrected)" "0"
+    rm -f "$HB_PIDFILE_R" "$HB_FILE_R"
+  fi
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #129. Long-running healthy `autonomous-dev` wrappers (~70+ min real run) were repeatedly classified DEAD by `pid_alive`, exhausting `MAX_RETRIES` and triggering `mark_stalled` despite continuous progress. The existing defences ([INV-24]/[INV-26]/[INV-27]) all missed because the heartbeat carrier itself was being deleted out from under the still-alive wrapper.

Two complementary fixes (both land in this PR):

- **(a) `dispatch-local.sh::kill_stale_wrapper`** preserves the PID file when its `kill -0 <old_pid>` returned failure (i.e. nothing was actually killed). The wrapper's heartbeat loop continues touching the file; `pid_alive`'s mtime fallback gets the data it needs. The file is still deleted when we (i) successfully signalled an alive holder or (ii) the content is empty / non-numeric.
- **(b) `lib-agent.sh::install_agent_heartbeat`** also touches a sibling `${AGENT_PID_FILE%.pid}.heartbeat` file. The wrapper's `cleanup` trap removes both. `kill_stale_wrapper` never references the sibling — its lifecycle is owned exclusively by the wrapper. `lib-dispatch.sh::pid_alive` extends to a three-tier check (kill -0 → PID-file mtime → heartbeat-sibling mtime). The heartbeat loop re-checks parent liveness immediately before each `touch` so a wrapper exit during the loop's sleep cannot resurrect either file (resurrection-race close).

New invariant **INV-29** documents both rules with full cross-references to INV-01/23/24/26/27.

## Design
- [x] Design canvas created (`docs/designs/dispatcher-pid-alive-long-running.md`)
- [x] Design self-approved (autonomous mode)

## Test Plan
- [x] Test cases documented (`docs/test-cases/dispatcher-pid-alive-long-running.md`)
- [x] New `tests/unit/test-pid-alive-long-running.sh` (18 cases) covers deletion policy, three-tier `pid_alive`, heartbeat sibling lifecycle, resurrection race, and INV-29 static cross-references
- [x] `tests/unit/test-kill-before-spawn.sh::TC-DKBS-003` updated to reflect the new `kill -0`-miss-preserves-PID-file contract
- [x] All unit tests pass locally (61 test files, 0 failures)
- [x] `shellcheck -S error` clean on all dispatcher scripts
- [x] code-simplifier review passed
- [x] pr-review-toolkit review passed (one Important resurrection-race finding addressed in commit 2)
- [ ] CI checks pass
- [ ] E2E in production confirms 75-min wrapper does not stall (validated downstream)

## Pipeline docs
- [x] `docs/pipeline/invariants.md` — new `INV-29` with INV-01/23/24/26/27 cross-references
- [x] `docs/pipeline/dispatcher-flow.md` — Step 5b paragraph mentions both mtime carriers

## Disable knob

`HEARTBEAT_INTERVAL_SECONDS=0` continues to disable both the wrapper-side heartbeat spawn AND the dispatcher-side mtime fallback, restoring legacy `kill -0`-only behaviour for operators who prefer it.

## Acceptance Criteria from #129

- [x] An `autonomous-dev` wrapper genuinely making progress for ≥ 75 min does NOT trigger `stalled`, regardless of how many dispatcher ticks fire (covered by Fix B + Fix A; verified at unit level)
- [x] If the wrapper genuinely dies, `stalled` still fires within `MAX_RETRIES * tick_interval` — TC-PALR-004 / 004b pin the legitimate-DEAD path
- [x] `kill_stale_wrapper` does NOT delete the PID file in the `kill -0` miss path AND a sibling heartbeat file provides an alternative liveness signal that survives PID-file deletion (both adopted)
- [x] Heartbeat loop is robust against PID drift (resurrection-race fix in commit 2 ensures no fake-ALIVE window after wrapper exit)
- [x] Test coverage proves both directions: TC-PALR-003b (75-min healthy repro: PID file gone, sibling fresh → ALIVE) and TC-PALR-004b (genuine death: both files gone → DEAD)

## Checklist
- [x] New unit tests written for new functionality
- [x] Existing test updated to reflect new contract
- [x] Documentation updated (design doc, test-cases doc, pipeline invariants + flow)
- [x] No backwards-compatibility shim needed — the older `pid_alive` (PID-file mtime only) still works against the new wrapper because the heartbeat loop also touches the PID file