### PR TITLE
fix(autonomous-dev): route Step-12 summary post through scripts/gh wrapper (#142)

### DIFF
--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -677,6 +677,54 @@ The transport's stdout is one of `ALIVE` / `DEAD` / empty. Indeterminate verdict
 
 Plus the existing `test-lib-agent-gemini.sh` (22 assertions) and `test-lib-agent-kiro-permission.sh` (16 assertions) updated to assert the post-#140 structural-only contract on the gemini and kiro branches.
 
+## INV-32: `gh` wrapper symlink is created in both auth modes
+
+**Rule**: `setup_github_auth` in `lib-auth.sh` MUST create the
+`${_LIB_AUTH_DIR}/gh` symlink (pointing at `gh-with-token-refresh.sh`) and
+prepend `_LIB_AUTH_DIR` to `PATH` regardless of `GH_AUTH_MODE`. Both `app`
+and `token` modes must produce a working `scripts/gh` invocation path.
+
+**Why**: agent-facing skill docs (`skills/autonomous-dev/SKILL.md` Step 12,
+`skills/autonomous-dev/references/autonomous-mode.md` "Posting Issue/PR
+Comments") prescribe `bash scripts/gh issue comment …` as the uniform rule
+for status / summary / progress comments — the explicit path forces
+resolution through the project-vendored wrapper symlink, sidestepping the
+agent's Bash tool's unreliable PATH-resolution for `gh` (the bug fixed by
+issue #142). For that uniform rule to actually work, the symlink must
+exist in both modes. The wrapper itself (`gh-with-token-refresh.sh`) is
+mode-agnostic — it consults `GH_TOKEN_FILE` only when set (app mode) and
+otherwise exec's the real `gh` inheriting the host's auth env (which IS
+the intended identity in token mode). Lifting the symlink creation out of
+the app-mode branch is therefore safe and necessary.
+
+**Producer**: `skills/autonomous-dispatcher/scripts/lib-auth.sh::setup_github_auth`.
+
+**Consumer**: agent-facing docs that prescribe `bash scripts/gh …`; agent
+processes that follow that prescription; any operator script that invokes
+`bash scripts/gh` from the project's `scripts/` directory.
+
+**Status**: **ENFORCED** by this PR (closes #142). Pre-#142, the symlink
+creation lived inside the `if [[ "$GH_AUTH_MODE" == "app" ]]` branch of
+`setup_github_auth` (lib-auth.sh:64-67), so token-mode invocations of the
+prescribed command path fell through to a "no such file" error.
+
+**Test**:
+- `tests/unit/test-lib-auth-gh-symlink.sh` (2 cases) — TC-AUTH-SYM-001
+  drives `setup_github_auth` in token mode and asserts the `gh` symlink
+  exists; TC-AUTH-SYM-002 is a source-level regression guard that asserts
+  the symlink-creation line is OUTSIDE the `GH_AUTH_MODE=app` branch in
+  `lib-auth.sh`.
+
+**Cross-references**:
+- Agent-facing rule: `skills/autonomous-dev/references/autonomous-mode.md`
+  "Posting Issue/PR Comments" section — describes when to use
+  `bash scripts/gh issue comment …` vs `bash scripts/gh-as-user.sh pr
+  comment …`. INV-32 is what makes the former actually work in both modes.
+- Doc-lint guard: `tests/unit/test-dev-skill-bash-scripts-gh.sh` — fails
+  on regressions to bare `gh issue comment` in `skills/autonomous-dev/`
+  markdown.
+
+
 ## Adding a new invariant
 
 When fixing a pipeline bug, after locating the bug on the state machine + flow docs:

--- a/docs/test-cases/dev-step-12-comment-identity.md
+++ b/docs/test-cases/dev-step-12-comment-identity.md
@@ -1,0 +1,179 @@
+# Test Cases: Dev Step 12 — Comment Identity in App Mode
+
+Issue: #142 — `fix(autonomous-dev): step-12 summary comment posts as host gh user instead of bot in app mode`
+
+## Background
+
+The autonomous-dev wrapper sets up a `${_LIB_AUTH_DIR}` PATH-prepend symlink so
+that any `gh` invocation routes through `gh-with-token-refresh.sh`. The wrapper
+itself hits the symlink (so its trailer comments are correctly attributed to
+the App-installed bot identity in `GH_AUTH_MODE=app`).
+
+The agent process inherits the same PATH but its embedded Bash tool does not
+reliably honor it for `gh` resolution — bare `gh issue comment …` resolves to
+`/usr/bin/gh`, which uses the host operator's `gh auth login` session and
+posts the Step-12 summary under the host user's identity, not the bot.
+
+The fix is documentation-only: agent-facing skill docs and the autonomous-mode
+reference must instruct the agent to use the explicit project-vendored wrapper
+path (`bash scripts/gh issue comment …`) for status/summary comments. A
+doc-lint guard prevents regression.
+
+## Scope
+
+- Behavioral assertions about runtime identity attribution (TC-COMMENT-001 …
+  TC-COMMENT-003) describe the **expected outcome** when an agent follows the
+  updated docs. They are **manual verification** — no bash unit test stubs
+  the GitHub API end-to-end.
+- The doc-lint guard (TC-COMMENT-004) is a **unit test** living in
+  `tests/unit/test-dev-skill-bash-scripts-gh.sh`.
+
+## Test Cases
+
+### TC-COMMENT-001 — Step 12 summary in app mode → bot identity
+
+**Mode**: `GH_AUTH_MODE=app`, `AGENT_CMD=claude` (or any agent CLI)
+
+**Setup**: throwaway issue in a test repo with the autonomous label and the
+required `## Dependencies` / `## Testing Requirements` sections so the
+dispatcher will pick it up.
+
+**Steps**:
+1. Run `bash scripts/autonomous-dev.sh --issue <N> --mode new` against the
+   throwaway issue.
+2. Let the wrapper run end-to-end through Step 12 (the agent's
+   "session complete" summary post).
+3. Inspect the issue comments with
+   `gh api repos/<owner>/<repo>/issues/<N>/comments --jq '.[] | {user: .user.login, body: .body[:80]}'`.
+
+**Expected**:
+- The wrapper-emitted "Agent Session Report (Dev)" trailer comment is
+  attributed to the App's bot identity (e.g., `<bot-name>[bot]`).
+- The agent-emitted Step-12 summary comment is **also** attributed to the
+  App's bot identity (NOT the host operator's `gh auth login` user).
+- Both comments share the same `user.login` value.
+
+**Verification**: manual. Recorded in the PR description that fixes #142
+(see "Manual app-mode verification" line in the Acceptance Criteria).
+
+---
+
+### TC-COMMENT-002 — Step 12 summary in token mode → host user identity
+
+**Mode**: `GH_AUTH_MODE=token`, agent CLI of choice.
+
+**Setup**: same throwaway issue, but operator has switched the project's
+`autonomous.conf` to `GH_AUTH_MODE=token` and `gh auth status` shows the host
+user logged in.
+
+**Steps**:
+1. Run `bash scripts/autonomous-dev.sh --issue <N> --mode new`.
+2. Let it run through Step 12.
+3. Inspect issue comments as in TC-COMMENT-001.
+
+**Expected**:
+- The wrapper trailer is attributed to the host operator's `gh auth login`
+  user (or the `GH_TOKEN` owner).
+- The agent's Step-12 summary is **also** attributed to the same host user.
+- This is **intentional** — token mode deliberately uses the host's session.
+
+**Regression guard**: confirms the fix did not over-correct and accidentally
+force bot identity in token mode.
+
+---
+
+### TC-COMMENT-003 — Review-bot trigger remains user-attributed in app mode
+
+**Mode**: `GH_AUTH_MODE=app`, `REVIEW_BOTS="q"` (or `codex` / `claude`).
+
+**Setup**: same as TC-COMMENT-001, but the project's autonomous.conf declares
+at least one built-in review bot.
+
+**Steps**:
+1. Run the dev wrapper through PR creation and Step 10 (Address Reviewer Bot
+   Findings).
+2. The agent will issue a review trigger comment. Inspect the comment's
+   `user.login` on the PR.
+
+**Expected**:
+- The `/q review` (or equivalent) comment is attributed to the **host user**
+  (via `bash scripts/gh-as-user.sh pr comment …`), NOT the App bot.
+- This is **intentional** — Q / Codex / Claude bots reject triggers from
+  GitHub App accounts, so user attribution is required for the trigger to
+  fire.
+
+**Regression guard**: confirms the new documentation rule
+("status/summary → `bash scripts/gh`, review-bot triggers →
+`bash scripts/gh-as-user.sh`") did not collapse both paths into one.
+
+---
+
+### TC-COMMENT-004 — Doc-lint: no bare `gh issue comment` in agent-facing docs
+
+**Type**: bash unit test in `tests/unit/test-dev-skill-bash-scripts-gh.sh`.
+
+**Scope of files checked**:
+- `skills/autonomous-dev/SKILL.md`
+- All files under `skills/autonomous-dev/references/*.md`
+
+**Rule**: every `gh issue comment` token in these files must be preceded by
+`scripts/` on the same line (i.e., must read as `bash scripts/gh issue comment`
+or `scripts/gh issue comment`). Bare `gh issue comment` (no `scripts/` prefix
+on the same line) fails the test.
+
+**Why bare-`gh-issue-comment` and not bare-`gh-pr-comment` too**: review-bot
+triggers (`gh pr comment` paired with `/q review` / `/codex review` /
+`@claude review`) intentionally route through `gh-as-user.sh`, not the
+default wrapper. The autonomous-mode reference and review-commands reference
+explicitly call out `bash scripts/gh-as-user.sh pr comment …` for those
+flows, and the docs must continue to allow that pattern. A future scope
+expansion could add a similar guard for `gh pr comment` once the docs are
+audited for false positives, but it is **out of scope** for #142.
+
+**Pass condition**: `grep -nE '(^|[^/])gh issue comment'` returns no matches
+across the scoped files (i.e., zero hits where `gh issue comment` is preceded
+by anything other than a `/`, which is how `scripts/gh` would appear).
+
+**Fail condition**: any hit indicates a regression where future edits
+re-introduced a bare-`gh issue comment` example in agent-facing docs.
+
+---
+
+### TC-AUTH-SYM-001/002 — `scripts/gh` symlink exists in both auth modes (INV-32)
+
+**Type**: bash unit test in `tests/unit/test-lib-auth-gh-symlink.sh`.
+
+**Context**: in addition to the doc edits, this PR makes a small enabling
+change to `lib-auth.sh::setup_github_auth` — lifting the `gh` symlink
+creation out of the app-mode branch. Without that change, the
+doc-prescribed `bash scripts/gh issue comment …` would fail with
+"No such file or directory" in token mode, because the symlink was only
+created inside the app-mode branch. The wrapper script
+(`gh-with-token-refresh.sh`) is itself mode-agnostic — it consults
+`GH_TOKEN_FILE` only when set (app mode) and otherwise exec's the real
+`gh` inheriting the host's auth env (which is the intended identity in
+token mode). See [INV-32](../pipeline/invariants.md) for the invariant.
+
+**TC-AUTH-SYM-001** — runtime: drives `setup_github_auth` in a sandboxed
+copy of `lib-auth.sh` with `GH_AUTH_MODE=token` and asserts that
+`${_LIB_AUTH_DIR}/gh` symlink exists and points at
+`gh-with-token-refresh.sh`.
+
+**TC-AUTH-SYM-002** — source-level regression guard: parses `lib-auth.sh`,
+locates the `if [[ "$GH_AUTH_MODE" == "app" ]]` branch and the
+symlink-creation line, asserts the latter is OUTSIDE the former. Catches
+any future contributor "tidying up" the function by moving the symlink
+back inside the app branch.
+
+---
+
+## Acceptance Criteria Mapping
+
+| Issue acceptance criterion | Covered by |
+|---|---|
+| All `gh issue comment` invocations in agent-facing skill docs use `bash scripts/gh issue comment …` | TC-COMMENT-004 (automated) |
+| `autonomous-mode.md` documents the rule distinguishing `bash scripts/gh` (status/summary) from `bash scripts/gh-as-user.sh` (review-bot triggers) | Manual review of the PR diff; reinforced by TC-COMMENT-003 (regression guard) |
+| Doc-lint test fails on any future bare-`gh issue comment` regression | TC-COMMENT-004 (automated) |
+| Test-cases doc exists with the four scenarios | THIS DOC |
+| Manual app-mode verification on a throwaway issue: wrapper trailer = bot, agent summary = bot | TC-COMMENT-001 (manual, recorded in PR description) |
+| (Implicit, surfaced during implementation) — `bash scripts/gh` works in token mode too, not just app mode | TC-AUTH-SYM-001/002 (automated) + INV-32 |

--- a/skills/autonomous-dev/SKILL.md
+++ b/skills/autonomous-dev/SKILL.md
@@ -381,7 +381,11 @@ For the full retrigger commands, reply patterns, and thread resolution semantics
    hooks/state-manager.sh mark e2e-tests
    ```
 3. Update PR checklist to show all items complete
-4. **STOP HERE**: report status to the user (interactive mode) or post a summary comment on the issue (autonomous mode)
+4. **STOP HERE**: report status to the user (interactive mode) or post a summary comment on the issue (autonomous mode). In autonomous mode, post via the project-vendored wrapper so the comment is attributed to the configured identity (bot in app mode, host user in token mode):
+   ```bash
+   bash scripts/gh issue comment <ISSUE_NUMBER> --body "<summary>"
+   ```
+   Do **not** call bare `gh issue comment` — the agent's Bash tool does not reliably resolve `gh` through the wrapper-injected PATH, so a bare call falls through to the system `gh` and posts under the host operator's identity. See [`references/autonomous-mode.md`](references/autonomous-mode.md#posting-issuepr-comments) for the full rule.
 5. User or review agent decides when to merge
 
 ---

--- a/skills/autonomous-dev/references/autonomous-mode.md
+++ b/skills/autonomous-dev/references/autonomous-mode.md
@@ -16,6 +16,41 @@ When a decision would normally require user input:
 | Test coverage questions | Write tests for happy path + main error cases |
 | Performance vs simplicity | Choose simplicity unless performance is the issue's focus |
 
+## Posting Issue/PR Comments
+
+In autonomous mode there are **two** wrappers, and they are not interchangeable. Pick the right one or your comment is attributed to the wrong identity.
+
+| Comment purpose | Wrapper to use | Resulting identity |
+|---|---|---|
+| Status / summary / progress / error / Step-12 completion comment | `bash scripts/gh issue comment …` (or `bash scripts/gh pr comment …`) | App mode → bot; token mode → host user. Both are intentional per `GH_AUTH_MODE`. |
+| Review-bot trigger (`/q review`, `/codex review`, `@claude review`) | `bash scripts/gh-as-user.sh pr comment …` | Always host user (Q / Codex / Claude bots reject GitHub-App-attributed triggers). |
+
+> **Never use bare `gh issue comment` or bare `gh pr comment`.** The wrapper injects `gh-with-token-refresh.sh` onto `PATH`, but the agent's embedded Bash tool does not reliably honor that injection for `gh` resolution — bare calls fall through to the system `/usr/bin/gh` and post under the host operator's `gh auth login` user instead of the configured pipeline identity. The explicit `bash scripts/gh …` form forces resolution through the project-vendored wrapper symlink.
+
+**Examples**:
+
+```bash
+# Step-12 completion summary (status post — wrapper-routed):
+bash scripts/gh issue comment "$ISSUE_NUMBER" \
+  --body "Implementation complete. PR: #$PR_NUMBER. All CI checks passed."
+
+# Review-bot trigger (must be user-attributed):
+bash scripts/gh-as-user.sh pr comment "$PR_NUMBER" --body "/q review"
+
+# Error/recovery comment (status post — wrapper-routed):
+bash scripts/gh issue comment "$ISSUE_NUMBER" \
+  --body "Build failed after 3 retry attempts. See logs at <url>. Bailing out."
+```
+
+**Self-check before Step-12 summary post** (optional but recommended for app mode):
+
+```bash
+bash scripts/gh api user --jq .login
+# In app mode this should print the bot login (e.g. "<bot-name>[bot]").
+# If it prints a human username, the wrapper symlink is not being resolved
+# and the summary post will be misattributed.
+```
+
 ## Resume Awareness
 
 On resume (or new session for a previously started issue), perform these checks before writing code:

--- a/skills/autonomous-dispatcher/scripts/lib-auth.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-auth.sh
@@ -60,11 +60,6 @@ setup_github_auth() {
 
     refresh_token_env
     export GH_TOKEN_FILE
-
-    if [[ -x "${_LIB_AUTH_DIR}/gh-with-token-refresh.sh" ]]; then
-      export PATH="${_LIB_AUTH_DIR}:${PATH}"
-      ln -sf "${_LIB_AUTH_DIR}/gh-with-token-refresh.sh" "${_LIB_AUTH_DIR}/gh" 2>/dev/null || true
-    fi
   else
     if [[ -z "${GH_TOKEN:-}" ]]; then
       if ! command -v gh &>/dev/null || ! gh auth status &>/dev/null 2>&1; then
@@ -72,6 +67,18 @@ setup_github_auth() {
         echo "Run 'export GH_TOKEN=<token>' or 'gh auth login'." >&2
       fi
     fi
+  fi
+
+  # [INV-32] Create the `gh` symlink in both modes. The wrapper itself
+  # (gh-with-token-refresh.sh) is mode-agnostic — it only reads from
+  # GH_TOKEN_FILE when that's set (app mode). In token mode the wrapper
+  # exec's the real gh and inherits the host's gh auth env, which IS the
+  # intended identity. Having the symlink in both modes lets agent-facing
+  # docs prescribe a single uniform rule (`bash scripts/gh issue comment …`)
+  # without mode-conditional branches. See issue #142.
+  if [[ -x "${_LIB_AUTH_DIR}/gh-with-token-refresh.sh" ]]; then
+    export PATH="${_LIB_AUTH_DIR}:${PATH}"
+    ln -sf "${_LIB_AUTH_DIR}/gh-with-token-refresh.sh" "${_LIB_AUTH_DIR}/gh" 2>/dev/null || true
   fi
 }
 

--- a/tests/unit/test-dev-skill-bash-scripts-gh.sh
+++ b/tests/unit/test-dev-skill-bash-scripts-gh.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# test-dev-skill-bash-scripts-gh.sh — Regression guard for issue #142.
+#
+# Asserts that agent-facing docs in the autonomous-dev skill never tell the
+# agent to call bare `gh issue comment` for status/summary/progress posts.
+#
+# Why: in GH_AUTH_MODE=app, the wrapper PATH-prepends a gh-with-token-refresh
+# symlink so all gh calls route through the App-installed bot identity. The
+# agent's embedded Bash tool, however, doesn't reliably honor that injected
+# PATH for `gh` resolution — bare `gh issue comment` resolves to /usr/bin/gh
+# and posts under the host operator's `gh auth login` user instead of the
+# bot. The fix is to instruct the agent to call the project-vendored wrapper
+# explicitly: `bash scripts/gh issue comment …`. This test ensures future
+# edits don't regress to bare `gh issue comment` in the agent-facing docs.
+#
+# Scope: skills/autonomous-dev/SKILL.md plus skills/autonomous-dev/references/*.md.
+# Other doc trees (docs/pipeline/, design docs, dispatcher SKILL) are NOT
+# agent-facing instructions and are out of scope.
+#
+# Run: bash tests/unit/test-dev-skill-bash-scripts-gh.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# scoped_files: every agent-facing markdown file in the autonomous-dev skill.
+mapfile -t scoped_files < <(
+  find "$PROJECT_ROOT/skills/autonomous-dev" -type f -name '*.md' | sort
+)
+
+if [[ ${#scoped_files[@]} -eq 0 ]]; then
+  echo -e "${RED}FAIL${NC}: no agent-facing markdown files found under skills/autonomous-dev"
+  exit 1
+fi
+
+echo "=== TC-COMMENT-004: no bare 'gh issue comment' in agent-facing docs ==="
+echo "  scoped files:"
+for f in "${scoped_files[@]}"; do
+  echo "    ${f#$PROJECT_ROOT/}"
+done
+echo ""
+
+# A "bare" hit is `gh issue comment` used as an actual command — i.e.,
+# followed by an argument (a number, a placeholder like {pr}/<id>/$VAR, or a
+# quoted string). Inline-code anti-pattern callouts like
+#   "Never use bare `gh issue comment` …"
+# are documentation OF the rule and don't represent commands the agent would
+# copy, so they are excluded.
+#
+# Allowed forms:
+#   bash scripts/gh issue comment …   (preceded by `/`)
+#   `gh issue comment` (inline-code, no argument — prose)
+#   "bare `gh issue comment`" (inline-code, anti-pattern callout — prose)
+#
+# Disallowed forms (regression):
+#   gh issue comment 142 --body …
+#   gh issue comment "$ISSUE" …
+#   gh issue comment {pr} …
+violations=()
+for f in "${scoped_files[@]}"; do
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && violations+=("${f#$PROJECT_ROOT/}:$line")
+  done < <(grep -nE "(^|[^/])gh issue comment[[:space:]]+([0-9\"'<{$]|--)" "$f" 2>/dev/null || true)
+done
+
+if [[ ${#violations[@]} -eq 0 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: zero bare 'gh issue comment' in agent-facing docs"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: bare 'gh issue comment' found — must be 'bash scripts/gh issue comment' instead"
+  for v in "${violations[@]}"; do
+    echo "      $v"
+  done
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-COMMENT-004b: autonomous-mode.md documents the dual-wrapper rule ==="
+# ---------------------------------------------------------------------------
+# Sanity check that the docs explain WHY there are two wrappers, so future
+# editors understand the intent and don't collapse both into one path.
+
+AUTO_MODE_MD="$PROJECT_ROOT/skills/autonomous-dev/references/autonomous-mode.md"
+if [[ ! -f "$AUTO_MODE_MD" ]]; then
+  echo -e "  ${RED}FAIL${NC}: $AUTO_MODE_MD missing"
+  FAIL=$((FAIL + 1))
+else
+  if grep -q 'bash scripts/gh issue comment' "$AUTO_MODE_MD" \
+     && grep -q 'gh-as-user.sh' "$AUTO_MODE_MD"; then
+    echo -e "  ${GREEN}PASS${NC}: autonomous-mode.md mentions both bash scripts/gh and gh-as-user.sh"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: autonomous-mode.md does not mention both wrappers (bash scripts/gh and gh-as-user.sh)"
+    FAIL=$((FAIL + 1))
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/tests/unit/test-lib-auth-gh-symlink.sh
+++ b/tests/unit/test-lib-auth-gh-symlink.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# test-lib-auth-gh-symlink.sh — Unit test for INV-32 (issue #142).
+#
+# Asserts that lib-auth.sh creates the `gh` symlink in BOTH auth modes
+# (app and token), so the agent-facing rule
+#   bash scripts/gh issue comment …
+# in skills/autonomous-dev/SKILL.md Step 12 and
+# skills/autonomous-dev/references/autonomous-mode.md works regardless of
+# GH_AUTH_MODE.
+#
+# Background: prior to issue #142, the symlink was created only inside the
+# app-mode branch, so token-mode operators had no `gh` file to invoke. The
+# wrapper script (gh-with-token-refresh.sh) is itself mode-agnostic — it
+# only reads from GH_TOKEN_FILE when set. In token mode it falls through
+# to exec the real gh inheriting the host's env (which IS the intended
+# identity in token mode). So lifting the symlink out of the app branch
+# is safe and unifies the rule.
+#
+# Run: bash tests/unit/test-lib-auth-gh-symlink.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_pass() {
+  echo -e "  ${GREEN}PASS${NC}: $1"
+  PASS=$((PASS + 1))
+}
+
+assert_fail() {
+  echo -e "  ${RED}FAIL${NC}: $1"
+  FAIL=$((FAIL + 1))
+}
+
+LIB_AUTH="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-auth.sh"
+WRAPPER="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/gh-with-token-refresh.sh"
+
+# ---------------------------------------------------------------------------
+echo "=== TC-AUTH-SYM-001: token-mode setup creates the gh symlink ==="
+# ---------------------------------------------------------------------------
+# Run setup_github_auth in a subshell with GH_AUTH_MODE=token. We don't
+# stub the PEM/app-id args because the token branch ignores them.
+# We sandbox _LIB_AUTH_DIR by copying the real lib + wrapper into a tmpdir
+# so the test never mutates production scripts.
+TMP1=$(mktemp -d)
+trap 'rm -rf "$TMP1" "${TMP2:-}"' EXIT
+cp "$LIB_AUTH" "$TMP1/lib-auth.sh"
+cp "$WRAPPER" "$TMP1/gh-with-token-refresh.sh"
+chmod +x "$TMP1/gh-with-token-refresh.sh"
+# lib-config.sh is sourced by lib-auth.sh; provide a minimal stub.
+cat > "$TMP1/lib-config.sh" <<'STUB'
+#!/bin/bash
+load_autonomous_conf() { return 0; }
+STUB
+
+# Run setup_github_auth in token mode. Suppress the "WARNING: No GH_TOKEN…"
+# message — we set GH_TOKEN to bypass it.
+GH_TOKEN="dummy-token-for-test" \
+  bash -c "
+    source '$TMP1/lib-auth.sh'
+    GH_AUTH_MODE='token'
+    setup_github_auth
+  " >/dev/null 2>&1
+
+if [[ -L "$TMP1/gh" ]]; then
+  target=$(readlink "$TMP1/gh")
+  if [[ "$target" == *"gh-with-token-refresh.sh" ]]; then
+    assert_pass "token-mode: gh symlink exists and points at gh-with-token-refresh.sh"
+  else
+    assert_fail "token-mode: gh symlink target is wrong: $target"
+  fi
+else
+  assert_fail "token-mode: gh symlink NOT created in _LIB_AUTH_DIR"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-AUTH-SYM-002: symlink creation is NOT inside the GH_AUTH_MODE=app branch ==="
+# ---------------------------------------------------------------------------
+# Source-level lockdown: a future contributor must not move the symlink
+# creation back inside the `if [[ "$GH_AUTH_MODE" == "app" ]]` branch.
+#
+# Strategy: find the line range of the app-mode branch
+# (`if [[ "$GH_AUTH_MODE" == "app" ]]; then` to its matching `else`),
+# then assert the symlink line is OUTSIDE that range.
+
+sym_line=$(grep -n 'ln -sf .*gh-with-token-refresh.sh.*"\${_LIB_AUTH_DIR}/gh"' "$LIB_AUTH" | head -1 | cut -d: -f1)
+app_branch_start=$(grep -n 'if \[\[ "\$GH_AUTH_MODE" == "app" \]\]' "$LIB_AUTH" | head -1 | cut -d: -f1)
+
+if [[ -z "$sym_line" ]]; then
+  assert_fail "could not locate the gh symlink-creation line in lib-auth.sh"
+elif [[ -z "$app_branch_start" ]]; then
+  assert_fail "could not locate the GH_AUTH_MODE=app branch in lib-auth.sh"
+else
+  # Find the `else` (or `fi` if there's no else) at the same indentation
+  # as the matching `if`. The if at app_branch_start is indented with two
+  # spaces (function-body indent). Look for `^  else` or `^  fi` after it.
+  app_branch_end=$(awk -v start="$app_branch_start" '
+    NR > start && /^  else$/ { print NR; exit }
+    NR > start && /^  fi$/   { print NR; exit }
+  ' "$LIB_AUTH")
+
+  if [[ -z "$app_branch_end" ]]; then
+    assert_fail "could not locate end of GH_AUTH_MODE=app branch (looked for ^  else or ^  fi)"
+  elif (( sym_line > app_branch_start && sym_line < app_branch_end )); then
+    assert_fail "symlink creation is INSIDE GH_AUTH_MODE=app branch (lines $app_branch_start..$app_branch_end), found at line $sym_line"
+  else
+    assert_pass "symlink creation is OUTSIDE GH_AUTH_MODE=app branch (line $sym_line, branch ends at $app_branch_end)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
Closes #142.

## Summary

- In `GH_AUTH_MODE=app`, the agent-emitted Step-12 "session complete" comment was attributed to the host operator's `gh auth login` user instead of the App's bot identity. The wrapper-injected PATH that should route `gh` through `gh-with-token-refresh.sh` isn't reliably honored by the agent's embedded Bash tool — bare `gh issue comment` resolves to `/usr/bin/gh` and uses the host session.
- Fix is documentation + a small enabling change. Agent-facing docs now prescribe `bash scripts/gh issue comment ...` (explicit path → forces wrapper resolution). `lib-auth.sh` is updated to create the `${_LIB_AUTH_DIR}/gh` symlink in **both** auth modes (the wrapper itself is mode-agnostic), so the uniform rule actually works in token mode too.
- New invariant **INV-32** in `docs/pipeline/invariants.md` documents the symlink-creation contract.

## Files

| File | Change |
|---|---|
| `skills/autonomous-dev/SKILL.md` | Step 12: prescribe `bash scripts/gh issue comment ...` for the autonomous summary post; explain the WHY |
| `skills/autonomous-dev/references/autonomous-mode.md` | New "Posting Issue/PR Comments" section: `bash scripts/gh` (status/summary, wrapper-routed) vs `bash scripts/gh-as-user.sh` (review-bot triggers) |
| `skills/autonomous-dispatcher/scripts/lib-auth.sh` | Lift `${_LIB_AUTH_DIR}/gh` symlink + `PATH` prepend out of the `if [[ "$GH_AUTH_MODE" == "app" ]]` branch so token mode also has a working `scripts/gh` |
| `docs/pipeline/invariants.md` | New INV-32 entry |
| `docs/test-cases/dev-step-12-comment-identity.md` | Test plan covering the four scenarios from the issue + INV-32 lockdown |
| `tests/unit/test-dev-skill-bash-scripts-gh.sh` | Doc-lint regression guard: fails on bare `gh issue comment` in `skills/autonomous-dev/**/*.md` |
| `tests/unit/test-lib-auth-gh-symlink.sh` | Runtime + source-level regression guard for INV-32 |

## Test Plan

- [x] Test cases documented (`docs/test-cases/dev-step-12-comment-identity.md`)
- [x] Doc-lint guard in `tests/unit/test-dev-skill-bash-scripts-gh.sh` (TC-COMMENT-004 + 004b) PASSes locally
- [x] INV-32 runtime + source-level guard in `tests/unit/test-lib-auth-gh-symlink.sh` (TC-AUTH-SYM-001/002) PASSes locally
- [x] Full unit-test suite (69 tests) PASSes locally
- [x] Shellcheck clean on `lib-auth.sh` and both new test files
- [x] Pipeline doc updated (INV-32) — required by `CLAUDE.md` "Pipeline Documentation Authority" because this PR touches `lib-auth.sh`
- [x] CI checks pass (all 4 checks: Amazon Q, pipeline-docs-gate, ShellCheck, Unit Tests)
- [x] Code simplification review passed (clean)
- [x] PR review agent review passed (clean after L1 nit fix)
- [x] Reviewer bot findings addressed (Amazon Q: COMMENTED, no defects, no inline findings)
- [x] E2E tests pass (N/A — doc + lib-only change)
- [x] Manual verification of the prescribed command path (see "AC #5 Verification" section below for token-mode evidence + app-mode waiver rationale)

## Acceptance Criteria (from issue)

- [x] All `gh issue comment` invocations in agent-facing skill docs use `bash scripts/gh issue comment ...` (verified by TC-COMMENT-004)
- [x] `skills/autonomous-dev/references/autonomous-mode.md` documents the `bash scripts/gh` vs `bash scripts/gh-as-user.sh` distinction
- [x] Doc-lint test in `tests/unit/` fails on any future bare-`gh-issue-comment` regression in agent-facing docs
- [x] Test-cases doc `docs/test-cases/dev-step-12-comment-identity.md` exists with the four scenarios
- [x] Manual verification recorded in this PR description (see "AC #5 Verification" section below — token-mode path verified end-to-end; app-mode path waived with TC-AUTH-SYM-001/002 + wrapper code-inspection rationale)

## AC #5 Verification

The issue's AC #5 reads: *"Manual app-mode verification on a throwaway issue: wrapper trailer attribution = bot, agent summary attribution = bot (one-time check, recorded in the PR description)"*. This is verified in two parts:

### Part 1 — Token-mode end-to-end (executed in this session)

Token-mode is the default for this dev box (no App credentials configured for `zxkane/autonomous-dev-team` itself). Sourced `skills/autonomous-dispatcher/scripts/lib-auth.sh`, ran `setup_github_auth` with `GH_AUTH_MODE=token`, then exercised the prescribed command path:

```
$ ls -la scripts/gh
scripts/gh -> .../skills/autonomous-dispatcher/scripts/gh-with-token-refresh.sh   # INV-32 holds in token mode

$ bash scripts/gh api user --jq .login
zxkane                                                                            # host operator's gh auth identity, as expected

$ bash scripts/gh api repos/zxkane/autonomous-dev-team/issues/143/comments \
    -f body='<!-- ac5-token-mode-verification-... --> ...'
{ "id": 4479456624, "user": { "login": "zxkane", ... } }                          # comment attributed to host user — correct for token mode
$ bash scripts/gh api -X DELETE .../issues/comments/4479456624                    # marker comment deleted; no PR-conversation residue
```

**Result**: in token mode, `bash scripts/gh issue comment …` resolves through `gh-with-token-refresh.sh`, which (with `GH_TOKEN_FILE` unset) exec's the host `gh` and produces a comment attributed to the host operator's `gh auth login` identity — exactly the intended token-mode behavior per `GH_AUTH_MODE` semantics. The marker comment was posted and deleted in the same script run.

### Part 2 — App-mode (waived; technical chain proven by tests + code inspection)

App-mode end-to-end on a throwaway issue is impractical from this dev box (would require provisioning App credentials, a separate test repo, full dev-wrapper run; out of proportion to a doc-only fix). The chain is instead proven by the following composition of evidence already in this PR:

| Link in chain | Evidence |
|---|---|
| `bash scripts/gh` resolves to the wrapper symlink in app mode | INV-32 + TC-AUTH-SYM-002 (source-level regression guard: symlink-creation line is OUTSIDE the `GH_AUTH_MODE=app` branch, so app mode also creates it) |
| Wrapper reads bot token from `GH_TOKEN_FILE` when set | `gh-with-token-refresh.sh:39-52` (existing, unchanged in this PR; `set GH_TOKEN=$(cat "$GH_TOKEN_FILE")` then `exec "$REAL_GH"`); covered by `tests/unit/test-gh-with-token-refresh-real-gh.sh` |
| `GH_TOKEN_FILE` is set in app mode | `lib-auth.sh:40-62` app-branch (existing, unchanged in this PR) |
| Bot token results in bot-attributed comment | GitHub API behavior — `gh` with `GH_TOKEN=<app-installation-token>` posts as the App's installation identity (`<bot-name>[bot]`) |

The novel risk this PR introduces is purely the symlink-creation contract (whether the wrapper is reachable as `scripts/gh`), which TC-AUTH-SYM-001/002 explicitly cover. The token-flow + identity-mapping plumbing is unchanged.

**Operator follow-up note**: the next operator who runs an autonomous-dev session in app mode against any project (existing OpenClaw fleet: `vidsyllabus`, `quant-scorer`, `podcast-curation`, `panoptes`, `llm-wiki`) will produce real-world app-mode evidence on the next dispatcher tick that hits Step 12. If that comment is mis-attributed, this PR can be reverted as the issue's listed test-cases doc has the regression scenarios documented and the code change is two lines in `lib-auth.sh`.

## Out-of-Scope Note

The issue listed lib-auth.sh changes as out-of-scope, but the prescribed `bash scripts/gh ...` rule literally doesn't work in token mode without lifting the symlink creation out of the app-mode branch (`scripts/gh` would not exist). The fix is two lines + a guard test + INV-32. The wrapper script itself was already mode-agnostic, so this is a pure no-op for app mode and a "now it works" for token mode. See INV-32 for the full rationale.

## Checklist

- [x] New unit tests written for new functionality (2 new test files)
- [x] Documentation updated (SKILL.md, autonomous-mode.md, invariants.md, new test-cases doc)
- [x] Pipeline doc update accompanies the lib-auth.sh code change (per CLAUDE.md "Pipeline Documentation Authority")