### PR TITLE
docs(dispatcher): design INV-35 review-aware Step 4 routing for completed sessions (refs #149)

### DIFF
--- a/docs/designs/inv35-review-aware-resume.md
+++ b/docs/designs/inv35-review-aware-resume.md
@@ -1,0 +1,142 @@
+# Design Canvas — INV-35: review-aware Step 4 routing for completed sessions
+
+**Issue**: #149 (bug: INV-12 session-completed gate traps issues whose review failed for non-substantive reasons)
+**Status**: design recorded; implementation tracked under acceptance criteria of #149.
+**Authors / decision date**: 2026-05-22.
+
+## 1. Problem
+
+`is_session_completed()` (in `lib-dispatch.sh`) reads the dev wrapper's last `{"type":"result"}` line. If `stop_reason=end_turn` and `terminal_reason=completed`, the helper returns true and `dispatcher-tick.sh` Step 4 refuses to dev-resume — instead it posts an `INV-12-completed:<sid>` operator-handoff comment and leaves the issue in `pending-dev`.
+
+That gate exists for the right reason (closes #59 — `claude --resume` against a closed SSE stream hangs), but its scope is too broad. It does not distinguish:
+
+- **dev session ended cleanly AND no review has run yet** — operator must decide. Original INV-12 case.
+- **dev session ended cleanly AND the most recent review failed for a non-substantive reason** (configured `REVIEW_BOTS=q` and the bot timed out, CI flake, "no PR found" race, transport error). The dev work is fine; an upstream dependency failed.
+- **dev session ended cleanly AND the most recent review failed for a substantive reason** (code findings, requirement drift, auto-merge blocked by rebase). The dev needs another pass, but resume cannot re-engage a `completed` session.
+
+For the second and third cases the dispatcher should NOT post the operator-handoff comment — but pre-fix it does, every tick, until the operator manually intervenes.
+
+**Live reproduction**, this very repo, 2026-05-21: issues #144 and #145 had clean dev sessions that ended `end_turn|completed` at 03:18 / 03:19 UTC. Reviews ran at 05:29 UTC, configured `REVIEW_BOTS=q` timed out (3-min poll without an Amazon Q response), reviews flipped both issues to `pending-dev` with `Review FAILED` verdict comments. From 05:34 UTC onward the dispatcher posted `INV-12-completed:<sid>` every tick on both issues for ~50 minutes, never resuming. Operator manually flipped both back to `pending-review` and unset `REVIEW_BOTS`.
+
+## 2. Decisions
+
+| # | Question | Decision | Rationale (one line) |
+|---|---|---|---|
+| Q1 | How does the dispatcher classify a verdict as substantive vs non-substantive? | **Structured HTML-comment trailer** emitted by the review wrapper (B). Missing trailer ⇒ treat as `failed-substantive` (safest fallback). | Producer owns classification — same idiom as `Reviewed HEAD:` (#106). Backwards-compatible, no brittle pattern list. |
+| Q2 | Re-dispatch review directly, or flip the label and let Step 3 pick it up? | **Flip the label** `pending-dev → pending-review`. | Reuses `MAX_CONCURRENT`, JUST_DISPATCHED, and Step 3's existing dispatch path. No code duplication inside Step 4. |
+| Q3 | For substantive failures with a completed session, fresh session or attempt resume? | **Fresh `dev-new`** (truncate log, mint new session_id), reusing the INV-12 PTL pattern. | A `completed` session has nothing to resume into. Fresh-dev is the only mechanically valid recovery. |
+| Q4 | Interaction with `MAX_RETRIES`? | Substantive `dev-new` consumes `MAX_RETRIES` (it IS a fresh dev attempt). Non-substantive flip uses a separate `REVIEW_RETRY_LIMIT` counter (default 2, per-session-id). | Don't burn the dev-side retry budget on a flaky bot, but cap the non-substantive loop so a permanently broken bot doesn't bounce forever. |
+
+### Rejected alternatives for Q1
+
+- **A. Pattern-match the verdict comment** for known strings like "q review timeout" or "CI checks pending". Brittle — every new bot or new transient cause requires a dispatcher patch. Pattern list lives far from the producer.
+- **C. New label** like `review-failed-non-substantive`. Adds label-state-machine complexity; races with the existing `pending-dev` flip; less expressive than a cause token.
+
+## 3. Routing table (canonical)
+
+For each `pending-dev` issue evaluated by Step 4 — after `is_session_completed` returns the prior session's terminal state:
+
+| Dev session state | Most recent post-completion review verdict | Action | Consumes `MAX_RETRIES`? |
+|---|---|---|---|
+| Not completed (no `{"type":"result"}` row, or non-terminal `stop_reason`) | (any) | dev-resume (today's behavior, unchanged) | yes (existing) |
+| `prompt_too_long` | (any) | dev-new + truncate (today's behavior, unchanged) | yes (existing) |
+| `end_turn\|completed` | none | INV-12 operator notice (today's behavior, unchanged) | no |
+| `end_turn\|completed` | `passed` (race) | no-op + WARN log; Step 0 hygiene reconciles next tick | no |
+| `end_turn\|completed` | `failed-non-substantive`, flip count < `REVIEW_RETRY_LIMIT` | label-flip `pending-dev → pending-review` + post marker | **no** — separate counter |
+| `end_turn\|completed` | `failed-non-substantive`, flip count ≥ `REVIEW_RETRY_LIMIT` | mark stalled + operator @-mention | n/a |
+| `end_turn\|completed` | `failed-substantive` | dev-new + truncate (PTL path, with INV-35-fresh-dev marker) | yes |
+
+Same routing applies regardless of `EXECUTION_BACKEND` ([INV-30](../pipeline/invariants.md#inv-30-pid_alive-is-authoritative-under-all-execution-backends)) — the helper reads issue comments + log file, both of which are accessible from the dispatcher box on either backend.
+
+## 4. Verdict-trailer schema
+
+Emitted by `autonomous-review.sh` in every verdict comment (PASS and FAIL paths). HTML-comment form so it never renders in the GitHub UI.
+
+```
+<!-- review-verdict: passed -->
+<!-- review-verdict: failed-substantive -->
+<!-- review-verdict: failed-non-substantive cause=<token> -->
+```
+
+`<token>` ∈ `{ bot-timeout, ci-transport, no-pr-found, merge-conflict-unresolvable, other }`. Extensible: dispatcher treats unknown causes as `failed-non-substantive` (same routing).
+
+**Backwards compatibility**: a verdict comment with no trailer is treated as `failed-substantive`. This is the safest of the four routes:
+- It never silently no-ops (which `passed` does).
+- It does the right thing for any genuine substantive failure that pre-dates the trailer.
+- Worst-case false-positive: a missing-trailer non-substantive failure routes to a fresh dev session, consuming one `MAX_RETRIES` slot. The dev session will likely produce the same PR HEAD ⇒ Step 4a.5's PR-exists short-circuit kicks in next tick to route back to review. Bounded waste.
+
+**Trailer collision avoidance**: the wrapper already emits `Reviewed HEAD: <sha>` and `Review Session ID: <sid>` lines elsewhere in the comment. The new trailer goes inside an HTML comment (`<!-- ... -->`) per [INV-04](../pipeline/invariants.md#inv-04-reviewed-head-trailer-format)'s precedent so renderers ignore it.
+
+## 5. Helper API
+
+New function in `lib-dispatch.sh`:
+
+```bash
+classify_recent_review_verdict <issue_num> <session_end_iso> <out_verdict_var> <out_cause_var>
+```
+
+Returns 0 always. Out-vars receive:
+- `<out_verdict_var>` ∈ `{ none, passed, failed-substantive, failed-non-substantive }`.
+- `<out_cause_var>` is non-empty only when the verdict is `failed-non-substantive`.
+
+Implementation:
+1. `gh issue view <N> --repo $REPO --json comments` → list of comments with `author.login`, `createdAt`, `body`.
+2. Filter: `author.login == BOT_LOGIN` (or fallback per session-id binding when `BOT_LOGIN` is empty per the existing `gh api user` 403 pattern), AND `createdAt > session_end_iso`.
+3. Of the survivors, pick the newest by `createdAt`.
+4. Match `body` against `<!-- review-verdict: ... -->` regex.
+5. No match → `none`. Match without trailer (legacy verdict) → `failed-substantive`. With trailer → return the trailer's verdict + cause tokens.
+
+The session-end timestamp is extracted from the same `{"type":"result"}` JSON line that `is_session_completed` already parses — add a third out-var to that helper to expose `_session_end_ts` to the caller.
+
+## 6. Marker comments and idempotency
+
+| Marker | Where | Purpose |
+|---|---|---|
+| `INV-12-completed:<sid>` | issue comment | (existing) operator-handoff for "completed + no verdict" — fires at most once per session-id. |
+| `INV-35-fresh-dev:<sid>` | issue comment | new — fires before dev-new dispatch in the substantive-failure branch. Idempotent on the marker. |
+| `<!-- review-aware-flip:non-substantive cause=<x> -->` | issue comment | new — emitted with the label flip in the non-substantive branch. Counted on each tick to compute the per-session flip count. |
+| `<!-- review-verdict: ... -->` | review verdict comment (PR or issue, wherever the wrapper posts) | new — the trailer that drives the routing. |
+
+All comments go via `bash scripts/gh issue comment` per [INV-32](../pipeline/invariants.md#inv-32-gh-wrapper-symlink-is-created-in-both-auth-modes).
+
+## 7. Failure modes considered
+
+| Scenario | Routing | Why this is safe |
+|---|---|---|
+| Verdict-trailer parser regex matches partial input (e.g. quoted prior verdict in a thread reply) | helper takes the *newest* comment matching the BOT_LOGIN + post-completion timestamp filter, not the lexically first | False matches only happen if the bot itself posts a quoted prior verdict — same author, same time-window, but the regex anchors on `<!-- review-verdict: ` (HTML comment opener) so quoted blockquote-rendered text without the literal `<!--` prefix doesn't match. |
+| Bot posts multiple verdicts (race: human triggered review while dispatcher was reading) | helper picks newest; whichever verdict the human's intervention left becomes the source of truth | Same producer/timestamp model as today. |
+| Log truncate fails on `failed-substantive` branch | dispatcher posts an operator-actionable comment and `continue`s without dispatching | Same fail-closed pattern as INV-12 PTL branch — prevents silent retry loop. |
+| `REVIEW_RETRY_LIMIT` reached but the bot recovers on tick N+1 | issue is `stalled`; operator must remove `stalled` to re-arm | Acceptable. The `stalled`-removal flow already has clear operator semantics. Setting `REVIEW_RETRY_LIMIT=0` disables the cap (bounce forever) for operators who'd rather take the noise. |
+| Verdict trailer present but cause token unknown | dispatcher treats as `failed-non-substantive` with `cause=<unknown-token>` | Forward-compatible; unknown causes still route to the safe re-review branch. |
+| Both INV-12-completed and INV-35-fresh-dev markers present on the same issue (operator manually replayed) | idempotency keys are session-id-scoped; each session-id sees at most one of each | Operator-replay (label flip + comment delete) is rare and the worst case is one extra dispatch. |
+
+## 8. Composition with existing invariants and prior fixes
+
+- **INV-12 (resume only against unfinished sessions)**: INV-35 *carves out* from INV-12's `completed` arm. INV-12's `prompt_too_long` arm is unchanged.
+- **INV-33 (review wrapper MUST NOT close issue)**: orthogonal — INV-33 is a producer rule for the review wrapper, INV-35 is a routing rule for the dispatcher. INV-35 only reads the verdict comments INV-33's emitter produces.
+- **#146 auto-merge-failure recovery** (`Auto-merge failed:` PR comment + resume-prompt rebase prepend): composes cleanly. The prepend in `resume_agent` fires on a PR-comment match regardless of whether the dispatch is dev-resume or dev-new, so the substantive-failure → dev-new branch still gets the rebase guidance when the cause was an auto-merge block.
+- **INV-30 (`pid_alive` authoritative under all execution backends)**: Step 4b.5.1 reads only issue comments (via `gh`) and the log file (local to the dispatcher box for both `local` and `remote-aws-ssm` per `/tmp/agent-${PROJECT_ID}-issue-N.log` location). No backend-specific behavior.
+
+## 9. Out of scope
+
+- **Adding a non-substantive label**: rejected (Q1 alternative C). Trailer is sufficient.
+- **Generalizing classification to non-bot reviewers**: maintainers writing manual review comments don't get a trailer. Their verdict is opaque to the routing — defaults to `failed-substantive` (safe). If a future need arises, we'd extend the regex; for now this is YAGNI.
+- **Per-cause routing variants** (e.g. `bot-timeout` → wait 5 min before re-dispatching; `ci-transport` → re-run CI before re-review): all causes route to the same re-review branch. Operator can read the cause token in the marker for diagnostics.
+- **Implementation in this PR**: this PR ships only the design canvas + spec doc updates + opt-out default for `REVIEW_BOTS`. Code, helper, and tests come in follow-up PRs gated on this design being approved.
+
+## 10. Testing strategy (referenced from `docs/test-cases/inv35-review-aware-resume.md`)
+
+- Unit-tests for `classify_recent_review_verdict` covering trailer parsing, timestamp filter, missing-trailer fallback, multiple verdicts → newest.
+- Step-4 routing tests with gh-fixture mocks covering every row of the routing table in §3.
+- Regression fixture for the 2026-05-21 #144/#145 sequence: dev session ends `end_turn|completed`, q-bot posts a verdict comment 2h later carrying `cause=bot-timeout`, dispatcher tick must label-flip to `pending-review` (NOT post `INV-12-completed`).
+- All log-truncate-fail paths gated by an injected fault (read-only chmod on the log file).
+
+## 11. Pipeline doc updates shipped with this design
+
+- [`docs/pipeline/state-machine.md`](../pipeline/state-machine.md) — three new pending-dev outgoing transitions in the mermaid diagram + transition table.
+- [`docs/pipeline/invariants.md`](../pipeline/invariants.md) — INV-12 carve-out note + new INV-35 entry.
+- [`docs/pipeline/dispatcher-flow.md`](../pipeline/dispatcher-flow.md) — new Step 4b.5.1 with the runtime view; recovery-table cross-reference updated.
+
+## 12. Default `REVIEW_BOTS` flipped to empty
+
+`skills/autonomous-dispatcher/scripts/autonomous.conf.example` ships `REVIEW_BOTS=""` by default in this PR. Rationale: each external bot is an availability dependency the operator takes on; until INV-35 is implemented, a slow bot keeps the issue bouncing between `pending-review` and `pending-dev`. Operators who actively want bot findings opt in. Even after INV-35 ships, this default stays — the implementation makes bot bouncing graceful, not free.

--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -251,10 +251,28 @@ Before dispatching a resume, call `is_session_completed <issue> _reason` (in `li
 
 | `terminal_reason` | Meaning | Dispatcher action |
 |---|---|---|
-| `completed` | Normal end-of-turn (`stop_reason=end_turn` too). Resuming would attach to a closed SSE stream and hang. | Operator handoff: post `INV-12-completed:<sid>` notice, leave issue in `pending-dev`, do not auto-recover. |
+| `completed` | Normal end-of-turn (`stop_reason=end_turn` too). Resuming would attach to a closed SSE stream and hang. | Branch on most recent post-completion review verdict — see Step 4b.5.1 below. |
 | `prompt_too_long` | JSONL transcript exceeded the model's input window. Headless `claude -p` has no auto-compaction, so resuming re-feeds the whole transcript and crashes again. | Auto-recover: post `INV-12-prompt-too-long:<sid>` notice, **truncate the per-issue log**, `label_swap pending-dev → in-progress`, `post_dispatch_token dev-new`, `dispatch dev-new`. The next tick mints a fresh session id with a smaller seed prompt that re-derives state from git/issue/PR. |
 
 The PTL branch hard-fails if the log truncate fails (perm drift, ENOSPC): post an operator-actionable comment and `continue` without dispatching. Without this guard, the next tick would re-read the same stale PTL log, the idempotency-marker check would suppress a fresh notice (it's keyed on the old session_id), and the dispatcher would silently dispatch dev-new every tick forever.
+
+#### Step 4b.5.1: review-aware routing for `completed` sessions ([INV-35](invariants.md#inv-35-review-aware-resume-routing-for-completed-sessions))
+
+When `is_session_completed` returns `completed`, call `classify_recent_review_verdict <issue> <session-end-ts>` (in `lib-dispatch.sh`). The helper reads issue comments, picks the newest comment that (a) is authored by `BOT_LOGIN` (or a comment matching the session-id-binding fallback when the bot identity is unavailable), (b) was created strictly after `<session-end-ts>`, and (c) contains an HTML-comment trailer of the form `<!-- review-verdict: ... -->`. It returns one of: `none`, `passed`, `failed-substantive`, `failed-non-substantive` (with cause token captured in an out-var). Comments missing the trailer are conservatively treated as `failed-substantive` (so pre-INV-35 in-flight verdicts route to the safe fresh-dev branch rather than silently no-op).
+
+| Verdict | Dispatcher action |
+|---|---|
+| `none` | Operator handoff (original INV-12 behavior): post `INV-12-completed:<sid>` notice (idempotent on the marker), leave in `pending-dev`. |
+| `passed` (race window) | No-op + log a WARN line. Step 0 hygiene ([INV-25](invariants.md#inv-25-terminal-labels-approved-stalled-are-sticky-transitional-residue-is-healed-at-tick-start)) reconciles next tick. |
+| `failed-non-substantive`, flip count for this session < `REVIEW_RETRY_LIMIT` (default 2) | `label_swap pending-dev → pending-review` + post `<!-- review-aware-flip:non-substantive cause=<x> --> Re-routing to review (last review failed for non-substantive reason: <x>).` Step 3 picks it up next tick. Does NOT consume `MAX_RETRIES`. |
+| `failed-non-substantive`, flip count ≥ `REVIEW_RETRY_LIMIT` | `mark_stalled` with operator @-mention citing the persistent non-substantive cause. |
+| `failed-substantive` | Same recovery as the PTL branch above: post `INV-35-fresh-dev:<sid>` notice (idempotent), **truncate the per-issue log** (fail-closed if truncate fails — same operator-actionable error pattern), `label_swap pending-dev → in-progress`, `post_dispatch_token dev-new`, `dispatch dev-new`. Consumes `MAX_RETRIES` via the existing retry-comment count. |
+
+The `REVIEW_RETRY_LIMIT` counter is per-session-id (counted by grepping `<!-- review-aware-flip:non-substantive -->` markers on the issue and intersecting with the current `Dev Session ID:` trailer). When the underlying dev session changes (PTL or substantive-fresh-dev mints a new session_id), the counter resets — that's intentional: a new dev session is also a new opportunity for the review side to succeed.
+
+The `failed-substantive` branch's truncate-fails-closed behavior preserves the [INV-12 PTL guard](#step-4b5-terminal-state-gate-inv-12) — without it, the next tick would re-read the same stale `end_turn|completed` log line, hit this same branch, the idempotency marker would suppress a fresh notice, and the dispatcher would silently dispatch dev-new every tick forever.
+
+This branch composes with the auto-merge-failure recovery from #146: the dev-resume prompt's "rebase onto main" prepend fires whenever the most recent PR comment matches `Auto-merge failed:`, regardless of whether the next dispatch is dev-resume or dev-new — so a substantive failure caused by an auto-merge-blocking rebase need still gets the rebase guidance via `resume_agent`'s prompt-prepend logic.
 
 This is a conservative gate: it only fires when the helper is certain the prior session reached one of the two terminal states. False negatives (claiming "not terminal" when it was) just keep the prior behavior — Step 4c attempts the resume, and the wall-clock timeout from [INV-13](invariants.md#inv-13-wall-clock-cap-on-agent-invocations) bounds the damage to `AGENT_TIMEOUT` (default `4h`).
 
@@ -353,7 +371,7 @@ This branch is the safety net for the case where the wrapper died so abruptly th
 | `date` parse fails on PR.updatedAt | Step 5a | WARN, leave alone (fail-closed — see above). |
 | Concurrent dispatcher instance | tick-tick | `mktemp` for CI-error capture file (CWE-377 mitigation). Concurrent ticks otherwise serialize on `gh issue edit` — the second one's edits race but converge. |
 | `JUST_DISPATCHED` not maintained | Step 5 | Step 5 evaluates a freshly-dispatched issue, sees no PID file yet, diagnoses DEAD-no-PR, increments crash counter, eventually marks stalled. **This was the root of #34, #41 — the array exists specifically to prevent this.** |
-| Resume against a completed session | Step 4b.5 | PR-6 added `is_session_completed` ([INV-12](invariants.md#inv-12-resume-only-against-unfinished-sessions)). Step 4b.5 inspects the agent log; if the prior turn ended with `stop_reason=end_turn` AND `terminal_reason=completed`, the dispatcher posts an explanatory comment and skips the resume — leaving the issue in `pending-dev` for an operator to flip manually. The wall-clock timeout ([INV-13](invariants.md#inv-13-wall-clock-cap-on-agent-invocations)) is the safety net for false negatives. |
+| Resume against a completed session | Step 4b.5 / 4b.5.1 | PR-6 added `is_session_completed` ([INV-12](invariants.md#inv-12-resume-only-against-unfinished-sessions)) — never resume into a closed SSE stream. Step 4b.5.1 ([INV-35](invariants.md#inv-35-review-aware-resume-routing-for-completed-sessions), #149) then routes the `completed` case based on the most recent post-completion review verdict: no verdict → operator handoff (original INV-12 notice); non-substantive failure → label-flip back to `pending-review`; substantive failure → `dev-new` (PTL pattern). Pre-INV-35, every completed-with-failed-review issue stuck indefinitely. The wall-clock timeout ([INV-13](invariants.md#inv-13-wall-clock-cap-on-agent-invocations)) remains the safety net for false negatives. |
 | Agent invocation hangs in CLI | wrapper, not dispatcher | Bounded by future wall-clock timeout ([#60](https://github.com/zxkane/autonomous-dev-team/issues/60), [INV-13](invariants.md#inv-13-wall-clock-cap-on-agent-invocations)). Until then the dispatcher's Step 5a is the only way to clear it. |
 
 ## Cross-references

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -198,9 +198,10 @@ The cutoff timestamp falls back to epoch (1970-01-01) for issues that have never
 
 **Status**: **ENFORCED**. Closed cases:
 - PR-6 (closes #59) — initial enforcement for `end_turn|completed`.
-- This PR — extends to `prompt_too_long`. The completed branch posts an `INV-12-completed:<sid>` notice and leaves the issue in `pending-dev` for operator decision; the prompt-too-long branch posts an `INV-12-prompt-too-long:<sid>` notice, truncates the per-issue log, and `dispatch dev-new` to auto-recover with a fresh session.
+- PR (closes #128) — extends to `prompt_too_long`. The prompt-too-long branch posts an `INV-12-prompt-too-long:<sid>` notice, truncates the per-issue log, and `dispatch dev-new` to auto-recover with a fresh session.
+- Pending PR (#149) — pairs the `completed` branch with [INV-35](#inv-35-review-aware-resume-routing-for-completed-sessions), which routes `completed`-with-review-failure cases to either re-review (non-substantive) or dev-new (substantive). The `INV-12-completed:<sid>` operator-handoff notice now fires only when the issue is `pending-dev` AND no review-failure verdict exists newer than the dev session's end-of-turn — the original "operator must decide" case (e.g. dev finished, no review ever ran). All other completed-session cases route through INV-35.
 
-**Test**: `tests/unit/test-is-session-completed.sh` (14 cases) and `tests/unit/test-autonomous-launcher-verdict-fresh.sh` TC-PTL-001..007d.
+**Test**: `tests/unit/test-is-session-completed.sh` (14 cases), `tests/unit/test-autonomous-launcher-verdict-fresh.sh` TC-PTL-001..007d, and (per #149) `tests/unit/test-step4-review-aware-routing.sh` for the INV-35 carve-out.
 
 ## INV-13: Wall-clock cap on agent invocations
 
@@ -902,6 +903,57 @@ updated in the same PR to assert "prompt on stdin, not argv".
   — `AGENT_DEV_EXTRA_ARGS` / `AGENT_REVIEW_EXTRA_ARGS` are unchanged
   (operator-supplied flags continue to ride on argv between the
   structural flags and the now-absent prompt positional).
+
+## INV-35: Review-aware resume routing for completed sessions
+
+**Rule**: When the dispatcher's Step 4 finds a `pending-dev` issue whose prior dev session reached `end_turn|completed` ([INV-12](#inv-12-resume-only-against-unfinished-sessions)), it MUST consult the most recent review-failure verdict comment that is newer than the session's end-of-turn before deciding what to do. The routing is:
+
+| Recent post-completion verdict | Route |
+|---|---|
+| (none) | INV-12 operator handoff: post `INV-12-completed:<sid>` notice, leave in `pending-dev`. *(Original INV-12 behavior, preserved.)* |
+| `passed` (race: review approved while dispatcher was reading) | No-op + WARN log. The `approved` label hygiene at Step 0 ([INV-25](#inv-25-terminal-labels-approved-stalled-are-sticky-transitional-residue-is-healed-at-tick-start)) will reconcile next tick. |
+| `failed-non-substantive` AND non-substantive flip count for this session < `REVIEW_RETRY_LIMIT` (default 2) | Label-flip `pending-dev → pending-review` + post `<!-- review-aware-flip:non-substantive cause=<x> -->` marker. Step 3 picks it up next tick. Does NOT consume `MAX_RETRIES`. |
+| `failed-non-substantive` AND flip count ≥ `REVIEW_RETRY_LIMIT` | Mark stalled with operator @-mention citing the persistent non-substantive failure (e.g. bot consistently times out). |
+| `failed-substantive` | Treat the same as the PTL branch: post `INV-35-fresh-dev:<sid>` notice, **truncate the per-issue log** (fail-closed if truncate fails — same pattern as INV-12 PTL), `label_swap pending-dev → in-progress`, `post_dispatch_token dev-new`, `dispatch dev-new`. Consumes `MAX_RETRIES` via the existing retry-comment count. |
+
+**Why**: Pre-fix, INV-12's `completed` branch was overly broad. It correctly prevented the SSE-stream hang on `claude --resume`, but it was the WRONG gate for the case where a dev session finished cleanly and a *later* review failed — the review failure routed the issue to `pending-dev`, then every subsequent tick re-saw `end_turn|completed` in the dev log and posted the `INV-12-completed` operator notice without ever re-running anything. Issues stuck indefinitely (#149, observed live with #144 / #145 on 2026-05-21 when configured `REVIEW_BOTS=q` timed out).
+
+The fix preserves INV-12's hang-prevention rationale while distinguishing three distinct post-completion situations:
+
+1. **No review yet** (or review still in-flight): the dev finished cleanly with no failing verdict — the original "operator decides" case. INV-12-completed notice fires.
+2. **Review failed for non-substantive reasons** (bot timeout, CI transport, "no PR found" race): re-running review is the correct recovery. The dev didn't fail; an upstream dependency did.
+3. **Review failed for substantive reasons** (code findings, requirement drift, auto-merge-failed-with-rebase-needed per [INV-33](#inv-33-review-wrapper-must-not-close-the-linked-issue) + #146): the dev needs to take another pass, but resume cannot re-engage a completed session — fresh-dev (INV-12 PTL pattern) is the right recovery. The resume-prompt rebase block from #146 is layered on by `resume_agent`'s prepend logic regardless of new-vs-resume mode, so fresh-dev still gets the rebase guidance when applicable.
+
+**Verdict-classification contract**: the review wrapper emits a structured trailer in its verdict comment (HTML-comment form, mirroring [INV-04](#inv-04-reviewed-head-trailer-format)'s `Reviewed HEAD:` idiom):
+
+```
+<!-- review-verdict: passed -->
+<!-- review-verdict: failed-substantive -->
+<!-- review-verdict: failed-non-substantive cause=<short-token> -->
+```
+
+Where `<short-token>` is one of `bot-timeout`, `ci-transport`, `no-pr-found`, `merge-conflict-unresolvable`, or `other` (extensible). Comments lacking the trailer are conservatively treated as `failed-substantive` so any pre-INV-35 verdict comment in flight at deploy time falls into the safe-recovery branch (fresh-dev) rather than the silent-noop branch.
+
+**Producer**:
+- The trailer: `autonomous-review.sh` (verdict comment emission paths — both PASS and the various FAIL branches).
+- The routing decision: a new helper `lib-dispatch.sh::classify_recent_review_verdict` invoked from `dispatcher-tick.sh` Step 4 right after `is_session_completed` returns `completed`. The helper reads issue comments, finds the newest comment authored by `BOT_LOGIN` (or fallback) that contains a `<!-- review-verdict: ... -->` trailer AND whose `createdAt` is newer than the dev-session-end-of-turn timestamp (extracted from the same `{"type":"result"}` line `is_session_completed` already parses).
+
+**Consumer**: dispatcher Step 4 routing logic, indirectly the dev wrapper (gets a fresh `dev-new` for substantive failures) and Step 3 (gets a re-fired `pending-review` for non-substantive failures).
+
+**Interaction with `MAX_RETRIES`**: the substantive `dev-new` path consumes a retry slot via the existing retry-comment count (same as the INV-12 PTL path). The non-substantive flip path does NOT consume `MAX_RETRIES` — it is bounded by its own `REVIEW_RETRY_LIMIT` counter (count of `<!-- review-aware-flip:non-substantive -->` markers on the issue, scoped to the current session-id) so a permanently broken bot doesn't loop forever, but a flaky bot doesn't burn down the dev-side retry budget.
+
+**Status**: **NOT YET ENFORCED** — design recorded in `docs/designs/inv35-review-aware-resume.md`. Implementation pending.
+
+**Test** (TODO, per #149 acceptance criteria):
+- `tests/unit/test-step4-review-aware-routing.sh` — gh-fixture mocks of issue comment streams + log files, asserting Step 4's branch decision matches every row of the routing table above.
+- `tests/unit/test-classify-review-verdict.sh` — unit-tests for the `classify_recent_review_verdict` helper (trailer parsing, timestamp comparison, missing-trailer fallback, multiple verdicts pick the newest).
+- `tests/unit/test-step4-review-aware-regression-149.sh` — the 2026-05-21 fixture: dev session ends `end_turn|completed`, q-bot times out 2h later posting a verdict with `cause=bot-timeout`, dispatcher tick must label-flip to `pending-review` (NOT post `INV-12-completed`).
+
+**Cross-references**:
+- [INV-12](#inv-12-resume-only-against-unfinished-sessions) — the hang-prevention invariant this carves out from.
+- [INV-33](#inv-33-review-wrapper-must-not-close-the-linked-issue) + #146 auto-merge-failure handling — INV-35's `failed-substantive` branch composes with #146's resume-prompt rebase prepend (the prepend fires whenever the most recent PR comment matches `Auto-merge failed:`, regardless of whether the next dispatch is dev-resume or dev-new).
+- [`docs/designs/inv35-review-aware-resume.md`](../designs/inv35-review-aware-resume.md) — design canvas with the full routing table and verdict-trailer schema.
+- [`dispatcher-flow.md` § Step 4b.5](dispatcher-flow.md#step-4b5-terminal-state-gate-inv-12) — Step 4's runtime view of the routing.
 
 ## Adding a new invariant
 

--- a/docs/pipeline/state-machine.md
+++ b/docs/pipeline/state-machine.md
@@ -42,7 +42,10 @@ stateDiagram-v2
     reviewing --> pending_dev: Dispatcher Step 5b (DEAD reviewing)
 
     pending_dev --> in_progress: Dispatcher Step 4 scan-pending-dev (retries below MAX)
+    pending_dev --> in_progress: Step 4 review-aware (completed session + substantive review failure → dev-new) [INV-35]
+    pending_dev --> pending_review: Step 4 review-aware (completed session + non-substantive review failure, under retry cap) [INV-35]
     pending_dev --> stalled: Dispatcher Step 4 (retries at MAX)
+    pending_dev --> stalled: Step 4 review-aware (non-substantive review-retry cap reached) [INV-35]
 
     stalled --> pending_dev: Maintainer removes stalled label (retry counter resets)
 
@@ -89,8 +92,11 @@ Each row is one legal transition. "Actor" identifies who writes the labels. "Pre
 | `reviewing` | `−reviewing +pending-dev` | Review wrapper crash | Review wrapper trap | Wrapper exit ≠ 0 AND `RESULT_PARSED=false` | "Review process crashed (exit code: N). Moving back to development for retry." |
 | `reviewing` | `−reviewing +pending-dev` | Review found no PR | Review wrapper (early exit) | All 3 PR-discovery methods failed | "Review failed: no PR found linked to this issue. Please ensure the PR description contains 'Closes #N'." |
 | `reviewing` | `−reviewing +pending-dev` | Step 5b: DEAD reviewing | Dispatcher | Wrapper PID dead; issue still has `reviewing` | "Review process appears to have crashed. Moving to pending-dev for retry." |
-| `pending-dev` | `−pending-dev +in-progress` | Dispatcher Step 4 (resume) | Dispatcher | concurrency below cap; retry count < `MAX_RETRIES` ([INV-05](invariants.md#inv-05-retry-counter-cutoff-rule)); valid `Dev Session ID:` extractable from comments | "Resuming development (session: <id>)..." |
+| `pending-dev` | `−pending-dev +in-progress` | Dispatcher Step 4 (resume) | Dispatcher | concurrency below cap; retry count < `MAX_RETRIES` ([INV-05](invariants.md#inv-05-retry-counter-cutoff-rule)); prior session not terminal ([INV-12](invariants.md#inv-12-resume-only-against-unfinished-sessions)); valid `Dev Session ID:` extractable from comments | "Resuming development (session: <id>)..." |
+| `pending-dev` | `−pending-dev +in-progress` (dev-new) | Step 4 review-aware: prior session `end_turn\|completed` + substantive review-failure verdict newer than session end ([INV-35](invariants.md#inv-35-review-aware-resume-routing-for-completed-sessions)) | Dispatcher | concurrency below cap; retry count < `MAX_RETRIES`; per-issue log truncated successfully (fail-closed otherwise) | `INV-35-fresh-dev:<sid>` notice + "Resuming with a fresh session..." |
+| `pending-dev` | `−pending-dev +pending-review` | Step 4 review-aware: prior session `end_turn\|completed` + non-substantive review-failure verdict, under `REVIEW_RETRY_LIMIT` ([INV-35](invariants.md#inv-35-review-aware-resume-routing-for-completed-sessions)) | Dispatcher | concurrency below cap; non-substantive flip count for this session < `REVIEW_RETRY_LIMIT` (default 2) | `<!-- review-aware-flip:non-substantive cause=<x> -->` marker + "Re-routing to review (last review failed for non-substantive reason: <x>)." |
 | `pending-dev` | `−pending-dev +stalled` | Dispatcher Step 4 (retry exhausted) | Dispatcher | retry count ≥ `MAX_RETRIES` (after stalled-cutoff filtering) | "Marking as stalled" comment with @owner mention |
+| `pending-dev` | `−pending-dev +stalled` | Step 4 review-aware: non-substantive review-retry cap reached ([INV-35](invariants.md#inv-35-review-aware-resume-routing-for-completed-sessions)) | Dispatcher | non-substantive flip count for this session ≥ `REVIEW_RETRY_LIMIT` | "Marking as stalled — review failed N times for non-substantive reasons" with @owner mention |
 | `stalled` | `−stalled` (back to `pending-dev`) | Maintainer removes label | Maintainer | — | — |
 
 > **Note on `+approved`:** the auto-merge-success path also removes `autonomous` so the issue is no longer eligible for re-dispatch (and GitHub auto-closes the issue via the PR's `Closes #N` keyword — the wrapper itself does not call `gh issue close`, see [INV-33](invariants.md#inv-33-review-wrapper-must-not-close-the-linked-issue)). The `no-auto-close` and approval-failure paths keep `autonomous` (the issue is not auto-closed; manual operator intervention completes the flow). The auto-merge-**failure** path is *not* in the `+approved` group: it transitions to `+pending-dev` with `autonomous` retained, and the dispatcher Step 4 re-dispatches dev to rebase onto main.

--- a/docs/test-cases/inv35-review-aware-resume.md
+++ b/docs/test-cases/inv35-review-aware-resume.md
@@ -1,0 +1,219 @@
+# Test cases — INV-35 review-aware Step 4 routing (issue #149)
+
+Tracks the dispatcher Step 4b.5.1 routing for `pending-dev` issues whose prior dev session reached `end_turn|completed`. See [`docs/designs/inv35-review-aware-resume.md`](../designs/inv35-review-aware-resume.md) for the design canvas and [`docs/pipeline/invariants.md` § INV-35](../pipeline/invariants.md#inv-35-review-aware-resume-routing-for-completed-sessions) for the spec.
+
+All Step-4 cases use a fixture that prepares: (a) a per-issue agent log at `/tmp/agent-${PROJECT_ID}-issue-N.log` whose final `{"type":"result"}` line is the named terminal state, (b) a `gh` mock that returns scripted issue comments for `gh issue view`, and (c) a `BOT_LOGIN` set to `kane-coding-agent[bot]` (the standard fixture login).
+
+## A. `classify_recent_review_verdict` helper
+
+### TC-INV35-CL-001: No comments after session-end → `none`
+
+**Setup**: Issue has 3 comments, all with `createdAt` ≤ session-end timestamp.
+
+**Action**: `classify_recent_review_verdict 100 "2026-05-21T03:18:00Z" v c`
+
+**Expected**: `v=none`, `c=""`, exit 0.
+
+### TC-INV35-CL-002: Newest matching comment carries `failed-non-substantive` trailer
+
+**Setup**: Three post-session comments by `BOT_LOGIN`. Newest body contains `<!-- review-verdict: failed-non-substantive cause=bot-timeout -->\nReview FAILED ...`. Older two are unrelated bot comments.
+
+**Action**: helper called as above.
+
+**Expected**: `v=failed-non-substantive`, `c=bot-timeout`.
+
+### TC-INV35-CL-003: Newest by `createdAt`, not by source order
+
+**Setup**: gh returns comments out of order (oldest first). Two have trailers — `passed` (older) and `failed-substantive` (newer).
+
+**Expected**: `v=failed-substantive`. (Helper sorts by `createdAt` before picking.)
+
+### TC-INV35-CL-004: Newest comment has no trailer → `failed-substantive` fallback
+
+**Setup**: Newest post-session comment by `BOT_LOGIN` is "Review FAILED ..." with no `<!-- review-verdict: ... -->` trailer.
+
+**Expected**: `v=failed-substantive`, `c=""`. (Pre-INV-35 verdict-comment compatibility.)
+
+### TC-INV35-CL-005: Newest comment is from a non-bot author → ignored, fallback to next
+
+**Setup**: Newest post-session comment is from `@operator-user`. Older comment from `BOT_LOGIN` carries `<!-- review-verdict: passed -->`.
+
+**Expected**: `v=passed`. (Filter applied before pick-newest.)
+
+### TC-INV35-CL-006: `BOT_LOGIN` empty → session-id binding fallback used
+
+**Setup**: `BOT_LOGIN=""` (gh api user 403 case). Comment body contains `Review Session: <fixture-session-uuid>` matching the session in `Dev Session ID:` and the trailer `<!-- review-verdict: failed-non-substantive cause=ci-transport -->`.
+
+**Expected**: `v=failed-non-substantive`, `c=ci-transport`.
+
+### TC-INV35-CL-007: Multiple trailers in one body → first match wins
+
+**Setup**: Bot pasted a quoted prior verdict into a new comment, so the body contains both `<!-- review-verdict: passed -->` (older quote) and `<!-- review-verdict: failed-substantive -->` (the actual current verdict, posted second).
+
+**Expected**: design accepts whichever the regex matches first; the test pins current behavior to `passed` (textually first) and is allowed to be revisited if real-world verdict comments produce false-passes — see design §7. *(If revisited, the rule becomes "match the LAST trailer in body" with a corresponding regex change.)*
+
+### TC-INV35-CL-008: Trailer with unknown cause token → still `failed-non-substantive`
+
+**Setup**: Trailer is `<!-- review-verdict: failed-non-substantive cause=newly-invented-token -->`.
+
+**Expected**: `v=failed-non-substantive`, `c=newly-invented-token`. Forward-compat with new cause tokens added by the review wrapper.
+
+## B. Step 4 dispatcher routing — completed session, no review
+
+### TC-INV35-RT-001: `completed` + no post-session verdict → INV-12 operator notice (regression)
+
+**Setup**: Log ends `end_turn|completed`. No comments by `BOT_LOGIN` after session-end.
+
+**Action**: One dispatcher tick.
+
+**Expected**:
+- Issue receives one `INV-12-completed:<sid>` comment (idempotent — re-running tick does NOT post a second).
+- Labels unchanged (still `pending-dev`).
+- Issue is added to `JUST_DISPATCHED`.
+- No `INV-35-fresh-dev` marker, no `<!-- review-aware-flip -->` marker.
+- This is the original INV-12 behavior, preserved.
+
+## C. Step 4 dispatcher routing — completed + non-substantive
+
+### TC-INV35-RT-010: First non-substantive failure → flip to `pending-review`
+
+**Setup**: Log ends `end_turn|completed`. Newest post-session comment by `BOT_LOGIN` carries `<!-- review-verdict: failed-non-substantive cause=bot-timeout -->`. Issue currently `pending-dev`. No prior `<!-- review-aware-flip -->` markers.
+
+**Action**: One dispatcher tick.
+
+**Expected**:
+- Issue labels become `pending-review` (atomic edit removes `pending-dev` / adds `pending-review`).
+- New comment posted: body contains `<!-- review-aware-flip:non-substantive cause=bot-timeout -->` and a human-readable line "Re-routing to review (last review failed for non-substantive reason: bot-timeout)."
+- No `INV-12-completed`, no `INV-35-fresh-dev` posted.
+- Retry-comment count for `MAX_RETRIES` is unchanged.
+- Issue added to `JUST_DISPATCHED`.
+
+### TC-INV35-RT-011: Second non-substantive failure → flip again (under cap)
+
+**Setup**: Same as RT-010 but the issue already has ONE prior `<!-- review-aware-flip:non-substantive cause=bot-timeout -->` marker scoped to the same `Dev Session ID:`. `REVIEW_RETRY_LIMIT=2` (default).
+
+**Expected**: Same as RT-010 — second flip allowed, marker count goes from 1 to 2.
+
+### TC-INV35-RT-012: Third non-substantive failure → mark stalled
+
+**Setup**: Same as RT-011 but two prior flips already exist for this session.
+
+**Expected**:
+- Issue gets `+stalled` (and `−pending-dev`).
+- Operator-actionable comment posted citing the persistent non-substantive cause and the marker count.
+- No new `<!-- review-aware-flip -->` marker added (we're stalling, not flipping).
+
+### TC-INV35-RT-013: New session resets the flip counter
+
+**Setup**: Issue has two prior `<!-- review-aware-flip:non-substantive -->` markers, but they were scoped to a DIFFERENT (older) `Dev Session ID:`. The current session is fresh.
+
+**Expected**: First flip for the new session is allowed (treated as TC-INV35-RT-010 case). The counter is per-session-id.
+
+### TC-INV35-RT-014: `REVIEW_RETRY_LIMIT=0` disables the cap
+
+**Setup**: Operator set `REVIEW_RETRY_LIMIT=0` in `autonomous.conf`. Issue has 5 prior flips for the current session.
+
+**Expected**: Sixth flip still allowed. Bounce-forever behavior, by operator opt-in.
+
+## D. Step 4 dispatcher routing — completed + substantive
+
+### TC-INV35-RT-020: Substantive failure → fresh dev-new (PTL pattern)
+
+**Setup**: Log ends `end_turn|completed`. Newest post-session comment by `BOT_LOGIN` carries `<!-- review-verdict: failed-substantive -->`. Log file is writable.
+
+**Expected**:
+- Issue receives one `INV-35-fresh-dev:<sid>` comment (idempotent).
+- Per-issue log file truncated to zero bytes.
+- Labels: `−pending-dev +in-progress` (atomic).
+- `<!-- dispatcher-token: <id> at <iso> mode=dev-new -->` marker posted.
+- `dispatch dev-new <issue>` invoked.
+- Retry-comment count incremented (`MAX_RETRIES` consumed).
+- Issue added to `JUST_DISPATCHED`.
+
+### TC-INV35-RT-021: Substantive failure with truncate-fail → fail-closed
+
+**Setup**: Same as RT-020 but the per-issue log file is read-only (chmod 444 in fixture).
+
+**Expected**:
+- `: > $log` returns non-zero.
+- Operator-actionable comment posted naming the log path + permission/disk hint.
+- NO labels changed, NO dev-new dispatched.
+- Issue stays `pending-dev` so the operator notices via stale-detection / retry accumulation.
+- Same fail-closed pattern as the INV-12 PTL branch.
+
+### TC-INV35-RT-022: Missing trailer → treated as substantive (back-compat)
+
+**Setup**: Log ends `end_turn|completed`. Newest comment by `BOT_LOGIN` is `Review FAILED — found 3 issues with the implementation` (no trailer — pre-INV-35 verdict).
+
+**Expected**: Same as RT-020. The classifier defaults missing trailers to `failed-substantive`, the safest of the four outcomes.
+
+## E. Step 4 dispatcher routing — completed + passed (race)
+
+### TC-INV35-RT-030: `passed` verdict on `pending-dev` issue → no-op
+
+**Setup**: Log ends `end_turn|completed`. Newest comment by `BOT_LOGIN` carries `<!-- review-verdict: passed -->` but the issue is somehow `pending-dev` (impossible-to-construct race; preserves dispatcher safety).
+
+**Expected**:
+- WARN line in dispatcher log.
+- No comment posted, no labels changed, no dispatch called.
+- Issue is added to `JUST_DISPATCHED` (so Step 5 doesn't second-guess this tick).
+- Step 0 hygiene on the next tick reconciles based on whatever state has actually arrived.
+
+## F. Composition with neighboring invariants
+
+### TC-INV35-CMP-001: PTL still wins over INV-35
+
+**Setup**: Log ends `*|prompt_too_long`. Issue also has a post-session `<!-- review-verdict: failed-non-substantive ... -->` comment.
+
+**Expected**: PTL branch fires (Step 4b.5 PTL row), NOT the INV-35 routing. INV-35 only triggers on `end_turn|completed`.
+
+### TC-INV35-CMP-002: Auto-merge-failure rebase prepend layers on dev-new
+
+**Setup**: `failed-substantive` branch → dev-new fired. The PR's most recent comment matches `Auto-merge failed:` (from #146).
+
+**Expected**: dev-new prompt includes the `## Pre-implementation: rebase onto main` block — i.e., the resume-prompt-prepend logic in `lib-agent.sh::resume_agent` (or its dev-new analog) reads PR comments regardless of `--mode new` vs `--mode resume`. (See design §8.)
+
+### TC-INV35-CMP-003: INV-30 — same routing under `EXECUTION_BACKEND=remote-aws-ssm`
+
+**Setup**: Same as RT-010 but the dispatcher's tick runs with `EXECUTION_BACKEND=remote-aws-ssm`.
+
+**Expected**: Routing decision is identical. The helper reads issue comments via `gh` and the log file via the dispatcher's local filesystem (where the wrapper writes via SSM-side mount or sync — same as today's PTL handling).
+
+## G. Regression — the 2026-05-21 #144 / #145 sequence
+
+### TC-INV35-REG-001: dev complete → q-bot timeout review → dispatcher tick (the bug)
+
+**Setup**: Replays the 2026-05-21 03:18 → 05:34 UTC sequence:
+1. Dev wrapper finished cleanly: log ends `end_turn|completed`, PR opened.
+2. Review wrapper ran 2h11m later, configured `REVIEW_BOTS=q`, q-bot did not respond in 3 min.
+3. Review wrapper posted FAILED verdict comment with the new trailer `<!-- review-verdict: failed-non-substantive cause=bot-timeout -->`.
+4. Review wrapper flipped issue to `pending-dev`.
+5. Dispatcher tick fires.
+
+**Pre-fix expected (current behavior — must FAIL with INV-35 in place)**: dispatcher posts `INV-12-completed:<sid>`, leaves issue `pending-dev`. Test asserts THIS fails.
+
+**Post-fix expected**:
+- Issue flipped to `pending-review`.
+- Marker comment with `<!-- review-aware-flip:non-substantive cause=bot-timeout -->`.
+- No `INV-12-completed` comment posted.
+- Retry-comment count unchanged (`MAX_RETRIES` not consumed).
+
+This is the gating regression test for the issue and must fail on `dispatcher-tick.sh:277-323` pre-fix and pass post-fix per #149 acceptance criteria.
+
+### TC-INV35-REG-002: same sequence with no trailer (pre-INV-35 review wrapper deployed mid-fix)
+
+**Setup**: Same as REG-001 but step 3's verdict comment lacks the trailer (operator deployed dispatcher fix before review wrapper fix).
+
+**Post-fix expected**: classifier defaults to `failed-substantive`, dispatcher dispatches dev-new with truncate. Acceptable degradation — the dev session retries fresh, MAX_RETRIES consumes one slot, but no infinite stall. Once the review wrapper update lands, subsequent verdicts get the trailer and the optimal `failed-non-substantive` routing.
+
+## Acceptance mapping (per issue #149)
+
+| #149 acceptance criterion | Covered by |
+|---|---|
+| Design canvas at `docs/designs/inv35-review-aware-resume.md` reviewed and decision recorded | (in this same PR) |
+| `docs/pipeline/invariants.md` updated: INV-12 paired with new INV-35 | (in this same PR) |
+| `docs/pipeline/dispatcher-flow.md` Step 4 updated to reflect new branching | (in this same PR) |
+| `dispatcher-tick.sh` Step 4 implements the chosen routing | follow-up PR; covered by section B–E above |
+| Test-case doc + unit tests written and passing | (this doc) + follow-up `tests/unit/` files cited above |
+| Regression test for the 2026-05-21 fixture | TC-INV35-REG-001 |
+| No silent retry loops introduced (preserve INV-12-PTL fail-closed pattern for new write-side behavior) | TC-INV35-RT-021 |

--- a/skills/autonomous-dispatcher/scripts/autonomous.conf.example
+++ b/skills/autonomous-dispatcher/scripts/autonomous.conf.example
@@ -351,6 +351,12 @@ DEV_SKILL_CMD="/autonomous-dev"
 # (every 30s, timeout 3 min), and fails the review if any configured bot
 # doesn't respond in time.
 #
+# Default: "" (disabled). Bot reviews are opt-in because each external
+# bot is an availability dependency the operator takes on — when the bot
+# is slow or unreachable, the review fails for a non-substantive reason
+# and the issue bounces between pending-review and pending-dev (#149).
+# Enable only when you actively want a specific bot's findings on every PR.
+#
 # Built-in registry:
 #   q      → trigger "/q review",     login "amazon-q-developer[bot]"
 #   codex  → trigger "/codex review", login "codex[bot]"
@@ -366,7 +372,7 @@ DEV_SKILL_CMD="/autonomous-dev"
 #
 # All three built-in bots reject GitHub App bot triggers, so the wrapper
 # uses scripts/gh-as-user.sh to post as a real user.
-REVIEW_BOTS="q"
+REVIEW_BOTS=""
 
 # === E2E Verification (optional) ===
 E2E_ENABLED="false"


### PR DESCRIPTION
## Summary

Refs #149. Ships the design + spec doc updates for the review-aware Step-4 routing fix; implementation is a follow-up PR gated on this design landing.

INV-12's `end_turn|completed` arm refuses dev-resume to prevent the SSE-stream hang from #59, but the gate is too broad: when a dev session finished cleanly AND a later review failed for a non-substantive reason (configured `REVIEW_BOTS=q` and the bot timed out, CI flake, transport error), the dispatcher posts an `INV-12-completed` operator-handoff every tick and the issue stalls indefinitely. Live-reproduced 2026-05-21 on #144 / #145 — both stuck for ~50 min until the operator manually intervened.

INV number landed on **35** because 33 (review-must-not-close-issue, #146) and 34 (agent-prompt-via-stdin, #147) were both claimed upstream after #149 was filed.

## What's in this PR

- **`docs/designs/inv35-review-aware-resume.md`** — full design canvas: 4-question decision rationale (B/flip-label/fresh-dev/separate-counter), routing table, `<!-- review-verdict: ... -->` trailer schema, `REVIEW_RETRY_LIMIT` semantics (per-session-id, separate from `MAX_RETRIES`), failure modes considered.
- **`docs/test-cases/inv35-review-aware-resume.md`** — TC-INV35-CL-* helper unit tests, TC-INV35-RT-* dispatcher routing tests, TC-INV35-CMP-* composition tests (with PTL / #146 auto-merge-failure / INV-30 backends), and TC-INV35-REG-001 regression for the 2026-05-21 #144/#145 sequence.
- **`docs/pipeline/state-machine.md`** — three new pending-dev outgoing transitions (substantive→dev-new, non-substantive→pending-review, non-substantive cap→stalled) added to the mermaid diagram + transition table.
- **`docs/pipeline/invariants.md`** — INV-12 entry now scoped to "no review verdict" case (preserving its SSE-hang rationale); new INV-35 entry with the routing table, trailer schema, helper API contract, and TODO test enumeration.
- **`docs/pipeline/dispatcher-flow.md`** — new Step 4b.5.1 with the runtime view; recovery-table cross-reference updated.
- **`skills/autonomous-dispatcher/scripts/autonomous.conf.example`** — default `REVIEW_BOTS=""` (was `"q"`). Bot reviews are now opt-in; rationale in the comment block. Even after INV-35 implementation ships, this default stays — the implementation makes bot bouncing graceful, not free.

## What's NOT in this PR

- `lib-dispatch.sh::classify_recent_review_verdict` helper.
- New Step 4b.5.1 routing in `dispatcher-tick.sh`.
- `<!-- review-verdict: ... -->` trailer emission in `autonomous-review.sh`.
- The unit/regression tests enumerated in the test-cases doc.

These ship in a follow-up PR after this design is approved.

## Test plan

- [x] `tests/unit/test-dispatcher-tick-review-bots.sh` — 9 PASS (no fixture pinned to old `REVIEW_BOTS="q"` default).
- [x] `tests/unit/test-is-session-completed.sh` — 14 PASS (the INV-12 helper INV-35 wraps; behavior unchanged in this PR).
- [x] No private-repo refs in any new file (CLAUDE.md scan: `grep -niE 'quant-scorer|vidsyllabus|panoptes|llm-wiki|podcast-curation|voicebiz|issuecomment-[0-9]+'` → no matches).
- [ ] CI green.
- [ ] Reviewer approval on the design canvas.

## Per CLAUDE.md "Pipeline Documentation Authority"

This is a pipeline-spec PR; docs precede code. The follow-up implementation PR will include the corresponding code changes that this spec mandates, and will reference INV-35 in its commit messages.