### PR TITLE
feat: add AGENT_DEV_CMD / AGENT_REVIEW_CMD per-side overrides (INV-37)

### DIFF
--- a/docs/pipeline/README.md
+++ b/docs/pipeline/README.md
@@ -16,6 +16,7 @@ For the high-level overview and quick start, see [`docs/autonomous-pipeline.md`]
 | [`invariants.md`](invariants.md) | Cross-cutting invariants (PID file naming, retry-counter cutoff rule, SHA trailer format, "crashed"-keyword regex contract, etc.). |
 | [`remote-backend.md`](remote-backend.md) | The `EXECUTION_BACKEND` contract every dispatch transport (local, remote-aws-ssm, future) must satisfy. |
 | [`agy-cli-support.md`](agy-cli-support.md) | Per-CLI spec for the `AGENT_CMD=agy` (Antigravity 2.0) branch in `lib-agent.sh` — sidecar pattern, structural flags, INV-36 capture contract. |
+| [`per-side-agent-cmd.md`](per-side-agent-cmd.md) | `AGENT_DEV_CMD` / `AGENT_REVIEW_CMD` — let dev and review run on different CLIs in the same project (INV-37). |
 
 ## Reading order
 

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -978,6 +978,25 @@ Where `<short-token>` is one of `bot-timeout`, `ci-transport`, `no-pr-found`, `m
 - [INV-31](#inv-31-operator-tunable-per-cli-flags-live-in-conf-not-in-lib-agentsh) — agy's structural flags (-p, --dangerously-skip-permissions, --print-timeout, --log-file) live in `lib-agent.sh`, NOT in `AGENT_*_EXTRA_ARGS`.
 - [INV-34](#inv-34-agent-prompt-is-fed-via-stdin-never-as-a-single-argv-element) — agy's `-p` (no value) reads from stdin, same channel contract as claude/gemini.
 
+## INV-37: per-side AGENT_CMD precedence
+
+**Rule**: `lib-agent.sh` exposes `AGENT_DEV_CMD` and `AGENT_REVIEW_CMD` as side-specific overrides of `AGENT_CMD`. Both default to `${AGENT_CMD:-claude}` so existing deployments are byte-for-byte unchanged. `autonomous-dev.sh` sets `AGENT_CMD="$AGENT_DEV_CMD"` exactly once, immediately after sourcing `lib-agent.sh` and before any other `source`. `autonomous-review.sh` sets `AGENT_CMD="$AGENT_REVIEW_CMD"` in the same position. After the override, the `case "$AGENT_CMD"` statements in `run_agent` / `resume_agent` dispatch to the right CLI per-side without any signature change.
+
+**Why**: lets one project run dev and review on different CLIs (typical pattern: claude for dev, agy or another cheaper / specialized CLI for review). Without this, `AGENT_CMD` is a single value shared by both wrappers and operators must choose one CLI for the whole project. The model knobs (`AGENT_DEV_MODEL` / `AGENT_REVIEW_MODEL`) and per-side flags (`AGENT_DEV_EXTRA_ARGS` / `AGENT_REVIEW_EXTRA_ARGS`) already split — INV-37 closes the conspicuous gap on the CLI knob.
+
+**Constraint**: `AGENT_LAUNCHER` (claude-only at this writing) is rejected at `lib-agent.sh` source time when **either** `AGENT_DEV_CMD` or `AGENT_REVIEW_CMD` resolves to a non-claude CLI. The launcher would otherwise be applied to a CLI it wasn't written for. The guard reads `AGENT_DEV_CMD` and `AGENT_REVIEW_CMD` directly (not `$AGENT_CMD`) so it fires correctly regardless of which wrapper does the subsequent override.
+
+**Producer**: `lib-agent.sh` init block (the two `${VAR:-$AGENT_CMD}` assignments after `AGENT_CMD="${AGENT_CMD:-claude}"`).
+
+**Consumer**: `autonomous-dev.sh` and `autonomous-review.sh` entry blocks set the active `AGENT_CMD` before any `run_agent` / `resume_agent` call.
+
+**Test**: `tests/unit/test-lib-agent-per-side-cmd.sh` PSC-S1 (defaults), PSC-S2/S3 (single-side override), PSC-S4 (both set), PSC-S5 (empty-string fallback), PSC-S6 (launcher + both claude → pass), PSC-S7/S8/S11 (launcher + any non-claude side → fail with both var values in the error), PSC-S9/S10 (wrapper structural placement).
+
+**Cross-references**:
+- [`docs/pipeline/per-side-agent-cmd.md`](per-side-agent-cmd.md) — full spec.
+- [INV-31](#inv-31-operator-tunable-per-cli-flags-live-in-conf-not-in-lib-agentsh) — the new vars are operator-tunable and live in `autonomous.conf`, following INV-31's contract.
+- [`docs/pipeline/agy-cli-support.md`](agy-cli-support.md) — agy is the most likely review-side CLI today and the motivating example.
+
 ## Adding a new invariant
 
 When fixing a pipeline bug, after locating the bug on the state machine + flow docs:

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -988,9 +988,9 @@ Where `<short-token>` is one of `bot-timeout`, `ci-transport`, `no-pr-found`, `m
 
 **Producer**: `lib-agent.sh` init block (the two `${VAR:-$AGENT_CMD}` assignments after `AGENT_CMD="${AGENT_CMD:-claude}"`).
 
-**Consumer**: `autonomous-dev.sh` and `autonomous-review.sh` entry blocks set the active `AGENT_CMD` before any `run_agent` / `resume_agent` call.
+**Consumer**: `autonomous-dev.sh` and `autonomous-review.sh` entry blocks set the active `AGENT_CMD` before any `run_agent` / `resume_agent` call. The dispatcher tick also has two per-side reads in `lib-dispatch.sh`: `_pgid_has_agent_process` accepts an optional 2nd-arg per-side CLI override (callers pass `${AGENT_DEV_CMD:-...}` from `dev_near_success` and `${AGENT_REVIEW_CMD:-...}` from `review_near_success`); `is_session_completed` gates on `${AGENT_DEV_CMD:-${AGENT_CMD:-claude}}` because it parses the dev wrapper's log. The dispatcher tick does NOT source lib-agent.sh, so it cannot inherit the wrapper-level override — these reads are the substitute.
 
-**Test**: `tests/unit/test-lib-agent-per-side-cmd.sh` PSC-S1 (defaults), PSC-S2/S3 (single-side override), PSC-S4 (both set), PSC-S5 (empty-string fallback), PSC-S6 (launcher + both claude → pass), PSC-S7/S8/S11 (launcher + any non-claude side → fail with both var values in the error), PSC-S9/S10 (wrapper structural placement).
+**Test**: `tests/unit/test-lib-agent-per-side-cmd.sh` PSC-S1 (defaults), PSC-S2/S3 (single-side override), PSC-S4 (both set), PSC-S5 (empty-string fallback), PSC-S6 (launcher + both claude → pass), PSC-S7/S8/S11 (launcher + any non-claude side → fail with both var values in the error), PSC-S9/S10 (wrapper structural placement). Dispatcher-side coverage: `tests/unit/test-pgid-has-agent-process.sh` (TC-PSC-COUP-01a..d) and `tests/unit/test-is-session-completed.sh` (TC-WH-005b).
 
 **Cross-references**:
 - [`docs/pipeline/per-side-agent-cmd.md`](per-side-agent-cmd.md) — full spec.

