### PR TITLE
feat(dispatcher): support cross-repo deps in check_deps_resolved (closes #157)

### DIFF
--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -162,7 +162,7 @@ Find issues labeled `autonomous` with **no other active state label** (no `in-pr
 
 For each match, in order:
 
-1. **Dependency check.** Read the issue body for a `## Dependencies` section. Extract every `#N` reference. For each, call `gh issue view N --json state` and require state `CLOSED` or `MERGED` ([INV-11](invariants.md#inv-11-dependency-state-includes-merged) — PRs report `MERGED`, not `CLOSED`). If any dependency is still open, **skip silently** — no comment, no label change. The issue picks up next tick once dependencies clear.
+1. **Dependency check.** Read the issue body for a `## Dependencies` section. Extract refs from list-item lines only — `#N` and `owner/repo#N` are recognized; prose and blockquotes are ignored ([INV-39](invariants.md#inv-39-dependency-parsing-is-list-item-scoped-and-supports-cross-repo-refs)). For each ref, call `gh issue view N --repo <repo> --json state` and require state `CLOSED` or `MERGED` ([INV-11](invariants.md#inv-11-dependency-state-includes-merged) — PRs report `MERGED`, not `CLOSED`; the same rule applies to cross-repo refs). If any dependency is still open, **skip silently** — no comment, no label change. The issue picks up next tick once dependencies clear.
 2. **Add `in-progress` label.**
 3. **Post dispatch token** ([INV-18](invariants.md#inv-18-cold-start-grace-period-before-stale-detection)): write `<!-- dispatcher-token: <id> at <iso> mode=dev-new -->` followed by the human-readable "Dispatching autonomous development..." line. The HTML comment encodes the dispatch timestamp for Step 5's grace-period check.
 4. **Dispatch**: `bash $PROJECT_DIR/scripts/dispatch-local.sh dev-new <issue>`

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -1025,7 +1025,7 @@ Where `<short-token>` is one of `bot-timeout`, `ci-transport`, `no-pr-found`, `m
 - `#N` — same-repo issue/PR, resolved against `$REPO`.
 - `owner/repo#N` — cross-repo issue/PR, resolved against the named repo.
 
-Both shapes require a left boundary (start-of-line or whitespace) so URL fragments like `https://github.com/owner/repo/issues/123` and inline punctuation don't misparse. The longer `owner/repo#N` shape is always matched before bare `#N` so a single ref is never double-counted.
+Both shapes require a left boundary (start-of-line, whitespace, or `(`) so URL fragments like `https://github.com/owner/repo/issues/123` and inline punctuation don't misparse, while parenthesized refs like `(owner/repo#42)` are still recognized. The longer `owner/repo#N` shape is always matched before bare `#N` so a single ref is never double-counted.
 
 **Why**: The pre-#157 implementation greedy-extracted every `#NNN` substring between `## Dependencies` and the next `## ` heading via `grep -oE '#[0-9]+'`, then looked each one up in `$REPO`. Two related failure modes followed:
 
@@ -1040,7 +1040,7 @@ List-item-only scope eliminates the prose false positives. Explicit `owner/repo#
 
 **Lookup-failure semantics**: when `gh issue view` returns a non-zero exit (404 / network error / private repo the dispatcher token can't see), the resulting empty `$state` MUST be treated as fail-safe block AND emit a stderr warning naming the failed `<repo>#N`. The original #157 bug was the silent-block half of this rule; without the warning half, a typo in `owner/repo#N` would silently recreate the same bug class.
 
-**Status**: **ENFORCED** in #157's fix. The function uses `grep -E '^[[:space:]]*([-*]|[0-9]+\.)[[:space:]]'` to filter the `## Dependencies` section to list items, then bash regex `(^|[[:space:]])([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#([0-9]+)` followed by `(^|[[:space:]])#([0-9]+)` for stage-2 extraction with a match-and-strip loop. Empty-state lookups emit a `[check_deps_resolved] WARNING: lookup failed for ...` line on stderr and return 1.
+**Status**: **ENFORCED** in #157's fix. The function uses `grep -E '^[[:space:]]*([-*]|[0-9]+\.)[[:space:]]'` to filter the `## Dependencies` section to list items, then bash regex `(^|[[:space:]\(])([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#([0-9]+)` followed by `(^|[[:space:]\(])#([0-9]+)` for stage-2 extraction with a match-and-strip loop. Empty-state lookups emit a `[check_deps_resolved] WARNING: lookup failed for ...` line on stderr and return 1.
 
 **Test**: `tests/unit/test-check-deps-resolved.sh` covers cross-repo CLOSED/MERGED/OPEN, same-repo + cross-repo mixed, prose-embedded refs (must not block), blockquote refs (must not block), URL-fragment refs (must not block), and lookup-failure warning (cross-repo ref to a non-existent repo blocks AND prints the warning). The mock `gh` keys state lookups on `<repo>:<num>` so the same number resolves to different states in different repos.
 

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -175,14 +175,14 @@ The cutoff timestamp falls back to epoch (1970-01-01) for issues that have never
 
 ## INV-11: Dependency state includes `MERGED`
 
-**Rule**: Step 2's dependency check MUST treat both `CLOSED` and `MERGED` as resolved states. PRs return `MERGED` when merged, NOT `CLOSED`.
+**Rule**: Step 2's dependency check MUST treat both `CLOSED` and `MERGED` as resolved states. PRs return `MERGED` when merged, NOT `CLOSED`. The same `state ∉ {"CLOSED", "MERGED"}` rule applies to cross-repo refs resolved under [INV-39](#inv-39-dependency-parsing-is-list-item-scoped-and-supports-cross-repo-refs).
 
 **Why**: When a `## Dependencies` section references a PR that has been merged, `gh issue view N --json state` returns `state: "MERGED"`. A naive `state != "CLOSED"` check leaves the dependent issue blocked forever (#61).
 
 **Producer**: dispatcher Step 2 (`lib-dispatch.sh::check_deps_resolved`).
 **Consumer**: itself.
-**Status**: **ENFORCED** in PR-4 (closes #61). The check now reads `state ∉ {"CLOSED", "MERGED"}`.
-**Test**: `tests/unit/test-check-deps-resolved.sh` covers single-CLOSED, single-MERGED, single-OPEN, and multi-dep mixed-state scenarios.
+**Status**: **ENFORCED** in PR-4 (closes #61). The check reads `state ∉ {"CLOSED", "MERGED"}` for both same-repo and cross-repo refs.
+**Test**: `tests/unit/test-check-deps-resolved.sh` covers single-CLOSED, single-MERGED, single-OPEN, multi-dep mixed-state scenarios, and cross-repo MERGED/CLOSED/OPEN.
 
 ## INV-12: Resume only against unfinished sessions
 
@@ -1017,6 +1017,36 @@ Where `<short-token>` is one of `bot-timeout`, `ci-transport`, `no-pr-found`, `m
 - [INV-37](#inv-37-per-side-agent_cmd-precedence) — per-side `AGENT_CMD`. INV-38 builds on it: the launcher guard now keys on per-side CLIs.
 - [INV-31](#inv-31-operator-tunable-per-cli-flags-live-in-conf-not-in-lib-agentsh) — operator-tunable flags live in `autonomous.conf`. The new vars follow that contract.
 - [INV-13](#inv-13-wall-clock-cap-on-agent-invocations) — wall-clock cap. Unaffected: each side's launcher still runs inside `_run_with_timeout` exactly as before.
+
+## INV-39: Dependency parsing is list-item scoped and supports cross-repo refs
+
+**Rule**: Step 2's dependency check parses ONLY list-item lines (lines that start with `-`, `*`, or `1.` after optional leading whitespace) inside the `## Dependencies` section. Prose, blockquotes (`> ...`), and headings between `## Dependencies` and the next `## ` heading are ignored — they MUST NOT cause an issue to be blocked. On each list item, two ref shapes are recognized:
+
+- `#N` — same-repo issue/PR, resolved against `$REPO`.
+- `owner/repo#N` — cross-repo issue/PR, resolved against the named repo.
+
+Both shapes require a left boundary (start-of-line or whitespace) so URL fragments like `https://github.com/owner/repo/issues/123` and inline punctuation don't misparse. The longer `owner/repo#N` shape is always matched before bare `#N` so a single ref is never double-counted.
+
+**Why**: The pre-#157 implementation greedy-extracted every `#NNN` substring between `## Dependencies` and the next `## ` heading via `grep -oE '#[0-9]+'`, then looked each one up in `$REPO`. Two related failure modes followed:
+
+1. Cross-repo refs (`owner/repo#NNN`) yielded a bare `NNN` which got queried against the wrong repo. If no such issue existed there, `gh issue view` errored, the surrounding `|| true` swallowed the error, the empty `$state` failed the `!= "CLOSED"` check, and the issue was silently blocked forever.
+2. The same greedy extraction picked up `#NNN` tokens inside prose, blockquotes, and inline-prose `owner/repo#NNN` mentions, producing identical silent blocks.
+
+List-item-only scope eliminates the prose false positives. Explicit `owner/repo#N` syntax makes cross-repo dependencies a first-class case instead of a silent failure.
+
+**Producer**: dispatcher Step 2 (`lib-dispatch.sh::check_deps_resolved`).
+
+**Consumer**: itself.
+
+**Lookup-failure semantics**: when `gh issue view` returns a non-zero exit (404 / network error / private repo the dispatcher token can't see), the resulting empty `$state` MUST be treated as fail-safe block AND emit a stderr warning naming the failed `<repo>#N`. The original #157 bug was the silent-block half of this rule; without the warning half, a typo in `owner/repo#N` would silently recreate the same bug class.
+
+**Status**: **ENFORCED** in #157's fix. The function uses `grep -E '^[[:space:]]*([-*]|[0-9]+\.)[[:space:]]'` to filter the `## Dependencies` section to list items, then bash regex `(^|[[:space:]])([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#([0-9]+)` followed by `(^|[[:space:]])#([0-9]+)` for stage-2 extraction with a match-and-strip loop. Empty-state lookups emit a `[check_deps_resolved] WARNING: lookup failed for ...` line on stderr and return 1.
+
+**Test**: `tests/unit/test-check-deps-resolved.sh` covers cross-repo CLOSED/MERGED/OPEN, same-repo + cross-repo mixed, prose-embedded refs (must not block), blockquote refs (must not block), URL-fragment refs (must not block), and lookup-failure warning (cross-repo ref to a non-existent repo blocks AND prints the warning). The mock `gh` keys state lookups on `<repo>:<num>` so the same number resolves to different states in different repos.
+
+**Cross-references**:
+- [INV-11](#inv-11-dependency-state-includes-merged) — `state ∉ {CLOSED, MERGED}` rule applies to both same-repo and cross-repo refs.
+- The `create-issue` skill's `## Dependencies` guidance documents the user-facing parsing rules (`skills/create-issue/SKILL.md`, `skills/create-issue/references/issue-templates.md`).
 
 ## Adding a new invariant
 

--- a/docs/superpowers/specs/2026-05-27-cross-repo-deps-design.md
+++ b/docs/superpowers/specs/2026-05-27-cross-repo-deps-design.md
@@ -1,0 +1,108 @@
+# Cross-repo dependency support in `check_deps_resolved`
+
+**Issue**: #157
+**Author**: zxkane
+**Date**: 2026-05-27
+**Status**: approved
+
+## Problem
+
+`check_deps_resolved` (`skills/autonomous-dispatcher/scripts/lib-dispatch.sh:286`) parses the `## Dependencies` section of an issue body by greedy-extracting every `#NNN` substring between the `## Dependencies` heading and the next `## ` heading, then looking each one up in the **current repo** via `gh issue view N --repo "$REPO"`.
+
+Two failure modes follow from this:
+
+1. **Cross-repo refs are silently treated as unresolved.** `owner/repo#NNN` in the section yields a bare `NNN`, queried against `$REPO`. If no such issue exists locally, `gh issue view` returns non-zero, the surrounding `|| true` swallows the error, `$state` is empty, and `[ "$state" != "CLOSED" ]` is true → the issue is **blocked forever**, with no log line and no comment to surface the cause.
+2. **Prose/blockquote false positives.** The regex `grep -oE '#[0-9]+'` matches every `#NNN` substring inside the line range, including ones inside blockquotes (`> requires owner/repo#4470 ...`), inline code (`` `#42` ``), and free-form prose. These leak into the loop and trigger the same silent-block failure if the number doesn't exist in `$REPO`.
+
+The function preserves [INV-11](../../pipeline/invariants.md#inv-11-dependency-state-includes-merged) (MERGED counts as resolved) and the portable extraction fix from PR-4. Both must remain green after this change.
+
+## Goals
+
+- Support `owner/repo#NNN` as a first-class dependency specifier.
+- Eliminate prose/blockquote false positives (Option B from #157).
+- Preserve INV-11 and #73 portability fixes.
+- No behavior change for issues that contain only bare `#NNN` list items.
+
+## Non-goals
+
+- URL-form refs (`https://github.com/owner/repo/issues/N`) — not in #157's acceptance criteria.
+- GitLab / Bitbucket cross-host refs.
+- Inline-code stripping (` `#42` ` on a list-item line is still extracted) — acceptable per #157 acceptance criteria; can be added later if needed.
+- Migration of existing issue bodies — old prose-style refs simply stop being parsed, which is the desired outcome.
+
+## Design
+
+### Parser rewrite (`check_deps_resolved`)
+
+Replace the current pipeline with a two-stage parse:
+
+**Stage 1 — restrict scope to list items.** Use `grep -E '^[[:space:]]*([-*]|[0-9]+\.)[[:space:]]'` to filter the `## Dependencies` section down to lines beginning with a markdown list marker. This drops blockquotes (`> ...`), prose paragraphs, and headings.
+
+**Stage 2 — extract refs with priority.** Per list-item line, scan twice:
+
+1. First, match `owner/repo#NNN` — bash regex `(^|[[:space:]\(])([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#([0-9]+)`. The leading anchor (start-of-line, whitespace, or `(`) prevents matching inside larger tokens like `https://github.com/owner/repo#NNN`. Each hit fires `gh issue view NNN --repo owner/repo`. Strip the matched substring from the line before continuing.
+2. Then, match bare `#NNN` — bash regex `(^|[[:space:]\(])#([0-9]+)`. Each hit fires `gh issue view NNN --repo "$REPO"` (existing same-repo behavior).
+
+State check is unchanged: `state ∉ {CLOSED, MERGED}` returns 1.
+
+Stripping the matched substring after each hit is what makes "match owner/repo#N first, then bare #N on the residue" work correctly — `owner/repo#42` no longer survives stage-1 to be re-extracted as `#42` in stage 2.
+
+### Tests (`tests/unit/test-check-deps-resolved.sh`)
+
+Mock-`gh` extension: state lookups currently key on issue number. They need to key on `repo:num` so the same number in two different repos resolves independently.
+
+```bash
+gh() {
+  local mode="" issue_num="" repo=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      view) issue_num="$2"; shift 2 ;;
+      --repo) repo="$2"; shift 2 ;;
+      --json) [[ "$2" == body ]] && mode=body; [[ "$2" == state ]] && mode=state; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  case "$mode" in
+    body)  printf '%s' "$_MOCK_BODY" ;;
+    state) printf '%s' "${_MOCK_STATES[${repo}:${issue_num}]:-OPEN}" ;;
+  esac
+}
+```
+
+Existing fixtures migrate to `_MOCK_STATES[zxkane/autonomous-dev-team:42]="CLOSED"` etc. — mechanical change.
+
+New cases (numbered to match the acceptance criteria in #157):
+
+1. **Cross-repo dep, list item, CLOSED in remote** → unblocked.
+2. **Cross-repo dep, list item, OPEN in remote** → blocked.
+3. **Same-repo `#NNN` embedded in prose between headings** → unblocked (was blocked, the regression #157 is about).
+4. **Blockquote `> requires owner/repo#4470 to be merged`** → unblocked.
+5. **Mixed list: same-repo `#42` (CLOSED) + cross-repo `owner/repo#7` (OPEN)** → blocked.
+6. **Inline-code on a list item: `- waiting on \`#99\` ` ** — extracted (documented limitation; not part of #157 acceptance, but worth a regression note).
+
+The five existing test cases (no-section / single-CLOSED / single-MERGED / single-OPEN / multi-mixed / portable-extract `#73`) continue to pass.
+
+### Pipeline doc updates
+
+Per the project's "Pipeline Documentation Authority" rule, this PR also updates:
+
+1. **`docs/pipeline/invariants.md`** — extend INV-11's status block to mention "extraction is restricted to list items; cross-repo `owner/repo#N` resolves against the named repo." A new invariant (INV-NN) is unnecessary; the parsing rule is a refinement of the same dependency-resolution invariant.
+2. **`docs/pipeline/dispatcher-flow.md:165`** — change "Extract every `#N` reference" to "Extract `#N` and `owner/repo#N` references from list items only (prose and blockquotes are ignored)."
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Bash 3.2 (macOS default) regex semantics differ from 5.x | Patterns use only POSIX char classes, no backreferences. Verify on macOS as part of test run. |
+| Existing issue bodies relying on prose extraction | None known; quick `gh issue list --search 'in:body'` audit on `zxkane/autonomous-dev-team`, `zxkane/podcast-curation`, `zxkane/Panoptes`, `zxkane/VidSyllabus`, `zxkane/llm-wiki`, `zxkane/voicebiz-editorial` to confirm no live issue would change blocked-state. |
+| `gh issue view --repo owner/repo` for a private repo the dispatcher token can't see | Returns non-zero like the same-repo case today. The current `|| true`-based silent-block is preserved for unknown / unauthorized — this is no worse than today. Future hardening could surface a comment, but is out-of-scope. |
+
+## Acceptance criteria (verbatim from #157)
+
+- [x] A same-repo dep on a list item (`- #NNN`) is checked in `$REPO` as before.
+- [x] A cross-repo dep on a list item (`- owner/repo#NNN`) is checked in `owner/repo`.
+- [x] A `#NNN` reference embedded in prose, blockquotes, or inline code between `## Dependencies` and the next heading does not cause a false block.
+- [x] `None` (or empty section with no list items) returns 0.
+- [x] Unit tests cover same-repo CLOSED/OPEN, cross-repo, prose-embedded, empty.
+
+(Inline code in a *list item* is the one carve-out, called out in Non-goals.)

--- a/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
@@ -307,9 +307,10 @@ check_deps_resolved() {
   while IFS= read -r line; do
     # Stage 2a: cross-repo `owner/repo#N`. Matched longest-first so that
     # `owner/repo#42` doesn't survive to be re-parsed as bare `#42`. The
-    # left boundary `(^|[[:space:]])` rules out URL fragments and inline
-    # punctuation.
-    while [[ "$line" =~ (^|[[:space:]])([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#([0-9]+) ]]; do
+    # left boundary `(^|[[:space:]\(])` rules out URL fragments and inline
+    # punctuation while still allowing parenthesized refs like
+    # `- (owner/repo#42)`.
+    while [[ "$line" =~ (^|[[:space:]\(])([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#([0-9]+) ]]; do
       matched="${BASH_REMATCH[0]}"
       dep_repo="${BASH_REMATCH[2]}"
       dep_num="${BASH_REMATCH[3]}"
@@ -327,7 +328,7 @@ check_deps_resolved() {
       line="${line/"$matched"/ }"
     done
     # Stage 2b: bare `#N` on the residue. Same-repo lookup against $REPO.
-    while [[ "$line" =~ (^|[[:space:]])#([0-9]+) ]]; do
+    while [[ "$line" =~ (^|[[:space:]\(])#([0-9]+) ]]; do
       matched="${BASH_REMATCH[0]}"
       dep_num="${BASH_REMATCH[2]}"
       state=$(gh issue view "$dep_num" --repo "$REPO" --json state -q '.state' 2>/dev/null || true)

--- a/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-dispatch.sh
@@ -280,28 +280,68 @@ run_hygiene_pass() {
 # Returns 1 (blocked) on the first unresolved dependency. Returns 0 if no
 # dependencies are listed.
 #
-# Closes #61 (MERGED PRs report `state: "MERGED"`, not `"CLOSED"`) and
-# #73 (replace GNU-only `grep -oP '#\K[0-9]+'` with portable extraction).
-# Both fixes are in the same function and ship together.
+# Parsing rules (see INV-11 in docs/pipeline/invariants.md):
+#   - Only list-item lines (`-`, `*`, or `1.` markers) inside the
+#     `## Dependencies` section are scanned. Prose, blockquotes, and
+#     headings are ignored — this is what stops false positives where a
+#     `#NNN` mentioned in passing got greedy-extracted (#157).
+#   - Two ref shapes are recognized, longest first per line:
+#       * `owner/repo#N` → resolved against the named repo
+#       * `#N`           → resolved against $REPO (same-repo)
+#   - Both shapes require a left boundary (start-of-line or whitespace) so
+#     URL fragments (`https://github.com/.../issues/123`) and inline
+#     punctuation aren't misparsed.
+#
+# Closes #61 (MERGED PRs report `state: "MERGED"`, not `"CLOSED"`),
+# #73 (replace GNU-only `grep -oP '#\K[0-9]+'` with portable extraction),
+# and #157 (cross-repo refs + list-only scope).
 check_deps_resolved() {
   local issue_num="$1"
-  local deps state
-  # Portable dep-number extraction: grep -oE matches `#NNN`, sed strips
-  # the leading `#`. Equivalent to the GNU-only `grep -oP '#\K[0-9]+'`
-  # but works on macOS / BSD grep too.
-  deps=$(gh issue view "$issue_num" --repo "$REPO" --json body -q '.body' \
-    | sed -n '/^## Dependencies/,/^## /p' \
-    | grep -oE '#[0-9]+' \
-    | sed 's/^#//' || true)
+  local body section line state dep_repo dep_num matched
+  body=$(gh issue view "$issue_num" --repo "$REPO" --json body -q '.body')
+  section=$(printf '%s\n' "$body" | sed -n '/^## Dependencies/,/^## /p')
 
-  for dep in $deps; do
-    state=$(gh issue view "$dep" --repo "$REPO" --json state -q '.state')
-    # Both CLOSED (issues, closed PRs) and MERGED (merged PRs) count as
-    # resolved. `gh issue view` on a merged PR returns state "MERGED".
-    if [ "$state" != "CLOSED" ] && [ "$state" != "MERGED" ]; then
-      return 1
-    fi
-  done
+  # Stage 1: restrict to list-item lines. `grep -E` exits non-zero when
+  # nothing matches; the trailing `|| true` keeps the pipeline alive so
+  # the while loop simply runs zero times and we fall through to rc=0.
+  while IFS= read -r line; do
+    # Stage 2a: cross-repo `owner/repo#N`. Matched longest-first so that
+    # `owner/repo#42` doesn't survive to be re-parsed as bare `#42`. The
+    # left boundary `(^|[[:space:]])` rules out URL fragments and inline
+    # punctuation.
+    while [[ "$line" =~ (^|[[:space:]])([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#([0-9]+) ]]; do
+      matched="${BASH_REMATCH[0]}"
+      dep_repo="${BASH_REMATCH[2]}"
+      dep_num="${BASH_REMATCH[3]}"
+      state=$(gh issue view "$dep_num" --repo "$dep_repo" --json state -q '.state' 2>/dev/null || true)
+      # Empty state means the lookup failed (404, network error, private
+      # repo). [INV-39]: fail-safe blocks dispatch, but the failure must
+      # be observable — otherwise we silently recreate the #157 bug class.
+      if [ -z "$state" ]; then
+        echo "[check_deps_resolved] WARNING: lookup failed for ${dep_repo}#${dep_num} (issue ${issue_num}); blocking" >&2
+        return 1
+      fi
+      if [ "$state" != "CLOSED" ] && [ "$state" != "MERGED" ]; then
+        return 1
+      fi
+      line="${line/"$matched"/ }"
+    done
+    # Stage 2b: bare `#N` on the residue. Same-repo lookup against $REPO.
+    while [[ "$line" =~ (^|[[:space:]])#([0-9]+) ]]; do
+      matched="${BASH_REMATCH[0]}"
+      dep_num="${BASH_REMATCH[2]}"
+      state=$(gh issue view "$dep_num" --repo "$REPO" --json state -q '.state' 2>/dev/null || true)
+      if [ -z "$state" ]; then
+        echo "[check_deps_resolved] WARNING: lookup failed for ${REPO}#${dep_num} (issue ${issue_num}); blocking" >&2
+        return 1
+      fi
+      if [ "$state" != "CLOSED" ] && [ "$state" != "MERGED" ]; then
+        return 1
+      fi
+      line="${line/"$matched"/ }"
+    done
+  done < <(printf '%s\n' "$section" | grep -E '^[[:space:]]*([-*]|[0-9]+\.)[[:space:]]' || true)
+
   return 0
 }
 

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -131,7 +131,7 @@ Frame the question as:
 - **Acceptance criteria**: Must be objectively verifiable, not subjective
 - **Scope**: Prefer smaller, focused issues over large multi-part ones
 - **References**: Link to related issues, PRD sections, or code paths when relevant
-- **Dependencies**: The `## Dependencies` section must contain **only** issues that must be closed/merged before this issue can be started. Do NOT include: parent epics referenced for context, issues this one unblocks, or any `#NNN` reference that isn't a true blocker. The autonomous dispatcher parses this section literally — any open `#NNN` here causes the issue to be silently skipped forever. If there are no blockers, write exactly `None`. Create issues in dependency order so earlier issue numbers are known when writing later ones.
+- **Dependencies**: The `## Dependencies` section must contain **only** issues that must be closed/merged before this issue can be started. Do NOT include: parent epics referenced for context, issues this one unblocks, or any `#NNN` reference that isn't a true blocker. The autonomous dispatcher parses this section literally — any open list-item ref causes this issue to be silently skipped until it closes/merges. Parsing scope: **list-item lines only** (lines starting with `-`, `*`, or `1.`); prose and blockquotes between `## Dependencies` and the next `## ` are ignored. On a list item, both `#N` (same-repo) and `owner/repo#N` (cross-repo) are recognized. If there are no blockers, write exactly `None`. Create issues in dependency order so earlier issue numbers are known when writing later ones.
 - **Testing Requirements**: ALWAYS include the "Testing Requirements" section. The dev agent follows the project's TDD workflow but has been observed to skip E2E tests or test-case docs when the issue doesn't explicitly call them out. Be specific about:
   - Key scenarios each test type must cover (2-4 bullet points)
   - For bugs: the regression test must fail before the fix and pass after
@@ -141,7 +141,7 @@ Frame the question as:
 When breaking a large feature into multiple issues:
 
 1. **Create issues in dependency order** — issues with no dependencies first, then issues that depend on them. This ensures issue numbers are known when writing dependency references.
-2. **Populate the `## Dependencies` section** in each issue body with `#N` links to **directly blocking** issues only. Do not reference parent epics, context issues, or issues this one unblocks — the dispatcher treats every `#NNN` in that section as a hard blocker.
+2. **Populate the `## Dependencies` section** in each issue body with `#N` (same-repo) or `owner/repo#N` (cross-repo) list-item links to **directly blocking** issues only. Do not reference parent epics, context issues, or issues this one unblocks — the dispatcher treats every list-item ref in that section as a hard blocker. Refs in prose or blockquotes are ignored.
 3. **Use a consistent naming scheme** — prefix titles with the project/feature name for easy filtering (e.g., "MyProject: Add DynamoDB infrastructure").
 4. **Cross-reference the plan** — if an implementation plan exists, link each issue to the relevant plan tasks/chunks.
 5. **The dispatcher skips blocked issues** — issues with open dependencies in the `## Dependencies` section are ignored by the autonomous dispatcher until all dependencies are resolved (closed/merged).

--- a/skills/create-issue/references/issue-templates.md
+++ b/skills/create-issue/references/issue-templates.md
@@ -45,12 +45,23 @@
     - Issues that this issue unblocks (i.e., issues that depend on THIS one)
     - Parent epics or meta-trackers referenced for context
     - Issues mentioned elsewhere in the body
-  The autonomous dispatcher parses this section literally — any #NNN here that is still
-  OPEN will cause this issue to be silently skipped until that issue is closed.
+
+  The autonomous dispatcher parses this section literally — any list-item ref
+  that is still OPEN will cause this issue to be silently skipped until that
+  ref is closed/merged. Parsing has two stages:
+    1. Only LIST-ITEM lines (lines starting with `-`, `*`, or `1.`) are scanned.
+       Prose, blockquotes (`> ...`), and headings between `## Dependencies` and
+       the next `## ` are ignored — they will NOT block dispatch.
+    2. On each list item, the dispatcher recognizes two ref shapes:
+         - `#N`             — same-repo issue/PR (this repo)
+         - `owner/repo#N`   — cross-repo issue/PR (resolved against owner/repo)
+       Any open ref of either shape blocks this issue.
 
   Pick exactly ONE of the two shapes below (delete the other):
     - If there are no blocking prerequisites, write exactly: None
-    - Otherwise, list each blocker on its own line: - #N (must be merged first because <specific reason>)
+    - Otherwise, list each blocker on its own line:
+        - #N (must be merged first because <specific reason>)
+        - owner/repo#N (cross-repo blocker because <specific reason>)
 -->
 - None
 

--- a/tests/unit/test-check-deps-resolved.sh
+++ b/tests/unit/test-check-deps-resolved.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
-# test-check-deps-resolved.sh — Regression tests for #61 (MERGED PR
-# dependencies) and #73 (cross-platform grep) in lib-dispatch.sh.
+# test-check-deps-resolved.sh — Regression tests for `check_deps_resolved`
+# in lib-dispatch.sh, covering:
+#   - #61: MERGED PR dependencies count as resolved
+#   - #73: portable (non-GNU) dep extraction
+#   - #157: cross-repo `owner/repo#N` deps + list-only extraction
 #
 # `check_deps_resolved` makes multiple gh calls in sequence:
-#   1. `gh issue view N --json body -q .body`           — get the body
-#   2. for each dep #M:
-#      `gh issue view M --json state -q .state`         — get the state
+#   1. `gh issue view N --repo $REPO --json body -q .body`
+#   2. for each dep: `gh issue view M --repo <repo> --json state -q .state`
 #
-# Mocking this needs a stateful gh that branches on which JSON field is
-# requested. We use a router function that inspects argv and dispatches.
+# The mock `gh` keys state lookups on "<repo>:<num>" so the same number can
+# resolve to different states in different repos.
 #
 # Run: bash tests/unit/test-check-deps-resolved.sh
 
@@ -32,15 +34,16 @@ export MAX_CONCURRENT=5
 
 # State: which JSON field was requested + what to return.
 # _MOCK_BODY: text the body lookup returns
-# _MOCK_STATES: associative array, dep_num → state ("CLOSED" / "MERGED" / "OPEN")
+# _MOCK_STATES: associative array, "<repo>:<num>" → "CLOSED"/"MERGED"/"OPEN"
 _MOCK_BODY=""
 declare -A _MOCK_STATES
 
 gh() {
-  local mode="" issue_num=""
+  local mode="" issue_num="" repo=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       view) issue_num="$2"; shift 2 ;;
+      --repo) repo="$2"; shift 2 ;;
       --json)
         case "$2" in
           body) mode="body" ;;
@@ -53,7 +56,15 @@ gh() {
   done
   case "$mode" in
     body)  printf '%s' "$_MOCK_BODY" ;;
-    state) printf '%s' "${_MOCK_STATES[$issue_num]:-OPEN}" ;;
+    state)
+      local s="${_MOCK_STATES[${repo}:${issue_num}]:-OPEN}"
+      # Sentinel: __FAIL__ simulates a real `gh issue view` failure
+      # (404 / network / unauthorized) — non-zero exit, empty stdout.
+      if [[ "$s" == "__FAIL__" ]]; then
+        return 1
+      fi
+      printf '%s' "$s"
+      ;;
   esac
 }
 export -f gh
@@ -73,12 +84,31 @@ assert_eq() {
   fi
 }
 
+# Reset _MOCK_STATES between tests. `unset` + `declare -A` is the only way
+# to clear an associative array reliably across bash 4/5 — assigning `()`
+# leaves stale keys on some versions.
+_reset_states() {
+  unset _MOCK_STATES
+  declare -gA _MOCK_STATES
+}
+
+# Register state for an arbitrary repo:issue pair.
+_set_repo_state() {
+  local repo="$1" num="$2" state="$3"
+  _MOCK_STATES["${repo}:${num}"]="$state"
+}
+
+# Convenience: register state for the default same-repo $REPO.
+_set_same_repo_state() {
+  _set_repo_state "$REPO" "$1" "$2"
+}
+
 # ---------------------------------------------------------------------------
 echo "=== check_deps_resolved: no deps section ==="
 # ---------------------------------------------------------------------------
 _MOCK_BODY="## Summary
 Some text without a Dependencies section."
-unset _MOCK_STATES; declare -A _MOCK_STATES
+_reset_states
 check_deps_resolved 99
 assert_eq "no deps section → resolved (rc=0)" "0" "$?"
 
@@ -93,7 +123,8 @@ foo
 - #42
 
 ## Other"
-declare -A _MOCK_STATES; _MOCK_STATES[42]="CLOSED"
+_reset_states
+_set_same_repo_state 42 CLOSED
 check_deps_resolved 99
 assert_eq "one CLOSED dep → resolved (rc=0)" "0" "$?"
 
@@ -101,7 +132,8 @@ assert_eq "one CLOSED dep → resolved (rc=0)" "0" "$?"
 echo ""
 echo "=== check_deps_resolved: single MERGED dep [INV-11, #61 fix] ==="
 # ---------------------------------------------------------------------------
-declare -A _MOCK_STATES; _MOCK_STATES[42]="MERGED"
+_reset_states
+_set_same_repo_state 42 MERGED
 check_deps_resolved 99
 assert_eq "one MERGED dep → resolved (rc=0) — was rc=1 before #61 fix" "0" "$?"
 
@@ -109,7 +141,8 @@ assert_eq "one MERGED dep → resolved (rc=0) — was rc=1 before #61 fix" "0" "
 echo ""
 echo "=== check_deps_resolved: single OPEN dep blocks ==="
 # ---------------------------------------------------------------------------
-declare -A _MOCK_STATES; _MOCK_STATES[42]="OPEN"
+_reset_states
+_set_same_repo_state 42 OPEN
 check_deps_resolved 99
 assert_eq "one OPEN dep → blocked (rc=1)" "1" "$?"
 
@@ -122,17 +155,17 @@ _MOCK_BODY="## Dependencies
 - #2 something
 - #3 something
 "
-declare -A _MOCK_STATES
-_MOCK_STATES[1]="CLOSED"
-_MOCK_STATES[2]="MERGED"
-_MOCK_STATES[3]="CLOSED"
+_reset_states
+_set_same_repo_state 1 CLOSED
+_set_same_repo_state 2 MERGED
+_set_same_repo_state 3 CLOSED
 check_deps_resolved 99
 assert_eq "all CLOSED+MERGED → resolved (rc=0) [#73 grep portability + #61 MERGED]" "0" "$?"
 
-declare -A _MOCK_STATES
-_MOCK_STATES[1]="CLOSED"
-_MOCK_STATES[2]="MERGED"
-_MOCK_STATES[3]="OPEN"
+_reset_states
+_set_same_repo_state 1 CLOSED
+_set_same_repo_state 2 MERGED
+_set_same_repo_state 3 OPEN
 check_deps_resolved 99
 assert_eq "any one OPEN among three → blocked (rc=1)" "1" "$?"
 
@@ -140,24 +173,192 @@ assert_eq "any one OPEN among three → blocked (rc=1)" "1" "$?"
 echo ""
 echo "=== check_deps_resolved: dep numbers extracted with portable regex (#73) ==="
 # ---------------------------------------------------------------------------
-# Regression guard: the new portable extraction (grep -oE '#[0-9]+' | sed)
-# must extract the same dep numbers as the old GNU-only `grep -oP '#\K[0-9]+'`.
-# Specifically: the # itself must be stripped from the output (the for-loop
-# expects bare numbers).
+# Regression guard: dep extraction must strip the leading `#` and pass bare
+# numbers to `gh issue view`. If the # is not stripped, our mock returns
+# the default "OPEN" → blocked, so a passing test here proves stripping works.
 
 _MOCK_BODY="## Dependencies
 - depends on #100 and #200
 - and also #300
 "
-declare -A _MOCK_STATES
-_MOCK_STATES[100]="CLOSED"
-_MOCK_STATES[200]="CLOSED"
-_MOCK_STATES[300]="CLOSED"
-# If # is not stripped, the gh state lookup gets called with "#100" not "100"
-# and our mock returns the default "OPEN" — which would BLOCK. So a passing
-# test here proves the # is correctly stripped.
+_reset_states
+_set_same_repo_state 100 CLOSED
+_set_same_repo_state 200 CLOSED
+_set_same_repo_state 300 CLOSED
 check_deps_resolved 99
 assert_eq "portable extraction strips '#' prefix from dep numbers (#73)" "0" "$?"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check_deps_resolved: cross-repo dep, CLOSED in remote (#157) ==="
+# ---------------------------------------------------------------------------
+_MOCK_BODY="## Dependencies
+- other-owner/other-repo#7
+"
+_reset_states
+_set_repo_state other-owner/other-repo 7 CLOSED
+check_deps_resolved 99
+assert_eq "cross-repo CLOSED dep → resolved (rc=0)" "0" "$?"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check_deps_resolved: cross-repo dep, MERGED in remote (#157) ==="
+# ---------------------------------------------------------------------------
+_reset_states
+_set_repo_state other-owner/other-repo 7 MERGED
+check_deps_resolved 99
+assert_eq "cross-repo MERGED dep → resolved (rc=0)" "0" "$?"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check_deps_resolved: cross-repo dep, OPEN in remote (#157) ==="
+# ---------------------------------------------------------------------------
+_reset_states
+_set_repo_state other-owner/other-repo 7 OPEN
+check_deps_resolved 99
+assert_eq "cross-repo OPEN dep → blocked (rc=1)" "1" "$?"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check_deps_resolved: cross-repo same number resolves to different state (#157) ==="
+# ---------------------------------------------------------------------------
+# Same number in two repos must NOT collide. #42 is OPEN in $REPO but
+# CLOSED in `other-owner/other-repo` — only the cross-repo ref is listed,
+# so the result must be unblocked.
+_MOCK_BODY="## Dependencies
+- other-owner/other-repo#42
+"
+_reset_states
+_set_same_repo_state 42 OPEN
+_set_repo_state other-owner/other-repo 42 CLOSED
+check_deps_resolved 99
+assert_eq "same number, different repos: cross-repo CLOSED wins → resolved (rc=0)" "0" "$?"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check_deps_resolved: mixed same-repo + cross-repo (#157) ==="
+# ---------------------------------------------------------------------------
+_MOCK_BODY="## Dependencies
+- #42
+- other-owner/other-repo#7
+"
+_reset_states
+_set_same_repo_state 42 CLOSED
+_set_repo_state other-owner/other-repo 7 OPEN
+check_deps_resolved 99
+assert_eq "same-repo CLOSED + cross-repo OPEN → blocked (rc=1)" "1" "$?"
+
+_reset_states
+_set_same_repo_state 42 CLOSED
+_set_repo_state other-owner/other-repo 7 MERGED
+check_deps_resolved 99
+assert_eq "same-repo CLOSED + cross-repo MERGED → resolved (rc=0)" "0" "$?"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check_deps_resolved: prose between headings does NOT block (#157) ==="
+# ---------------------------------------------------------------------------
+# Pre-#157, a prose line `requires #4470` between `## Dependencies` and the
+# next `## ` heading was greedy-extracted. If 4470 doesn't exist in $REPO,
+# `gh issue view` returns empty state and the dep was treated as unresolved
+# — silent permanent block. After #157, prose is ignored entirely.
+_MOCK_BODY="## Dependencies
+
+This issue does not directly depend on anything, but is related to
+the work happening in #4470 — see that PR for context.
+
+## Acceptance Criteria
+"
+_reset_states
+# 4470 is intentionally NOT registered — pre-#157 this would have caused
+# a silent block. Post-fix, the prose line is ignored.
+check_deps_resolved 99
+assert_eq "prose-embedded #N reference (no list marker) → resolved (rc=0)" "0" "$?"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check_deps_resolved: blockquote does NOT block (#157) ==="
+# ---------------------------------------------------------------------------
+_MOCK_BODY="## Dependencies
+
+> Note: requires other-owner/other-repo#4470 to be merged first.
+
+## Other
+"
+_reset_states
+check_deps_resolved 99
+assert_eq "blockquote-embedded cross-repo ref → resolved (rc=0)" "0" "$?"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check_deps_resolved: numbered list items are extracted (#157) ==="
+# ---------------------------------------------------------------------------
+_MOCK_BODY="## Dependencies
+
+1. #1
+2. other-owner/other-repo#2
+
+## Other
+"
+_reset_states
+_set_same_repo_state 1 CLOSED
+_set_repo_state other-owner/other-repo 2 CLOSED
+check_deps_resolved 99
+assert_eq "numbered list (1./2.) → resolved (rc=0)" "0" "$?"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check_deps_resolved: 'None' marker → resolved (#157 acceptance) ==="
+# ---------------------------------------------------------------------------
+_MOCK_BODY="## Dependencies
+
+None.
+
+## Other
+"
+_reset_states
+check_deps_resolved 99
+assert_eq "'None' (no list items, no refs) → resolved (rc=0)" "0" "$?"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check_deps_resolved: URL-form ref in prose does NOT block (#157) ==="
+# ---------------------------------------------------------------------------
+# A literal GitHub URL on a prose line — including the trailing `#NNN`
+# fragment — must NOT be parsed as a dep. URL refs aren't supported syntax.
+_MOCK_BODY="## Dependencies
+
+See https://github.com/other-owner/other-repo/issues/123 for related context.
+
+## Other
+"
+_reset_states
+check_deps_resolved 99
+assert_eq "URL fragment in prose → resolved (rc=0)" "0" "$?"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check_deps_resolved: failed lookup blocks AND warns (INV-39) ==="
+# ---------------------------------------------------------------------------
+# Cross-repo ref to a non-existent / unauthorized repo: the real `gh issue
+# view` exits non-zero with empty stdout. The dispatcher MUST fail-safe
+# (return 1) AND emit a stderr warning naming the failed ref. Without the
+# warning, a typo silently recreates the #157 bug class.
+_MOCK_BODY="## Dependencies
+- typo-owner/nonexistent#456
+"
+_reset_states
+_set_repo_state typo-owner/nonexistent 456 __FAIL__
+err=$(check_deps_resolved 99 2>&1 >/dev/null)
+rc=$?
+assert_eq "failed cross-repo lookup → blocked (rc=1)" "1" "$rc"
+if [[ "$err" == *"WARNING: lookup failed for typo-owner/nonexistent#456"* ]]; then
+  echo -e "  ${GREEN}PASS${NC}: failed lookup emits stderr warning naming the ref"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: missing stderr warning (got: ${err})"
+  FAIL=$((FAIL + 1))
+fi
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/unit/test-check-deps-resolved.sh
+++ b/tests/unit/test-check-deps-resolved.sh
@@ -338,6 +338,60 @@ assert_eq "URL fragment in prose → resolved (rc=0)" "0" "$?"
 
 # ---------------------------------------------------------------------------
 echo ""
+echo "=== check_deps_resolved: URL-form ref ON A LIST-ITEM does NOT block (#157, INV-39) ==="
+# ---------------------------------------------------------------------------
+# Even when a list-item line contains a GitHub URL with a numeric `#NNN`
+# fragment (e.g., `#456`), the left-boundary anchor must reject it: in
+# `repo/issues/123#456`, the `#` is preceded by digits, not whitespace
+# / `(` / start-of-line, AND `issues/123` is preceded by `/`, not a
+# left-boundary character. This test exercises Stage 2's boundary
+# logic directly — the prose-only test above is filtered out at Stage 1.
+# If `_MOCK_STATES` is unset and the regex did match, the lookup would
+# return default OPEN (or, here, the registered CLOSED) — so we register
+# CLOSED for the would-be-extracted numbers; if any of them were
+# extracted it would still resolve, but the better signal is to register
+# OPEN and confirm rc=0 anyway (proving they were filtered out).
+_MOCK_BODY="## Dependencies
+- See https://github.com/other-owner/other-repo/issues/123#456 for context
+"
+_reset_states
+# Pre-fix, the greedy old parser could have extracted 123 or 456 against
+# $REPO. Register both as OPEN so a regression that re-introduces
+# greedy extraction would block (rc=1). Post-fix, the line is filtered
+# at Stage 1 anyway (it's a list item, but the URL fragment fails Stage
+# 2's left-boundary check).
+_set_same_repo_state 123 OPEN
+_set_same_repo_state 456 OPEN
+_set_repo_state other-owner/other-repo 123 OPEN
+_set_repo_state other-owner/other-repo 456 OPEN
+check_deps_resolved 99
+assert_eq "URL fragment on list item → resolved (rc=0); fragment ignored, repo path ignored" "0" "$?"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check_deps_resolved: parenthesized refs are recognized (INV-39) ==="
+# ---------------------------------------------------------------------------
+# `- (owner/repo#42)` and `- (#42)` should still match — the spec permits
+# `(` as a left boundary so common Markdown phrasings like
+# `- waiting on (owner/repo#42)` parse correctly.
+_MOCK_BODY="## Dependencies
+- waiting on (other-owner/other-repo#42)
+- and also (#7)
+"
+_reset_states
+_set_repo_state other-owner/other-repo 42 CLOSED
+_set_same_repo_state 7 CLOSED
+check_deps_resolved 99
+assert_eq "parenthesized cross-repo + same-repo, both CLOSED → resolved (rc=0)" "0" "$?"
+
+_reset_states
+_set_repo_state other-owner/other-repo 42 OPEN
+_set_same_repo_state 7 CLOSED
+check_deps_resolved 99
+assert_eq "parenthesized cross-repo OPEN → blocked (rc=1)" "1" "$?"
+
+# ---------------------------------------------------------------------------
+echo ""
 echo "=== check_deps_resolved: failed lookup blocks AND warns (INV-39) ==="
 # ---------------------------------------------------------------------------
 # Cross-repo ref to a non-existent / unauthorized repo: the real `gh issue


### PR DESCRIPTION
## Summary

- Fix `check_deps_resolved` two-bug class (#157): cross-repo `owner/repo#N` refs were collapsing to bare `N` queried in the wrong repo, and prose/blockquote `#N` mentions were greedy-extracted — both ending in the same silent-block-forever path.
- Restrict extraction to list-item lines only; recognize `owner/repo#N` (cross-repo) and `#N` (same-repo) with left-boundary anchors so URL fragments and inline punctuation don't misparse.
- On lookup failure (empty `$state` from `gh issue view`), fail-safe block AND emit a stderr warning naming the failed ref — without that, a typo would silently recreate the original bug class.

## Spec & docs

- **Design doc**: `docs/superpowers/specs/2026-05-27-cross-repo-deps-design.md`
- **New invariant**: [INV-39](https://github.com/zxkane/autonomous-dev-team/blob/feat/cross-repo-deps/docs/pipeline/invariants.md#inv-39-dependency-parsing-is-list-item-scoped-and-supports-cross-repo-refs) — list-item scope, cross-repo support, lookup-failure semantics.
- **Updated invariant**: INV-11 cross-references INV-39 (`state ∉ {CLOSED, MERGED}` rule applies to both same-repo and cross-repo refs).
- **Flow doc**: `docs/pipeline/dispatcher-flow.md` Step 2 description updated.
- **User-facing**: `skills/create-issue/SKILL.md` and `references/issue-templates.md` document list-item scope + `owner/repo#N` syntax.

## Test plan

- [x] All existing `#61`/`#73` regression cases continue to pass (no behavior change for bare-`#N`-on-list-item).
- [x] Cross-repo `owner/repo#N`: CLOSED/MERGED → resolved; OPEN → blocked.
- [x] Same number in two repos resolves independently (`#42` OPEN in this repo + `other/other#42` CLOSED → resolved).
- [x] Mixed list items: same-repo CLOSED + cross-repo OPEN → blocked.
- [x] Prose-embedded `#N` between headings → ignored (was the silent-block bug).
- [x] Blockquote `> ... owner/repo#N ...` → ignored.
- [x] URL fragment `https://github.com/.../issues/123` → ignored.
- [x] Numbered list (`1.` / `2.`) → extracted correctly.
- [x] Failed `gh issue view` (404 / unauthorized) → blocks AND emits stderr warning naming the failed ref.

`bash tests/unit/test-check-deps-resolved.sh` — 20/20 PASS.
`bash tests/unit/test-create-issue-dependencies-guidance.sh` — 10/10 PASS.
`bash tests/unit/test-lib-dispatch.sh` — 21/21 PASS.

Closes #157.