### PR TITLE
fix(dispatcher): add process-group signal to review_near_success (#132, INV-24)

### DIFF
--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -421,14 +421,17 @@ The `Mode: startup-failure` exclusion matters: `autonomous-dev.sh`'s startup-fai
 
 ## INV-24: Review wrapper DEAD detection requires both pid_alive miss AND no near-success PR signal
 
-**Rule**: The dispatcher's Step 5b review-DEAD branch MUST NOT post a "Review process appears to have crashed" comment or flip `reviewing` → `pending-dev` on a bare `pid_alive` miss. It must additionally consult `review_near_success` (in `lib-dispatch.sh`), which returns 0 (skip) when ANY of these PR-state signals are positive within `REVIEW_NEAR_SUCCESS_WINDOW_SECONDS` (default 300s):
+**Rule**: The dispatcher's Step 5b review-DEAD branch MUST NOT post a "Review process appears to have crashed" comment or flip `reviewing` → `pending-dev` on a bare `pid_alive` miss. It must additionally consult `review_near_success` (in `lib-dispatch.sh`), which returns 0 (skip) when ANY of these signals are positive within `REVIEW_NEAR_SUCCESS_WINDOW_SECONDS` (default 300s):
 
 1. `PR.mergedAt` within the window — wrapper is finishing the merge step.
 2. Most recent `APPROVED` review event within the window — wrapper has reached approve step.
 3. Most recent `^Review (PASSED|findings)` comment within the window — wrapper completed verdict, may be merging or just exiting normally.
 4. Defensive `kill -0 <pid>` against the current PID-file content now succeeds — the original `pid_alive` miss raced with the wrapper's normal scheduling.
+5. Process-group walk (#132): the review wrapper's PGID — equal to the content of `review-${ISSUE}.pid` because `_run_with_timeout`'s `setsid` makes the session-leader PID == PGID — has at least one descendant whose `comm` matches `AGENT_CMD`. Implemented in `_review_pgid_has_agent_process` via `pgrep -g <pgid>` + `ps -o comm= -p <pid>`; tolerant of Linux's 15-char `comm` truncation via substring match. Skipped silently when PID file is empty / unparseable, or when `pgrep`/`ps` are absent on the host — never fail-closed.
 
-Only when ALL four signals are negative does the existing crash + label-swap fire.
+Only when ALL five signals are negative does the existing crash + label-swap fire.
+
+**Note on signal 5 (added 2026-05-16, #132)**: Signals 1–4 cover wrappers that have produced an externally visible state change (PR merged / APPROVED review submitted / verdict comment posted / live PID-file PID). They do not cover the gap between "review wrapper is processing" and "review wrapper has emitted its first artifact" — empirically 5–15 min for E2E + multi-bot rounds + line-by-line review. Reproduced on a downstream consumer's #209 (2026-05-15 16:00:39Z): `pid_alive` triple miss (kill -0 / PID-file mtime / heartbeat sibling mtime all stale), four PR-state signals all negative, declare crashed → `reviewing → pending-dev`; 4 minutes later the same wrapper posted its verdict + APPROVED + merged the PR. Signal 5 is additive — never replaces an existing positive signal — and runs last in the cost-ordered chain so the happy path is unchanged. Ordering is pinned by TC-RNS-009.
 
 Complementary, `pid_alive` itself MUST honor a heartbeat-based mtime fallback: when `kill -0 <pid>` fails but the PID file's mtime is within `HEARTBEAT_INTERVAL_SECONDS * 3` (default 360s), still treat as ALIVE. The wrapper's `install_agent_heartbeat` helper (in `lib-agent.sh`) refreshes the mtime every `HEARTBEAT_INTERVAL_SECONDS` (default 120s) for its lifetime, so a stale mtime is strong evidence the process is genuinely dead.
 
@@ -447,7 +450,7 @@ Pre-fix, a transient `pid_alive` miss (race or short-lived sub-shell exit) withi
 **Status**: **ENFORCED** in this PR (closes #111).
 
 **Test**:
-- `tests/unit/test-dispatcher-review-near-success.sh` (6 cases) — TC-RNS-001..004 cover each signal positive; TC-RNS-005 covers all signals negative (crash path still fires); TC-RNS-006 covers the `=0` legacy strict knob.
+- `tests/unit/test-dispatcher-review-near-success.sh` (15 cases as of #132) — TC-RNS-001..004 cover each legacy signal positive; TC-RNS-005 covers all signals negative (crash path still fires); TC-RNS-006 covers the `=0` legacy strict knob; TC-RNS-007..011 (#132) cover the process-group signal: alone-positive (007), all-five-negative (008), legacy-positive-short-circuits-before-pgrep (009 ordering pin), strict-knob-overrides-pgrep (010), empty-PID-skips-pgrep-silently (011 defensive guard).
 - `tests/unit/test-wrapper-heartbeat.sh` (7 cases) — TC-HB-001..004 cover `pid_alive` decision matrix; TC-HB-005..007 cover heartbeat lifecycle (touches mtime, exits with parent, `=0` no-op).
 
 ## INV-25: Terminal labels (`approved`, `stalled`) are sticky; transitional residue is healed at tick start

--- a/docs/test-cases/review-near-success-pgrp-signal.md
+++ b/docs/test-cases/review-near-success-pgrp-signal.md
@@ -1,0 +1,108 @@
+# Test cases — `review_near_success` process-group signal (#132)
+
+Covers the fifth signal added to `lib-dispatch.sh::review_near_success`: walk
+the review wrapper's process group (PGID == content of `review-${ISSUE}.pid`)
+and treat as ALIVE/skip-crash if any group member's `comm` matches `AGENT_CMD`.
+
+Closes the gap reproduced on a downstream consumer's #209: long-running
+review wrapper, `pid_alive` triple miss (kill -0 / PID-file mtime / heartbeat
+sibling mtime all stale), and four PR-state signals all trail the still-mid-
+flight wrapper.
+
+Located in `tests/unit/test-dispatcher-review-near-success.sh` (extending the
+existing 6-case file). Run via:
+
+```bash
+bash tests/unit/test-dispatcher-review-near-success.sh
+```
+
+## TC-RNS-007 — process-group signal alone short-circuits when all four legacy signals are negative
+
+**Intent**: The whole point of the change. Reproduces the #209 16:00:39Z
+window: PR not merged, no APPROVED review, no verdict comment, defensive
+`kill -0` misses, but `pgrep -g <pgid>` finds an `AGENT_CMD` child. Must
+return 0 (skip crash).
+
+**Setup**:
+- `_MOCK_PR_INFO=` empty (no PR data — both signal 1 and 2 negative).
+- `_MOCK_VERDICT_AGE=` empty (signal 3 negative).
+- `_MOCK_PID=12345`, `_MOCK_KILL0_RC=1` (signal 4 negative — same miss as `pid_alive`).
+- `_MOCK_PGREP_AGENT_FOUND=1` (the new signal positive).
+
+**Expected**:
+- `review_near_success 99` returns 0.
+
+## TC-RNS-008 — all five signals negative, returns 1 (legitimate crash path)
+
+**Intent**: Pin that the new signal alone can't false-positive when the
+wrapper is genuinely dead. The crash + label-swap path must still fire.
+
+**Setup**:
+- All four legacy mocks negative (same as TC-RNS-007 above for 1–4).
+- `_MOCK_PGREP_AGENT_FOUND=0`.
+
+**Expected**:
+- `review_near_success 99` returns 1.
+
+## TC-RNS-009 — legacy positive signal short-circuits before the new signal runs
+
+**Intent**: Regression-pin ordering. The new signal sits at the END of the
+function (cheapest legacy signals first); when an earlier signal is
+positive, the new code path must never execute. Without this pin a future
+refactor could reorder and accidentally make pgrep the dominant cost on
+every call.
+
+**Setup**:
+- `_MOCK_VERDICT_AGE=10` (signal 3 positive).
+- `_MOCK_PGREP_AGENT_FOUND=0` (new signal would be negative if asked).
+- The pgrep stub records whether it was called via a `_MOCK_PGREP_CALLED` counter.
+
+**Expected**:
+- `review_near_success 99` returns 0 (signal 3 wins).
+- `_MOCK_PGREP_CALLED=0` after the call (the new signal was not consulted).
+
+## TC-RNS-010 — `REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=0` strict knob still wins over the new signal
+
+**Intent**: Ops escape hatch. Setting the window to 0 must restore legacy
+strict behaviour (every `pid_alive` miss declares crashed) — even when the
+new process-group signal would have said ALIVE. Without this lock, the
+operator's "I want strict, I'll deal with the false positives" override
+silently loses to the new signal.
+
+**Setup**:
+- `REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=0`.
+- `_MOCK_PGREP_AGENT_FOUND=1` (would have rescued in TC-RNS-007).
+
+**Expected**:
+- `review_near_success 99` returns 1 (the function exits at the early
+  numeric guard before any signal runs).
+
+## TC-RNS-011 — empty / unparseable PID skips the new signal silently (defensive guard)
+
+**Intent**: When `review-${ISSUE}.pid` is absent or its content is empty
+or non-numeric (race with `kill_stale_wrapper` deletion, or never written
+because the wrapper crashed in `acquire_pid_guard`), the new signal must
+NOT call `pgrep` with garbage args — it must skip the signal silently and
+return based on the four legacy signals alone. Without this guard, a typo
+in PID-file content could surface as a misleading shellcheck-/CI-level
+error in the dispatcher log.
+
+**Setup**:
+- All four legacy mocks negative.
+- `_MOCK_PID=""` (PID file empty).
+- `_MOCK_PGREP_AGENT_FOUND=1` (the stub would say positive *if* asked).
+- `_MOCK_PGREP_CALLED=0` baseline.
+
+**Expected**:
+- `review_near_success 99` returns 1 (no signal positive).
+- `_MOCK_PGREP_CALLED=0` after the call (the bad-PID branch never reached pgrep).
+
+## Out of scope
+
+- Reproducing the #209 timing race against a real review wrapper. That'd
+  60× the test runtime; the mock-driven cases above cover the same
+  decision matrix in seconds.
+- `AGENT_CMD` matching subtleties (`claude` vs `claude-cli`, comm-truncation
+  to 15 chars on Linux). The substring-match design tolerates these by
+  construction; a focused matcher unit test would be redundant against
+  TC-RNS-007's positive path.

--- a/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
@@ -883,9 +883,50 @@ dev_near_success() {
   return 1
 }
 
+# _review_pgid_has_agent_process <pgid>
+#
+# Signal-5 helper for review_near_success (#132). Walks the review
+# wrapper's process group (PGID == content of review-${ISSUE}.pid;
+# setsid in lib-agent.sh::_run_with_timeout makes the session-leader
+# PID equal to the PGID) and returns 0 if any group member's `comm`
+# matches the configured AGENT_CMD.
+#
+# Returns 1 silently in three cases — never fail-closed:
+#   - PGID is not a positive integer (empty / unparseable PID file)
+#   - `pgrep` or `ps` not on PATH (mismatched host)
+#   - No member of the group has a comm matching AGENT_CMD
+#
+# Substring match (`*${AGENT_CMD}*`) is intentionally tolerant: Linux
+# truncates `comm` to 15 chars (so `claude-cli-with-extras` shows up as
+# `claude-cli-with`), and AGENT_CMD values are typically 5–10 chars.
+# Over-match is safe here — this signal only runs after pid_alive missed
+# AND signals 1–4 already failed, so a false positive defers a crash
+# declaration by one tick at most, while a false negative reproduces
+# the #209 false-crash that drove the addition of this signal.
+_review_pgid_has_agent_process() {
+  local pgid="$1"
+  [[ "$pgid" =~ ^[0-9]+$ ]] || return 1
+  [ "$pgid" -gt 0 ] || return 1
+  command -v pgrep >/dev/null 2>&1 || return 1
+  command -v ps >/dev/null 2>&1 || return 1
+
+  local agent_cmd="${AGENT_CMD:-claude}"
+  local pid comm
+  while read -r pid; do
+    [[ "$pid" =~ ^[0-9]+$ ]] || continue
+    comm=$(ps -o comm= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+    [ -n "$comm" ] || continue
+    if [[ "$comm" == *"$agent_cmd"* ]]; then
+      return 0
+    fi
+  done < <(pgrep -g "$pgid" 2>/dev/null)
+
+  return 1
+}
+
 # Step 5b: review_near_success <issue_num>
 #
-# Returns 0 (skip the "crashed" path) if ANY of these PR-state signals are
+# Returns 0 (skip the "crashed" path) if ANY of these signals are
 # positive within REVIEW_NEAR_SUCCESS_WINDOW_SECONDS (default 300s):
 #
 #   1. PR.mergedAt within window — wrapper finished merging.
@@ -896,11 +937,24 @@ dev_near_success() {
 #   4. Defensive `kill -0 <pid>` against the current PID-file content
 #      now succeeds — the original pid_alive miss raced with the
 #      wrapper's normal scheduling.
+#   5. Process-group walk (#132): the review wrapper's PGID still has
+#      at least one descendant whose comm matches AGENT_CMD. Catches
+#      the "long-running review wrapper, pre-verdict window" case where
+#      signals 1–4 all trail the still-mid-flight wrapper. Reproduced
+#      on a downstream consumer's #209 (2026-05-15 UTC).
 #
-# REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=0 disables the short-circuit (legacy
-# strict behavior — every pid_alive miss declares crashed).
+# Signal ordering is cost-driven, cheapest first: 1+2 share one
+# fetch_pr_for_issue call, 3 is one gh-api call, 4 is a single kill -0,
+# 5 hits the kernel proc table. Earlier signals short-circuit before
+# later ones run; TC-RNS-009 pins this ordering so a future refactor
+# can't silently reorder and double the per-tick cost.
 #
-# Returns 1 if all four signals are negative — caller proceeds with the
+# REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=0 disables the entire short-circuit
+# (legacy strict behavior — every pid_alive miss declares crashed). The
+# strict knob fires at the early numeric guard, before any signal runs;
+# TC-RNS-010 pins that the new signal cannot override the strict knob.
+#
+# Returns 1 if all five signals are negative — caller proceeds with the
 # existing crashed-comment + label-swap.
 review_near_success() {
   local issue_num="$1"
@@ -943,6 +997,14 @@ review_near_success() {
   local pid
   pid=$(get_pid review "$issue_num")
   if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+
+  # Signal 5: process-group walk (#132). Skipped silently when PID is
+  # empty / unparseable (TC-RNS-011) — the helper's own integer guard
+  # would catch it, but checking here keeps the caller's contract
+  # explicit and avoids ever spawning the helper subshell on bad input.
+  if [ -n "$pid" ] && _review_pgid_has_agent_process "$pid"; then
     return 0
   fi
 

--- a/tests/unit/test-dispatcher-review-near-success.sh
+++ b/tests/unit/test-dispatcher-review-near-success.sh
@@ -42,6 +42,8 @@ _MOCK_PR_INFO=""        # JSON returned by fetch_pr_for_issue_with_reviews
 _MOCK_VERDICT_AGE=""    # seconds since most recent verdict comment ("" = none)
 _MOCK_PID=""            # PID stored "in" the PID file
 _MOCK_KILL0_RC="1"      # rc returned by defensive kill -0 (0 = alive)
+_MOCK_PGREP_AGENT_FOUND="0"  # signal 5 (#132): 1 = pgrep -g <pgid> finds an AGENT_CMD child
+_MOCK_PGREP_CALLED="0"  # observability: incremented each time the pgrep stub is consulted
 
 # Override fetch helper used by review_near_success.
 fetch_pr_for_issue() {
@@ -68,6 +70,15 @@ kill() {
   command kill "$@"
 }
 
+# Signal 5 helper (#132): mock the lib-dispatch.sh helper that walks the
+# review wrapper's process group looking for an AGENT_CMD child. Tests
+# control its return code via _MOCK_PGREP_AGENT_FOUND, and inspect
+# _MOCK_PGREP_CALLED to assert ordering / defensive-guard behaviour.
+_review_pgid_has_agent_process() {
+  _MOCK_PGREP_CALLED=$((_MOCK_PGREP_CALLED + 1))
+  [ "$_MOCK_PGREP_AGENT_FOUND" = "1" ]
+}
+
 # Source the lib AFTER the mocks so the helpers can be redefined.
 # shellcheck disable=SC1090
 source "$LIB"
@@ -86,12 +97,18 @@ get_pid() {
 latest_review_verdict_age_seconds() {
   printf '%s' "$_MOCK_VERDICT_AGE"
 }
+_review_pgid_has_agent_process() {
+  _MOCK_PGREP_CALLED=$((_MOCK_PGREP_CALLED + 1))
+  [ "$_MOCK_PGREP_AGENT_FOUND" = "1" ]
+}
 
 reset_mocks() {
   _MOCK_PR_INFO=""
   _MOCK_VERDICT_AGE=""
   _MOCK_PID=""
   _MOCK_KILL0_RC="1"
+  _MOCK_PGREP_AGENT_FOUND="0"
+  _MOCK_PGREP_CALLED="0"
 }
 
 assert() {
@@ -101,6 +118,17 @@ assert() {
     PASS=$((PASS + 1))
   else
     echo -e "  ${RED}FAIL${NC}: $label (got rc=$rc, expected rc=$expected_rc)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_eq() {
+  local label="$1" actual="$2" expected="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo -e "  ${GREEN}PASS${NC}: $label ($actual)"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $label (got '$actual', expected '$expected')"
     FAIL=$((FAIL + 1))
   fi
 }
@@ -164,6 +192,73 @@ recent_iso=$(date -u -d "@$(( $(date -u +%s) - 60 ))" +"%Y-%m-%dT%H:%M:%SZ" 2>/d
 _MOCK_PR_INFO=$(printf '{"number":42,"mergedAt":"%s","reviews":[]}' "$recent_iso")
 REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=0 review_near_success 42
 assert "window=0 → legacy strict (return 1)" "$?" "1"
+
+echo
+echo "=== TC-RNS-007: process-group signal alone short-circuits when 4 legacy signals all negative (#132) ==="
+# Reproduces the podcast-curation #209 16:00:39Z window: PR not merged, no
+# APPROVED, no verdict comment, defensive kill -0 misses, but a long-running
+# review wrapper still has agent-CLI children alive in its PGID.
+reset_mocks
+old_iso=$(date -u -d "@$(( $(date -u +%s) - 99999 ))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+  || date -u -v-99999S +"%Y-%m-%dT%H:%M:%SZ")
+_MOCK_PR_INFO=$(printf '{"number":42,"mergedAt":"%s","reviews":[{"state":"COMMENTED","submittedAt":"%s"}]}' "$old_iso" "$old_iso")
+_MOCK_VERDICT_AGE=""
+_MOCK_PID="12345"
+_MOCK_KILL0_RC="1"
+_MOCK_PGREP_AGENT_FOUND="1"
+REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=300 review_near_success 42
+assert "pgrep finds agent in PGID → near-success" "$?" "0"
+assert_eq "pgrep helper consulted exactly once" "$_MOCK_PGREP_CALLED" "1"
+
+echo
+echo "=== TC-RNS-008: all five signals negative → declares crashed (#132) ==="
+reset_mocks
+_MOCK_PR_INFO=$(printf '{"number":42,"mergedAt":"%s","reviews":[{"state":"COMMENTED","submittedAt":"%s"}]}' "$old_iso" "$old_iso")
+_MOCK_VERDICT_AGE=""
+_MOCK_PID="12345"
+_MOCK_KILL0_RC="1"
+_MOCK_PGREP_AGENT_FOUND="0"
+REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=300 review_near_success 42
+assert "all five negative → declare crashed" "$?" "1"
+
+echo
+echo "=== TC-RNS-009: legacy positive signal short-circuits BEFORE the new signal runs (#132 ordering pin) ==="
+# Cost / ordering invariant: pgrep is the most expensive signal (pings the
+# kernel proc table); when an earlier signal already says ALIVE we must
+# NEVER reach the pgrep helper. Without this pin a future refactor could
+# reorder and silently double the per-tick cost.
+reset_mocks
+_MOCK_PR_INFO='{"number":42,"mergedAt":null,"reviews":[]}'
+_MOCK_VERDICT_AGE="60"  # signal 3 positive
+_MOCK_PGREP_AGENT_FOUND="0"
+REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=300 review_near_success 42
+assert "verdict-age positive → near-success" "$?" "0"
+assert_eq "pgrep helper NOT consulted (legacy signal won)" "$_MOCK_PGREP_CALLED" "0"
+
+echo
+echo "=== TC-RNS-010: WINDOW=0 strict knob still wins over the new signal (#132) ==="
+# Ops escape hatch: even if the new signal would have rescued, the strict
+# knob disables the entire short-circuit at the early numeric guard.
+reset_mocks
+_MOCK_PGREP_AGENT_FOUND="1"
+REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=0 review_near_success 42
+assert "window=0 → strict (return 1 even with pgrep positive)" "$?" "1"
+assert_eq "pgrep helper NOT consulted under strict knob" "$_MOCK_PGREP_CALLED" "0"
+
+echo
+echo "=== TC-RNS-011: empty PID file → pgrep skipped silently (#132 defensive guard) ==="
+# Race with kill_stale_wrapper deletion or wrapper crash before
+# acquire_pid_guard wrote anything: PID content is empty / unparseable.
+# The new signal MUST skip silently rather than calling pgrep with garbage.
+reset_mocks
+_MOCK_PR_INFO=$(printf '{"number":42,"mergedAt":"%s","reviews":[{"state":"COMMENTED","submittedAt":"%s"}]}' "$old_iso" "$old_iso")
+_MOCK_VERDICT_AGE=""
+_MOCK_PID=""             # empty PID file
+_MOCK_KILL0_RC="1"
+_MOCK_PGREP_AGENT_FOUND="1"  # would say positive IF asked
+REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=300 review_near_success 42
+assert "empty PID + 4 legacy negative → declare crashed" "$?" "1"
+assert_eq "pgrep helper NOT consulted with empty PID" "$_MOCK_PGREP_CALLED" "0"
 
 echo
 echo "==============================================="


### PR DESCRIPTION
## Summary
- Adds a fifth signal to `review_near_success` (`skills/autonomous-dispatcher/scripts/lib-dispatch.sh`): walk the review wrapper's process group via `pgrep -g <pgid>` + `ps -o comm= -p <pid>` and treat as ALIVE/skip-crash if any group member's `comm` matches `AGENT_CMD`. PGID == content of `review-${ISSUE}.pid` because `_run_with_timeout`'s `setsid` makes session-leader PID == PGID.
- Closes the gap reproduced on a downstream consumer's #209 (2026-05-15 16:00:39Z): a 14-min review wrapper hit `pid_alive` triple miss (kill -0 / PID-file mtime / heartbeat sibling mtime all stale) AND four legacy PR-state signals all negative (PR not merged, no APPROVED, no verdict comment, defensive kill -0 missed) — dispatcher declared crashed, label flipped to pending-dev, and 4 minutes later a phantom dev-resume fired one second before the same wrapper successfully merged the PR.
- INV-24 in `docs/pipeline/invariants.md` enumerates all 5 signals with a dated 2026-05-16 note explaining the gap signal 5 closes.

## Why "additive, last in chain"
Signal ordering is cost-cheapest first: 1+2 share one `fetch_pr_for_issue` call, 3 is one gh-api call, 4 is a single `kill -0`, 5 hits the kernel proc table. Earlier signals short-circuit before signal 5 runs (regression-pinned by TC-RNS-009). The new signal never replaces a positive earlier signal — only augments the all-negative path. `REVIEW_NEAR_SUCCESS_WINDOW_SECONDS=0` strict-knob override fires at the early numeric guard before any signal runs (TC-RNS-010 pins).

## Defensive guards (all silent skips, never fail-closed)
1. PGID must parse as positive integer (rejects empty file / `pgrep -g 0` which returns kernel processes).
2. `pgrep` must be on PATH.
3. `ps` must be on PATH.

Substring match `*${AGENT_CMD}*` tolerates Linux's 15-char `comm` truncation. Over-match is preferred here because the signal only runs after 4 others already failed; a false positive defers crash declaration by one tick at most, while a false negative reproduces #209.

## Test Plan
- [x] Test cases documented (`docs/test-cases/review-near-success-pgrp-signal.md`)
- [x] `tests/unit/test-dispatcher-review-near-success.sh` extended from 6 cases to 11 (TC-RNS-007..011: positive-alone / all-five-negative / legacy-positive-short-circuits-before-pgrep / strict-knob-overrides-pgrep / empty-PID-skips-pgrep-silently)
- [x] Full unit-test suite green (61 files locally)
- [x] `shellcheck -S error` clean on `lib-dispatch.sh` + extended test file
- [x] Code review passed (no findings ≥ Medium; verified helper behaviour against live process group)
- [x] Pipeline doc INV-24 updated in same PR (CLAUDE.md authority rule)

## Checklist
- [x] New unit tests written for new functionality
- [x] Pipeline docs updated in same PR
- [x] No E2E required — lives entirely in shell unit-test territory

Closes #132