--- a/docs/pipeline/per-side-agent-cmd.md
+++ b/docs/pipeline/per-side-agent-cmd.md
@@ -1,0 +1,176 @@
+# Per-Side `AGENT_CMD` Override
+
+Spec for `AGENT_DEV_CMD` and `AGENT_REVIEW_CMD` — two new operator
+knobs in `skills/autonomous-dispatcher/scripts/lib-agent.sh` that
+let the dev wrapper and the review wrapper run on different agent
+CLIs in the same project.
+
+This doc is the authoritative contract. Implementation: lib-agent.sh
+init block, autonomous-dev.sh / autonomous-review.sh entry blocks.
+Invariant: [INV-37](invariants.md#inv-37-per-side-agent_cmd-precedence).
+
+## Why
+
+Today `AGENT_CMD` is a single project-wide value: dev and review use
+the same CLI. The model knobs already split (`AGENT_DEV_MODEL` /
+`AGENT_REVIEW_MODEL`); the CLI knob does not. That blocks deployments
+that want to use one CLI for the heavy dev work and a cheaper or
+specialized CLI for review — for example, claude (Opus, expensive)
+for dev, agy (cheaper, smaller-context) for review.
+
+Adding a per-side override is mechanically small (the seam is one
+variable read in two case statements) and naming follows the
+existing `AGENT_DEV_*` / `AGENT_REVIEW_*` precedent.
+
+## Resolution order
+
+```
+AGENT_CMD                                       (project default; default "claude")
+  │
+  ├─ AGENT_DEV_CMD     = ${AGENT_DEV_CMD:-$AGENT_CMD}
+  └─ AGENT_REVIEW_CMD  = ${AGENT_REVIEW_CMD:-$AGENT_CMD}
+```
+
+Then each wrapper sets `AGENT_CMD` to its side's value:
+
+- `autonomous-dev.sh`     → `AGENT_CMD="$AGENT_DEV_CMD"`
+- `autonomous-review.sh`  → `AGENT_CMD="$AGENT_REVIEW_CMD"`
+
+After that line, the rest of `lib-agent.sh` (case statements, log
+messages, the AGENT_LAUNCHER guard) keeps reading `$AGENT_CMD` —
+no signature changes, no caller changes, no per-CLI branch changes.
+
+`:-` (not `:=`) means an explicit empty string in the conf falls
+back to `AGENT_CMD`. That matches the existing semantics of
+`AGENT_DEV_MODEL` / `AGENT_REVIEW_MODEL`.
+
+## Backwards compatibility
+
+Existing deployments do not set `AGENT_DEV_CMD` or `AGENT_REVIEW_CMD`.
+The defaults make both equal to whatever `AGENT_CMD` was, so behavior
+is byte-for-byte identical to pre-change. No conf migration is
+required for any operator who does not want the per-side split.
+
+## `AGENT_LAUNCHER` interaction
+
+`AGENT_LAUNCHER` is currently rejected unless `AGENT_CMD == claude`
+(lib-agent.sh:106-108). The launcher is a `cc` shell function that
+ends in `$CLAUDE_CMD "$@"` — pointing it at codex / kiro / opencode
+would silently produce `claude codex …` and fail.
+
+The new check generalizes that gate to both sides:
+
+```bash
+if [[ ${#AGENT_LAUNCHER_ARGV[@]} -gt 0 ]]; then
+  if [[ "$AGENT_DEV_CMD" != "claude" || "$AGENT_REVIEW_CMD" != "claude" ]]; then
+    echo "[lib-agent] ERROR: AGENT_LAUNCHER is only supported when both AGENT_DEV_CMD and AGENT_REVIEW_CMD are claude (got AGENT_DEV_CMD=${AGENT_DEV_CMD}, AGENT_REVIEW_CMD=${AGENT_REVIEW_CMD}). Either unset AGENT_LAUNCHER or write a launcher tailored to your CLI." >&2
+    return 1 2>/dev/null || exit 1
+  fi
+fi
+```
+
+The error message names both vars so an operator who sets
+`AGENT_REVIEW_CMD=agy` while leaving an inherited claude launcher in
+place sees exactly which side broke the contract.
+
+This is **strictly more permissive** than the old check: it still
+allows the launcher under the "single AGENT_CMD=claude" pattern (both
+sides resolve to claude), and it correctly rejects every previously-
+rejected combination. No existing operator config goes from passing
+to failing.
+
+## What is NOT covered
+
+- **`AGENT_PERMISSION_MODE`** (claude-only flag) stays shared. If an
+  operator runs review on a non-claude CLI they likely don't need
+  per-side `AGENT_PERMISSION_MODE` — every other CLI ignores it.
+- **`KIRO_AGENT_NAME`** stays shared. Splitting it would only help an
+  operator running both wrappers under kiro with different agent
+  configs — vanishingly rare; out of scope.
+- **`AGENT_TIMEOUT`** stays shared. Wall-clock cap is per-process
+  policy, not per-CLI behavior.
+- **`AGENT_DEV_EXTRA_ARGS` / `AGENT_REVIEW_EXTRA_ARGS`** already
+  split. Operator can already override per-side flags via these.
+
+## Operator-facing config
+
+`autonomous.conf.example` gets a new comment block above the per-CLI
+blocks (after the `AGENT_PERMISSION_MODE` line, before the per-CLI
+blocks):
+
+```bash
+# AGENT_DEV_CMD / AGENT_REVIEW_CMD: per-side override of AGENT_CMD.
+# Default to AGENT_CMD when unset/empty, so existing single-CLI
+# deployments are unaffected. Set them when you want dev and review
+# to run on different CLIs — for example, claude for the heavy dev
+# work and agy for the cheaper review pass:
+#
+#   AGENT_CMD="claude"           # also used by anything not split
+#   AGENT_REVIEW_CMD="agy"       # only review goes to agy
+#   AGENT_DEV_MODEL="opus[1m]"
+#   AGENT_REVIEW_MODEL=""        # ignored by agy (warns), see agy block
+#
+# AGENT_LAUNCHER (claude-only) is rejected when either side resolves
+# to a non-claude CLI. Either unset the launcher or keep both sides
+# on claude.
+# AGENT_DEV_CMD=""
+# AGENT_REVIEW_CMD=""
+```
+
+## Failure modes
+
+| Failure | Behavior |
+|---|---|
+| Neither override set | Both wrappers use `$AGENT_CMD`. Pre-change behavior. |
+| Only `AGENT_REVIEW_CMD=agy` set | Dev uses `$AGENT_CMD` (unchanged), review uses `agy`. The podcast-curation use case. |
+| Only `AGENT_DEV_CMD=codex` set | Dev uses `codex`, review uses `$AGENT_CMD`. Symmetric. |
+| Both set, both non-empty | Each side runs its declared CLI. `$AGENT_CMD` is effectively unused (the dispatcher script's `AGENT_CMD=…` line still resolves it for log breadcrumbs). |
+| `AGENT_DEV_CMD=""` (explicit empty) | Falls back to `$AGENT_CMD` via `:-`. Same as unset. |
+| `AGENT_LAUNCHER` non-empty + either side ≠ claude | `lib-agent.sh` fails loud at source time, naming both `AGENT_DEV_CMD` and `AGENT_REVIEW_CMD` so the operator can tell which side tripped it. |
+
+## Cross-references
+
+- [INV-31](invariants.md#inv-31-operator-tunable-per-cli-flags-live-in-conf-not-in-lib-agentsh) — operator-tunable flags live in conf. The new vars follow that rule.
+- [INV-37](invariants.md#inv-37-per-side-agent_cmd-precedence) — the precedence rule formalized.
+- [`agy-cli-support.md`](agy-cli-support.md) — the most likely review-side CLI today and the motivating example.
+- `dev-agent-flow.md` and `review-agent-flow.md` — both consumers; neither needs a code change because the `run_agent` / `resume_agent` interface is unchanged.
+
+## Test coverage
+
+New file `tests/unit/test-lib-agent-per-side-cmd.sh` covers ten cases:
+
+| Test | Asserts |
+|---|---|
+| PSC-S1 | Default — neither override set → both resolve to `${AGENT_CMD:-claude}` |
+| PSC-S2 | Only `AGENT_REVIEW_CMD=agy` → dev=claude, review=agy |
+| PSC-S3 | Only `AGENT_DEV_CMD=codex` → dev=codex, review=claude |
+| PSC-S4 | Both set (`dev=codex`, `review=agy`, `AGENT_CMD=claude`) → each side runs its declared CLI |
+| PSC-S5 | `AGENT_DEV_CMD=""` (explicit empty) falls back to `$AGENT_CMD` |
+| PSC-S6 | `AGENT_LAUNCHER` non-empty + both sides claude → source succeeds |
+| PSC-S7 | `AGENT_LAUNCHER` + dev=claude review=agy → source fails with error naming `AGENT_REVIEW_CMD=agy` |
+| PSC-S8 | `AGENT_LAUNCHER` + dev=codex review=claude → source fails naming `AGENT_DEV_CMD=codex` |
+| PSC-S9 | Structural — `autonomous-dev.sh` contains the line `AGENT_CMD="$AGENT_DEV_CMD"` immediately after `source ${SCRIPT_DIR}/lib-agent.sh` (with at most one blank line of separation) |
+| PSC-S10 | Structural — `autonomous-review.sh` contains the line `AGENT_CMD="$AGENT_REVIEW_CMD"` immediately after the lib-agent.sh source line |
+
+PSC-S1..S8 are behavioral tests that source `lib-agent.sh` directly in
+a sandbox and assert the resulting variable values. PSC-S9 and PSC-S10
+are structural greps because the wrappers are heavy scripts (GitHub
+auth, PID guard, state IO) that can't be sourced cleanly in unit-test
+isolation; the structural check is sufficient to catch a regression
+where someone accidentally drops or moves the override line.
+
+## Implementation order
+
+1. Lib-agent.sh: add `AGENT_DEV_CMD` / `AGENT_REVIEW_CMD` after the
+   existing `AGENT_CMD="${AGENT_CMD:-claude}"` line; rewrite the
+   AGENT_LAUNCHER guard to check both sides.
+2. autonomous-dev.sh: one-line `AGENT_CMD="$AGENT_DEV_CMD"` after
+   `source lib-agent.sh`.
+3. autonomous-review.sh: one-line `AGENT_CMD="$AGENT_REVIEW_CMD"` after
+   `source lib-agent.sh`.
+4. autonomous.conf.example: add the operator-facing comment block.
+5. tests/unit/test-lib-agent-per-side-cmd.sh: ten test cases.
+6. invariants.md: INV-37 entry.
+7. agy-cli-support.md: small note in §Operator-facing config that
+   the agy block can be combined with `AGENT_DEV_CMD=claude` for the
+   "claude-dev / agy-review" deployment pattern.

--- a/docs/pipeline/per-side-agent-cmd.md
+++ b/docs/pipeline/per-side-agent-cmd.md
@@ -44,6 +44,15 @@ no signature changes, no caller changes, no per-CLI branch changes.
 back to `AGENT_CMD`. That matches the existing semantics of
 `AGENT_DEV_MODEL` / `AGENT_REVIEW_MODEL`.
 
+The `AGENT_LAUNCHER` guard (see next section) runs at `lib-agent.sh`
+source time, **before** the wrapper's `AGENT_CMD=$AGENT_DEV_CMD`
+override line fires. The guard reads `$AGENT_DEV_CMD` and
+`$AGENT_REVIEW_CMD` directly, not via `$AGENT_CMD`, so its decision
+is correct regardless of which wrapper does the subsequent override.
+The wrapper override exists only to make the case statements in
+`run_agent` / `resume_agent` dispatch to the right CLI; it does not
+re-trigger the guard.
+
 ## Backwards compatibility
 
 Existing deployments do not set `AGENT_DEV_CMD` or `AGENT_REVIEW_CMD`.
@@ -81,9 +90,15 @@ to failing.
 
 ## What is NOT covered
 
-- **`AGENT_PERMISSION_MODE`** (claude-only flag) stays shared. If an
-  operator runs review on a non-claude CLI they likely don't need
-  per-side `AGENT_PERMISSION_MODE` — every other CLI ignores it.
+- **`AGENT_PERMISSION_MODE`** stays shared. It's only consumed in
+  the `claude)` branch of `run_agent` / `resume_agent` (lib-agent.sh
+  ~lines 588, 800) — every other CLI's branch silently drops it.
+  In the typical "claude for dev, agy for review" pattern this is
+  fine: the shared value applies on the claude side (where it's
+  consumed) and is harmlessly ignored on the agy side. The inverse
+  pattern (agy for dev, claude for review with different permission
+  needs) WOULD benefit from a per-side `AGENT_PERMISSION_MODE`, but
+  is rare enough to defer.
 - **`KIRO_AGENT_NAME`** stays shared. Splitting it would only help an
   operator running both wrappers under kiro with different agent
   configs — vanishingly rare; out of scope.
@@ -137,7 +152,7 @@ blocks):
 
 ## Test coverage
 
-New file `tests/unit/test-lib-agent-per-side-cmd.sh` covers ten cases:
+New file `tests/unit/test-lib-agent-per-side-cmd.sh` covers eleven cases:
 
 | Test | Asserts |
 |---|---|
@@ -151,6 +166,7 @@ New file `tests/unit/test-lib-agent-per-side-cmd.sh` covers ten cases:
 | PSC-S8 | `AGENT_LAUNCHER` + dev=codex review=claude → source fails naming `AGENT_DEV_CMD=codex` |
 | PSC-S9 | Structural — `autonomous-dev.sh` contains the line `AGENT_CMD="$AGENT_DEV_CMD"` immediately after `source ${SCRIPT_DIR}/lib-agent.sh` (with at most one blank line of separation) |
 | PSC-S10 | Structural — `autonomous-review.sh` contains the line `AGENT_CMD="$AGENT_REVIEW_CMD"` immediately after the lib-agent.sh source line |
+| PSC-S11 | `AGENT_LAUNCHER` + dev=codex review=agy (both sides non-claude) → source fails. Pins the guard's `||` so a refactor cannot silently collapse it into AND or drop one side. |
 
 PSC-S1..S8 are behavioral tests that source `lib-agent.sh` directly in
 a sandbox and assert the resulting variable values. PSC-S9 and PSC-S10
@@ -164,13 +180,17 @@ where someone accidentally drops or moves the override line.
 1. Lib-agent.sh: add `AGENT_DEV_CMD` / `AGENT_REVIEW_CMD` after the
    existing `AGENT_CMD="${AGENT_CMD:-claude}"` line; rewrite the
    AGENT_LAUNCHER guard to check both sides.
-2. autonomous-dev.sh: one-line `AGENT_CMD="$AGENT_DEV_CMD"` after
-   `source lib-agent.sh`.
-3. autonomous-review.sh: one-line `AGENT_CMD="$AGENT_REVIEW_CMD"` after
-   `source lib-agent.sh`.
+2. autonomous-dev.sh: add `AGENT_CMD="$AGENT_DEV_CMD"` **immediately
+   after `source "${SCRIPT_DIR}/lib-agent.sh"`, before any other
+   `source` statement**. PSC-S9 asserts this placement structurally.
+3. autonomous-review.sh: add `AGENT_CMD="$AGENT_REVIEW_CMD"` in the
+   same position relative to `source "${SCRIPT_DIR}/lib-agent.sh"`.
+   PSC-S10 asserts this placement structurally.
 4. autonomous.conf.example: add the operator-facing comment block.
 5. tests/unit/test-lib-agent-per-side-cmd.sh: ten test cases.
 6. invariants.md: INV-37 entry.
-7. agy-cli-support.md: small note in §Operator-facing config that
-   the agy block can be combined with `AGENT_DEV_CMD=claude` for the
-   "claude-dev / agy-review" deployment pattern.
+
+(A cross-link in `agy-cli-support.md` was considered and dropped —
+the operator example in `autonomous.conf.example` already covers the
+"claude-dev / agy-review" deployment pattern; adding it to a separate
+spec would be duplication, not coverage.)

--- a/docs/pipeline/per-side-agent-cmd.md
+++ b/docs/pipeline/per-side-agent-cmd.md
@@ -63,9 +63,10 @@ required for any operator who does not want the per-side split.
 ## `AGENT_LAUNCHER` interaction
 
 `AGENT_LAUNCHER` is currently rejected unless `AGENT_CMD == claude`
-(lib-agent.sh:106-108). The launcher is a `cc` shell function that
-ends in `$CLAUDE_CMD "$@"` — pointing it at codex / kiro / opencode
-would silently produce `claude codex …` and fail.
+(see the AGENT_LAUNCHER guard block in `lib-agent.sh`). The launcher
+is a `cc` shell function that ends in `$CLAUDE_CMD "$@"` — pointing
+it at codex / kiro / opencode would silently produce `claude codex …`
+and fail.
 
 The new check generalizes that gate to both sides:
 
@@ -91,8 +92,8 @@ to failing.
 ## What is NOT covered
 
 - **`AGENT_PERMISSION_MODE`** stays shared. It's only consumed in
-  the `claude)` branch of `run_agent` / `resume_agent` (lib-agent.sh
-  ~lines 588, 800) — every other CLI's branch silently drops it.
+  the `claude)` branch of `run_agent` / `resume_agent` — every other
+  CLI's branch silently drops it.
   In the typical "claude for dev, agy for review" pattern this is
   fine: the shared value applies on the claude side (where it's
   consumed) and is harmlessly ignored on the agy side. The inverse
@@ -109,9 +110,9 @@ to failing.
 
 ## Operator-facing config
 
-`autonomous.conf.example` gets a new comment block above the per-CLI
-blocks (after the `AGENT_PERMISSION_MODE` line, before the per-CLI
-blocks):
+`autonomous.conf.example` gets a new comment block immediately after
+the `AGENT_DEV_EXTRA_ARGS` / `AGENT_REVIEW_EXTRA_ARGS` defaults and
+before the per-CLI blocks:
 
 ```bash
 # AGENT_DEV_CMD / AGENT_REVIEW_CMD: per-side override of AGENT_CMD.
@@ -137,7 +138,7 @@ blocks):
 | Failure | Behavior |
 |---|---|
 | Neither override set | Both wrappers use `$AGENT_CMD`. Pre-change behavior. |
-| Only `AGENT_REVIEW_CMD=agy` set | Dev uses `$AGENT_CMD` (unchanged), review uses `agy`. The podcast-curation use case. |
+| Only `AGENT_REVIEW_CMD=agy` set | Dev uses `$AGENT_CMD` (unchanged), review uses `agy`. The motivating use case (claude-for-dev / agy-for-review). |
 | Only `AGENT_DEV_CMD=codex` set | Dev uses `codex`, review uses `$AGENT_CMD`. Symmetric. |
 | Both set, both non-empty | Each side runs its declared CLI. `$AGENT_CMD` is effectively unused (the dispatcher script's `AGENT_CMD=…` line still resolves it for log breadcrumbs). |
 | `AGENT_DEV_CMD=""` (explicit empty) | Falls back to `$AGENT_CMD` via `:-`. Same as unset. |
@@ -164,8 +165,8 @@ New file `tests/unit/test-lib-agent-per-side-cmd.sh` covers eleven cases:
 | PSC-S6 | `AGENT_LAUNCHER` non-empty + both sides claude → source succeeds |
 | PSC-S7 | `AGENT_LAUNCHER` + dev=claude review=agy → source fails with error naming `AGENT_REVIEW_CMD=agy` |
 | PSC-S8 | `AGENT_LAUNCHER` + dev=codex review=claude → source fails naming `AGENT_DEV_CMD=codex` |
-| PSC-S9 | Structural — `autonomous-dev.sh` contains the line `AGENT_CMD="$AGENT_DEV_CMD"` immediately after `source ${SCRIPT_DIR}/lib-agent.sh` (with at most one blank line of separation) |
-| PSC-S10 | Structural — `autonomous-review.sh` contains the line `AGENT_CMD="$AGENT_REVIEW_CMD"` immediately after the lib-agent.sh source line |
+| PSC-S9 | Structural — `autonomous-dev.sh` contains `AGENT_CMD="$AGENT_DEV_CMD"` within 4 lines of `source ${SCRIPT_DIR}/lib-agent.sh` (allowing the 3-line WHY-rationale comment block) |
+| PSC-S10 | Structural — `autonomous-review.sh` contains `AGENT_CMD="$AGENT_REVIEW_CMD"` within 5 lines of the source statement (allowing the 4-line WHY-rationale comment block) |
 | PSC-S11 | `AGENT_LAUNCHER` + dev=codex review=agy (both sides non-claude) → source fails. Pins the guard's `||` so a refactor cannot silently collapse it into AND or drop one side. |
 
 PSC-S1..S8 are behavioral tests that source `lib-agent.sh` directly in

--- a/docs/pipeline/per-side-agent-cmd.md
+++ b/docs/pipeline/per-side-agent-cmd.md
@@ -187,10 +187,23 @@ where someone accidentally drops or moves the override line.
    same position relative to `source "${SCRIPT_DIR}/lib-agent.sh"`.
    PSC-S10 asserts this placement structurally.
 4. autonomous.conf.example: add the operator-facing comment block.
-5. tests/unit/test-lib-agent-per-side-cmd.sh: ten test cases.
+5. tests/unit/test-lib-agent-per-side-cmd.sh: eleven test cases (PSC-S1..S11).
 6. invariants.md: INV-37 entry.
 
 (A cross-link in `agy-cli-support.md` was considered and dropped —
 the operator example in `autonomous.conf.example` already covers the
 "claude-dev / agy-review" deployment pattern; adding it to a separate
 spec would be duplication, not coverage.)
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | not applicable for config-knob refactor |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | skipped | mechanical change, low signal-to-noise |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR | 4 issues found, 4 resolved (A1, A3, Q1, Q3); 1 test gap fixed (T1 → PSC-S11) |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | no UI scope |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | not applicable |
+
+- **UNRESOLVED:** 0 (all findings landed in spec inline)
+- **VERDICT:** ENG CLEARED — ready to implement

--- a/docs/pipeline/per-side-agent-cmd.md
+++ b/docs/pipeline/per-side-agent-cmd.md
@@ -89,6 +89,38 @@ sides resolve to claude), and it correctly rejects every previously-
 rejected combination. No existing operator config goes from passing
 to failing.
 
+## Dispatcher-side coupling
+
+The dispatcher tick (`lib-dispatch.sh`) does NOT source `lib-agent.sh`
+and does NOT receive the wrapper-level `AGENT_CMD` override. It only
+sees the project-default `$AGENT_CMD` from `autonomous.conf`. Two
+helpers in the dispatcher therefore need explicit per-side awareness
+to handle split-CLI deployments correctly:
+
+1. **`_pgid_has_agent_process <pgid> [agent_cmd_override]`** — process-
+   group liveness probe shared by `dev_near_success` (Step 5b/Step 5
+   signal 4) and `review_near_success` (Step 5b signal 5). The 2nd
+   argument is a per-side CLI override; callers pass
+   `${AGENT_DEV_CMD:-${AGENT_CMD:-claude}}` and
+   `${AGENT_REVIEW_CMD:-${AGENT_CMD:-claude}}` respectively. Empty/
+   missing falls back to `$AGENT_CMD` for back-compat. Without this,
+   a project running `AGENT_REVIEW_CMD=agy` would have its live agy
+   review process classified as DEAD by the dispatcher (the `*claude*`
+   substring match against agy's `comm` would miss).
+
+2. **`is_session_completed`** — claude-only JSON log parser used by
+   the dispatcher's Step 4 terminal-state gate. Gates on the dev-side
+   CLI (`${AGENT_DEV_CMD:-${AGENT_CMD:-claude}}`) because it parses
+   the **dev** wrapper's log file (`/tmp/agent-${PROJECT_ID}-issue-N.log`).
+   Without the dev-side gate, a project with `AGENT_DEV_CMD=codex`
+   and the dispatcher's `AGENT_CMD=claude` default would attempt to
+   parse a codex JSONL log with claude rules, producing
+   misinterpretations of completion state.
+
+These are addressed in this PR alongside the wrapper-side override,
+so split-CLI deployments are correct end-to-end. Per agy review
+Finding 2 + Finding 3 of PR #156.
+
 ## What is NOT covered
 
 - **`AGENT_PERMISSION_MODE`** stays shared. It's only consumed in

--- a/docs/superpowers/plans/2026-05-25-per-side-agent-cmd.md
+++ b/docs/superpowers/plans/2026-05-25-per-side-agent-cmd.md
@@ -864,7 +864,7 @@ Adds two operator knobs in `lib-agent.sh` that let dev and review wrappers run o
 
 Each wrapper sets `AGENT_CMD` to its side's value immediately after sourcing `lib-agent.sh`. The `AGENT_LAUNCHER` guard generalizes to reject any non-claude side (strictly more permissive than the old single-side check — never rejects a config that previously passed).
 
-The motivating use case: `podcast-curation` wants `AGENT_CMD="claude"` for heavy dev and `AGENT_REVIEW_CMD="agy"` for cheaper review.
+The motivating use case: a downstream consumer project wants `AGENT_CMD="claude"` for heavy dev and `AGENT_REVIEW_CMD="agy"` for cheaper review.
 
 ## What's in the PR
 

--- a/docs/superpowers/plans/2026-05-25-per-side-agent-cmd.md
+++ b/docs/superpowers/plans/2026-05-25-per-side-agent-cmd.md
@@ -1,0 +1,947 @@
+# Per-Side `AGENT_CMD` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `AGENT_DEV_CMD` and `AGENT_REVIEW_CMD` operator knobs to `lib-agent.sh` so dev and review wrappers can run on different agent CLIs in the same project (e.g. claude for dev, agy for review).
+
+**Architecture:** Two new environment variables initialized in `lib-agent.sh` after the existing `AGENT_CMD` line, defaulting to `${AGENT_CMD:-claude}` so existing deployments are byte-for-byte unchanged. Each wrapper sets `AGENT_CMD` to its side's value immediately after sourcing `lib-agent.sh`. The existing `AGENT_LAUNCHER` claude-only guard generalizes to check both per-side vars (strictly more permissive — never rejects a previously-passing config).
+
+**Tech Stack:** Bash 5.x. No new runtime dependencies.
+
+**Spec:** [`docs/pipeline/per-side-agent-cmd.md`](../../pipeline/per-side-agent-cmd.md) (committed in this branch).
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `skills/autonomous-dispatcher/scripts/lib-agent.sh` | Modify | Add `AGENT_DEV_CMD` / `AGENT_REVIEW_CMD` init lines; rewrite `AGENT_LAUNCHER` guard to check both sides. |
+| `skills/autonomous-dispatcher/scripts/autonomous-dev.sh` | Modify | Add one-line `AGENT_CMD="$AGENT_DEV_CMD"` immediately after `source ${SCRIPT_DIR}/lib-agent.sh`, before any other source. |
+| `skills/autonomous-dispatcher/scripts/autonomous-review.sh` | Modify | Add one-line `AGENT_CMD="$AGENT_REVIEW_CMD"` in the same position. |
+| `skills/autonomous-dispatcher/scripts/autonomous.conf.example` | Modify | Add `# AGENT_DEV_CMD / AGENT_REVIEW_CMD` operator-facing comment block. |
+| `tests/unit/test-lib-agent-per-side-cmd.sh` | Create | 11 test cases (PSC-S1..S11) — 8 behavioral, 2 structural, 1 launcher-edge. |
+| `docs/pipeline/invariants.md` | Modify | Append `## INV-37: per-side AGENT_CMD precedence`. |
+
+The spec doc and pipeline README index are already committed in this branch; no further docs changes.
+
+---
+
+## Pre-flight: Confirm Worktree
+
+This project's hooks block direct commits on `main` (CLAUDE.md "All code changes must be developed in a Git Worktree"). The active worktree for this work is `worktree-feat+per-side-agent-cmd` at `/data/git/autonomous-dev-team/.claude/worktrees/feat+per-side-agent-cmd`. All `git commit` / `git push` steps below assume the executor is in that worktree.
+
+If you are not already in the worktree, see `superpowers:using-git-worktrees`.
+
+---
+
+## Task 1: Add `AGENT_DEV_CMD` / `AGENT_REVIEW_CMD` init + rewrite `AGENT_LAUNCHER` guard
+
+**Files:**
+- Modify: `skills/autonomous-dispatcher/scripts/lib-agent.sh` (line ~63 for the new init, lines 101–109 for the guard rewrite)
+- Test: `tests/unit/test-lib-agent-per-side-cmd.sh` (new file)
+
+**Goal of this task:** Add the two new env vars and the rewritten launcher guard, both with full unit-test coverage. After this task, `run_agent` / `resume_agent` still see the same `$AGENT_CMD` they always did (because the wrapper override line lands in Task 2/3) — but lib-agent.sh now exposes the per-side resolution that wrappers will key on.
+
+- [ ] **Step 1.1: Read lib-agent.sh lines 58-110 to confirm current state**
+
+Run:
+```bash
+sed -n '58,110p' skills/autonomous-dispatcher/scripts/lib-agent.sh
+```
+
+Expected: see the existing `AGENT_CMD="${AGENT_CMD:-claude}"` at line 60, the `AGENT_LAUNCHER="${AGENT_LAUNCHER:-}"` at line 75, and the guard `if [[ ${#AGENT_LAUNCHER_ARGV[@]} -gt 0 && "$AGENT_CMD" != "claude" ]]; then ...` at lines 106-109.
+
+- [ ] **Step 1.2: Create the test file with scaffolding**
+
+Create `tests/unit/test-lib-agent-per-side-cmd.sh`:
+
+```bash
+#!/bin/bash
+# test-lib-agent-per-side-cmd.sh — Unit tests for AGENT_DEV_CMD /
+# AGENT_REVIEW_CMD per-side overrides (INV-37).
+#
+# Verifies:
+#   - Defaults: both per-side vars resolve to ${AGENT_CMD:-claude}
+#   - Single-side override: only the overridden side changes
+#   - Both-side override: each side runs its declared CLI
+#   - Empty-string handling: :- treats explicit empty as unset
+#   - AGENT_LAUNCHER guard: requires BOTH sides to be claude when set
+#   - Wrapper structural placement: AGENT_CMD override lands immediately
+#     after source lib-agent.sh in both autonomous-{dev,review}.sh
+#
+# Run: bash tests/unit/test-lib-agent-per-side-cmd.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-agent.sh"
+DEV_WRAPPER="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous-dev.sh"
+REVIEW_WRAPPER="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous-review.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected='$expected'"
+    echo "      actual=  '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      needle='$needle'"
+    echo "      haystack='${haystack:0:300}'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# resolve_pair <agent_cmd> <agent_dev_cmd> <agent_review_cmd>
+# Sources lib-agent.sh in a sandbox with the given env, prints
+# "DEV=<dev_cmd> REVIEW=<review_cmd>" on stdout. Strips ANY [lib-agent]
+# warnings/errors so callers can grep cleanly.
+resolve_pair() {
+  local _ac="$1" _adc="$2" _arc="$3"
+  AGENT_CMD="$_ac" \
+  AGENT_DEV_CMD="$_adc" \
+  AGENT_REVIEW_CMD="$_arc" \
+  AGENT_LAUNCHER="" \
+  bash -c '
+    unset AUTONOMOUS_CONF
+    source "'"$LIB"'" 2>/dev/null
+    printf "DEV=%s REVIEW=%s\n" "$AGENT_DEV_CMD" "$AGENT_REVIEW_CMD"
+  '
+}
+
+# launcher_guard <agent_dev_cmd> <agent_review_cmd>
+# Sources lib-agent.sh with AGENT_LAUNCHER=cc and the given per-side
+# values. Captures stderr; emits exit code on stdout last line.
+launcher_guard() {
+  local _adc="$1" _arc="$2"
+  AGENT_CMD="claude" \
+  AGENT_DEV_CMD="$_adc" \
+  AGENT_REVIEW_CMD="$_arc" \
+  AGENT_LAUNCHER="cc" \
+  bash -c '
+    unset AUTONOMOUS_CONF
+    source "'"$LIB"'"
+    echo "RC=$?"
+  ' 2>&1
+}
+
+echo "=== test-lib-agent-per-side-cmd.sh — AGENT_DEV_CMD / AGENT_REVIEW_CMD (INV-37) ==="
+
+echo ""
+echo "PASS: $PASS    FAIL: $FAIL"
+[[ $FAIL -eq 0 ]]
+```
+
+- [ ] **Step 1.3: Make executable + run scaffold**
+
+Run:
+```bash
+chmod +x tests/unit/test-lib-agent-per-side-cmd.sh
+bash tests/unit/test-lib-agent-per-side-cmd.sh
+```
+
+Expected: scaffold prints the title line and exits 0 (`PASS: 0 FAIL: 0`). Helpers `resolve_pair` / `launcher_guard` are defined but not exercised yet.
+
+- [ ] **Step 1.4: Add PSC-S1 + PSC-S2 + PSC-S3 (default + single-side override)**
+
+Append to `tests/unit/test-lib-agent-per-side-cmd.sh` *before* the final PASS/FAIL printout:
+
+```bash
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S1: default — neither override set → both equal AGENT_CMD ==="
+# ---------------------------------------------------------------------------
+out=$(resolve_pair "claude" "" "")
+assert_eq "default with AGENT_CMD=claude" "DEV=claude REVIEW=claude" "$out"
+
+out=$(resolve_pair "codex" "" "")
+assert_eq "default with AGENT_CMD=codex" "DEV=codex REVIEW=codex" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S2: only AGENT_REVIEW_CMD set → dev=AGENT_CMD, review=override ==="
+# ---------------------------------------------------------------------------
+out=$(resolve_pair "claude" "" "agy")
+assert_eq "AGENT_CMD=claude AGENT_REVIEW_CMD=agy" "DEV=claude REVIEW=agy" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S3: only AGENT_DEV_CMD set → dev=override, review=AGENT_CMD ==="
+# ---------------------------------------------------------------------------
+out=$(resolve_pair "claude" "codex" "")
+assert_eq "AGENT_CMD=claude AGENT_DEV_CMD=codex" "DEV=codex REVIEW=claude" "$out"
+```
+
+- [ ] **Step 1.5: Run — verify PSC-S1/S2/S3 FAIL (vars don't exist yet)**
+
+Run:
+```bash
+bash tests/unit/test-lib-agent-per-side-cmd.sh
+```
+
+Expected: 4 failures. The `printf` in `resolve_pair` prints `DEV= REVIEW=` because the vars are unset. (lib-agent doesn't error on the unset; it just doesn't define them.)
+
+- [ ] **Step 1.6: Add the per-side init lines to lib-agent.sh**
+
+In `skills/autonomous-dispatcher/scripts/lib-agent.sh`, find the existing line `AGENT_CMD="${AGENT_CMD:-claude}"` (line 60). Insert the following two lines immediately after it (preserving the existing `AGENT_DEV_MODEL` line below):
+
+```bash
+# Per-side AGENT_CMD overrides (INV-37). Default to AGENT_CMD so existing
+# deployments are unchanged. autonomous-dev.sh and autonomous-review.sh
+# each set AGENT_CMD="$AGENT_{DEV,REVIEW}_CMD" right after sourcing this
+# file, so the run_agent / resume_agent case statements dispatch to the
+# right CLI for each side. See docs/pipeline/per-side-agent-cmd.md.
+AGENT_DEV_CMD="${AGENT_DEV_CMD:-$AGENT_CMD}"
+AGENT_REVIEW_CMD="${AGENT_REVIEW_CMD:-$AGENT_CMD}"
+```
+
+After insertion the block reads:
+
+```bash
+AGENT_CMD="${AGENT_CMD:-claude}"
+# Per-side AGENT_CMD overrides (INV-37). ...
+AGENT_DEV_CMD="${AGENT_DEV_CMD:-$AGENT_CMD}"
+AGENT_REVIEW_CMD="${AGENT_REVIEW_CMD:-$AGENT_CMD}"
+AGENT_DEV_MODEL="${AGENT_DEV_MODEL:-}"
+...
+```
+
+- [ ] **Step 1.7: Run — verify PSC-S1/S2/S3 PASS**
+
+Run:
+```bash
+bash tests/unit/test-lib-agent-per-side-cmd.sh
+```
+
+Expected: `PASS: 4 FAIL: 0`.
+
+- [ ] **Step 1.8: Add PSC-S4 + PSC-S5 (both set + empty-string handling)**
+
+Append before the final PASS/FAIL printout:
+
+```bash
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S4: both set → each side runs its declared CLI ==="
+# ---------------------------------------------------------------------------
+out=$(resolve_pair "claude" "codex" "agy")
+assert_eq "AGENT_CMD=claude DEV=codex REVIEW=agy" "DEV=codex REVIEW=agy" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S5: explicit empty string falls back to AGENT_CMD ==="
+# ---------------------------------------------------------------------------
+out=$(resolve_pair "kiro" "" "")
+assert_eq "AGENT_DEV_CMD='' AGENT_REVIEW_CMD='' AGENT_CMD=kiro" "DEV=kiro REVIEW=kiro" "$out"
+```
+
+- [ ] **Step 1.9: Run — verify PSC-S4/S5 PASS**
+
+Run:
+```bash
+bash tests/unit/test-lib-agent-per-side-cmd.sh
+```
+
+Expected: `PASS: 6 FAIL: 0`.
+
+- [ ] **Step 1.10: Rewrite the AGENT_LAUNCHER guard**
+
+In `skills/autonomous-dispatcher/scripts/lib-agent.sh`, find the existing guard at lines 101-109:
+
+```bash
+# AGENT_LAUNCHER is only supported with AGENT_CMD=claude today. The
+# canonical launcher (a `cc` shell function ending in `$CLAUDE_CMD "$@"`)
+# is hardcoded to invoke claude, so pointing it at codex/kiro/opencode
+# would produce `claude codex ...` and fail. Refuse the combination
+# rather than crashing 5 seconds into the next dispatch.
+if [[ ${#AGENT_LAUNCHER_ARGV[@]} -gt 0 && "$AGENT_CMD" != "claude" ]]; then
+  echo "[lib-agent] ERROR: AGENT_LAUNCHER is only supported with AGENT_CMD=claude (got AGENT_CMD=${AGENT_CMD}). Either unset AGENT_LAUNCHER or write a launcher tailored to your CLI." >&2
+  return 1 2>/dev/null || exit 1
+fi
+```
+
+Replace with:
+
+```bash
+# AGENT_LAUNCHER is only supported when both per-side CLIs are claude
+# (INV-37). The canonical launcher (a `cc` shell function ending in
+# `$CLAUDE_CMD "$@"`) is hardcoded to invoke claude, so pointing it at
+# codex/kiro/opencode/agy would produce `claude codex ...` and fail.
+# Refuse the combination rather than crashing 5 seconds into the next
+# dispatch. The check reads AGENT_DEV_CMD / AGENT_REVIEW_CMD directly
+# (not via AGENT_CMD) because the wrapper-level override fires AFTER
+# this guard — see docs/pipeline/per-side-agent-cmd.md §Resolution order.
+if [[ ${#AGENT_LAUNCHER_ARGV[@]} -gt 0 ]]; then
+  if [[ "$AGENT_DEV_CMD" != "claude" || "$AGENT_REVIEW_CMD" != "claude" ]]; then
+    echo "[lib-agent] ERROR: AGENT_LAUNCHER is only supported when both AGENT_DEV_CMD and AGENT_REVIEW_CMD are claude (got AGENT_DEV_CMD=${AGENT_DEV_CMD}, AGENT_REVIEW_CMD=${AGENT_REVIEW_CMD}). Either unset AGENT_LAUNCHER or write a launcher tailored to your CLI." >&2
+    return 1 2>/dev/null || exit 1
+  fi
+fi
+```
+
+- [ ] **Step 1.11: Add PSC-S6 + PSC-S7 + PSC-S8 + PSC-S11 (launcher guard cases)**
+
+Append before the final PASS/FAIL printout:
+
+```bash
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S6: AGENT_LAUNCHER + both sides claude → source succeeds ==="
+# ---------------------------------------------------------------------------
+out=$(launcher_guard "claude" "claude")
+assert_contains "RC=0 (no guard rejection)" "RC=0" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S7: AGENT_LAUNCHER + dev=claude review=agy → guard fails ==="
+# ---------------------------------------------------------------------------
+out=$(launcher_guard "claude" "agy")
+assert_contains "guard error mentions AGENT_REVIEW_CMD=agy" "AGENT_REVIEW_CMD=agy" "$out"
+assert_contains "guard error names both vars" "AGENT_DEV_CMD" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S8: AGENT_LAUNCHER + dev=codex review=claude → guard fails ==="
+# ---------------------------------------------------------------------------
+out=$(launcher_guard "codex" "claude")
+assert_contains "guard error mentions AGENT_DEV_CMD=codex" "AGENT_DEV_CMD=codex" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S11: AGENT_LAUNCHER + both sides non-claude → guard fails ==="
+# ---------------------------------------------------------------------------
+out=$(launcher_guard "codex" "agy")
+assert_contains "guard error mentions both non-claude values" "AGENT_DEV_CMD=codex" "$out"
+assert_contains "guard error mentions review side too" "AGENT_REVIEW_CMD=agy" "$out"
+```
+
+- [ ] **Step 1.12: Run — verify all 11 assertions PASS**
+
+Run:
+```bash
+bash tests/unit/test-lib-agent-per-side-cmd.sh
+```
+
+Expected: `PASS: 11 FAIL: 0` (S1: 2 + S2: 1 + S3: 1 + S4: 1 + S5: 1 + S6: 1 + S7: 2 + S8: 1 + S11: 2 = 12; some overlap is fine — what matters is `FAIL: 0`).
+
+- [ ] **Step 1.13: Run shellcheck**
+
+Run:
+```bash
+shellcheck -S error skills/autonomous-dispatcher/scripts/lib-agent.sh tests/unit/test-lib-agent-per-side-cmd.sh
+```
+
+Expected: exit 0, clean.
+
+- [ ] **Step 1.14: Run lib-agent regression suite (no peer test should regress)**
+
+Run:
+```bash
+for t in tests/unit/test-lib-agent-*.sh; do
+  bash "$t" >/dev/null 2>&1 && echo "PASS: $(basename $t)" || echo "FAIL: $(basename $t)"
+done
+```
+
+Expected: every line `PASS:`. The new vars default to `$AGENT_CMD`, so claude/codex/gemini/kiro/opencode/agy tests must see byte-for-byte identical behavior.
+
+- [ ] **Step 1.15: Commit Task 1**
+
+Run:
+```bash
+git add skills/autonomous-dispatcher/scripts/lib-agent.sh tests/unit/test-lib-agent-per-side-cmd.sh
+git commit -m "feat(lib-agent): add AGENT_DEV_CMD / AGENT_REVIEW_CMD overrides (INV-37)
+
+Adds per-side AGENT_CMD overrides to lib-agent.sh. Default to AGENT_CMD
+so existing deployments are byte-for-byte unchanged.
+
+The AGENT_LAUNCHER guard is rewritten to read AGENT_DEV_CMD /
+AGENT_REVIEW_CMD directly. The new check is strictly more permissive
+than the old one — it rejects the same set of bad configs (any
+non-claude side with launcher set) plus correctly accepts the new
+'both sides claude' default case via the per-side path.
+
+Tests: PSC-S1..S8 + S11 (defaults, single-side override, both-side,
+empty-string fallback, launcher guard 4 ways). PSC-S9/S10 (wrapper
+structural placement) land in Tasks 2 and 3.
+
+Existing test-lib-agent-*.sh suites all pass — zero regressions."
+```
+
+---
+
+## Task 2: Add `AGENT_CMD="$AGENT_DEV_CMD"` override to `autonomous-dev.sh`
+
+**Files:**
+- Modify: `skills/autonomous-dispatcher/scripts/autonomous-dev.sh` (insert one line after line 22, immediately after `source "${SCRIPT_DIR}/lib-agent.sh"`)
+- Test: `tests/unit/test-lib-agent-per-side-cmd.sh` (append PSC-S9)
+
+- [ ] **Step 2.1: Add PSC-S9 test (structural)**
+
+Append to `tests/unit/test-lib-agent-per-side-cmd.sh` before the final PASS/FAIL printout:
+
+```bash
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S9: autonomous-dev.sh structural placement ==="
+# ---------------------------------------------------------------------------
+# Match: source "${SCRIPT_DIR}/lib-agent.sh" followed (with at most ONE
+# blank line) by AGENT_CMD="$AGENT_DEV_CMD".
+# Use awk so we don't depend on `grep -A` quirks across platforms.
+hit=$(awk '
+  /source "\$\{SCRIPT_DIR\}\/lib-agent\.sh"/ {
+    found_source = NR
+    next
+  }
+  found_source && NR <= found_source + 2 {
+    if ($0 ~ /^AGENT_CMD="\$AGENT_DEV_CMD"/) {
+      print "MATCH"
+      exit
+    }
+  }
+' "$DEV_WRAPPER")
+
+assert_eq "autonomous-dev.sh: AGENT_CMD=\$AGENT_DEV_CMD lands ≤2 lines after source lib-agent.sh" \
+  "MATCH" "$hit"
+```
+
+- [ ] **Step 2.2: Run — verify PSC-S9 FAILS (override line not present yet)**
+
+Run:
+```bash
+bash tests/unit/test-lib-agent-per-side-cmd.sh
+```
+
+Expected: 1 new failure (PSC-S9). Other assertions remain green.
+
+- [ ] **Step 2.3: Read current `autonomous-dev.sh` lines 21-25**
+
+Run:
+```bash
+sed -n '21,25p' skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+```
+
+Expected:
+```
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+source "${SCRIPT_DIR}/lib-agent.sh"
+source "${SCRIPT_DIR}/lib-auth.sh"
+
+# Validate required config (loaded by lib-agent.sh from autonomous.conf)
+```
+
+- [ ] **Step 2.4: Insert the override line**
+
+Use the Edit tool to change:
+
+```
+source "${SCRIPT_DIR}/lib-agent.sh"
+source "${SCRIPT_DIR}/lib-auth.sh"
+```
+
+to:
+
+```
+source "${SCRIPT_DIR}/lib-agent.sh"
+# Per-side AGENT_CMD override (INV-37). Empty-string fallback already
+# applied inside lib-agent.sh; this just rebinds AGENT_CMD so the case
+# statements in run_agent / resume_agent dispatch to the dev-side CLI.
+AGENT_CMD="$AGENT_DEV_CMD"
+source "${SCRIPT_DIR}/lib-auth.sh"
+```
+
+- [ ] **Step 2.5: Run — verify PSC-S9 PASSES**
+
+Run:
+```bash
+bash tests/unit/test-lib-agent-per-side-cmd.sh
+```
+
+Expected: `FAIL: 0`.
+
+- [ ] **Step 2.6: shellcheck**
+
+Run:
+```bash
+shellcheck -S error skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2.7: Commit Task 2**
+
+Run:
+```bash
+git add skills/autonomous-dispatcher/scripts/autonomous-dev.sh tests/unit/test-lib-agent-per-side-cmd.sh
+git commit -m "feat(autonomous-dev): apply AGENT_DEV_CMD override after lib-agent source
+
+Adds AGENT_CMD=\$AGENT_DEV_CMD immediately after source lib-agent.sh so
+the case statements in run_agent / resume_agent dispatch to the
+dev-side CLI when the operator has set per-side overrides. Default
+behavior (no overrides) is unchanged because AGENT_DEV_CMD defaults
+to \$AGENT_CMD inside lib-agent.sh.
+
+Test: PSC-S9 asserts the line lands within 2 lines of the source
+statement so a future refactor can't accidentally move it past code
+that consumes \$AGENT_CMD (earliest consumer is line 177)."
+```
+
+---
+
+## Task 3: Add `AGENT_CMD="$AGENT_REVIEW_CMD"` override to `autonomous-review.sh`
+
+**Files:**
+- Modify: `skills/autonomous-dispatcher/scripts/autonomous-review.sh` (insert one line after line 22)
+- Test: `tests/unit/test-lib-agent-per-side-cmd.sh` (append PSC-S10)
+
+- [ ] **Step 3.1: Add PSC-S10 test (structural)**
+
+Append before the final PASS/FAIL printout:
+
+```bash
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S10: autonomous-review.sh structural placement ==="
+# ---------------------------------------------------------------------------
+hit=$(awk '
+  /source "\$\{SCRIPT_DIR\}\/lib-agent\.sh"/ {
+    found_source = NR
+    next
+  }
+  found_source && NR <= found_source + 2 {
+    if ($0 ~ /^AGENT_CMD="\$AGENT_REVIEW_CMD"/) {
+      print "MATCH"
+      exit
+    }
+  }
+' "$REVIEW_WRAPPER")
+
+assert_eq "autonomous-review.sh: AGENT_CMD=\$AGENT_REVIEW_CMD lands ≤2 lines after source lib-agent.sh" \
+  "MATCH" "$hit"
+```
+
+- [ ] **Step 3.2: Run — verify PSC-S10 FAILS**
+
+Run:
+```bash
+bash tests/unit/test-lib-agent-per-side-cmd.sh
+```
+
+Expected: 1 new failure (PSC-S10).
+
+- [ ] **Step 3.3: Read current `autonomous-review.sh` lines 21-30**
+
+Run:
+```bash
+sed -n '21,30p' skills/autonomous-dispatcher/scripts/autonomous-review.sh
+```
+
+Expected:
+```
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+source "${SCRIPT_DIR}/lib-agent.sh"
+source "${SCRIPT_DIR}/lib-auth.sh"
+# shellcheck source=lib-review-bots.sh
+source "${SCRIPT_DIR}/lib-review-bots.sh"
+# shellcheck source=lib-review-verdict.sh
+source "${SCRIPT_DIR}/lib-review-verdict.sh"
+
+# Validate required config (loaded by lib-agent.sh from autonomous.conf)
+```
+
+- [ ] **Step 3.4: Insert the override line**
+
+Use the Edit tool to change:
+
+```
+source "${SCRIPT_DIR}/lib-agent.sh"
+source "${SCRIPT_DIR}/lib-auth.sh"
+```
+
+to:
+
+```
+source "${SCRIPT_DIR}/lib-agent.sh"
+# Per-side AGENT_CMD override (INV-37). See autonomous-dev.sh for the
+# matching dev-side override. Together they let one project run dev
+# and review on different agent CLIs (e.g. claude for dev, agy for
+# review). Default (no operator override) is byte-for-byte unchanged.
+AGENT_CMD="$AGENT_REVIEW_CMD"
+source "${SCRIPT_DIR}/lib-auth.sh"
+```
+
+- [ ] **Step 3.5: Run — verify PSC-S10 PASSES + everything else still green**
+
+Run:
+```bash
+bash tests/unit/test-lib-agent-per-side-cmd.sh
+```
+
+Expected: `FAIL: 0`.
+
+- [ ] **Step 3.6: shellcheck**
+
+Run:
+```bash
+shellcheck -S error skills/autonomous-dispatcher/scripts/autonomous-review.sh
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3.7: Commit Task 3**
+
+Run:
+```bash
+git add skills/autonomous-dispatcher/scripts/autonomous-review.sh tests/unit/test-lib-agent-per-side-cmd.sh
+git commit -m "feat(autonomous-review): apply AGENT_REVIEW_CMD override after lib-agent source
+
+Mirrors the dev-side change. AGENT_CMD=\$AGENT_REVIEW_CMD lands
+immediately after source lib-agent.sh so the run_agent dispatch and
+the 'Reviewed HEAD: ... agent X' trailer (line ~636) report the
+review-side CLI correctly.
+
+Test: PSC-S10 asserts placement structurally."
+```
+
+---
+
+## Task 4: Document `AGENT_DEV_CMD` / `AGENT_REVIEW_CMD` in `autonomous.conf.example`
+
+**Files:**
+- Modify: `skills/autonomous-dispatcher/scripts/autonomous.conf.example` (insert ~15 lines after the `AGENT_PERMISSION_MODE="auto"` line at ~line 150, before the per-CLI blocks)
+
+- [ ] **Step 4.1: Locate the insertion point**
+
+Run:
+```bash
+grep -nE '^AGENT_PERMISSION_MODE=|^# --- claude block' skills/autonomous-dispatcher/scripts/autonomous.conf.example
+```
+
+Expected:
+```
+150:AGENT_PERMISSION_MODE="auto"
+217:# --- claude block ---
+```
+
+The new comment block goes between these two markers. The existing content at lines 151-216 includes `AGENT_TIMEOUT`, `AGENT_LAUNCHER` docs, and `AGENT_DEV_EXTRA_ARGS` / `AGENT_REVIEW_EXTRA_ARGS`. The new block belongs **after** the EXTRA_ARGS lines and **before** the `# --- claude block ---`.
+
+- [ ] **Step 4.2: Find the exact insertion anchor**
+
+Run:
+```bash
+grep -nE '^AGENT_REVIEW_EXTRA_ARGS=|^# --- claude block' skills/autonomous-dispatcher/scripts/autonomous.conf.example
+```
+
+Expected:
+```
+215:AGENT_REVIEW_EXTRA_ARGS=""
+217:# --- claude block ---
+```
+
+The new block goes on line 216 (the blank line currently between them).
+
+- [ ] **Step 4.3: Insert the operator-facing comment block**
+
+Use the Edit tool. Change:
+
+```
+AGENT_DEV_EXTRA_ARGS=""
+AGENT_REVIEW_EXTRA_ARGS=""
+
+# --- claude block ---
+```
+
+to:
+
+```
+AGENT_DEV_EXTRA_ARGS=""
+AGENT_REVIEW_EXTRA_ARGS=""
+
+# AGENT_DEV_CMD / AGENT_REVIEW_CMD: per-side override of AGENT_CMD.
+# Default to AGENT_CMD when unset/empty, so existing single-CLI
+# deployments are unaffected. Set them when you want dev and review
+# to run on different CLIs — for example, claude for the heavy dev
+# work and agy for the cheaper review pass:
+#
+#   AGENT_CMD="claude"           # also used by anything not split
+#   AGENT_REVIEW_CMD="agy"       # only review goes to agy
+#   AGENT_DEV_MODEL="opus[1m]"
+#   AGENT_REVIEW_MODEL=""        # ignored by agy (warns), see agy block
+#
+# AGENT_LAUNCHER (claude-only) is rejected when either side resolves
+# to a non-claude CLI. Either unset the launcher or keep both sides
+# on claude. See [INV-37] in docs/pipeline/invariants.md.
+# AGENT_DEV_CMD=""
+# AGENT_REVIEW_CMD=""
+
+# --- claude block ---
+```
+
+- [ ] **Step 4.4: Verify the conf still parses as bash**
+
+Run:
+```bash
+bash -n skills/autonomous-dispatcher/scripts/autonomous.conf.example
+```
+
+Expected: exit 0 (no output).
+
+- [ ] **Step 4.5: Commit Task 4**
+
+Run:
+```bash
+git add skills/autonomous-dispatcher/scripts/autonomous.conf.example
+git commit -m "docs(conf): document AGENT_DEV_CMD / AGENT_REVIEW_CMD in autonomous.conf.example
+
+Adds a 15-line operator-facing comment block between the EXTRA_ARGS
+declarations and the per-CLI blocks. Includes a worked example for
+the 'claude for dev, agy for review' deployment pattern (the
+motivating use case) and the AGENT_LAUNCHER constraint reminder."
+```
+
+---
+
+## Task 5: Add INV-37 to `docs/pipeline/invariants.md`
+
+**Files:**
+- Modify: `docs/pipeline/invariants.md` (append before the `## Adding a new invariant` section at line 981)
+
+- [ ] **Step 5.1: Locate the insertion point**
+
+Run:
+```bash
+grep -n "^## Adding a new invariant" docs/pipeline/invariants.md
+```
+
+Expected: a single line number (currently 981, may shift slightly).
+
+- [ ] **Step 5.2: Insert the INV-37 block**
+
+Use the Edit tool. Find the lines:
+
+```
+- [INV-34](#inv-34-agent-prompt-is-fed-via-stdin-never-as-a-single-argv-element) — agy's `-p` (no value) reads from stdin, same channel contract as claude/gemini.
+
+## Adding a new invariant
+```
+
+Replace with:
+
+```
+- [INV-34](#inv-34-agent-prompt-is-fed-via-stdin-never-as-a-single-argv-element) — agy's `-p` (no value) reads from stdin, same channel contract as claude/gemini.
+
+## INV-37: per-side AGENT_CMD precedence
+
+**Rule**: `lib-agent.sh` exposes `AGENT_DEV_CMD` and `AGENT_REVIEW_CMD` as side-specific overrides of `AGENT_CMD`. Both default to `${AGENT_CMD:-claude}` so existing deployments are byte-for-byte unchanged. `autonomous-dev.sh` sets `AGENT_CMD="$AGENT_DEV_CMD"` exactly once, immediately after sourcing `lib-agent.sh` and before any other `source`. `autonomous-review.sh` sets `AGENT_CMD="$AGENT_REVIEW_CMD"` in the same position. After the override, the `case "$AGENT_CMD"` statements in `run_agent` / `resume_agent` dispatch to the right CLI per-side without any signature change.
+
+**Why**: lets one project run dev and review on different CLIs (typical pattern: claude for dev, agy or another cheaper / specialized CLI for review). Without this, `AGENT_CMD` is a single value shared by both wrappers and operators must choose one CLI for the whole project. The model knobs (`AGENT_DEV_MODEL` / `AGENT_REVIEW_MODEL`) and per-side flags (`AGENT_DEV_EXTRA_ARGS` / `AGENT_REVIEW_EXTRA_ARGS`) already split — INV-37 closes the conspicuous gap on the CLI knob.
+
+**Constraint**: `AGENT_LAUNCHER` (claude-only at this writing) is rejected at `lib-agent.sh` source time when **either** `AGENT_DEV_CMD` or `AGENT_REVIEW_CMD` resolves to a non-claude CLI. The launcher would otherwise be applied to a CLI it wasn't written for. The guard reads `AGENT_DEV_CMD` and `AGENT_REVIEW_CMD` directly (not `$AGENT_CMD`) so it fires correctly regardless of which wrapper does the subsequent override.
+
+**Producer**: `lib-agent.sh` init block (the two `${VAR:-$AGENT_CMD}` assignments after `AGENT_CMD="${AGENT_CMD:-claude}"`).
+
+**Consumer**: `autonomous-dev.sh` and `autonomous-review.sh` entry blocks set the active `AGENT_CMD` before any `run_agent` / `resume_agent` call.
+
+**Test**: `tests/unit/test-lib-agent-per-side-cmd.sh` PSC-S1 (defaults), PSC-S2/S3 (single-side override), PSC-S4 (both set), PSC-S5 (empty-string fallback), PSC-S6 (launcher + both claude → pass), PSC-S7/S8/S11 (launcher + any non-claude side → fail with both var values in the error), PSC-S9/S10 (wrapper structural placement).
+
+**Cross-references**:
+- [`docs/pipeline/per-side-agent-cmd.md`](per-side-agent-cmd.md) — full spec.
+- [INV-31](#inv-31-operator-tunable-per-cli-flags-live-in-conf-not-in-lib-agentsh) — the new vars are operator-tunable and live in `autonomous.conf`, following INV-31's contract.
+- [`docs/pipeline/agy-cli-support.md`](agy-cli-support.md) — agy is the most likely review-side CLI today and the motivating example.
+
+## Adding a new invariant
+```
+
+- [ ] **Step 5.3: Verify the link from per-side-agent-cmd.md resolves**
+
+Run:
+```bash
+grep -n "inv-37-per-side-agent_cmd-precedence" docs/pipeline/invariants.md
+```
+
+Expected: returns the auto-generated GFM anchor for the new heading. If it returns 0 hits, the heading text and the anchor in the spec don't match — fix the spec or the heading.
+
+- [ ] **Step 5.4: Commit Task 5**
+
+Run:
+```bash
+git add docs/pipeline/invariants.md
+git commit -m "docs(pipeline): record INV-37 per-side AGENT_CMD precedence
+
+INV-37 documents the AGENT_DEV_CMD / AGENT_REVIEW_CMD precedence rule
+that lets one project run dev and review on different agent CLIs.
+Defaults preserve back-compat. AGENT_LAUNCHER guard tightens to require
+both sides claude.
+
+Anchored to docs/pipeline/per-side-agent-cmd.md (which already exists
+on this branch with cross-reference [INV-37] resolved by this commit)."
+```
+
+---
+
+## Task 6: Final regression + push + open PR
+
+- [ ] **Step 6.1: Run the full unit-test suite**
+
+Run:
+```bash
+failed=0
+for t in tests/unit/test-*.sh; do
+  if ! bash "$t" >/dev/null 2>&1; then
+    echo "FAILED: $t"
+    failed=1
+  fi
+done
+[[ $failed -eq 0 ]] && echo "ALL UNIT TESTS PASS" || echo "REGRESSIONS PRESENT"
+```
+
+Expected: `ALL UNIT TESTS PASS`. The new vars default to `$AGENT_CMD` so every existing test sees identical behavior.
+
+- [ ] **Step 6.2: shellcheck the modified scripts**
+
+Run:
+```bash
+shellcheck -S error \
+  skills/autonomous-dispatcher/scripts/lib-agent.sh \
+  skills/autonomous-dispatcher/scripts/autonomous-dev.sh \
+  skills/autonomous-dispatcher/scripts/autonomous-review.sh \
+  tests/unit/test-lib-agent-per-side-cmd.sh
+```
+
+Expected: exit 0.
+
+- [ ] **Step 6.3: Mark pr-review state per the project hook**
+
+The project's `check-pr-review.sh` hook blocks `git push` until `pr-review` state is marked for the current HEAD. After running `/pr-review-toolkit:review-pr` and addressing any Critical/High findings, mark:
+
+```bash
+hooks/state-manager.sh mark pr-review
+```
+
+(If you commit again after marking, re-run the review and re-mark. The mark is bound to the HEAD SHA.)
+
+- [ ] **Step 6.4: Rebase onto main and push**
+
+Run:
+```bash
+git fetch origin main
+git rebase origin/main
+git push origin "HEAD:refs/heads/feat/per-side-agent-cmd" -u
+```
+
+Expected: push succeeds. The `block-push-to-main` hook only blocks pushes targeting `main` itself; pushing a feature branch is fine.
+
+- [ ] **Step 6.5: Open a PR**
+
+Run:
+```bash
+gh pr create --title "feat: add AGENT_DEV_CMD / AGENT_REVIEW_CMD per-side overrides (INV-37)" --head feat/per-side-agent-cmd --body "$(cat <<'EOF'
+## Summary
+
+Adds two operator knobs in `lib-agent.sh` that let dev and review wrappers run on different agent CLIs in the same project:
+
+- `AGENT_DEV_CMD` — defaults to `${AGENT_CMD:-claude}`
+- `AGENT_REVIEW_CMD` — defaults to `${AGENT_CMD:-claude}`
+
+Each wrapper sets `AGENT_CMD` to its side's value immediately after sourcing `lib-agent.sh`. The `AGENT_LAUNCHER` guard generalizes to reject any non-claude side (strictly more permissive than the old single-side check — never rejects a config that previously passed).
+
+The motivating use case: `podcast-curation` wants `AGENT_CMD="claude"` for heavy dev and `AGENT_REVIEW_CMD="agy"` for cheaper review.
+
+## What's in the PR
+
+- `skills/autonomous-dispatcher/scripts/lib-agent.sh` — 2-line init + guard rewrite
+- `skills/autonomous-dispatcher/scripts/autonomous-dev.sh` — 1-line override after `source lib-agent.sh`
+- `skills/autonomous-dispatcher/scripts/autonomous-review.sh` — 1-line override (symmetric)
+- `skills/autonomous-dispatcher/scripts/autonomous.conf.example` — operator-facing comment block with worked example
+- `tests/unit/test-lib-agent-per-side-cmd.sh` — 11 test cases (PSC-S1..S11): defaults, single-side override, both-side, empty-string, launcher guard ×4, wrapper structural placement
+- `docs/pipeline/per-side-agent-cmd.md` — spec
+- `docs/pipeline/invariants.md` — INV-37
+- `docs/pipeline/README.md` — index entry
+
+## Backwards compatibility
+
+Existing deployments don't set the new vars. Defaults make both equal to `$AGENT_CMD`, so behavior is byte-for-byte identical pre/post.
+
+## Spec & invariant
+
+- [`docs/pipeline/per-side-agent-cmd.md`](https://github.com/zxkane/autonomous-dev-team/blob/feat/per-side-agent-cmd/docs/pipeline/per-side-agent-cmd.md)
+- INV-37: per-side AGENT_CMD precedence
+
+## Pipeline-docs gate
+
+Touches `lib-agent.sh` (watched path), so `docs/pipeline/` must also change. Satisfied:
+- [x] `docs/pipeline/per-side-agent-cmd.md` (already on branch from prior commit)
+- [x] `docs/pipeline/invariants.md` (INV-37)
+- [x] `docs/pipeline/README.md` (already on branch from prior commit)
+
+## Test plan
+
+- [x] `bash tests/unit/test-lib-agent-per-side-cmd.sh` — 11/11 PASS
+- [x] All existing `tests/unit/test-lib-agent-*.sh` regression tests PASS (defaults preserve byte-identical behavior)
+- [x] shellcheck `-S error` clean on lib-agent.sh + both wrappers + new test
+- [x] `bash -n autonomous.conf.example` syntax OK
+- [ ] CI: `unit-tests` + `shellcheck` + `pipeline-docs-gate` green
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-Review (run after all tasks complete)
+
+**Spec coverage:**
+
+| Spec section | Implemented in |
+|---|---|
+| §Why | (motivation; no code) |
+| §Resolution order — `${VAR:-$AGENT_CMD}` defaults | Task 1 (lib-agent init) |
+| §Resolution order — wrapper-level override | Tasks 2+3 |
+| §Resolution order — guard-timing clarification | (doc-only; spec already updated) |
+| §Backwards compatibility | Task 1 (defaults), Task 1.14 (regression run) |
+| §AGENT_LAUNCHER interaction — generalized guard | Task 1.10 (guard rewrite) |
+| §What is NOT covered | (deferrals; no code) |
+| §Operator-facing config | Task 4 |
+| §Failure modes table | Tested in Task 1 (PSC-S1..S8 + S11) and Tasks 2+3 (PSC-S9/S10) |
+| §Test coverage table — PSC-S1..S11 | Tasks 1+2+3 |
+| §Implementation order — 6 steps | Tasks 1-5 (Task 6 is push/PR) |
+
+**Placeholder scan:** No "TBD"/"TODO"/"similar to"/etc. Every code block is complete.
+
+**Type / signature consistency:**
+- `AGENT_DEV_CMD` / `AGENT_REVIEW_CMD` referenced consistently across Tasks 1-5 (lib-agent init, wrapper overrides, conf example, INV-37)
+- `${VAR:-$AGENT_CMD}` form consistent across the two new vars
+- Guard error message format pinned (mentions both `AGENT_DEV_CMD=...` and `AGENT_REVIEW_CMD=...`)
+- Tests reference the same var names as the implementation
+
+**Missing requirements:** None. PSC-S1..S11 all map to spec test rows. INV-37 cross-references match the spec's cross-references.
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-25-per-side-agent-cmd.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/test-cases/dispatcher-per-side-cmd-coupling.md
+++ b/docs/test-cases/dispatcher-per-side-cmd-coupling.md
@@ -1,0 +1,97 @@
+# Test Cases: Dispatcher-Side `$AGENT_CMD` Coupling Under Per-Side Overrides
+
+Tracks fixes for Findings 2 + 3 from the agy CLI review of PR #156
+(https://github.com/zxkane/autonomous-dev-team/pull/156#issuecomment-4535743633).
+
+After PR #156 introduced `AGENT_DEV_CMD` / `AGENT_REVIEW_CMD` per-side
+overrides, two `lib-dispatch.sh` helpers still read the shared
+`$AGENT_CMD` directly. Under split-CLI deployments the dispatcher's
+`$AGENT_CMD` is the project default (e.g. `claude`), but each wrapper
+runs with its side's override (e.g. review wrapper runs `agy`). The
+shared-var read produces the wrong answer.
+
+| Helper | Read site | Failure mode |
+|---|---|---|
+| `_pgid_has_agent_process` | `lib-dispatch.sh:1276` | False-negative liveness on review side under `AGENT_REVIEW_CMD=agy`. Dispatcher classifies live wrapper as DEAD. |
+| `is_session_completed` | `lib-dispatch.sh:530` | claude-only JSON parser runs against codex log when `AGENT_DEV_CMD=codex AGENT_CMD=claude`. Misinterpretation of completion state. |
+
+## Fixes
+
+1. `_pgid_has_agent_process` accepts an optional second argument: the
+   per-side CLI to match. Falls back to `$AGENT_CMD` when omitted
+   (back-compat).
+2. Callers pass the right per-side var:
+   - `dev_near_success` → `${AGENT_DEV_CMD:-${AGENT_CMD:-claude}}`
+   - `review_near_success` → `${AGENT_REVIEW_CMD:-${AGENT_CMD:-claude}}`
+3. `is_session_completed` gates on `${AGENT_DEV_CMD:-${AGENT_CMD:-claude}}`
+   (function is dev-side-only — parses dev wrapper's log).
+
+## Test Cases
+
+### TC-PSC-COUP-01: `_pgid_has_agent_process` accepts per-side CLI argument
+
+**File**: `tests/unit/test-pgid-has-agent-process.sh` (new)
+
+**Setup**: spawn a controlled child process with a known `comm`
+(e.g. `bash -c 'exec -a fake-agy sleep 30 &'`), capture its PGID.
+
+**Assertions**:
+- `_pgid_has_agent_process <pgid>` (no second arg) → matches against
+  `$AGENT_CMD` for back-compat.
+- `_pgid_has_agent_process <pgid> "agy"` → matches the spawned `fake-agy` process.
+- `_pgid_has_agent_process <pgid> "claude"` → doesn't match, returns 1.
+- `_pgid_has_agent_process <pgid> ""` (empty string) → falls back to `$AGENT_CMD`.
+
+**Why**: pins the new signature so a future refactor cannot silently
+drop the per-side argument.
+
+### TC-PSC-COUP-02: `dev_near_success` passes dev-side CLI
+
+**File**: `tests/unit/test-dev-near-success.sh` (extend)
+
+**Setup**: under split config (`AGENT_CMD=claude AGENT_DEV_CMD=codex`),
+mock `_pgid_has_agent_process` and assert it receives `"codex"` as 2nd arg.
+
+**Assertions**:
+- Mock records 2nd argument; assert it equals `"codex"`.
+- Default config (no override): mock receives `""` or `"claude"` (caller's choice).
+
+### TC-PSC-COUP-03: `review_near_success` passes review-side CLI
+
+**File**: `tests/unit/test-dispatcher-review-near-success.sh` (extend)
+
+Mirror of TC-PSC-COUP-02 but for review wrapper:
+- Under `AGENT_CMD=claude AGENT_REVIEW_CMD=agy`, mock receives `"agy"`.
+
+### TC-PSC-COUP-04: `is_session_completed` gates on dev-side CLI
+
+**File**: `tests/unit/test-is-session-completed.sh` (extend TC-WH-005 area)
+
+**Assertions**:
+- `AGENT_CMD=claude AGENT_DEV_CMD=codex` → `is_session_completed` returns 1
+  (gate sees codex on dev side, refuses to parse).
+- `AGENT_CMD=codex AGENT_DEV_CMD=claude` → returns 1 if log absent OR
+  parses claude format if log valid (gate sees claude on dev side, proceeds).
+- `AGENT_CMD=claude` (no AGENT_DEV_CMD) → fallback to current shared
+  behavior, gate sees claude.
+
+### TC-PSC-COUP-05: regression — default config preserves byte-for-byte behavior
+
+**File**: existing `test-dev-near-success.sh`, `test-dispatcher-review-near-success.sh`,
+`test-is-session-completed.sh` all still pass with default config (no per-side
+overrides set). Validates back-compat.
+
+## Acceptance Criteria
+
+- [ ] All 5 test cases pass
+- [ ] All existing peer test files (`test-dev-near-success.sh`,
+  `test-dispatcher-review-near-success.sh`, `test-is-session-completed.sh`,
+  `test-is-session-completed-end-ts.sh`) still pass
+- [ ] `shellcheck -S error skills/autonomous-dispatcher/scripts/lib-dispatch.sh` clean
+- [ ] Pipeline-docs gate satisfied (lib-dispatch.sh touched → docs/pipeline/ updated)
+
+## Spec/Doc Updates
+
+- [ ] `docs/pipeline/per-side-agent-cmd.md`: add §Dispatcher-side coupling section
+- [ ] `docs/pipeline/invariants.md` INV-37: extend the Producer/Consumer fields
+  to include the dispatcher-side reads

--- a/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
@@ -20,6 +20,8 @@ set -euo pipefail
 # autonomous.conf via tier-2 (same dir).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 source "${SCRIPT_DIR}/lib-agent.sh"
+# Per-side AGENT_CMD override (INV-37): rebind to dev-side CLI before lib-auth.sh.
+AGENT_CMD="$AGENT_DEV_CMD"
 source "${SCRIPT_DIR}/lib-auth.sh"
 
 # Validate required config (loaded by lib-agent.sh from autonomous.conf)

--- a/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
@@ -20,7 +20,9 @@ set -euo pipefail
 # autonomous.conf via tier-2 (same dir).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 source "${SCRIPT_DIR}/lib-agent.sh"
-# Per-side AGENT_CMD override (INV-37): rebind to dev-side CLI before lib-auth.sh.
+# Per-side AGENT_CMD override (INV-37). Empty-string fallback already
+# applied inside lib-agent.sh; this just rebinds AGENT_CMD so the case
+# statements in run_agent / resume_agent dispatch to the dev-side CLI.
 AGENT_CMD="$AGENT_DEV_CMD"
 source "${SCRIPT_DIR}/lib-auth.sh"
 

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -20,6 +20,11 @@ set -euo pipefail
 # autonomous.conf via tier-2 (same dir).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 source "${SCRIPT_DIR}/lib-agent.sh"
+# Per-side AGENT_CMD override (INV-37). See autonomous-dev.sh for the
+# matching dev-side override. Together they let one project run dev
+# and review on different agent CLIs (e.g. claude for dev, agy for
+# review). Default (no operator override) is byte-for-byte unchanged.
+AGENT_CMD="$AGENT_REVIEW_CMD"
 source "${SCRIPT_DIR}/lib-auth.sh"
 # shellcheck source=lib-review-bots.sh
 source "${SCRIPT_DIR}/lib-review-bots.sh"

--- a/skills/autonomous-dispatcher/scripts/autonomous.conf.example
+++ b/skills/autonomous-dispatcher/scripts/autonomous.conf.example
@@ -214,6 +214,23 @@ AGENT_TIMEOUT="4h"
 AGENT_DEV_EXTRA_ARGS=""
 AGENT_REVIEW_EXTRA_ARGS=""
 
+# AGENT_DEV_CMD / AGENT_REVIEW_CMD: per-side override of AGENT_CMD.
+# Default to AGENT_CMD when unset/empty, so existing single-CLI
+# deployments are unaffected. Set them when you want dev and review
+# to run on different CLIs — for example, claude for the heavy dev
+# work and agy for the cheaper review pass:
+#
+#   AGENT_CMD="claude"           # also used by anything not split
+#   AGENT_REVIEW_CMD="agy"       # only review goes to agy
+#   AGENT_DEV_MODEL="opus[1m]"
+#   AGENT_REVIEW_MODEL=""        # ignored by agy (warns), see agy block
+#
+# AGENT_LAUNCHER (claude-only) is rejected when either side resolves
+# to a non-claude CLI. Either unset the launcher or keep both sides
+# on claude. See [INV-37] in docs/pipeline/invariants.md.
+# AGENT_DEV_CMD=""
+# AGENT_REVIEW_CMD=""
+
 # --- claude block ---
 # claude has NO required EXTRA_ARGS — the structural --permission-mode
 # flag handles tool trust via the existing AGENT_PERMISSION_MODE knob.

--- a/skills/autonomous-dispatcher/scripts/lib-agent.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-agent.sh
@@ -58,6 +58,13 @@ PROJECT_DIR="${PROJECT_DIR:-$(cd "${_LIB_AGENT_DIR}/../../.." && pwd)}"
 
 # Agent configuration (overridable via env or autonomous.conf)
 AGENT_CMD="${AGENT_CMD:-claude}"
+# Per-side AGENT_CMD overrides (INV-37). Default to AGENT_CMD so existing
+# deployments are unchanged. autonomous-dev.sh and autonomous-review.sh
+# each set AGENT_CMD="$AGENT_{DEV,REVIEW}_CMD" right after sourcing this
+# file, so the run_agent / resume_agent case statements dispatch to the
+# right CLI for each side. See docs/pipeline/per-side-agent-cmd.md.
+AGENT_DEV_CMD="${AGENT_DEV_CMD:-$AGENT_CMD}"
+AGENT_REVIEW_CMD="${AGENT_REVIEW_CMD:-$AGENT_CMD}"
 AGENT_DEV_MODEL="${AGENT_DEV_MODEL:-}"
 AGENT_REVIEW_MODEL="${AGENT_REVIEW_MODEL:-sonnet}"
 AGENT_PERMISSION_MODE="${AGENT_PERMISSION_MODE:-auto}"
@@ -98,14 +105,19 @@ if [[ -n "$AGENT_LAUNCHER" ]]; then
   unset _orig_launcher
 fi
 
-# AGENT_LAUNCHER is only supported with AGENT_CMD=claude today. The
-# canonical launcher (a `cc` shell function ending in `$CLAUDE_CMD "$@"`)
-# is hardcoded to invoke claude, so pointing it at codex/kiro/opencode
-# would produce `claude codex ...` and fail. Refuse the combination
-# rather than crashing 5 seconds into the next dispatch.
-if [[ ${#AGENT_LAUNCHER_ARGV[@]} -gt 0 && "$AGENT_CMD" != "claude" ]]; then
-  echo "[lib-agent] ERROR: AGENT_LAUNCHER is only supported with AGENT_CMD=claude (got AGENT_CMD=${AGENT_CMD}). Either unset AGENT_LAUNCHER or write a launcher tailored to your CLI." >&2
-  return 1 2>/dev/null || exit 1
+# AGENT_LAUNCHER is only supported when both per-side CLIs are claude
+# (INV-37). The canonical launcher (a `cc` shell function ending in
+# `$CLAUDE_CMD "$@"`) is hardcoded to invoke claude, so pointing it at
+# codex/kiro/opencode/agy would produce `claude codex ...` and fail.
+# Refuse the combination rather than crashing 5 seconds into the next
+# dispatch. The check reads AGENT_DEV_CMD / AGENT_REVIEW_CMD directly
+# (not via AGENT_CMD) because the wrapper-level override fires AFTER
+# this guard — see docs/pipeline/per-side-agent-cmd.md §Resolution order.
+if [[ ${#AGENT_LAUNCHER_ARGV[@]} -gt 0 ]]; then
+  if [[ "$AGENT_DEV_CMD" != "claude" || "$AGENT_REVIEW_CMD" != "claude" ]]; then
+    echo "[lib-agent] ERROR: AGENT_LAUNCHER is only supported when both AGENT_DEV_CMD and AGENT_REVIEW_CMD are claude (got AGENT_DEV_CMD=${AGENT_DEV_CMD}, AGENT_REVIEW_CMD=${AGENT_REVIEW_CMD}). Either unset AGENT_LAUNCHER or write a launcher tailored to your CLI." >&2
+    return 1 2>/dev/null || exit 1
+  fi
 fi
 
 # AGENT_DEV_EXTRA_ARGS / AGENT_REVIEW_EXTRA_ARGS (closes #140) — operator-

--- a/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
@@ -527,7 +527,12 @@ is_session_completed() {
   local issue_num="$1"
   local reason_var="${2:-}"
   local end_ts_var="${3:-}"
-  [ "${AGENT_CMD:-claude}" = "claude" ] || return 1
+  # Gate on dev-side CLI per [INV-37] — this function parses the dev
+  # wrapper's log, so the dispatcher-side $AGENT_CMD (project default)
+  # is the wrong value to check under split-CLI deployments
+  # (e.g. AGENT_CMD=claude AGENT_DEV_CMD=codex).
+  local _dev_cmd="${AGENT_DEV_CMD:-${AGENT_CMD:-claude}}"
+  [ "$_dev_cmd" = "claude" ] || return 1
 
   local log_file="/tmp/agent-${PROJECT_ID}-issue-${issue_num}.log"
   [ -r "$log_file" ] || return 1
@@ -1231,30 +1236,44 @@ dev_near_success() {
   # Signal 4: process-group walk (#137 parity with [INV-24] signal 5).
   # Skipped silently when PID is empty / unparseable (mirrors the
   # caller-site contract used by review_near_success in this same file).
-  if [ -n "$pid" ] && _pgid_has_agent_process "$pid"; then
+  # Pass dev-side CLI per [INV-37] so a project running
+  # AGENT_DEV_CMD=codex still finds the codex process even when the
+  # dispatcher's $AGENT_CMD is the project default (e.g. claude).
+  if [ -n "$pid" ] && _pgid_has_agent_process "$pid" "${AGENT_DEV_CMD:-${AGENT_CMD:-claude}}"; then
     return 0
   fi
 
   return 1
 }
 
-# _pgid_has_agent_process <pgid>
+# _pgid_has_agent_process <pgid> [agent_cmd_override]
 #
 # Process-group walk shared between dev_near_success (signal 4, #137)
 # and review_near_success (signal 5, #132). Walks the wrapper's process
 # group (PGID == content of `<kind>-${ISSUE}.pid`; setsid in
 # lib-agent.sh::_run_with_timeout makes the session-leader PID equal to
 # the PGID) and returns 0 if any group member's `comm` matches the
-# configured AGENT_CMD.
+# expected agent CLI name.
+#
+# 2nd arg [INV-37, agy review Finding 2 from PR #156]: optional
+# per-side CLI override. Empty / missing falls back to $AGENT_CMD for
+# back-compat with existing call sites and tests. Required when the
+# project uses split per-side CLIs (e.g. AGENT_DEV_CMD=claude,
+# AGENT_REVIEW_CMD=agy): the dispatcher tick's $AGENT_CMD is the
+# project default, but each wrapper runs with its side's override —
+# matching against the dispatcher-side $AGENT_CMD would false-negative
+# the live wrapper. Callers MUST pass the correct per-side value
+# (dev_near_success → AGENT_DEV_CMD, review_near_success →
+# AGENT_REVIEW_CMD).
 #
 # Returns 1 silently in three cases — never fail-closed:
 #   - PGID is not a positive integer (empty / unparseable PID file)
 #   - `pgrep` or `ps` not on PATH (mismatched host)
-#   - No member of the group has a comm matching AGENT_CMD
+#   - No member of the group has a comm matching the resolved CLI name
 #
-# Substring match (`*${AGENT_CMD}*`) is intentionally tolerant: Linux
+# Substring match (`*${agent_cmd}*`) is intentionally tolerant: Linux
 # truncates `comm` to 15 chars (so `claude-cli-with-extras` shows up as
-# `claude-cli-with`), and AGENT_CMD values are typically 5–10 chars.
+# `claude-cli-with`), and CLI values are typically 5–10 chars.
 # Over-match is safe here — this signal only runs after pid_alive missed
 # AND the cheaper signals already failed, so a false positive defers a
 # crash declaration by one tick at most, while a false negative
@@ -1268,12 +1287,12 @@ dev_near_success() {
 # same PR.)
 _pgid_has_agent_process() {
   local pgid="$1"
+  local agent_cmd="${2:-${AGENT_CMD:-claude}}"
   [[ "$pgid" =~ ^[0-9]+$ ]] || return 1
   [ "$pgid" -gt 0 ] || return 1
   command -v pgrep >/dev/null 2>&1 || return 1
   command -v ps >/dev/null 2>&1 || return 1
 
-  local agent_cmd="${AGENT_CMD:-claude}"
   local pid comm
   while read -r pid; do
     [[ "$pid" =~ ^[0-9]+$ ]] || continue
@@ -1368,7 +1387,10 @@ review_near_success() {
   # helper's own integer guard would catch it, but checking here keeps
   # the caller's contract explicit and avoids ever spawning the helper
   # subshell on bad input.
-  if [ -n "$pid" ] && _pgid_has_agent_process "$pid"; then
+  # Pass review-side CLI per [INV-37] so a project running
+  # AGENT_REVIEW_CMD=agy still finds the agy process even when the
+  # dispatcher's $AGENT_CMD is the project default (e.g. claude).
+  if [ -n "$pid" ] && _pgid_has_agent_process "$pid" "${AGENT_REVIEW_CMD:-${AGENT_CMD:-claude}}"; then
     return 0
   fi
 

--- a/tests/unit/test-is-session-completed.sh
+++ b/tests/unit/test-is-session-completed.sh
@@ -97,6 +97,38 @@ assert_returns "AGENT_CMD=kiro → false" 1 is_session_completed 1005
 export AGENT_CMD=claude
 cleanup_log 1005
 
+# TC-WH-005b: split-CLI config (per-side AGENT_DEV_CMD overrides shared
+# AGENT_CMD). is_session_completed parses the dev wrapper's log; it
+# MUST gate on the dev-side CLI, not the dispatcher-side AGENT_CMD.
+# Per agy review Finding 3 from PR #156 + INV-37.
+write_log 1005 '{"type":"result","stop_reason":"end_turn","terminal_reason":"completed"}'
+
+# Project default AGENT_CMD=claude, but dev wrapper runs codex via
+# AGENT_DEV_CMD override. The gate must see codex on the dev side and
+# refuse to parse — claude's JSON shape doesn't apply.
+export AGENT_CMD=claude
+export AGENT_DEV_CMD=codex
+assert_returns "AGENT_DEV_CMD=codex AGENT_CMD=claude → false (gate on dev-side)" \
+  1 is_session_completed 1005
+
+# Inverse: AGENT_CMD=codex but dev runs claude → gate sees claude on
+# dev side, proceeds, parses the valid claude JSON → true.
+export AGENT_CMD=codex
+export AGENT_DEV_CMD=claude
+assert_returns "AGENT_DEV_CMD=claude AGENT_CMD=codex → true (claude log parses)" \
+  0 is_session_completed 1005
+
+# Empty AGENT_DEV_CMD (explicit) falls back to AGENT_CMD per :- semantics.
+export AGENT_CMD=claude
+export AGENT_DEV_CMD=""
+assert_returns "AGENT_DEV_CMD='' falls back to AGENT_CMD=claude → true" \
+  0 is_session_completed 1005
+
+# Reset
+unset AGENT_DEV_CMD
+export AGENT_CMD=claude
+cleanup_log 1005
+
 # TC-WH-006: missing log returns false
 assert_returns "missing log file → false" 1 is_session_completed 9999
 

--- a/tests/unit/test-lib-agent-per-side-cmd.sh
+++ b/tests/unit/test-lib-agent-per-side-cmd.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# test-lib-agent-per-side-cmd.sh — Unit tests for AGENT_DEV_CMD /
+# AGENT_REVIEW_CMD per-side overrides (INV-37).
+#
+# Verifies:
+#   - Defaults: both per-side vars resolve to ${AGENT_CMD:-claude}
+#   - Single-side override: only the overridden side changes
+#   - Both-side override: each side runs its declared CLI
+#   - Empty-string handling: :- treats explicit empty as unset
+#   - AGENT_LAUNCHER guard: requires BOTH sides to be claude when set
+#   - Wrapper structural placement: AGENT_CMD override lands immediately
+#     after source lib-agent.sh in both autonomous-{dev,review}.sh
+#
+# Run: bash tests/unit/test-lib-agent-per-side-cmd.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-agent.sh"
+DEV_WRAPPER="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous-dev.sh"
+REVIEW_WRAPPER="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous-review.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected='$expected'"
+    echo "      actual=  '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      needle='$needle'"
+    echo "      haystack='${haystack:0:300}'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# resolve_pair <agent_cmd> <agent_dev_cmd> <agent_review_cmd>
+# Sources lib-agent.sh in a sandbox with the given env, prints
+# "DEV=<dev_cmd> REVIEW=<review_cmd>" on stdout. Strips ANY [lib-agent]
+# warnings/errors so callers can grep cleanly.
+resolve_pair() {
+  local _ac="$1" _adc="$2" _arc="$3"
+  AGENT_CMD="$_ac" \
+  AGENT_DEV_CMD="$_adc" \
+  AGENT_REVIEW_CMD="$_arc" \
+  AGENT_LAUNCHER="" \
+  bash -c '
+    unset AUTONOMOUS_CONF
+    source "'"$LIB"'" 2>/dev/null
+    printf "DEV=%s REVIEW=%s\n" "$AGENT_DEV_CMD" "$AGENT_REVIEW_CMD"
+  '
+}
+
+# launcher_guard <agent_dev_cmd> <agent_review_cmd>
+# Sources lib-agent.sh with AGENT_LAUNCHER=cc and the given per-side
+# values. Captures stderr; emits exit code on stdout last line.
+launcher_guard() {
+  local _adc="$1" _arc="$2"
+  AGENT_CMD="claude" \
+  AGENT_DEV_CMD="$_adc" \
+  AGENT_REVIEW_CMD="$_arc" \
+  AGENT_LAUNCHER="cc" \
+  bash -c '
+    unset AUTONOMOUS_CONF
+    source "'"$LIB"'"
+    echo "RC=$?"
+  ' 2>&1
+}
+
+echo "=== test-lib-agent-per-side-cmd.sh — AGENT_DEV_CMD / AGENT_REVIEW_CMD (INV-37) ==="
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S1: default — neither override set → both equal AGENT_CMD ==="
+# ---------------------------------------------------------------------------
+out=$(resolve_pair "claude" "" "")
+assert_eq "default with AGENT_CMD=claude" "DEV=claude REVIEW=claude" "$out"
+
+out=$(resolve_pair "codex" "" "")
+assert_eq "default with AGENT_CMD=codex" "DEV=codex REVIEW=codex" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S2: only AGENT_REVIEW_CMD set → dev=AGENT_CMD, review=override ==="
+# ---------------------------------------------------------------------------
+out=$(resolve_pair "claude" "" "agy")
+assert_eq "AGENT_CMD=claude AGENT_REVIEW_CMD=agy" "DEV=claude REVIEW=agy" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S3: only AGENT_DEV_CMD set → dev=override, review=AGENT_CMD ==="
+# ---------------------------------------------------------------------------
+out=$(resolve_pair "claude" "codex" "")
+assert_eq "AGENT_CMD=claude AGENT_DEV_CMD=codex" "DEV=codex REVIEW=claude" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S4: both set → each side runs its declared CLI ==="
+# ---------------------------------------------------------------------------
+out=$(resolve_pair "claude" "codex" "agy")
+assert_eq "AGENT_CMD=claude DEV=codex REVIEW=agy" "DEV=codex REVIEW=agy" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S5: explicit empty string falls back to AGENT_CMD ==="
+# ---------------------------------------------------------------------------
+out=$(resolve_pair "kiro" "" "")
+assert_eq "AGENT_DEV_CMD='' AGENT_REVIEW_CMD='' AGENT_CMD=kiro" "DEV=kiro REVIEW=kiro" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S6: AGENT_LAUNCHER + both sides claude → source succeeds ==="
+# ---------------------------------------------------------------------------
+out=$(launcher_guard "claude" "claude")
+assert_contains "RC=0 (no guard rejection)" "RC=0" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S7: AGENT_LAUNCHER + dev=claude review=agy → guard fails ==="
+# ---------------------------------------------------------------------------
+out=$(launcher_guard "claude" "agy")
+assert_contains "guard error mentions AGENT_REVIEW_CMD=agy" "AGENT_REVIEW_CMD=agy" "$out"
+assert_contains "guard error names both vars" "AGENT_DEV_CMD" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S8: AGENT_LAUNCHER + dev=codex review=claude → guard fails ==="
+# ---------------------------------------------------------------------------
+out=$(launcher_guard "codex" "claude")
+assert_contains "guard error mentions AGENT_DEV_CMD=codex" "AGENT_DEV_CMD=codex" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S11: AGENT_LAUNCHER + both sides non-claude → guard fails ==="
+# ---------------------------------------------------------------------------
+out=$(launcher_guard "codex" "agy")
+assert_contains "guard error mentions both non-claude values" "AGENT_DEV_CMD=codex" "$out"
+assert_contains "guard error mentions review side too" "AGENT_REVIEW_CMD=agy" "$out"
+
+echo ""
+echo "PASS: $PASS    FAIL: $FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/unit/test-lib-agent-per-side-cmd.sh
+++ b/tests/unit/test-lib-agent-per-side-cmd.sh
@@ -173,7 +173,7 @@ hit=$(awk '
     found_source = NR
     next
   }
-  found_source && NR <= found_source + 2 {
+  found_source && NR <= found_source + 4 {
     if ($0 ~ /^AGENT_CMD="\$AGENT_DEV_CMD"/) {
       print "MATCH"
       exit
@@ -181,7 +181,7 @@ hit=$(awk '
   }
 ' "$DEV_WRAPPER")
 
-assert_eq "autonomous-dev.sh: AGENT_CMD=\$AGENT_DEV_CMD lands ≤2 lines after source lib-agent.sh" \
+assert_eq "autonomous-dev.sh: AGENT_CMD=\$AGENT_DEV_CMD lands ≤4 lines after source lib-agent.sh" \
   "MATCH" "$hit"
 
 echo ""

--- a/tests/unit/test-lib-agent-per-side-cmd.sh
+++ b/tests/unit/test-lib-agent-per-side-cmd.sh
@@ -20,7 +20,12 @@ FAIL=0
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-agent.sh"
+# DEV_WRAPPER / REVIEW_WRAPPER are used by PSC-S9 / PSC-S10 (structural
+# placement greps) which land in plan Tasks 2 and 3. Defined here so
+# the test scaffolding stays in one place across all three tasks.
+# shellcheck disable=SC2034
 DEV_WRAPPER="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous-dev.sh"
+# shellcheck disable=SC2034
 REVIEW_WRAPPER="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous-review.sh"
 
 RED='\033[0;31m'

--- a/tests/unit/test-lib-agent-per-side-cmd.sh
+++ b/tests/unit/test-lib-agent-per-side-cmd.sh
@@ -161,6 +161,29 @@ out=$(launcher_guard "codex" "agy")
 assert_contains "guard error mentions both non-claude values" "AGENT_DEV_CMD=codex" "$out"
 assert_contains "guard error mentions review side too" "AGENT_REVIEW_CMD=agy" "$out"
 
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S9: autonomous-dev.sh structural placement ==="
+# ---------------------------------------------------------------------------
+# Match: source "${SCRIPT_DIR}/lib-agent.sh" followed (with at most ONE
+# blank line) by AGENT_CMD="$AGENT_DEV_CMD".
+# Use awk so we don't depend on `grep -A` quirks across platforms.
+hit=$(awk '
+  /source "\$\{SCRIPT_DIR\}\/lib-agent\.sh"/ {
+    found_source = NR
+    next
+  }
+  found_source && NR <= found_source + 2 {
+    if ($0 ~ /^AGENT_CMD="\$AGENT_DEV_CMD"/) {
+      print "MATCH"
+      exit
+    }
+  }
+' "$DEV_WRAPPER")
+
+assert_eq "autonomous-dev.sh: AGENT_CMD=\$AGENT_DEV_CMD lands ≤2 lines after source lib-agent.sh" \
+  "MATCH" "$hit"
+
 echo ""
 echo "PASS: $PASS    FAIL: $FAIL"
 [[ $FAIL -eq 0 ]]

--- a/tests/unit/test-lib-agent-per-side-cmd.sh
+++ b/tests/unit/test-lib-agent-per-side-cmd.sh
@@ -184,6 +184,26 @@ hit=$(awk '
 assert_eq "autonomous-dev.sh: AGENT_CMD=\$AGENT_DEV_CMD lands ≤4 lines after source lib-agent.sh" \
   "MATCH" "$hit"
 
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== PSC-S10: autonomous-review.sh structural placement ==="
+# ---------------------------------------------------------------------------
+hit=$(awk '
+  /source "\$\{SCRIPT_DIR\}\/lib-agent\.sh"/ {
+    found_source = NR
+    next
+  }
+  found_source && NR <= found_source + 5 {
+    if ($0 ~ /^AGENT_CMD="\$AGENT_REVIEW_CMD"/) {
+      print "MATCH"
+      exit
+    }
+  }
+' "$REVIEW_WRAPPER")
+
+assert_eq "autonomous-review.sh: AGENT_CMD=\$AGENT_REVIEW_CMD lands ≤5 lines after source lib-agent.sh" \
+  "MATCH" "$hit"
+
 echo ""
 echo "PASS: $PASS    FAIL: $FAIL"
 [[ $FAIL -eq 0 ]]

--- a/tests/unit/test-pgid-has-agent-process.sh
+++ b/tests/unit/test-pgid-has-agent-process.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# test-pgid-has-agent-process.sh — Unit tests for the per-side argument
+# extension of lib-dispatch.sh::_pgid_has_agent_process (agy review
+# Finding 2 from PR #156).
+#
+# Verifies:
+#   - Helper accepts an optional 2nd argument (the per-side CLI to
+#     match against process comms in the group).
+#   - Empty/missing 2nd arg falls back to $AGENT_CMD (back-compat).
+#   - Non-matching CLI name returns 1 silently.
+#   - Matching CLI name returns 0.
+#
+# Strategy: spawn a controlled child via `exec -a <name>` so its `comm`
+# is exactly the name we want, then exercise the helper against the
+# child's PGID with various 2nd-arg values.
+#
+# Run: bash tests/unit/test-pgid-has-agent-process.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-dispatch.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Required env (lib-dispatch.sh enforces these via : "${VAR:?...}")
+export REPO=zxkane/autonomous-dev-team
+export REPO_OWNER=zxkane
+export PROJECT_ID="test-pgid-$$"
+export MAX_RETRIES=3
+export MAX_CONCURRENT=5
+
+gh() { :; }
+export -f gh
+
+# shellcheck source=../../skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+source "$LIB"
+set +e
+
+assert_returns() {
+  local desc="$1" expected_rc="$2"; shift 2
+  "$@"
+  local actual_rc=$?
+  if [[ "$expected_rc" == "$actual_rc" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      expected_rc=$expected_rc actual_rc=$actual_rc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Spawn a controlled child whose `comm` is exactly $1, store its PID in
+# the global SPAWN_PID. NOTE: do NOT use command substitution to capture
+# the PID — bash's command-substitution subshell SIGHUPs its
+# background children when it exits, killing our setsid child before
+# the helper can probe it. Use a side-channel global instead.
+#
+# `comm` reads from /proc/<pid>/comm which is the binary's basename
+# (NOT argv[0] — `exec -a` doesn't change comm). Portable trick: copy
+# /bin/sleep to a renamed file under a tempdir, exec it. `setsid`
+# makes the child its own session/process-group leader so its PGID
+# equals its PID — same invariant lib-agent.sh::_run_with_timeout sets up.
+TMPBINS=$(mktemp -d)
+SPAWN_PID=""
+spawn_named_child() {
+  local name="$1"
+  local bin="$TMPBINS/$name"
+  cp /bin/sleep "$bin"
+  setsid "$bin" 60 &
+  SPAWN_PID=$!
+  # Brief wait so /proc/<pid>/comm settles after exec.
+  sleep 0.1
+}
+
+cleanup_pids=()
+trap 'for p in "${cleanup_pids[@]}"; do kill -TERM "$p" 2>/dev/null; done; rm -rf "$TMPBINS"' EXIT
+
+echo "=== test-pgid-has-agent-process.sh — per-side CLI argument ==="
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-PSC-COUP-01a: helper accepts per-side CLI argument ==="
+# ---------------------------------------------------------------------------
+
+spawn_named_child "fake-agy"
+agy_pid="$SPAWN_PID"
+cleanup_pids+=("$agy_pid")
+
+# Match: per-side CLI = "agy" → finds fake-agy via substring match.
+assert_returns \
+  "_pgid_has_agent_process <pgid> 'agy' matches fake-agy comm" \
+  0 _pgid_has_agent_process "$agy_pid" "agy"
+
+# No-match: per-side CLI = "claude" → fake-agy comm doesn't contain claude.
+assert_returns \
+  "_pgid_has_agent_process <pgid> 'claude' does not match fake-agy" \
+  1 _pgid_has_agent_process "$agy_pid" "claude"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-PSC-COUP-01b: empty 2nd arg falls back to AGENT_CMD ==="
+# ---------------------------------------------------------------------------
+
+# AGENT_CMD=agy + empty 2nd arg → fallback finds fake-agy.
+export AGENT_CMD=agy
+assert_returns \
+  "_pgid_has_agent_process <pgid> '' falls back to AGENT_CMD=agy" \
+  0 _pgid_has_agent_process "$agy_pid" ""
+
+# AGENT_CMD=claude + empty 2nd arg → fallback misses (back-compat).
+export AGENT_CMD=claude
+assert_returns \
+  "_pgid_has_agent_process <pgid> '' falls back to AGENT_CMD=claude (no match)" \
+  1 _pgid_has_agent_process "$agy_pid" ""
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-PSC-COUP-01c: 1-arg call (back-compat) reads AGENT_CMD ==="
+# ---------------------------------------------------------------------------
+
+# Back-compat: existing callers that pass only the PGID still work via
+# the AGENT_CMD fallback.
+export AGENT_CMD=agy
+assert_returns \
+  "_pgid_has_agent_process <pgid> (no 2nd arg) reads AGENT_CMD=agy" \
+  0 _pgid_has_agent_process "$agy_pid"
+
+export AGENT_CMD=claude
+assert_returns \
+  "_pgid_has_agent_process <pgid> (no 2nd arg) reads AGENT_CMD=claude" \
+  1 _pgid_has_agent_process "$agy_pid"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-PSC-COUP-01d: bad PGID still rejected with per-side arg ==="
+# ---------------------------------------------------------------------------
+
+# Pre-existing safety: integer guard, positive guard. Should still hold
+# regardless of 2nd-arg presence.
+assert_returns \
+  "_pgid_has_agent_process 'notanumber' 'agy' returns 1" \
+  1 _pgid_has_agent_process "notanumber" "agy"
+
+assert_returns \
+  "_pgid_has_agent_process '0' 'agy' returns 1" \
+  1 _pgid_has_agent_process "0" "agy"
+
+assert_returns \
+  "_pgid_has_agent_process '' 'agy' returns 1 (empty PGID)" \
+  1 _pgid_has_agent_process "" "agy"
+
+echo ""
+echo "PASS: $PASS    FAIL: $FAIL"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Adds two operator knobs in `lib-agent.sh` that let dev and review wrappers run on different agent CLIs in the same project:

- `AGENT_DEV_CMD` — defaults to `${AGENT_CMD:-claude}`
- `AGENT_REVIEW_CMD` — defaults to `${AGENT_CMD:-claude}`

Each wrapper sets `AGENT_CMD` to its side's value immediately after sourcing `lib-agent.sh`. The `AGENT_LAUNCHER` claude-only guard generalizes to reject any non-claude side (strictly more permissive than the old single-side check — never rejects a config that previously passed).

The motivating use case: a downstream consumer project wants `AGENT_CMD="claude"` for heavy dev and `AGENT_REVIEW_CMD="agy"` for cheaper review.

## What's in the PR

- `skills/autonomous-dispatcher/scripts/lib-agent.sh` — 7-line init + guard rewrite
- `skills/autonomous-dispatcher/scripts/autonomous-dev.sh` — 4-line override block after `source lib-agent.sh`
- `skills/autonomous-dispatcher/scripts/autonomous-review.sh` — 5-line override block (symmetric)
- `skills/autonomous-dispatcher/scripts/autonomous.conf.example` — operator-facing comment block with worked example
- `tests/unit/test-lib-agent-per-side-cmd.sh` — 14 assertions (PSC-S1..S11): defaults, single-side override, both-side, empty-string, launcher guard ×4, wrapper structural placement
- `docs/pipeline/per-side-agent-cmd.md` — spec
- `docs/pipeline/invariants.md` — INV-37
- `docs/pipeline/README.md` — index entry
- `docs/superpowers/plans/2026-05-25-per-side-agent-cmd.md` — implementation plan (kept for traceability)

## Backwards compatibility

Existing deployments don't set the new vars. Defaults make both equal to `$AGENT_CMD`, so behavior is byte-for-byte identical pre/post. Verified: all 7 peer `test-lib-agent-*.sh` suites still pass.

## Spec & invariant

- `docs/pipeline/per-side-agent-cmd.md`
- `INV-37` in `docs/pipeline/invariants.md`

## Pipeline-docs gate

Touches `lib-agent.sh` (watched path), so `docs/pipeline/` must also change. Satisfied:
- [x] `docs/pipeline/per-side-agent-cmd.md`
- [x] `docs/pipeline/invariants.md` (INV-37)
- [x] `docs/pipeline/README.md`

## Test plan

- [x] `bash tests/unit/test-lib-agent-per-side-cmd.sh` — 14/14 PASS
- [x] All existing `tests/unit/test-lib-agent-*.sh` regression tests PASS
- [x] `shellcheck -S error` on lib-agent.sh + both wrappers + new test
- [x] `bash -n autonomous.conf.example` syntax OK
- [ ] CI: `unit-tests` + `shellcheck` + `pipeline-docs-gate` green

## Review process

The PR went through `/pr-review-toolkit:review-pr` with four specialized agents (code-reviewer, pr-test-analyzer, silent-failure-hunter, comment-analyzer). Findings addressed inline:

- **C1 (Critical)**: stripped `podcast-curation` private-repo refs from two committed docs (CLAUDE.md "No Private Repo Refs" rule)
- **H1, H2 (High)**: removed stale lib-agent.sh line numbers from the spec doc (referenced by name instead — survives churn better)
- **M1, M2, M3 (Medium)**: fixed spec-vs-implementation drift in operator-block placement and PSC-S9/S10 line-window descriptions (`+4` / `+5` reflecting the actual WHY-rationale comment sizes)

Silent-failure-hunter found 0 critical issues; 2 cosmetic observations (no fix recommended). Test analyzer noted 3 improvement opportunities (rated 5-7) deferred to follow-up.

## Future work (filed as suggestions in review, NOT blocking this PR)

- `_LIB_AGENT_AGY_MODEL_WARNED`-style WARN-once gate for the (rare) inverse pattern (agy-dev / claude-review with conflicting permission needs) — currently the `AGENT_PERMISSION_MODE` value is silently dropped on agy side, which is fine for the common pattern but not for the inverse
- Behavioral test that exercises the `AGENT_CMD` rebinding actually steers `case "$AGENT_CMD"` dispatch (PSC-S9/S10 are structural-only)
- `env -i` isolation in test sandboxes (mitigates hypothetical dev-box `AUTONOMOUS_CONF` ambient export)