### PR TITLE
feat(review): E2E_MODE=command for backend pipeline / CLI / library projects (closes #161)

### DIFF
--- a/docs/designs/e2e-mode-command.md
+++ b/docs/designs/e2e-mode-command.md
@@ -1,0 +1,93 @@
+# Design Canvas — E2E_MODE: pluggable E2E channel for the autonomous-review wrapper
+
+**Issue**: #161
+**Status**: design recorded; implementation merged on the branch alongside this canvas.
+**Authors / decision date**: 2026-05-29.
+
+## 1. Problem
+
+`autonomous-review`'s E2E channel is hardcoded to **browser-driven UI smoke testing** via Chrome DevTools MCP — login flow, navigate, screenshot upload, structured report. This shape only fits SaaS web apps with a per-PR preview URL.
+
+Concrete trigger: a backend-pipeline consumer's PR required a 30–60 min run on a deployed PR-stage (DDB row state + S3 artifact assertions + visual confirmation of an LLM-cleaned transcript). The existing wrapper had no way to dispatch this — the review agent looped 3 times against operator-gated findings, the dev agent self-deescalated by removing the `autonomous` label, the operator ran the E2E manually and pasted the evidence by hand. Next consumer in this shape should not need that ceremony.
+
+Three project shapes are NOT served by the existing `browser` channel:
+
+- **Backend pipelines** — verification is "did the artifact land + assert its content shape", not "is this button clickable on the page".
+- **CLI tools / libraries** — no preview URL, no login flow.
+- **Infra-as-code / ML pipelines** — verify by reading deploy outputs / DDB rows / S3 keys.
+
+## 2. Decisions
+
+| # | Question | Decision | Rationale |
+|---|---|---|---|
+| Q1 | One mode, or multiple? | **Three modes** via `E2E_MODE`: `none` (default), `browser` (existing logic), `command` (new). | Browser-mode preserves back-compat for the SaaS web app case; command-mode covers the three new shapes; `none` is the explicit no-E2E default. |
+| Q2 | Default value of `E2E_MODE` when unset? | **`none`** — explicit opt-in to a specific mode. | Implicit-default-to-`browser` was the prior shape and the most common upgrade footgun. Making opt-in explicit catches the typo at startup. |
+| Q3 | What if `E2E_ENABLED=true` but `E2E_MODE` is unset? | **Fail-loud at wrapper startup** with the three accepted values listed. | Existing projects had only `E2E_ENABLED`. Without fail-loud, the upgrade silently falls through to `none` and projects believe E2E is wired up. |
+| Q4 | Who owns the evidence block — agent or project? | **Project** (`E2E_COMMAND_EVIDENCE_PARSER` is REQUIRED in command-mode). | Pipeline-specific evidence (raw.json clusters, DDB row state, prod-baseline diff) is project knowledge. Agent is the runner + judge, not the author. |
+| Q5 | Marker format for evidence-block detection? | **SHA-bound: `<!-- e2e-evidence: complete sha="${PR_HEAD_SHA}" -->`** | Without the SHA, a stale evidence comment from a prior commit can silently satisfy a re-review of newer code. The wrapper exports `PR_HEAD_SHA` so the parser can embed it. |
+| Q6 | Sync vs async execution? | **MVP is synchronous** — the agent waits for `E2E_COMMAND` under `timeout(1)` with `E2E_COMMAND_TIMEOUT_SECONDS` (default 3600). | Async with an `e2e-running` PR label is the right shape for >60 min cases but adds dispatcher state-machine complexity. Defer to follow-up. |
+| Q7 | Parser invocation gating? | **Run parser only when `EXIT_CODE ∈ {0, 124}`.** Other failures post a `tail -50` of the log file directly. | Parsers consume successful runs; a hard-failure log is malformed and crashes the parser, masking the real failure. |
+| Q8 | Decision-block FAIL message — shared or per-mode? | **Per-mode** (`case ${E2E_MODE}` in the prompt's "Decision" section). | `browser` says "screenshot evidence", `command` says "verify-command exit code + log tail". Sharing the message confuses the agent in command-mode (no browser, no screenshots). |
+| Q9 | Unbraced `$PR_NUMBER` in command-mode fields? | **Reject at config validation.** | The wrapper substitutes only braced `${PR_NUMBER}`. Bare `$PR_NUMBER` would render as empty and target the wrong stage. |
+| Q10 | Pipeline-doc impact? | **Update `docs/pipeline/review-agent-flow.md`** with E2E mode dispatch + Step 4b stale-evidence guard. **No new INV-NN.** | This is a wrapper-config schema, not a label-state-machine invariant. Existing INV set is unchanged. |
+
+### Rejected alternatives
+
+- **A. New skill (e.g. `autonomous-review-pipeline`).** Doubles the maintenance surface; project switching between web-app and pipeline shapes (e.g. a monorepo) would need two confs.
+- **B. GHA workflow indirection** — `gh workflow run` to trigger E2E on the runner, agent only reads the comment. Adds CI/CD round-trip to every review tick; fights with the wrapper's existing token / cost-attribution model.
+- **C. Implicit-default `browser` when `E2E_MODE` unset.** The most common upgrade footgun pattern. See Q3 rationale.
+
+## 3. Configuration schema (canonical)
+
+```bash
+# autonomous.conf
+E2E_ENABLED="true"          # legacy back-compat toggle (still respected)
+E2E_MODE="command"          # none | browser | command — REQUIRED if ENABLED=true
+
+# Browser-mode fields (used when E2E_MODE=browser)
+E2E_PREVIEW_URL_PATTERN="https://pr-{N}.example.com"
+E2E_TEST_USER_EMAIL="..."
+E2E_TEST_USER_PASSWORD="..."
+E2E_SCREENSHOT_UPLOAD="false"
+
+# Command-mode fields (used when E2E_MODE=command)
+E2E_COMMAND='bash scripts/e2e-pr-stage.sh ${PR_NUMBER}'           # required
+E2E_COMMAND_EVIDENCE_PARSER='bash scripts/e2e-evidence.sh'        # required
+E2E_COMMAND_PRE_HOOKS='bash scripts/e2e-seed-pr-stage.sh ${PR_NUMBER}'  # optional
+E2E_COMMAND_TIMEOUT_SECONDS=3600                                   # optional, default 3600
+```
+
+`${PR_NUMBER}` placeholder is substituted at render time by the wrapper. Operators MUST single-quote the assignments so the shell does not eagerly expand at conf-source time.
+
+## 4. Dispatch table (canonical)
+
+For each rendered review prompt:
+
+| `E2E_MODE` | Wrapper behavior | Agent receives |
+|---|---|---|
+| unset | `validate_e2e_config` returns 0 (no-E2E path) | no E2E section in prompt |
+| `none` | as above | no E2E section |
+| `browser` | extract preview URL from PR comments + pattern; export test creds | existing browser block (mandatory) |
+| `command` | export `PR_NUMBER` + `PR_HEAD_SHA`; substitute `${PR_NUMBER}` in command-mode fields | new command block (mandatory) |
+| any other value | fail-loud at startup with three accepted values listed | (wrapper exits 1) |
+
+`E2E_ENABLED=true` + `E2E_MODE` unset → fail-loud. Same fail-loud for command-mode without `E2E_COMMAND` or `E2E_COMMAND_EVIDENCE_PARSER`, or for command-mode fields populated when `E2E_MODE` is `none`/`browser`.
+
+The `E2E_ACTIVE` flag (true when mode ∈ {browser, command}) is a derived internal var. Downstream prompt language (decision-gate, env-export block, "E2E completed" suffix) gates off `E2E_ACTIVE` rather than `E2E_ENABLED`. Legacy `E2E_ENABLED` is preserved in conf for back-compat but the wrapper's source of truth is `E2E_MODE`.
+
+## 5. Project-side contract for command-mode
+
+Two scripts the project supplies:
+
+1. **`E2E_COMMAND`** — the verify command. Reads PR_NUMBER from substitution. Exits 0 on success, 124 on timeout, other non-zero on hard fail. Idempotent against retries.
+
+2. **`E2E_COMMAND_EVIDENCE_PARSER`** — reads the verify command's log file as `$1`, emits a markdown evidence block to stdout. Block MUST end with `<!-- e2e-evidence: complete sha="${PR_HEAD_SHA}" -->` (parser reads `PR_HEAD_SHA` from env). Returns 0 on success, non-zero if log is malformed or required artifacts are missing.
+
+Full contract: `skills/autonomous-review/references/e2e-command-mode.md`.
+
+## 6. Out of scope (follow-up)
+
+- **Background / async long-running E2E** with `e2e-running` PR label, for >60 min cases without blocking the agent session. The MVP's `timeout(1)` cap is sufficient for the first consumer (~48 min observed) but won't scale.
+- **Wrapper-side last-line marker validation** — currently the agent parses the marker. Future PR may move it into the wrapper.
+- **`timeout-124` stale-artifact acceptance hardening** — require artifacts to embed `PR_NUMBER` + nonce so a hung pipeline can't fall back on yesterday's S3 object.
+- **`E2E_ENABLED=false` + `E2E_MODE=command` semantic ambiguity** — today the wrapper drives off `E2E_MODE` exclusively; `E2E_ENABLED=false` is a no-op once `E2E_MODE` is set. Future schema cleanup may either honor `E2E_ENABLED` as a hard kill switch or remove it entirely.

--- a/docs/pipeline/review-agent-flow.md
+++ b/docs/pipeline/review-agent-flow.md
@@ -95,19 +95,22 @@ If browser-mode E2E is enabled but preview URL extraction yields nothing, the ag
 
 ### Command rendering (command mode only)
 
-In `command` mode the wrapper substitutes the literal `${PR_NUMBER}` placeholder in `E2E_COMMAND`, `E2E_COMMAND_PRE_HOOKS`, and `E2E_COMMAND_EVIDENCE_PARSER` with the resolved PR number before pasting them into the prompt. Operators MUST single-quote those assignments in `autonomous.conf` so the shell does not eagerly expand `${PR_NUMBER}` when sourcing the conf file.
+In `command` mode the wrapper substitutes the literal `${PR_NUMBER}` placeholder in `E2E_COMMAND`, `E2E_COMMAND_PRE_HOOKS`, and `E2E_COMMAND_EVIDENCE_PARSER` with the resolved PR number before pasting them into the prompt. Operators MUST single-quote those assignments in `autonomous.conf` so the shell does not eagerly expand `${PR_NUMBER}` when sourcing the conf file. Unbraced `$PR_NUMBER` is rejected at config-validation time (would silently render as empty since the var is exported only inside the command-mode block, after substitution).
+
+The wrapper exports `PR_NUMBER` and `PR_HEAD_SHA` into the agent process's environment when `E2E_MODE=command`. The project's evidence parser reads `PR_HEAD_SHA` from env to embed in the evidence-block marker.
 
 The agent's command-mode prompt block instructs it to:
 
 1. Run `E2E_COMMAND_PRE_HOOKS` if set (e.g. seed test data into the per-PR stage).
 2. Run `E2E_COMMAND` under `timeout(1)` with `E2E_COMMAND_TIMEOUT_SECONDS`.
-3. Interpret the exit code (0 = pass, 124 = timeout, other = fail).
-4. Run `E2E_COMMAND_EVIDENCE_PARSER` to extract a markdown evidence block from the log.
-5. Validate the block ends with the literal marker `<!-- e2e-evidence: complete -->`.
-6. Post the evidence block as a PR comment.
-7. Decide PASS/FAIL based on exit code + AC coverage in the evidence block.
+3. Interpret the exit code (0 = pass, 124 = timeout still parses for partial artifact, other = hard fail).
+4. **If exit ∈ {0, 124}**: run `E2E_COMMAND_EVIDENCE_PARSER` to extract a markdown evidence block from the log. Hard-failure exits skip the parser (its input log would be malformed) and post a `tail -50` of the log file as the failure comment.
+4b. **Stale-evidence guard** — before invoking the verify command, the agent checks the PR for an existing comment whose marker contains `sha="${PR_HEAD_SHA}"` (the current PR HEAD). If found, the agent reuses that comment's body as `$EVIDENCE` and jumps to Step 6 — no E2E re-run. The SHA binding is load-bearing: without it, a stale evidence comment from a prior commit would silently satisfy a re-review of newer code.
+5. Validate the block ends with the SHA-bound marker `<!-- e2e-evidence: complete sha="${PR_HEAD_SHA}" -->`.
+6. Post the evidence block (or log-tail failure comment) as a PR comment.
+7. Decide PASS/FAIL based on exit code + AC coverage in the evidence block. The decision-block FAIL message is mode-aware: `browser` requests "screenshot evidence", `command` requests "verify-command exit code + log tail" — branching prevents agent confusion in command-mode where there are no screenshots.
 
-For the project-side contract (`E2E_COMMAND` semantics, evidence-block format), see `skills/autonomous-review/references/e2e-command-mode.md`.
+For the project-side contract (`E2E_COMMAND` semantics, evidence-block format, parser PR_HEAD_SHA usage), see `skills/autonomous-review/references/e2e-command-mode.md`.
 
 ## Prompt construction
 
@@ -122,7 +125,7 @@ Major prompt sections:
 | **Review checklist** | Process compliance, code quality, testing, infra. The Kiro path skips `code-simplifier` / `pr-review` items since Kiro doesn't support those. |
 | **Acceptance criteria verification** | For each `## Acceptance Criteria` checkbox in the issue body, verify against PR code/tests/build then mark via `bash scripts/mark-issue-checkbox.sh`. ALL must be checked before approving. |
 | **Amazon Q Developer trigger** | Mandatory bot-review trigger. Q ignores `/q review` from bot accounts ⇒ wrapper instructs the agent to use `bash scripts/gh-as-user.sh pr comment N --body "/q review"`. Poll up to 3 min for the bot to respond. |
-| **E2E verification (if `E2E_MODE` ∈ {browser, command})** | Branch on `E2E_MODE`. `browser`: Chrome DevTools MCP procedure (navigate, login, execute happy-path + feature test cases, screenshot+upload each, post structured E2E report on PR). `command`: invoke project-supplied `E2E_COMMAND`, run `E2E_COMMAND_EVIDENCE_PARSER`, post evidence block ending with marker `<!-- e2e-evidence: complete -->` as PR comment. See **E2E mode dispatch** above. |
+| **E2E verification (if `E2E_MODE` ∈ {browser, command})** | Branch on `E2E_MODE`. `browser`: Chrome DevTools MCP procedure (navigate, login, execute happy-path + feature test cases, screenshot+upload each, post structured E2E report on PR). `command`: invoke project-supplied `E2E_COMMAND`, run `E2E_COMMAND_EVIDENCE_PARSER`, post evidence block ending with SHA-bound marker `<!-- e2e-evidence: complete sha="${PR_HEAD_SHA}" -->` as PR comment. See **E2E mode dispatch** above. |
 | **Decision** | Single line: PASS ⇒ post "Review PASSED ... Review Session: \`<id>\`" on the **issue** (not PR). FAIL ⇒ post "Review findings: ..." with numbered remediation list, ending with the same session-id trailer. |
 
 The session-id trailer is the wrapper's only way to identify which comment is its own verdict — see [Verdict polling](#verdict-polling) below.

--- a/docs/pipeline/review-agent-flow.md
+++ b/docs/pipeline/review-agent-flow.md
@@ -26,7 +26,7 @@ sequenceDiagram
         W->>GH: remove reviewing, add pending-dev
         W-->>D: exit 1
     end
-    W->>GH: extract preview URL (if E2E_ENABLED)
+    W->>GH: extract preview URL (if E2E_MODE=browser)
     W->>W: build review prompt (mergeability, drift, checklist, decision)
     W->>L: run_agent
     L->>A: printf '%s' PROMPT | claude --session-id ... --model sonnet -p
@@ -73,11 +73,41 @@ If all three fail → comment "Review failed: no PR found linked to this issue. 
 
 This is one of the five legitimate ways the wrapper can transition to `pending-dev` even though the agent never ran. The dispatcher's Step 4a retry counter does NOT count this as a dev-failure — only `Agent Session Report (Dev)` comments and the dispatcher's own crash regex feed the counter.
 
-## Preview URL extraction (E2E only)
+## E2E mode dispatch (issue #161)
 
-Only relevant when `E2E_ENABLED=true` AND `E2E_PREVIEW_URL_PATTERN` is configured. The wrapper builds a URL from the pattern (replacing `{N}` with the PR number) and also scans PR comments for the most recent comment containing "Preview" + an `https://` URL. Comment-extracted URL takes priority (it's specific to the actual deploy).
+The review wrapper supports three E2E modes via `E2E_MODE` in `autonomous.conf`:
 
-If E2E is enabled but preview URL extraction yields nothing, the agent's review prompt receives `Preview URL: NOT_FOUND`, and the agent is instructed to FAIL the review with "E2E verification failed: PR preview URL not found."
+| `E2E_MODE` | Activates when | Prompt block |
+|---|---|---|
+| `none` (default when unset) | always — no E2E section in the prompt | (none) |
+| `browser` | project explicitly opts in | Chrome DevTools MCP UI smoke test (existing) |
+| `command` | project explicitly opts in | Project-supplied verify command (new) |
+
+**Fail-loud at startup**: `E2E_ENABLED=true` with `E2E_MODE` unset exits the wrapper non-zero. Projects must opt into a specific mode rather than implicitly inheriting `browser`. This catches the most common upgrade footgun (existing projects had only `E2E_ENABLED`).
+
+The wrapper internally derives `E2E_ACTIVE` (true when mode is `browser` or `command`); downstream prompt language gates off this flag rather than `E2E_ENABLED`.
+
+### Preview URL extraction (browser mode only)
+
+Only relevant when `E2E_MODE=browser` AND `E2E_PREVIEW_URL_PATTERN` is configured. The wrapper builds a URL from the pattern (replacing `{N}` with the PR number) and also scans PR comments for the most recent comment containing "Preview" + an `https://` URL. Comment-extracted URL takes priority (it's specific to the actual deploy).
+
+If browser-mode E2E is enabled but preview URL extraction yields nothing, the agent's review prompt receives `Preview URL: NOT_FOUND`, and the agent is instructed to FAIL the review with "E2E verification failed: PR preview URL not found."
+
+### Command rendering (command mode only)
+
+In `command` mode the wrapper substitutes the literal `${PR_NUMBER}` placeholder in `E2E_COMMAND`, `E2E_COMMAND_PRE_HOOKS`, and `E2E_COMMAND_EVIDENCE_PARSER` with the resolved PR number before pasting them into the prompt. Operators MUST single-quote those assignments in `autonomous.conf` so the shell does not eagerly expand `${PR_NUMBER}` when sourcing the conf file.
+
+The agent's command-mode prompt block instructs it to:
+
+1. Run `E2E_COMMAND_PRE_HOOKS` if set (e.g. seed test data into the per-PR stage).
+2. Run `E2E_COMMAND` under `timeout(1)` with `E2E_COMMAND_TIMEOUT_SECONDS`.
+3. Interpret the exit code (0 = pass, 124 = timeout, other = fail).
+4. Run `E2E_COMMAND_EVIDENCE_PARSER` to extract a markdown evidence block from the log.
+5. Validate the block ends with the literal marker `<!-- e2e-evidence: complete -->`.
+6. Post the evidence block as a PR comment.
+7. Decide PASS/FAIL based on exit code + AC coverage in the evidence block.
+
+For the project-side contract (`E2E_COMMAND` semantics, evidence-block format), see `skills/autonomous-review/references/e2e-command-mode.md`.
 
 ## Prompt construction
 
@@ -92,7 +122,7 @@ Major prompt sections:
 | **Review checklist** | Process compliance, code quality, testing, infra. The Kiro path skips `code-simplifier` / `pr-review` items since Kiro doesn't support those. |
 | **Acceptance criteria verification** | For each `## Acceptance Criteria` checkbox in the issue body, verify against PR code/tests/build then mark via `bash scripts/mark-issue-checkbox.sh`. ALL must be checked before approving. |
 | **Amazon Q Developer trigger** | Mandatory bot-review trigger. Q ignores `/q review` from bot accounts ⇒ wrapper instructs the agent to use `bash scripts/gh-as-user.sh pr comment N --body "/q review"`. Poll up to 3 min for the bot to respond. |
-| **E2E verification (if enabled)** | Chrome DevTools MCP procedure: navigate, login, execute happy-path + feature test cases, screenshot+upload each, post structured E2E report on PR. |
+| **E2E verification (if `E2E_MODE` ∈ {browser, command})** | Branch on `E2E_MODE`. `browser`: Chrome DevTools MCP procedure (navigate, login, execute happy-path + feature test cases, screenshot+upload each, post structured E2E report on PR). `command`: invoke project-supplied `E2E_COMMAND`, run `E2E_COMMAND_EVIDENCE_PARSER`, post evidence block ending with marker `<!-- e2e-evidence: complete -->` as PR comment. See **E2E mode dispatch** above. |
 | **Decision** | Single line: PASS ⇒ post "Review PASSED ... Review Session: \`<id>\`" on the **issue** (not PR). FAIL ⇒ post "Review findings: ..." with numbered remediation list, ending with the same session-id trailer. |
 
 The session-id trailer is the wrapper's only way to identify which comment is its own verdict — see [Verdict polling](#verdict-polling) below.

--- a/docs/test-cases/e2e-mode-command.md
+++ b/docs/test-cases/e2e-mode-command.md
@@ -1,0 +1,80 @@
+# Test Cases: E2E_MODE=command
+
+Coverage for issue #161 — `E2E_MODE` dispatch in `autonomous-review.sh`. All cases use the source-of-truth grep pattern from `tests/unit/test-autonomous-review-prompt.sh` (no end-to-end agent execution; the wrapper is rendered under different env permutations and the resulting prompt or stderr is asserted against).
+
+## Background
+
+`E2E_MODE` is a new field in `autonomous.conf`. Three accepted values:
+
+| `E2E_MODE` | Behavior |
+|---|---|
+| unset / `none` | No E2E section in the rendered prompt. |
+| `browser` | Existing Chrome-DevTools-MCP block (back-compat for explicit opt-in). |
+| `command` | New block; agent invokes `$E2E_COMMAND`, captures evidence via `$E2E_COMMAND_EVIDENCE_PARSER`, posts as PR comment. |
+
+`E2E_ENABLED=true` with `E2E_MODE` unset is a **fail-loud** condition (no implicit default).
+
+## Test cases
+
+### TC-E2E-MODE-001: missing-mode fail-loud
+
+**Setup:** `E2E_ENABLED=true`, `E2E_MODE` unset. All other env minimal.
+**Action:** invoke `autonomous-review.sh` config-validation path.
+**Expectation:** wrapper exits non-zero. stderr contains the literal string `E2E_MODE` AND mentions all three accepted values (`none`, `browser`, `command`).
+
+### TC-E2E-MODE-002: mode=none silences E2E
+
+**Setup:** `E2E_MODE=none` (with `E2E_ENABLED=true` or unset, both behave the same).
+**Action:** render prompt.
+**Expectation:** prompt contains NEITHER the browser block header (`E2E Verification via Chrome DevTools MCP`) NOR the command-mode header (`E2E Verification via project command`).
+
+### TC-E2E-MODE-003: mode=browser preserves existing block
+
+**Setup:** `E2E_ENABLED=true`, `E2E_MODE=browser`, `E2E_PREVIEW_URL_PATTERN` set.
+**Action:** render prompt.
+**Expectation:** prompt contains the existing `E2E Verification via Chrome DevTools MCP — MANDATORY` header. Back-compat for projects that explicitly opt into browser mode.
+
+### TC-E2E-MODE-004: mode=command injects new block
+
+**Setup:** `E2E_ENABLED=true`, `E2E_MODE=command`, `E2E_COMMAND="bash scripts/e2e.sh pr-${PR_NUMBER}"`, `E2E_COMMAND_EVIDENCE_PARSER="bash scripts/e2e-evidence.sh"`.
+**Action:** render prompt for `PR_NUMBER=344`.
+**Expectation:** prompt contains:
+- A header matching `E2E Verification via project command — MANDATORY` (or equivalent that names the mode)
+- The literal value of `$E2E_COMMAND` after `${PR_NUMBER}` substitution
+- The literal value of `$E2E_COMMAND_EVIDENCE_PARSER`
+- The evidence marker literal `<!-- e2e-evidence: complete -->`
+- A clear PASS / FAIL decision rule referencing exit code + evidence-block presence
+
+### TC-E2E-MODE-005: mode=command without E2E_COMMAND fails
+
+**Setup:** `E2E_ENABLED=true`, `E2E_MODE=command`, `E2E_COMMAND` unset, `E2E_COMMAND_EVIDENCE_PARSER` set.
+**Action:** invoke wrapper config-validation path.
+**Expectation:** wrapper exits non-zero. stderr names `E2E_COMMAND` as the missing field.
+
+### TC-E2E-MODE-006: mode=command without evidence parser fails
+
+**Setup:** `E2E_ENABLED=true`, `E2E_MODE=command`, `E2E_COMMAND` set, `E2E_COMMAND_EVIDENCE_PARSER` unset.
+**Action:** invoke wrapper config-validation path.
+**Expectation:** wrapper exits non-zero. stderr names `E2E_COMMAND_EVIDENCE_PARSER` as the missing field.
+
+### TC-E2E-MODE-007: invalid mode value fails
+
+**Setup:** `E2E_ENABLED=true`, `E2E_MODE=foo`.
+**Action:** invoke wrapper config-validation path.
+**Expectation:** wrapper exits non-zero. stderr lists the three accepted values explicitly.
+
+### TC-E2E-MODE-008: PR_NUMBER substitution
+
+**Setup:** `E2E_ENABLED=true`, `E2E_MODE=command`, `E2E_COMMAND='bash scripts/e2e.sh pr-${PR_NUMBER}'`, `E2E_COMMAND_EVIDENCE_PARSER="bash scripts/e2e-evidence.sh"`. Wrapper invoked with `PR_NUMBER=344`.
+**Action:** render prompt.
+**Expectation:** prompt contains the literal substring `bash scripts/e2e.sh pr-344` (no unresolved `${PR_NUMBER}` in the rendered command).
+
+## Backward-compatibility cases (existing tests must still pass)
+
+- `tests/unit/test-autonomous-review-prompt.sh` — full file, unchanged invariants.
+- `tests/unit/test-autonomous-review-auto-merge-failure.sh` — unchanged.
+- `tests/unit/test-autonomous-review-reviewed-head-annotation.sh` — unchanged.
+- `tests/unit/test-autonomous-review-verdict-regex.sh` — unchanged.
+- `tests/unit/test-autonomous-review-verdict-trailer.sh` — unchanged.
+
+The absent-config path (`E2E_MODE` unset, `E2E_ENABLED` unset or `false`) is the dominant case and is exercised by every existing test that sources the wrapper without setting `E2E_*`. Those must continue to render a prompt with no E2E section.

--- a/docs/test-cases/e2e-mode-command.md
+++ b/docs/test-cases/e2e-mode-command.md
@@ -69,6 +69,52 @@ Coverage for issue #161 — `E2E_MODE` dispatch in `autonomous-review.sh`. All c
 **Action:** render prompt.
 **Expectation:** prompt contains the literal substring `bash scripts/e2e.sh pr-344` (no unresolved `${PR_NUMBER}` in the rendered command).
 
+## Post-review hardening cases (added in fixup)
+
+### TC-E2E-MODE-009: case-sensitivity rejected
+
+**Setup:** `E2E_MODE=Browser` or `E2E_MODE=COMMAND` (capitalization variants).
+**Action:** invoke wrapper config-validation path.
+**Expectation:** wrapper exits non-zero. Mode comparison is exact-match (case-sensitive); capitalized variants hit the invalid-mode branch.
+
+### TC-E2E-MODE-010: command-mode fields without E2E_MODE=command
+
+**Setup:** `E2E_COMMAND` set, but `E2E_MODE=none` or `E2E_MODE=browser`.
+**Action:** invoke wrapper config-validation path.
+**Expectation:** wrapper exits non-zero. Catches the "operator filled in E2E_COMMAND but forgot E2E_MODE=command" footgun.
+
+### TC-E2E-MODE-011: substitution survives unset E2E_COMMAND_PRE_HOOKS
+
+**Setup:** `E2E_MODE=command`, `E2E_COMMAND` and `E2E_COMMAND_EVIDENCE_PARSER` set, `E2E_COMMAND_PRE_HOOKS` left unset.
+**Action:** wrapper substitution block (lines around 388-397) must use `:-` defaults.
+**Expectation:** substitution lines reference `${VAR:-}` form; an explicit PR_NUMBER empty-guard precedes substitution. Without `:-` defaults, `set -u` would crash the wrapper before the agent runs.
+
+### TC-E2E-MODE-012: F1 fix — decision FAIL message branches on E2E_MODE
+
+**Setup:** code inspection of the wrapper's "Decision" section.
+**Expectation:** the FAIL message uses a `case ${E2E_MODE}` branch — `browser` says "screenshot evidence", `command` says "log tail evidence". Pre-fix: both modes received the same screenshot-flavored language, confusing the agent in command mode.
+
+### TC-E2E-MODE-013: F2 fix — evidence marker requires SHA binding
+
+**Setup:** code inspection of the wrapper's prompt.
+**Expectation:** the marker spec is `<!-- e2e-evidence: complete sha="${PR_HEAD_SHA}" -->`, and the prompt contains a stale-evidence guard step that re-binds skip behavior to exact SHA match. Plain marker without SHA does NOT count.
+
+### TC-E2E-MODE-014: F3 fix — parser only on EXIT_CODE ∈ {0, 124}
+
+**Setup:** code inspection of the wrapper's command-mode Step 4.
+**Expectation:** parser invocation is gated on `EXIT_CODE -eq 0 || EXIT_CODE -eq 124`. Hard failures (other non-zero) skip the parser and post a `tail -50` of the log file as the failure comment instead.
+
+### TC-E2E-MODE-015: F4 fix — unbraced `$PR_NUMBER` rejected
+
+**Setup:** `E2E_COMMAND='bash scripts/x.sh $PR_NUMBER'` (unbraced).
+**Action:** invoke wrapper config-validation path.
+**Expectation:** wrapper exits non-zero. Stderr names the offending field. Without this guard, the unbraced form would silently render as empty and target the wrong stage. Braced form `${PR_NUMBER}` validates clean.
+
+### TC-E2E-MODE-016: command-mode exports PR_NUMBER + PR_HEAD_SHA
+
+**Setup:** code inspection of the wrapper's env-export block.
+**Expectation:** when `E2E_MODE=command`, the wrapper exports both `PR_NUMBER` and `PR_HEAD_SHA` so the project's evidence parser script can read `PR_HEAD_SHA` from env to embed in the marker.
+
 ## Backward-compatibility cases (existing tests must still pass)
 
 - `tests/unit/test-autonomous-review-prompt.sh` — full file, unchanged invariants.

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -91,6 +91,16 @@ validate_e2e_config() {
 
   case "$mode" in
     none|browser)
+      # In the non-command modes the command-mode fields must NOT be
+      # set. Catches the "operator filled in E2E_COMMAND but forgot to
+      # set E2E_MODE=command" footgun — without this guard the fields
+      # would be silently ignored and the operator would think
+      # command-mode was wired up.
+      if [[ -n "${E2E_COMMAND:-}" || -n "${E2E_COMMAND_EVIDENCE_PARSER:-}" || -n "${E2E_COMMAND_PRE_HOOKS:-}" ]]; then
+        echo "Error: E2E_COMMAND* fields are set but E2E_MODE='${mode}', not 'command'." >&2
+        echo "  Either set E2E_MODE=command or unset E2E_COMMAND / E2E_COMMAND_PRE_HOOKS / E2E_COMMAND_EVIDENCE_PARSER." >&2
+        return 1
+      fi
       ;;
     command)
       if [[ -z "${E2E_COMMAND:-}" ]]; then
@@ -377,18 +387,31 @@ if [[ -n "$BOT_LOGIN" ]]; then
   log "Verdict will bind to actor=${BOT_LOGIN}, createdAt >= ${WRAPPER_START_TS}, body must contain 'Review Session'"
 fi
 
-# E2E_MODE=command: substitute ${PR_NUMBER} placeholder in command-mode
-# fields so the agent receives a fully-resolved command string. The
-# placeholder is the literal six-character sequence `${PR_NUMBER}` —
-# operators write it in autonomous.conf with single quotes to defer
-# expansion (e.g. E2E_COMMAND='bash scripts/e2e.sh pr-${PR_NUMBER}').
+# E2E_MODE=command: substitute the literal `${PR_NUMBER}` placeholder in
+# command-mode fields so the agent receives a fully-resolved command
+# string. Operators write the placeholder in autonomous.conf with single
+# quotes to defer expansion (e.g.
+# E2E_COMMAND='bash scripts/e2e.sh pr-${PR_NUMBER}').
+#
+# `:-` defaults are required: under `set -u`, `${VAR//pat/repl}` against
+# an unset VAR aborts the wrapper. E2E_COMMAND_PRE_HOOKS is documented
+# as optional; without the default an operator who simply omits the
+# line crashes the wrapper before the agent ever runs.
 E2E_COMMAND_RENDERED=""
 E2E_COMMAND_PRE_HOOKS_RENDERED=""
 E2E_COMMAND_EVIDENCE_PARSER_RENDERED=""
 if [[ "${E2E_MODE:-none}" == "command" ]]; then
-  E2E_COMMAND_RENDERED="${E2E_COMMAND//\$\{PR_NUMBER\}/${PR_NUMBER}}"
-  E2E_COMMAND_PRE_HOOKS_RENDERED="${E2E_COMMAND_PRE_HOOKS//\$\{PR_NUMBER\}/${PR_NUMBER}}"
-  E2E_COMMAND_EVIDENCE_PARSER_RENDERED="${E2E_COMMAND_EVIDENCE_PARSER//\$\{PR_NUMBER\}/${PR_NUMBER}}"
+  if [[ -z "$PR_NUMBER" ]]; then
+    log "ERROR: E2E_MODE=command but PR_NUMBER is empty — refusing to render"
+    log "       a placeholder-substituted command that would target the wrong PR."
+    exit 1
+  fi
+  E2E_COMMAND_RENDERED="${E2E_COMMAND:-}"
+  E2E_COMMAND_RENDERED="${E2E_COMMAND_RENDERED//\$\{PR_NUMBER\}/${PR_NUMBER}}"
+  E2E_COMMAND_PRE_HOOKS_RENDERED="${E2E_COMMAND_PRE_HOOKS:-}"
+  E2E_COMMAND_PRE_HOOKS_RENDERED="${E2E_COMMAND_PRE_HOOKS_RENDERED//\$\{PR_NUMBER\}/${PR_NUMBER}}"
+  E2E_COMMAND_EVIDENCE_PARSER_RENDERED="${E2E_COMMAND_EVIDENCE_PARSER:-}"
+  E2E_COMMAND_EVIDENCE_PARSER_RENDERED="${E2E_COMMAND_EVIDENCE_PARSER_RENDERED//\$\{PR_NUMBER\}/${PR_NUMBER}}"
 fi
 
 PROMPT="$(cat <<EOF

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -717,12 +717,15 @@ plain marker matches do NOT count (would let stale evidence from a
 prior commit pass).
 
 \`\`\`bash
-EXISTING=\$(gh pr view ${PR_NUMBER} --repo ${REPO} --json comments \\
-  --jq '.comments[].body' | grep -F 'e2e-evidence: complete sha="${PR_HEAD_SHA}"' | head -1)
-if [[ -n "\$EXISTING" ]]; then
+# Use jq to fetch the FULL comment body (not just the marker line) so
+# Step 6 can evaluate AC coverage against the existing evidence's table.
+EVIDENCE=\$(gh pr view ${PR_NUMBER} --repo ${REPO} --json comments \\
+  --jq '.comments[] | select(.body | contains("e2e-evidence: complete sha=\\"${PR_HEAD_SHA}\\"")) | .body' \\
+  | head -1)
+if [[ -n "\$EVIDENCE" ]]; then
   echo "Evidence already exists for HEAD ${PR_HEAD_SHA}, skipping E2E re-run"
-  # Use the existing evidence; jump to Step 6 PASS/FAIL decision based
-  # on its contents.
+  # \$EVIDENCE now holds the full markdown comment body. Jump to Step 6
+  # PASS/FAIL decision based on its contents (AC table coverage).
 fi
 \`\`\`
 
@@ -759,7 +762,7 @@ EOF_FAIL
 PASS when **all** of:
 - Pre-hooks (if configured) exited 0
 - Verify command exited 0 (or 124 with the artifact-recovery exception above)
-- Evidence block ends with the marker \`<!-- e2e-evidence: complete -->\`
+- Evidence block ends with the SHA-bound marker \`<!-- e2e-evidence: complete sha="${PR_HEAD_SHA}" -->\`
 - Every issue-body acceptance criterion that names a verifiable artifact
   (file path, S3 key, DDB row state, log line, count) is satisfied by
   the evidence block

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -68,19 +68,88 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# E2E config validation (issue #161)
+#
+# E2E_MODE accepts: none (default), browser (existing), command (new).
+# E2E_ENABLED=true requires E2E_MODE to be set explicitly — projects must
+# opt into a specific mode rather than implicitly inheriting "browser".
+# ---------------------------------------------------------------------------
+validate_e2e_config() {
+  local mode="${E2E_MODE:-none}"
+
+  # E2E_ENABLED=true with no mode set is the most common upgrade footgun:
+  # projects that were on the old wrapper had only E2E_ENABLED. Fail loud
+  # with the three accepted values listed.
+  if [[ "${E2E_ENABLED:-false}" == "true" ]] && [[ -z "${E2E_MODE:-}" ]]; then
+    echo "Error: E2E_ENABLED=true requires E2E_MODE to be set explicitly." >&2
+    echo "  Accepted values for E2E_MODE: none, browser, command" >&2
+    echo "  - none:    no E2E section in review prompt (equivalent to E2E_ENABLED=false)" >&2
+    echo "  - browser: existing Chrome DevTools MCP UI smoke test (set E2E_PREVIEW_URL_PATTERN, E2E_TEST_USER_EMAIL, E2E_TEST_USER_PASSWORD)" >&2
+    echo "  - command: project-supplied command for backend / CLI / pipeline projects (set E2E_COMMAND, E2E_COMMAND_EVIDENCE_PARSER)" >&2
+    return 1
+  fi
+
+  case "$mode" in
+    none|browser)
+      ;;
+    command)
+      if [[ -z "${E2E_COMMAND:-}" ]]; then
+        echo "Error: E2E_MODE=command requires E2E_COMMAND to be set." >&2
+        echo "  Example: E2E_COMMAND='bash scripts/e2e-pr-stage.sh \${PR_NUMBER}'" >&2
+        return 1
+      fi
+      if [[ -z "${E2E_COMMAND_EVIDENCE_PARSER:-}" ]]; then
+        echo "Error: E2E_MODE=command requires E2E_COMMAND_EVIDENCE_PARSER to be set." >&2
+        echo "  The parser MUST output a markdown evidence block ending with the" >&2
+        echo "  literal marker: <!-- e2e-evidence: complete -->" >&2
+        echo "  See references/e2e-command-mode.md for the contract." >&2
+        return 1
+      fi
+      ;;
+    *)
+      echo "Error: invalid E2E_MODE='${mode}'." >&2
+      echo "  Accepted values for E2E_MODE: none, browser, command" >&2
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+validate_e2e_config || exit 1
+
+# Derived flag: true when E2E_MODE is one of {browser, command}. Used by
+# downstream blocks that need to know whether E2E is producing output
+# (for the decision-gate language and env-var export). The legacy
+# E2E_ENABLED toggle is preserved for back-compat in autonomous.conf
+# but the wrapper internally drives off E2E_MODE — that's the source
+# of truth.
+case "${E2E_MODE:-none}" in
+  browser|command) E2E_ACTIVE="true" ;;
+  *)               E2E_ACTIVE="false" ;;
+esac
+
+# ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
 ISSUE_NUMBER=""
+VALIDATE_CONFIG_ONLY=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --issue)
       [[ $# -ge 2 ]] || { echo "Error: --issue requires argument" >&2; exit 1; }
       ISSUE_NUMBER="$2"; shift 2 ;;
+    --validate-config-only)
+      # Exit cleanly after config validation; used by tests/unit/test-e2e-mode-command.sh.
+      VALIDATE_CONFIG_ONLY=1; shift ;;
     *)
       echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
+
+if [[ "$VALIDATE_CONFIG_ONLY" -eq 1 ]]; then
+  exit 0
+fi
 
 if [[ -z "$ISSUE_NUMBER" ]]; then
   echo "Usage: $0 --issue <number>" >&2
@@ -237,7 +306,7 @@ log "Found PR #${PR_NUMBER} for issue #${ISSUE_NUMBER}"
 # ---------------------------------------------------------------------------
 PREVIEW_URL=""
 
-if [[ "${E2E_ENABLED:-false}" == "true" && -n "${E2E_PREVIEW_URL_PATTERN:-}" ]]; then
+if [[ "${E2E_ACTIVE:-false}" == "true" && -n "${E2E_PREVIEW_URL_PATTERN:-}" ]]; then
   log "Extracting preview URL for PR #${PR_NUMBER}..."
 
   # Build expected URL from config, replacing {N} with PR number
@@ -266,7 +335,7 @@ if [[ "${E2E_SCREENSHOT_UPLOAD:-false}" == "true" && -x "${PROJECT_DIR}/skills/a
   log "Screenshot upload script available"
 else
   SCREENSHOT_UPLOAD_AVAILABLE="false"
-  if [[ "${E2E_ENABLED:-false}" == "true" ]]; then
+  if [[ "${E2E_ACTIVE:-false}" == "true" ]]; then
     log "WARNING: Screenshot upload not available (set E2E_SCREENSHOT_UPLOAD=true and ensure upload-screenshot.sh is executable)"
   fi
 fi
@@ -306,6 +375,20 @@ if [[ "$BOT_LOGIN" == "null" || -z "$BOT_LOGIN" ]]; then
 fi
 if [[ -n "$BOT_LOGIN" ]]; then
   log "Verdict will bind to actor=${BOT_LOGIN}, createdAt >= ${WRAPPER_START_TS}, body must contain 'Review Session'"
+fi
+
+# E2E_MODE=command: substitute ${PR_NUMBER} placeholder in command-mode
+# fields so the agent receives a fully-resolved command string. The
+# placeholder is the literal six-character sequence `${PR_NUMBER}` —
+# operators write it in autonomous.conf with single quotes to defer
+# expansion (e.g. E2E_COMMAND='bash scripts/e2e.sh pr-${PR_NUMBER}').
+E2E_COMMAND_RENDERED=""
+E2E_COMMAND_PRE_HOOKS_RENDERED=""
+E2E_COMMAND_EVIDENCE_PARSER_RENDERED=""
+if [[ "${E2E_MODE:-none}" == "command" ]]; then
+  E2E_COMMAND_RENDERED="${E2E_COMMAND//\$\{PR_NUMBER\}/${PR_NUMBER}}"
+  E2E_COMMAND_PRE_HOOKS_RENDERED="${E2E_COMMAND_PRE_HOOKS//\$\{PR_NUMBER\}/${PR_NUMBER}}"
+  E2E_COMMAND_EVIDENCE_PARSER_RENDERED="${E2E_COMMAND_EVIDENCE_PARSER//\$\{PR_NUMBER\}/${PR_NUMBER}}"
 fi
 
 PROMPT="$(cat <<EOF
@@ -398,7 +481,12 @@ Read the issue body for an \`## Acceptance Criteria\` section. For EACH criterio
 
 $(render_bot_review_section "$REVIEW_BOTS_VALIDATED" "$PR_NUMBER" "$REPO")
 
-$(if [[ "${E2E_ENABLED:-false}" == "true" ]]; then cat <<E2E_BLOCK
+$(case "${E2E_MODE:-none}" in
+  none)
+    : # no E2E section
+    ;;
+  browser)
+    cat <<E2E_BLOCK
 ## E2E Verification via Chrome DevTools MCP — MANDATORY
 
 **This section is NON-NEGOTIABLE. You MUST perform E2E verification using Chrome DevTools MCP.**
@@ -504,7 +592,106 @@ else
 fi)
 \`\`\`
 E2E_BLOCK
-fi)
+    ;;
+  command)
+    cat <<COMMAND_E2E_BLOCK
+## E2E Verification via project command — MANDATORY
+
+**This section is NON-NEGOTIABLE. You MUST run the project-supplied verify command and validate its evidence output.**
+
+This project does not have a browser-driven UI E2E. Instead the project
+defines its own verify command (typical for backend pipelines, CLI tools,
+infra-as-code, or ML pipelines). Your job is: invoke the command, wait
+for it to finish (or timeout), validate the evidence block it produces,
+and post the evidence as a PR comment.
+
+### Configuration (resolved by the wrapper)
+
+- Verify command: \`${E2E_COMMAND_RENDERED}\`
+- Pre-hooks: \`${E2E_COMMAND_PRE_HOOKS_RENDERED:-(none)}\`
+- Evidence parser: \`${E2E_COMMAND_EVIDENCE_PARSER_RENDERED}\`
+- Timeout (seconds): ${E2E_COMMAND_TIMEOUT_SECONDS:-3600}
+
+### Step 1: Run pre-hooks (if configured)
+
+If "Pre-hooks" above is not "(none)", run that command first. A non-zero
+exit code from pre-hooks aborts the E2E with status FAIL.
+
+\`\`\`bash
+${E2E_COMMAND_PRE_HOOKS_RENDERED:-:}
+\`\`\`
+
+Pre-hooks typically prepare per-PR test data (e.g. seed a DDB row,
+provision a sandbox project, deploy a preview stack).
+
+### Step 2: Run the verify command
+
+\`\`\`bash
+timeout ${E2E_COMMAND_TIMEOUT_SECONDS:-3600} \
+  ${E2E_COMMAND_RENDERED} \
+  > /tmp/e2e-${PR_NUMBER}.log 2>&1
+EXIT_CODE=\$?
+\`\`\`
+
+Stream output to a log file so you can analyze partial results on timeout.
+\`EXIT_CODE=124\` from \`timeout\` means the command was killed for exceeding
+the deadline — treat as FAIL but still parse partial evidence below.
+
+### Step 3: Inspect outcome
+
+- **EXIT_CODE=0** → PASS pending evidence validation.
+- **EXIT_CODE=124** → TIMEOUT → FAIL. Include log tail in your findings.
+- **EXIT_CODE!=0 and !=124** → FAIL. The command itself reports the error.
+
+Some pipelines have late-stage tail-end errors that fire AFTER the
+artifact has actually landed (e.g. cleanup race). In that case you MAY
+re-validate by inspecting the authoritative artifact source (S3 / DDB /
+file) directly via the evidence parser before marking FAIL.
+
+### Step 4: Generate evidence block via parser
+
+\`\`\`bash
+EVIDENCE=\$(${E2E_COMMAND_EVIDENCE_PARSER_RENDERED} /tmp/e2e-${PR_NUMBER}.log)
+\`\`\`
+
+The parser MUST output a markdown evidence block ending with the literal
+marker:
+
+\`\`\`
+<!-- e2e-evidence: complete -->
+\`\`\`
+
+If the parser exits non-zero or the marker is missing, the evidence is
+malformed — post a "Review findings" comment naming
+\`E2E_COMMAND_EVIDENCE_PARSER\` as the subsystem at fault and exit.
+
+### Step 5: Post evidence as a PR comment
+
+\`\`\`bash
+gh pr comment ${PR_NUMBER} --body "\$EVIDENCE"
+\`\`\`
+
+The evidence block is the authoritative E2E artifact. Reviewers (and
+this same wrapper on subsequent ticks) can grep for the marker to
+detect prior evidence and skip re-running.
+
+### Step 6: Decide PASS / FAIL
+
+PASS when **all** of:
+- Pre-hooks (if configured) exited 0
+- Verify command exited 0 (or 124 with the artifact-recovery exception above)
+- Evidence block ends with the marker \`<!-- e2e-evidence: complete -->\`
+- Every issue-body acceptance criterion that names a verifiable artifact
+  (file path, S3 key, DDB row state, log line, count) is satisfied by
+  the evidence block
+
+FAIL when any of those conditions is not met. Include the relevant log
+tail in your findings.
+
+For the full contract, consult \`references/e2e-command-mode.md\`.
+COMMAND_E2E_BLOCK
+    ;;
+esac)
 
 ## Decision
 After thorough review:
@@ -517,25 +704,25 @@ the FAILED branch and the dispatcher will eventually mark the issue
 shown below — alternative phrasings like "APPROVED FOR MERGE" or "LGTM"
 also work, but stick to the canonical form when possible.
 
-- If ALL checklist items pass AND code quality is good$(if [[ "${E2E_ENABLED:-false}" == "true" ]]; then echo " AND all E2E tests pass"; fi) AND no requirement drift detected:
+- If ALL checklist items pass AND code quality is good$(if [[ "${E2E_ACTIVE:-false}" == "true" ]]; then echo " AND all E2E tests pass"; fi) AND no requirement drift detected:
   Post a comment on issue #${ISSUE_NUMBER} starting with the exact text
   **\`Review PASSED\`** on the FIRST LINE, like:
 
-  > Review PASSED - All checklist items verified, code quality good.$(if [[ "${E2E_ENABLED:-false}" == "true" ]]; then echo " E2E verification completed."; fi) No requirement drift.
+  > Review PASSED - All checklist items verified, code quality good.$(if [[ "${E2E_ACTIVE:-false}" == "true" ]]; then echo " E2E verification completed."; fi) No requirement drift.
   > Review Session: \`${SESSION_ID}\`
 
   Then exit.
 
-- If ANY item fails$(if [[ "${E2E_ENABLED:-false}" == "true" ]]; then echo " OR any E2E test fails OR preview URL is unavailable"; fi) OR requirement drift is detected:
+- If ANY item fails$(if [[ "${E2E_ACTIVE:-false}" == "true" ]]; then echo " OR any E2E test fails OR preview URL is unavailable"; fi) OR requirement drift is detected:
   Post a comment on issue #${ISSUE_NUMBER} starting with the exact text
   **\`Review findings:\`** on the FIRST LINE, followed by a numbered list
-  of each failing item with specific remediation instructions.$(if [[ "${E2E_ENABLED:-false}" == "true" ]]; then echo "
+  of each failing item with specific remediation instructions.$(if [[ "${E2E_ACTIVE:-false}" == "true" ]]; then echo "
   Include E2E failure details with screenshot evidence."; fi)
   End the comment with: \`Review Session: \\\`${SESSION_ID}\\\`\`
   Then exit.
 
 IMPORTANT: Work autonomously. Be thorough but fair. Focus on correctness and compliance.
-$(if [[ "${E2E_ENABLED:-false}" == "true" ]]; then echo "E2E verification is MANDATORY — do NOT skip it, do NOT treat it as optional."; fi)
+$(if [[ "${E2E_ACTIVE:-false}" == "true" ]]; then echo "E2E verification is MANDATORY — do NOT skip it, do NOT treat it as optional."; fi)
 EOF
 )"
 
@@ -546,7 +733,7 @@ SESSION_NAME="review-pr-${PR_NUMBER}-issue-${ISSUE_NUMBER}"
 log "Starting review session: ${SESSION_ID} (name: ${SESSION_NAME}, model: ${AGENT_REVIEW_MODEL:-sonnet})"
 
 # Export E2E credentials as env vars (not in prompt) for agent to read at runtime
-if [[ "${E2E_ENABLED:-false}" == "true" ]]; then
+if [[ "${E2E_ACTIVE:-false}" == "true" ]]; then
   export E2E_TEST_USER_EMAIL="${E2E_TEST_USER_EMAIL:-}"
   export E2E_TEST_USER_PASSWORD="${E2E_TEST_USER_PASSWORD:-}"
 fi
@@ -693,7 +880,7 @@ if [[ "$PASSED_VERDICT" == "true" ]]; then
   fi
   log "Submitting PR approval for PR #${PR_NUMBER}..."
   if gh pr review "$PR_NUMBER" --repo "$REPO" --approve \
-    --body "All acceptance criteria verified.$(if [[ "${E2E_ENABLED:-false}" == "true" ]]; then echo " E2E verification passed."; fi)" 2>&1; then
+    --body "All acceptance criteria verified.$(if [[ "${E2E_ACTIVE:-false}" == "true" ]]; then echo " E2E verification passed."; fi)" 2>&1; then
     log "PR #${PR_NUMBER} approved successfully."
   else
     log "ERROR: Failed to submit PR approval for PR #${PR_NUMBER}."

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -111,10 +111,26 @@ validate_e2e_config() {
       if [[ -z "${E2E_COMMAND_EVIDENCE_PARSER:-}" ]]; then
         echo "Error: E2E_MODE=command requires E2E_COMMAND_EVIDENCE_PARSER to be set." >&2
         echo "  The parser MUST output a markdown evidence block ending with the" >&2
-        echo "  literal marker: <!-- e2e-evidence: complete -->" >&2
+        echo "  literal marker: <!-- e2e-evidence: complete sha=\"<HEAD>\" -->" >&2
         echo "  See references/e2e-command-mode.md for the contract." >&2
         return 1
       fi
+      # Reject unbraced $PR_NUMBER in command-mode fields. The wrapper only
+      # substitutes the BRACED form ${PR_NUMBER}; a bare $PR_NUMBER would
+      # silently render as empty (PR_NUMBER is not exported), potentially
+      # targeting the wrong stage or the prod stage. This guard catches
+      # the typo at config-validation time. Match \$PR_NUMBER NOT followed
+      # by '{' or alphanum (so we don't false-fire on `${PR_NUMBER}` or
+      # `$PR_NUMBER_FOO`).
+      for _field in E2E_COMMAND E2E_COMMAND_PRE_HOOKS E2E_COMMAND_EVIDENCE_PARSER; do
+        local _value="${!_field:-}"
+        if [[ "$_value" =~ \$PR_NUMBER([^A-Za-z0-9_{]|$) ]]; then
+          echo "Error: ${_field} contains unbraced \$PR_NUMBER." >&2
+          echo "  Use \${PR_NUMBER} (with braces) so the wrapper can substitute it." >&2
+          echo "  Found in: ${_field}=${_value}" >&2
+          return 1
+        fi
+      done
       ;;
     *)
       echo "Error: invalid E2E_MODE='${mode}'." >&2
@@ -662,41 +678,81 @@ the deadline — treat as FAIL but still parse partial evidence below.
 
 ### Step 3: Inspect outcome
 
-- **EXIT_CODE=0** → PASS pending evidence validation.
-- **EXIT_CODE=124** → TIMEOUT → FAIL. Include log tail in your findings.
-- **EXIT_CODE!=0 and !=124** → FAIL. The command itself reports the error.
+- **EXIT_CODE=0** → PASS pending evidence validation. **Proceed to Step 4.**
+- **EXIT_CODE=124** → TIMEOUT. Some pipelines write artifacts BEFORE a
+  late-stage cleanup races and triggers timeout. **Proceed to Step 4** to
+  let the evidence parser inspect the authoritative artifact source
+  (S3 / DDB / file). The parser, not the exit code, is the source of
+  truth for whether the artifact is acceptable.
+- **EXIT_CODE!=0 and !=124** → FAIL. **SKIP Step 4 (do NOT run the
+  parser — its input log is malformed).** Jump directly to Step 5 with
+  a log tail as evidence.
 
-Some pipelines have late-stage tail-end errors that fire AFTER the
-artifact has actually landed (e.g. cleanup race). In that case you MAY
-re-validate by inspecting the authoritative artifact source (S3 / DDB /
-file) directly via the evidence parser before marking FAIL.
-
-### Step 4: Generate evidence block via parser
+### Step 4: Generate evidence block via parser (ONLY if EXIT_CODE ∈ {0, 124})
 
 \`\`\`bash
-EVIDENCE=\$(${E2E_COMMAND_EVIDENCE_PARSER_RENDERED} /tmp/e2e-${PR_NUMBER}.log)
+if [[ \$EXIT_CODE -eq 0 || \$EXIT_CODE -eq 124 ]]; then
+  EVIDENCE=\$(${E2E_COMMAND_EVIDENCE_PARSER_RENDERED} /tmp/e2e-${PR_NUMBER}.log)
+fi
 \`\`\`
 
 The parser MUST output a markdown evidence block ending with the literal
-marker:
+marker (note the embedded SHA — see Step 4b):
 
 \`\`\`
-<!-- e2e-evidence: complete -->
+<!-- e2e-evidence: complete sha="${PR_HEAD_SHA}" -->
 \`\`\`
 
 If the parser exits non-zero or the marker is missing, the evidence is
 malformed — post a "Review findings" comment naming
 \`E2E_COMMAND_EVIDENCE_PARSER\` as the subsystem at fault and exit.
 
+### Step 4b: Stale-evidence guard — REQUIRED on every tick
+
+**Before running the verify command at all**, check whether the PR
+already has a valid evidence comment for the current HEAD SHA. The
+current HEAD SHA is \`${PR_HEAD_SHA}\`. The marker is considered
+"matching" only if it contains exactly \`sha="${PR_HEAD_SHA}"\` —
+plain marker matches do NOT count (would let stale evidence from a
+prior commit pass).
+
+\`\`\`bash
+EXISTING=\$(gh pr view ${PR_NUMBER} --repo ${REPO} --json comments \\
+  --jq '.comments[].body' | grep -F 'e2e-evidence: complete sha="${PR_HEAD_SHA}"' | head -1)
+if [[ -n "\$EXISTING" ]]; then
+  echo "Evidence already exists for HEAD ${PR_HEAD_SHA}, skipping E2E re-run"
+  # Use the existing evidence; jump to Step 6 PASS/FAIL decision based
+  # on its contents.
+fi
+\`\`\`
+
+If the existing comment's marker SHA does NOT match \`${PR_HEAD_SHA}\`,
+the evidence is stale — re-run E2E from Step 1.
+
 ### Step 5: Post evidence as a PR comment
+
+For PASS or TIMEOUT (EXIT_CODE ∈ {0, 124}):
 
 \`\`\`bash
 gh pr comment ${PR_NUMBER} --body "\$EVIDENCE"
 \`\`\`
 
-The evidence block is the authoritative E2E artifact. Reviewers (and
-this same wrapper on subsequent ticks) can grep for the marker to
-detect prior evidence and skip re-running.
+For other failures (EXIT_CODE not in {0, 124}), post a log-tail comment
+instead — do NOT invoke the parser:
+
+\`\`\`bash
+gh pr comment ${PR_NUMBER} --body "\$(cat <<EOF_FAIL
+## E2E Failure (verify command exit code: \$EXIT_CODE)
+
+Command: \\\`${E2E_COMMAND_RENDERED}\\\`
+
+Last 50 lines of /tmp/e2e-${PR_NUMBER}.log:
+\\\`\\\`\\\`
+\$(tail -50 /tmp/e2e-${PR_NUMBER}.log)
+\\\`\\\`\\\`
+EOF_FAIL
+)"
+\`\`\`
 
 ### Step 6: Decide PASS / FAIL
 
@@ -736,11 +792,12 @@ also work, but stick to the canonical form when possible.
 
   Then exit.
 
-- If ANY item fails$(if [[ "${E2E_ACTIVE:-false}" == "true" ]]; then echo " OR any E2E test fails OR preview URL is unavailable"; fi) OR requirement drift is detected:
+- If ANY item fails$(case "${E2E_MODE:-none}" in browser) echo " OR any E2E test fails OR preview URL is unavailable" ;; command) echo " OR the verify command fails OR the evidence block is missing/malformed" ;; esac) OR requirement drift is detected:
   Post a comment on issue #${ISSUE_NUMBER} starting with the exact text
   **\`Review findings:\`** on the FIRST LINE, followed by a numbered list
-  of each failing item with specific remediation instructions.$(if [[ "${E2E_ACTIVE:-false}" == "true" ]]; then echo "
-  Include E2E failure details with screenshot evidence."; fi)
+  of each failing item with specific remediation instructions.$(case "${E2E_MODE:-none}" in browser) echo "
+  Include E2E failure details with screenshot evidence." ;; command) echo "
+  Include the verify-command exit code and a tail of /tmp/e2e-${PR_NUMBER}.log as evidence." ;; esac)
   End the comment with: \`Review Session: \\\`${SESSION_ID}\\\`\`
   Then exit.
 
@@ -759,6 +816,18 @@ log "Starting review session: ${SESSION_ID} (name: ${SESSION_NAME}, model: ${AGE
 if [[ "${E2E_ACTIVE:-false}" == "true" ]]; then
   export E2E_TEST_USER_EMAIL="${E2E_TEST_USER_EMAIL:-}"
   export E2E_TEST_USER_PASSWORD="${E2E_TEST_USER_PASSWORD:-}"
+fi
+
+# Command-mode: export PR_NUMBER and PR_HEAD_SHA so the project's
+# E2E_COMMAND / parser scripts can read them. This is required by the
+# evidence-block contract (parser must embed PR_HEAD_SHA in the marker
+# for stale-evidence guard) and convenient for verify commands that use
+# the unbraced shell form `$PR_NUMBER` after a future opt-in. Today
+# unbraced is rejected at config-validation time, but parsers commonly
+# read these.
+if [[ "${E2E_MODE:-none}" == "command" ]]; then
+  export PR_NUMBER="${PR_NUMBER}"
+  export PR_HEAD_SHA="${PR_HEAD_SHA:-}"
 fi
 
 set +e

--- a/skills/autonomous-dispatcher/scripts/autonomous.conf.example
+++ b/skills/autonomous-dispatcher/scripts/autonomous.conf.example
@@ -505,6 +505,8 @@ E2E_COMMAND_TIMEOUT_SECONDS=3600
 # verify command's log file as $1, emits a markdown evidence block to
 # stdout. The block MUST end with the literal marker:
 #   <!-- e2e-evidence: complete -->
-# The wrapper validates the marker is present before posting the
-# comment. See references/e2e-command-mode.md for the full contract.
+# The review agent (not the wrapper) checks for the marker before
+# posting the comment, per the command-mode prompt block in
+# autonomous-review.sh. See references/e2e-command-mode.md for the
+# full contract.
 E2E_COMMAND_EVIDENCE_PARSER=""

--- a/skills/autonomous-dispatcher/scripts/autonomous.conf.example
+++ b/skills/autonomous-dispatcher/scripts/autonomous.conf.example
@@ -449,8 +449,62 @@ DEV_SKILL_CMD="/autonomous-dev"
 REVIEW_BOTS=""
 
 # === E2E Verification (optional) ===
+#
+# E2E has three modes (issue #161). The mode is selected by E2E_MODE.
+# E2E_ENABLED is the legacy back-compat toggle but the wrapper internally
+# drives off E2E_MODE.
+#
+#   E2E_MODE=none     — no E2E section in the review prompt (default
+#                       when unset; equivalent to E2E_ENABLED=false).
+#   E2E_MODE=browser  — Chrome DevTools MCP UI smoke test. For SaaS web
+#                       apps with a per-PR preview URL. Requires
+#                       E2E_PREVIEW_URL_PATTERN, E2E_TEST_USER_EMAIL,
+#                       E2E_TEST_USER_PASSWORD. See
+#                       skills/autonomous-review/references/e2e-verification.md
+#   E2E_MODE=command  — invoke a project-supplied verify command. For
+#                       backend pipelines, CLI tools, libraries,
+#                       infra-as-code, or ML pipelines. Requires
+#                       E2E_COMMAND, E2E_COMMAND_EVIDENCE_PARSER. See
+#                       skills/autonomous-review/references/e2e-command-mode.md
+#
+# E2E_ENABLED=true with E2E_MODE unset is a fail-loud condition — the
+# wrapper exits at startup. Projects must opt into a specific mode
+# rather than implicitly inheriting "browser".
 E2E_ENABLED="false"
+E2E_MODE=""
+
+# --- Browser mode fields (used when E2E_MODE=browser) -----------------------
 E2E_PREVIEW_URL_PATTERN=""
 E2E_TEST_USER_EMAIL=""
 E2E_TEST_USER_PASSWORD=""
 E2E_SCREENSHOT_UPLOAD="false"
+
+# --- Command mode fields (used when E2E_MODE=command) -----------------------
+#
+# E2E_COMMAND: the verify command. The literal `${PR_NUMBER}` placeholder
+# is substituted by the wrapper at render time. ALWAYS single-quote the
+# value so your shell does not eagerly expand the placeholder when
+# sourcing this file.
+#
+# Example for a backend-pipeline project:
+#   E2E_COMMAND='bash scripts/e2e-pr-stage.sh ${PR_NUMBER}'
+E2E_COMMAND=""
+
+# E2E_COMMAND_PRE_HOOKS: optional. Runs before E2E_COMMAND. Failure aborts
+# E2E. Same `${PR_NUMBER}` substitution. Example:
+#   E2E_COMMAND_PRE_HOOKS='bash scripts/e2e-seed-pr-stage.sh ${PR_NUMBER}'
+E2E_COMMAND_PRE_HOOKS=""
+
+# E2E_COMMAND_TIMEOUT_SECONDS: hard cap, enforced via timeout(1).
+# Default 3600 (60 min). MVP runs synchronously — values >3600 may
+# exceed the agent's stalled-detection threshold. For longer pipelines
+# wait for the background-mode follow-up.
+E2E_COMMAND_TIMEOUT_SECONDS=3600
+
+# E2E_COMMAND_EVIDENCE_PARSER: REQUIRED when E2E_MODE=command. Reads the
+# verify command's log file as $1, emits a markdown evidence block to
+# stdout. The block MUST end with the literal marker:
+#   <!-- e2e-evidence: complete -->
+# The wrapper validates the marker is present before posting the
+# comment. See references/e2e-command-mode.md for the full contract.
+E2E_COMMAND_EVIDENCE_PARSER=""

--- a/skills/autonomous-dispatcher/scripts/autonomous.conf.example
+++ b/skills/autonomous-dispatcher/scripts/autonomous.conf.example
@@ -503,10 +503,13 @@ E2E_COMMAND_TIMEOUT_SECONDS=3600
 
 # E2E_COMMAND_EVIDENCE_PARSER: REQUIRED when E2E_MODE=command. Reads the
 # verify command's log file as $1, emits a markdown evidence block to
-# stdout. The block MUST end with the literal marker:
-#   <!-- e2e-evidence: complete -->
-# The review agent (not the wrapper) checks for the marker before
-# posting the comment, per the command-mode prompt block in
-# autonomous-review.sh. See references/e2e-command-mode.md for the
-# full contract.
+# stdout. The block MUST end with a SHA-bound marker:
+#   <!-- e2e-evidence: complete sha="${PR_HEAD_SHA}" -->
+# The wrapper exports PR_HEAD_SHA into the parser's environment;
+# embedding it in the marker is load-bearing for idempotency (prevents
+# a stale evidence comment from a prior commit silently satisfying a
+# re-review of newer code). The review agent (not the wrapper) checks
+# for the SHA-matching marker before posting and before reusing prior
+# evidence, per the command-mode prompt block in autonomous-review.sh.
+# See references/e2e-command-mode.md for the full contract.
 E2E_COMMAND_EVIDENCE_PARSER=""

--- a/skills/autonomous-review/SKILL.md
+++ b/skills/autonomous-review/SKILL.md
@@ -103,10 +103,11 @@ For custom bots declared via `REVIEW_BOTS_<NAME>_TRIGGER`, use the configured tr
 
 Do NOT use the default `gh pr comment` for bot review triggers — it authenticates as a bot. If `scripts/gh-as-user.sh` is not available in your project, fall back to `gh pr comment` and accept that some bots may ignore the trigger.
 
-### 6. E2E Verification via Chrome DevTools MCP
+### 6. E2E Verification
 
-> **If E2E verification is configured (preview URL provided in the prompt), this section is MANDATORY. If no preview URL is configured, skip this section.**
+> **If E2E verification is configured, this section is MANDATORY.** The wrapper injects one of two procedures based on `E2E_MODE`. If neither appears in the prompt, skip this section.
 
+**Browser mode** (`E2E_MODE=browser`, for SaaS web apps):
 - [ ] Preview URL extracted from PR comments
 - [ ] Preview URL navigated successfully via Chrome DevTools MCP
 - [ ] Test user login verified on preview environment
@@ -115,6 +116,13 @@ Do NOT use the default `gh pr comment` for bot review triggers — it authentica
 - [ ] Regression tests executed (auth, navigation, console errors)
 - [ ] Screenshots captured, uploaded, and linked as evidence
 - [ ] E2E verification report posted as PR comment with screenshot links
+
+**Command mode** (`E2E_MODE=command`, for backend pipelines / CLI / libraries):
+- [ ] Pre-hooks executed (if configured) — exit 0
+- [ ] Verify command executed within timeout — exit 0 (or recoverable timeout)
+- [ ] Evidence parser produced a markdown block ending with `<!-- e2e-evidence: complete -->`
+- [ ] Evidence block posted as a PR comment
+- [ ] Every issue-body acceptance criterion that names a verifiable artifact is covered by the evidence block
 
 ## Merge Conflict Resolution — MANDATORY Pre-Review Step
 
@@ -180,9 +188,16 @@ If no test case documents exist, execute a basic smoke test:
 
 ## E2E Verification Procedure
 
-> **This section applies only when E2E verification is configured.** The review wrapper script (`autonomous-review.sh`) will indicate whether E2E is enabled and provide the necessary configuration in the prompt.
+> **This section applies only when E2E verification is configured.** The review wrapper script (`autonomous-review.sh`) will inject one of two E2E procedures into your prompt depending on the project's `E2E_MODE` setting in `autonomous.conf`:
+>
+> - **`E2E_MODE=browser`** — Chrome DevTools MCP UI smoke test (login, navigate, screenshot). For SaaS web apps with a per-PR preview URL.
+> - **`E2E_MODE=command`** — invoke a project-supplied verify command, validate its evidence output. For backend pipelines, CLI tools, libraries, infra-as-code, or ML pipelines.
 
-For the complete step-by-step E2E procedure (browser automation, screenshot upload, test execution, report format), consult **`references/e2e-verification.md`**.
+If neither block appears in your prompt, the project has E2E disabled (`E2E_MODE=none` or unset). Skip this section.
+
+### Browser mode
+
+For the complete step-by-step browser-mode procedure (browser automation, screenshot upload, test execution, report format), consult **`references/e2e-verification.md`**.
 
 Key steps:
 1. Verify preview URL is available
@@ -191,6 +206,19 @@ Key steps:
 4. Execute happy path and feature test cases
 5. Run regression checks (auth, navigation, console errors)
 6. Post structured E2E report on the PR with screenshot evidence
+
+### Command mode
+
+For the complete contract (project-side script requirements, evidence-block format, exit-code semantics, onboarding example), consult **`references/e2e-command-mode.md`**.
+
+Key steps:
+1. Run pre-hooks if configured (e.g. seed test data into the per-PR stage)
+2. Run the verify command with timeout
+3. Inspect exit code (0 = pass; 124 = timeout; other = fail)
+4. Run the evidence parser to extract a structured markdown block
+5. Validate the block ends with the marker `<!-- e2e-evidence: complete -->`
+6. Post the evidence block as a PR comment
+7. Decide PASS/FAIL based on exit code + evidence-vs-AC coverage
 
 ## Marking Acceptance Criteria
 
@@ -234,5 +262,6 @@ Post the review result as a comment on the **issue** (NOT the PR). Use "Review P
 
 For detailed procedures, consult:
 - **`references/merge-conflict-resolution.md`** -- Complete rebase procedure, conflict handling, and failure protocol
-- **`references/e2e-verification.md`** -- Browser automation steps, screenshot upload, test execution, E2E report format
+- **`references/e2e-verification.md`** -- Browser automation steps, screenshot upload, test execution, E2E report format (`E2E_MODE=browser`)
+- **`references/e2e-command-mode.md`** -- Project-supplied verify command contract, evidence-block format, onboarding example (`E2E_MODE=command`)
 - **`references/decision-gate.md`** -- Finding classification, blocking rules, decision criteria, and output format

--- a/skills/autonomous-review/SKILL.md
+++ b/skills/autonomous-review/SKILL.md
@@ -120,7 +120,7 @@ Do NOT use the default `gh pr comment` for bot review triggers — it authentica
 **Command mode** (`E2E_MODE=command`, for backend pipelines / CLI / libraries):
 - [ ] Pre-hooks executed (if configured) — exit 0
 - [ ] Verify command executed within timeout — exit 0 (or recoverable timeout)
-- [ ] Evidence parser produced a markdown block ending with `<!-- e2e-evidence: complete -->`
+- [ ] Evidence parser produced a markdown block ending with `<!-- e2e-evidence: complete sha="${PR_HEAD_SHA}" -->`
 - [ ] Evidence block posted as a PR comment
 - [ ] Every issue-body acceptance criterion that names a verifiable artifact is covered by the evidence block
 
@@ -216,7 +216,7 @@ Key steps:
 2. Run the verify command with timeout
 3. Inspect exit code (0 = pass; 124 = timeout; other = fail)
 4. Run the evidence parser to extract a structured markdown block
-5. Validate the block ends with the marker `<!-- e2e-evidence: complete -->`
+5. Validate the block ends with the SHA-bound marker `<!-- e2e-evidence: complete sha="${PR_HEAD_SHA}" -->` (SHA is required to prevent stale evidence from a prior commit reusing the comment)
 6. Post the evidence block as a PR comment
 7. Decide PASS/FAIL based on exit code + evidence-vs-AC coverage
 

--- a/skills/autonomous-review/references/e2e-command-mode.md
+++ b/skills/autonomous-review/references/e2e-command-mode.md
@@ -47,7 +47,7 @@ The project supplies two scripts.
 - Reads its arguments, including any rendered `${PR_NUMBER}`.
 - Performs whatever real work the E2E entails (deploy a stage, submit a job, poll for completion, dump logs).
 - Streams informative output to stdout/stderr.
-- Exits 0 on success, non-zero on failure. The wrapper interprets exit code 124 (from `timeout`) as TIMEOUT.
+- Exits 0 on success, non-zero on failure. Exit code 124 (from `timeout(1)`) signals TIMEOUT; the review agent (per Step 3 of the command-mode prompt block) treats it as FAIL but still runs the evidence parser to capture partial results.
 - Has access to whatever credentials the wrapper has (GitHub App token via the wrapper's auth, plus whatever the project's per-stage IAM affords).
 - Should be idempotent against retries — the wrapper may re-dispatch on subsequent ticks.
 
@@ -55,8 +55,8 @@ The project supplies two scripts.
 
 - Takes the verify-command's log file as `$1`.
 - Reads the log + any artifact-of-truth (S3 objects, DDB rows, local files) the verify command produced.
-- Emits a markdown evidence block to stdout that the wrapper will paste verbatim into a PR comment.
-- The block MUST end with the literal marker `<!-- e2e-evidence: complete -->` so subsequent ticks can detect prior evidence and skip re-running.
+- Emits a markdown evidence block to stdout. The review agent (per the prompt instructions injected by `autonomous-review.sh`) pastes it verbatim into a PR comment via `gh pr comment`.
+- The block MUST end with the literal marker `<!-- e2e-evidence: complete -->` so subsequent ticks can detect prior evidence and skip re-running. The review agent — not the wrapper — checks for this marker before posting; see Step 4 of the command-mode prompt block in `skills/autonomous-dispatcher/scripts/autonomous-review.sh`.
 - Returns 0 on success, non-zero if the log is malformed or required artifacts are missing.
 
 ### Evidence block contract

--- a/skills/autonomous-review/references/e2e-command-mode.md
+++ b/skills/autonomous-review/references/e2e-command-mode.md
@@ -56,7 +56,11 @@ The project supplies two scripts.
 - Takes the verify-command's log file as `$1`.
 - Reads the log + any artifact-of-truth (S3 objects, DDB rows, local files) the verify command produced.
 - Emits a markdown evidence block to stdout. The review agent (per the prompt instructions injected by `autonomous-review.sh`) pastes it verbatim into a PR comment via `gh pr comment`.
-- The block MUST end with the literal marker `<!-- e2e-evidence: complete -->` so subsequent ticks can detect prior evidence and skip re-running. The review agent — not the wrapper — checks for this marker before posting; see Step 4 of the command-mode prompt block in `skills/autonomous-dispatcher/scripts/autonomous-review.sh`.
+- The block MUST end with a SHA-bearing marker matching the PR's current HEAD commit:
+  ```
+  <!-- e2e-evidence: complete sha="<HEAD-SHA>" -->
+  ```
+  The review wrapper exposes the HEAD SHA via `${PR_HEAD_SHA}` in the prompt; the project's evidence parser MUST embed that SHA in the output. **The SHA binding is load-bearing for idempotency** — without it, a stale evidence comment from a prior commit would falsely satisfy a re-review of newer code. The review agent — not the wrapper — checks the SHA matches before reusing prior evidence; see Step 4 / Step 4b of the command-mode prompt block in `skills/autonomous-dispatcher/scripts/autonomous-review.sh`.
 - Returns 0 on success, non-zero if the log is malformed or required artifacts are missing.
 
 ### Evidence block contract
@@ -66,7 +70,7 @@ The markdown block MUST contain:
 1. A `## E2E Evidence` (or similar) top-level header.
 2. A summary table mapping each acceptance-criterion item from the issue body to a verifiable result. The review agent uses this to mark issue checkboxes.
 3. Pointers to authoritative artifacts (S3 keys, DDB rows, log timestamps) so the reviewer (human or agent) can spot-check.
-4. The literal marker `<!-- e2e-evidence: complete -->` as the LAST line.
+4. The marker `<!-- e2e-evidence: complete sha="<PR-HEAD-SHA>" -->` as the LAST line. The SHA is required — see the "Idempotency" section.
 
 Optional but recommended:
 
@@ -80,13 +84,15 @@ The wrapper does NOT validate the structure beyond checking for the marker. The 
 
 ## Exit-code semantics
 
-| `E2E_COMMAND` exit code | Wrapper interpretation | Agent action |
-|---|---|---|
-| 0 | success | run evidence parser → post comment → check evidence vs AC → PASS or FAIL based on coverage |
-| 124 | TIMEOUT (from `timeout`) | run evidence parser anyway (some pipelines write artifacts before late-stage cleanup); evidence block must annotate timeout context; agent decides PASS/FAIL on partial evidence |
-| any other non-zero | failure | post failure comment with log tail; FAIL |
+| `E2E_COMMAND` exit code | Agent action |
+|---|---|
+| 0 | run evidence parser → post comment → check evidence vs AC → PASS or FAIL based on coverage |
+| 124 | TIMEOUT (from `timeout`). Run evidence parser anyway (some pipelines write artifacts before late-stage cleanup); evidence block must annotate timeout context; agent decides PASS/FAIL on partial evidence. |
+| any other non-zero | **DO NOT** run the evidence parser (its input log is malformed). Post a failure comment with the verify-command exit code + a tail of the log file. FAIL. |
 
-The "TIMEOUT but recoverable" path exists because backend pipelines often have late-stage tail-end errors (cleanup races, monitor-tool glitches) that fire AFTER the artifact has actually landed. The evidence parser, not the verify command, is the source of truth for whether the artifact is acceptable.
+The "TIMEOUT but recoverable" path exists because backend pipelines often have late-stage tail-end errors (cleanup races, monitor-tool glitches) that fire AFTER the artifact has actually landed. The evidence parser, not the verify command, is the source of truth for whether the artifact is acceptable on `EXIT_CODE=124`.
+
+The "skip parser on other failures" rule is critical: parsers are written to consume successful runs. Feeding them a half-written log from a hard failure leads to confusing parser crashes that mask the real failure cause.
 
 ---
 
@@ -135,6 +141,9 @@ LOG="${1:?log file required}"
 CLUSTERS=$(aws s3 cp "s3://...transcripts.../raw.json" - | jq '[.segments[].speaker] | unique | length')
 SPEAKER_MAP=$(aws s3 cp "s3://...transcripts.../verified.json" - | jq -r '.speaker_map')
 
+# PR_HEAD_SHA is exported by the wrapper — read it from env.
+HEAD_SHA="${PR_HEAD_SHA:?PR_HEAD_SHA must be set by the wrapper}"
+
 cat <<EVIDENCE
 ## E2E Evidence (auto)
 
@@ -147,7 +156,7 @@ S3 artifacts:
 - s3://...transcripts.../raw.json
 - s3://...transcripts.../verified.json
 
-<!-- e2e-evidence: complete -->
+<!-- e2e-evidence: complete sha="${HEAD_SHA}" -->
 EVIDENCE
 ```
 
@@ -155,9 +164,18 @@ EVIDENCE
 
 ## Idempotency
 
-Subsequent review-tick wrappers re-render the prompt with the same `E2E_COMMAND`. To avoid burning compute on already-validated commits, the agent SHOULD check for an existing evidence comment on the PR matching the current HEAD SHA before invoking `E2E_COMMAND`. The literal marker `<!-- e2e-evidence: complete -->` is what to grep for.
+Subsequent review-tick wrappers re-render the prompt with the same `E2E_COMMAND`. To avoid burning compute on already-validated commits, the agent checks for an existing evidence comment on the PR whose marker SHA matches the current HEAD before invoking `E2E_COMMAND`.
 
-The MVP wrapper does NOT enforce this skip — it's the agent's responsibility per the prompt instructions in `autonomous-review.sh`. A future PR may move the skip into the wrapper itself (via a comment-grep + label combination similar to `reviewing` / `pending-review`).
+**Match criterion:** the comment must contain the exact substring
+```
+e2e-evidence: complete sha="<current-PR-HEAD-SHA>"
+```
+
+A plain marker (without `sha="..."`) does NOT match — that would let stale evidence from a prior commit silently satisfy a re-review of newer code, which was a real footgun in the pre-SHA design.
+
+If the comment SHA does not match the current HEAD SHA, the evidence is stale; the agent re-runs E2E from Step 1.
+
+The MVP wrapper does NOT enforce this skip — it's the agent's responsibility per the prompt instructions in `autonomous-review.sh` (Step 4b of the command-mode prompt block). A future PR may move the skip into the wrapper itself (via a comment-grep + label combination similar to `reviewing` / `pending-review`).
 
 ---
 

--- a/skills/autonomous-review/references/e2e-command-mode.md
+++ b/skills/autonomous-review/references/e2e-command-mode.md
@@ -1,0 +1,176 @@
+# E2E Command Mode
+
+> **This reference applies only when `E2E_MODE=command` is set in `autonomous.conf`.** For browser-driven UI smoke testing, see `e2e-verification.md`.
+
+This mode lets a project supply its own verify command instead of using Chrome DevTools MCP. It's the right shape for:
+
+- **Backend pipelines** — the artifact-of-truth lives in S3 / DDB / a database row, not on a page.
+- **CLI tools** — verification is "did the binary produce the expected output", not "is this button clickable".
+- **Libraries** — `npm pack && npm install ./pkg && node -e ...`, no preview URL.
+- **Infra-as-code / ML pipelines** — verify by reading deploy outputs, not by clicking around.
+
+---
+
+## Configuration
+
+In `autonomous.conf`:
+
+```bash
+E2E_ENABLED="true"
+E2E_MODE="command"
+E2E_COMMAND='bash scripts/e2e-pr-stage.sh ${PR_NUMBER}'
+E2E_COMMAND_TIMEOUT_SECONDS=3600
+E2E_COMMAND_PRE_HOOKS='bash scripts/e2e-seed-pr-stage.sh ${PR_NUMBER}'   # optional
+E2E_COMMAND_EVIDENCE_PARSER='bash scripts/e2e-evidence.sh'
+```
+
+The wrapper expands `${PR_NUMBER}` literally at render time (not in shell). Always single-quote the assignment so your shell doesn't eagerly expand the placeholder when sourcing the conf file.
+
+| Field | Required | Purpose |
+|---|---|---|
+| `E2E_MODE=command` | yes | Selects this branch in the wrapper. |
+| `E2E_COMMAND` | yes | The verify command. Stdout/stderr go to `/tmp/e2e-${PR_NUMBER}.log`. Exit code interpreted per Section "Exit-code semantics". |
+| `E2E_COMMAND_EVIDENCE_PARSER` | yes | Reads the log, emits a markdown evidence block to stdout (see "Evidence block contract"). |
+| `E2E_COMMAND_TIMEOUT_SECONDS` | no | Default 3600. Wrapper enforces via `timeout(1)`. Soft cap; for >60min E2E wait for the background-mode follow-up. |
+| `E2E_COMMAND_PRE_HOOKS` | no | Runs before the verify command (e.g. seed test data). Failure aborts E2E. |
+
+`E2E_ENABLED=true` with `E2E_MODE` unset is a fail-loud condition — projects must opt into a specific mode rather than implicitly inheriting `browser`.
+
+---
+
+## Project-side contract
+
+The project supplies two scripts.
+
+### 1. The verify command (`E2E_COMMAND`)
+
+- Reads its arguments, including any rendered `${PR_NUMBER}`.
+- Performs whatever real work the E2E entails (deploy a stage, submit a job, poll for completion, dump logs).
+- Streams informative output to stdout/stderr.
+- Exits 0 on success, non-zero on failure. The wrapper interprets exit code 124 (from `timeout`) as TIMEOUT.
+- Has access to whatever credentials the wrapper has (GitHub App token via the wrapper's auth, plus whatever the project's per-stage IAM affords).
+- Should be idempotent against retries — the wrapper may re-dispatch on subsequent ticks.
+
+### 2. The evidence parser (`E2E_COMMAND_EVIDENCE_PARSER`)
+
+- Takes the verify-command's log file as `$1`.
+- Reads the log + any artifact-of-truth (S3 objects, DDB rows, local files) the verify command produced.
+- Emits a markdown evidence block to stdout that the wrapper will paste verbatim into a PR comment.
+- The block MUST end with the literal marker `<!-- e2e-evidence: complete -->` so subsequent ticks can detect prior evidence and skip re-running.
+- Returns 0 on success, non-zero if the log is malformed or required artifacts are missing.
+
+### Evidence block contract
+
+The markdown block MUST contain:
+
+1. A `## E2E Evidence` (or similar) top-level header.
+2. A summary table mapping each acceptance-criterion item from the issue body to a verifiable result. The review agent uses this to mark issue checkboxes.
+3. Pointers to authoritative artifacts (S3 keys, DDB rows, log timestamps) so the reviewer (human or agent) can spot-check.
+4. The literal marker `<!-- e2e-evidence: complete -->` as the LAST line.
+
+Optional but recommended:
+
+- Comparison against a baseline (prod / main-branch result).
+- Visual confirmation section if the project requires human eyeballs (e.g. transcripts, generated images).
+- A "What this evidence does NOT cover" section for known limitations.
+
+The wrapper does NOT validate the structure beyond checking for the marker. The PR reviewer (human) and the review agent (LLM) are the structural reviewers — keep the format readable.
+
+---
+
+## Exit-code semantics
+
+| `E2E_COMMAND` exit code | Wrapper interpretation | Agent action |
+|---|---|---|
+| 0 | success | run evidence parser → post comment → check evidence vs AC → PASS or FAIL based on coverage |
+| 124 | TIMEOUT (from `timeout`) | run evidence parser anyway (some pipelines write artifacts before late-stage cleanup); evidence block must annotate timeout context; agent decides PASS/FAIL on partial evidence |
+| any other non-zero | failure | post failure comment with log tail; FAIL |
+
+The "TIMEOUT but recoverable" path exists because backend pipelines often have late-stage tail-end errors (cleanup races, monitor-tool glitches) that fire AFTER the artifact has actually landed. The evidence parser, not the verify command, is the source of truth for whether the artifact is acceptable.
+
+---
+
+## Onboarding example
+
+A backend pipeline project wants to validate that a fix to its transcription worker produces N-cluster output instead of the old broken 2-cluster output. The fix lives behind a PR-stage deployment.
+
+```bash
+# autonomous.conf
+E2E_ENABLED="true"
+E2E_MODE="command"
+E2E_COMMAND='bash scripts/e2e-pr-stage.sh ${PR_NUMBER}'
+E2E_COMMAND_TIMEOUT_SECONDS=3600
+E2E_COMMAND_PRE_HOOKS='bash scripts/e2e-seed-pr-stage.sh ${PR_NUMBER}'
+E2E_COMMAND_EVIDENCE_PARSER='bash scripts/e2e-evidence.sh'
+```
+
+```bash
+# scripts/e2e-seed-pr-stage.sh
+#!/usr/bin/env bash
+# Pre-hook: copy fixture data from prod to the per-PR stage tables.
+set -euo pipefail
+PR="${1:?PR number required}"
+aws dynamodb get-item --table-name prod-Foo --key '{"pk":...}' --output json \
+  | jq '.Item' > /tmp/prod-row.json
+aws dynamodb put-item --table-name "pr-${PR}-Foo" --item file:///tmp/prod-row.json
+```
+
+```bash
+# scripts/e2e-pr-stage.sh
+#!/usr/bin/env bash
+# Verify command: kick off the workflow, poll until terminal, dump logs.
+set -euo pipefail
+PR="${1:?PR number required}"
+# ... submit, poll, assert, exit 0 on success ...
+```
+
+```bash
+# scripts/e2e-evidence.sh
+#!/usr/bin/env bash
+# Evidence parser: read log + artifacts, emit markdown block.
+set -euo pipefail
+LOG="${1:?log file required}"
+
+# Pull authoritative artifact metrics
+CLUSTERS=$(aws s3 cp "s3://...transcripts.../raw.json" - | jq '[.segments[].speaker] | unique | length')
+SPEAKER_MAP=$(aws s3 cp "s3://...transcripts.../verified.json" - | jq -r '.speaker_map')
+
+cat <<EVIDENCE
+## E2E Evidence (auto)
+
+| Acceptance criterion | Result |
+|---|---|
+| raw.json has ≥3 distinct clusters | $([ "$CLUSTERS" -ge 3 ] && echo "✅ ($CLUSTERS)" || echo "❌ ($CLUSTERS)") |
+| verified.json has ≥3 named speakers | $(...) |
+
+S3 artifacts:
+- s3://...transcripts.../raw.json
+- s3://...transcripts.../verified.json
+
+<!-- e2e-evidence: complete -->
+EVIDENCE
+```
+
+---
+
+## Idempotency
+
+Subsequent review-tick wrappers re-render the prompt with the same `E2E_COMMAND`. To avoid burning compute on already-validated commits, the agent SHOULD check for an existing evidence comment on the PR matching the current HEAD SHA before invoking `E2E_COMMAND`. The literal marker `<!-- e2e-evidence: complete -->` is what to grep for.
+
+The MVP wrapper does NOT enforce this skip — it's the agent's responsibility per the prompt instructions in `autonomous-review.sh`. A future PR may move the skip into the wrapper itself (via a comment-grep + label combination similar to `reviewing` / `pending-review`).
+
+---
+
+## When NOT to use command-mode
+
+- **Your project is a SaaS web app with a preview URL.** Use `browser` mode — that's what it's for.
+- **Your verify command takes >60 minutes.** The MVP runs synchronously inside the agent session, which has its own stalled-detection. Wait for the background-mode follow-up (tracked separately).
+- **You want the review agent to author evidence.** This mode requires the project to ship `E2E_COMMAND_EVIDENCE_PARSER`. The agent is the runner + judge, not the author.
+
+---
+
+## Cross-references
+
+- `e2e-verification.md` — the browser-mode counterpart (Chrome DevTools MCP, screenshot upload, login flow).
+- `decision-gate.md` — the PASS/FAIL gate the agent applies after E2E completes.
+- `docs/pipeline/review-agent-flow.md` — the wrapper's overall flow including the E2E branch dispatch.

--- a/tests/unit/test-e2e-mode-command.sh
+++ b/tests/unit/test-e2e-mode-command.sh
@@ -126,8 +126,8 @@ assert_grep "command-mode prompt references E2E_COMMAND" \
   '\$\{?E2E_COMMAND[^_]' "$WRAPPER"
 assert_grep "command-mode prompt references E2E_COMMAND_EVIDENCE_PARSER" \
   'E2E_COMMAND_EVIDENCE_PARSER' "$WRAPPER"
-assert_grep "evidence marker literal present in wrapper" \
-  '<!-- e2e-evidence: complete -->' "$WRAPPER"
+assert_grep "SHA-bound evidence marker present in wrapper" \
+  'e2e-evidence: complete sha=' "$WRAPPER"
 assert_grep "command-mode declares MANDATORY" \
   "E2E Verification via project command — MANDATORY" "$WRAPPER"
 
@@ -269,6 +269,58 @@ assert_grep "wrapper exports PR_HEAD_SHA in command mode" \
   'export PR_HEAD_SHA' "$WRAPPER"
 assert_grep "wrapper exports PR_NUMBER in command mode" \
   'export PR_NUMBER' "$WRAPPER"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-017: F7 fix — Step 4b fetches full comment body via jq ==="
+# ---------------------------------------------------------------------------
+# Pre-fix: `gh pr view --jq '.comments[].body' | grep -F` returned only
+# the marker LINE; agent couldn't actually use prior evidence in Step 6.
+# Post-fix: jq filter returns the whole matching comment body.
+assert_grep "Step 4b uses jq select(.body | contains(...)) form" \
+  'comments\[\].*select.*\.body.*contains' "$WRAPPER"
+assert_grep "Step 4b assigns full body to EVIDENCE (not EXISTING)" \
+  'EVIDENCE=\\\$\(gh pr view' "$WRAPPER"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-018: marker format consistency across docs + wrapper ==="
+# ---------------------------------------------------------------------------
+# All references to the evidence marker MUST include the SHA binding
+# (F2 fix). Pre-fixup: SKILL.md and autonomous.conf.example used the
+# old non-SHA marker — would lead project owners to write parsers that
+# fail the SHA-matching idempotency guard.
+SKILL="$PROJECT_ROOT/skills/autonomous-review/SKILL.md"
+CONF="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous.conf.example"
+REF="$PROJECT_ROOT/skills/autonomous-review/references/e2e-command-mode.md"
+PIPELINE="$PROJECT_ROOT/docs/pipeline/review-agent-flow.md"
+
+# Wrapper, SKILL.md, conf.example, ref doc, pipeline doc all reference the
+# SHA-bound marker form. The non-SHA form should NOT appear except as
+# part of a SHA-bound longer string.
+for f in "$WRAPPER" "$SKILL" "$CONF" "$REF" "$PIPELINE"; do
+  if grep -qE 'e2e-evidence:[[:space:]]*complete[[:space:]]*-->' "$f"; then
+    echo -e "  ${RED}FAIL${NC}: $f contains pre-SHA marker form"
+    FAIL=$((FAIL + 1))
+  else
+    echo -e "  ${GREEN}PASS${NC}: $(basename "$f") uses SHA-bound marker"
+    PASS=$((PASS + 1))
+  fi
+done
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-019: F6 fix — pipeline doc documents Step 4b ==="
+# ---------------------------------------------------------------------------
+# CLAUDE.md "Pipeline Documentation Authority" requires wrapper changes
+# to update docs/pipeline/*.md in same PR. Step 4b was added in fixup
+# 6a5d210; this test pins that the pipeline doc references it.
+assert_grep "pipeline doc documents Step 4b stale-evidence guard" \
+  '(4b|[Ss]tale-evidence)' "$PIPELINE"
+assert_grep "pipeline doc explains parser-skip on hard failures" \
+  'skip the parser|skips the parser|parser would be malformed' "$PIPELINE"
+assert_grep "pipeline doc explains mode-aware decision FAIL message" \
+  'mode-aware|screenshot.*log tail|log tail.*screenshot' "$PIPELINE"
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/unit/test-e2e-mode-command.sh
+++ b/tests/unit/test-e2e-mode-command.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# test-e2e-mode-command.sh — Coverage for issue #161 (E2E_MODE field).
+#
+# Strategy: hybrid of source-of-truth grep against the wrapper (for prompt
+# rendering branches) and config-validation invocation (for fail-loud
+# branches). The wrapper supports a hidden `--validate-config-only` flag
+# added in this PR that exits after validation without dispatching.
+#
+# Run: bash tests/unit/test-e2e-mode-command.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WRAPPER="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous-review.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_grep() {
+  local desc="$1" pattern="$2" file="$3"
+  if grep -qE "$pattern" "$file"; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (pattern: $pattern)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Minimum config the wrapper needs to reach E2E validation. Each test
+# helper unsets E2E_* first so leaked parent-env values don't pollute.
+_RUN_VALIDATE() {
+  unset E2E_ENABLED E2E_MODE E2E_COMMAND E2E_COMMAND_TIMEOUT_SECONDS \
+    E2E_COMMAND_PRE_HOOKS E2E_COMMAND_EVIDENCE_PARSER \
+    E2E_PREVIEW_URL_PATTERN E2E_TEST_USER_EMAIL E2E_TEST_USER_PASSWORD \
+    E2E_SCREENSHOT_UPLOAD
+  export ISSUE_NUMBER=1 REPO=zxkane/test PROJECT_ID=test \
+    REPO_OWNER=zxkane REPO_NAME=test PROJECT_DIR="$PROJECT_ROOT" \
+    AGENT_CMD=claude AGENT_PERMISSION_MODE=bypassPermissions
+  # Apply per-test overrides — each arg is "VAR=value" (value may contain spaces)
+  while [[ $# -gt 0 ]]; do
+    local kv="$1"
+    local k="${kv%%=*}"
+    local v="${kv#*=}"
+    export "$k=$v"
+    shift
+  done
+  bash "$WRAPPER" --validate-config-only 2>&1
+}
+
+assert_validate_fails() {
+  local desc="$1" expected_pattern="$2"
+  shift 2
+  local output exit_code
+  output=$(_RUN_VALIDATE "$@")
+  exit_code=$?
+  if [[ $exit_code -ne 0 ]] && echo "$output" | grep -qE "$expected_pattern"; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (exit=$exit_code, output did not match: $expected_pattern)"
+    echo "    output was: $(echo "$output" | head -3)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_validate_succeeds() {
+  local desc="$1"
+  shift
+  local output exit_code
+  output=$(_RUN_VALIDATE "$@")
+  exit_code=$?
+  if [[ $exit_code -eq 0 ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc (exit=$exit_code)"
+    echo "    output was: $(echo "$output" | head -3)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+echo "=== TC-E2E-MODE-001: E2E_ENABLED=true with E2E_MODE unset → fail-loud ==="
+# ---------------------------------------------------------------------------
+assert_validate_fails "wrapper exits non-zero with helpful E2E_MODE error" \
+  "E2E_MODE.*(none|browser|command).*" \
+  E2E_ENABLED=true
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-002: E2E_MODE=none silences E2E section ==="
+# ---------------------------------------------------------------------------
+# The wrapper renders the E2E block conditionally. With E2E_MODE=none (or
+# unset entirely), neither block should appear in the wrapper's heredoc.
+# Verified by checking the wrapper has explicit `case` branches that gate
+# the block rendering on E2E_MODE.
+assert_grep "wrapper has E2E_MODE case dispatch (the gate)" \
+  'case[[:space:]]+"\$\{?E2E_MODE' "$WRAPPER"
+assert_grep "wrapper has explicit 'none' branch in case" \
+  '[[:space:]]+none\)' "$WRAPPER"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-003: E2E_MODE=browser preserves existing block ==="
+# ---------------------------------------------------------------------------
+# Existing block header must remain reachable when E2E_MODE=browser.
+assert_grep "browser-mode prompt header present" \
+  "E2E Verification via Chrome DevTools MCP" "$WRAPPER"
+assert_grep "browser branch in case statement" \
+  '[[:space:]]+browser\)' "$WRAPPER"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-004: E2E_MODE=command injects command-mode block ==="
+# ---------------------------------------------------------------------------
+assert_grep "command-mode prompt header present" \
+  "E2E Verification via project command" "$WRAPPER"
+assert_grep "command branch in case statement" \
+  '[[:space:]]+command\)' "$WRAPPER"
+assert_grep "command-mode prompt references E2E_COMMAND" \
+  '\$\{?E2E_COMMAND[^_]' "$WRAPPER"
+assert_grep "command-mode prompt references E2E_COMMAND_EVIDENCE_PARSER" \
+  'E2E_COMMAND_EVIDENCE_PARSER' "$WRAPPER"
+assert_grep "evidence marker literal present in wrapper" \
+  '<!-- e2e-evidence: complete -->' "$WRAPPER"
+assert_grep "command-mode declares MANDATORY" \
+  "E2E Verification via project command — MANDATORY" "$WRAPPER"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-005: E2E_MODE=command without E2E_COMMAND → fail-loud ==="
+# ---------------------------------------------------------------------------
+assert_validate_fails "wrapper names E2E_COMMAND as missing" \
+  "E2E_COMMAND" \
+  E2E_ENABLED=true E2E_MODE=command \
+  'E2E_COMMAND_EVIDENCE_PARSER=bash scripts/x.sh'
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-006: E2E_MODE=command without evidence parser → fail-loud ==="
+# ---------------------------------------------------------------------------
+assert_validate_fails "wrapper names E2E_COMMAND_EVIDENCE_PARSER as missing" \
+  "E2E_COMMAND_EVIDENCE_PARSER" \
+  E2E_ENABLED=true E2E_MODE=command \
+  'E2E_COMMAND=bash scripts/x.sh'
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-007: invalid E2E_MODE value → fail-loud ==="
+# ---------------------------------------------------------------------------
+assert_validate_fails "wrapper rejects unknown mode and lists accepted values" \
+  "E2E_MODE.*(none.*browser.*command|browser.*command|command)" \
+  E2E_ENABLED=true E2E_MODE=foo
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-008: PR_NUMBER substitution shape ==="
+# ---------------------------------------------------------------------------
+# Verify the wrapper substitutes ${PR_NUMBER} in E2E_COMMAND at render time.
+# Source-of-truth grep: the wrapper must have the substitution machinery.
+assert_grep "wrapper substitutes PR_NUMBER in E2E_COMMAND" \
+  'E2E_COMMAND.*//.*PR_NUMBER|PR_NUMBER.*E2E_COMMAND' "$WRAPPER"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-back-compat: absent-config path validates clean ==="
+# ---------------------------------------------------------------------------
+# E2E_ENABLED unset, E2E_MODE unset, E2E_ENABLED=false — all must validate.
+assert_validate_succeeds "no-E2E config validates clean"
+
+assert_validate_succeeds "E2E_ENABLED=false validates clean (no MODE needed)" \
+  E2E_ENABLED=false
+
+assert_validate_succeeds "E2E_MODE=none alone validates clean (no E2E_ENABLED needed)" \
+  E2E_MODE=none
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-syntax: bash -n on wrapper ==="
+# ---------------------------------------------------------------------------
+if bash -n "$WRAPPER" 2>/dev/null; then
+  echo -e "  ${GREEN}PASS${NC}: wrapper passes bash -n"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: wrapper has syntax errors"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/tests/unit/test-e2e-mode-command.sh
+++ b/tests/unit/test-e2e-mode-command.sh
@@ -168,6 +168,45 @@ assert_grep "wrapper substitutes PR_NUMBER in E2E_COMMAND" \
 
 # ---------------------------------------------------------------------------
 echo ""
+echo "=== TC-E2E-MODE-009: case-sensitivity — capitalized values rejected ==="
+# ---------------------------------------------------------------------------
+assert_validate_fails "E2E_MODE=Browser (capitalized) hits invalid-mode branch" \
+  "invalid E2E_MODE" \
+  E2E_ENABLED=true E2E_MODE=Browser
+assert_validate_fails "E2E_MODE=COMMAND (uppercase) hits invalid-mode branch" \
+  "invalid E2E_MODE" \
+  E2E_ENABLED=true E2E_MODE=COMMAND
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-010: command-mode fields without E2E_MODE=command rejected ==="
+# ---------------------------------------------------------------------------
+# Catches the "operator filled in E2E_COMMAND but forgot E2E_MODE=command"
+# footgun. Without this guard the fields are silently ignored.
+assert_validate_fails "E2E_COMMAND set with E2E_MODE=none rejected" \
+  "E2E_COMMAND.*set.*E2E_MODE" \
+  E2E_MODE=none 'E2E_COMMAND=bash scripts/x.sh'
+assert_validate_fails "E2E_COMMAND set with E2E_MODE=browser rejected" \
+  "E2E_COMMAND.*set.*E2E_MODE" \
+  E2E_MODE=browser 'E2E_COMMAND=bash scripts/x.sh'
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-011: PRE_HOOKS-unset substitution does not crash ==="
+# ---------------------------------------------------------------------------
+# Regression for set -u + ${VAR//pat/repl} on unset E2E_COMMAND_PRE_HOOKS.
+# The substitution lines around line 388-394 must use :- defaults.
+assert_grep "E2E_COMMAND_PRE_HOOKS substitution uses :- default" \
+  'E2E_COMMAND_PRE_HOOKS:-' "$WRAPPER"
+assert_grep "E2E_COMMAND substitution uses :- default" \
+  'E2E_COMMAND:-' "$WRAPPER"
+assert_grep "E2E_COMMAND_EVIDENCE_PARSER substitution uses :- default" \
+  'E2E_COMMAND_EVIDENCE_PARSER:-' "$WRAPPER"
+assert_grep "PR_NUMBER empty-guard before substitution" \
+  '\[\[ -z "\$PR_NUMBER" \]\]' "$WRAPPER"
+
+# ---------------------------------------------------------------------------
+echo ""
 echo "=== TC-E2E-MODE-back-compat: absent-config path validates clean ==="
 # ---------------------------------------------------------------------------
 # E2E_ENABLED unset, E2E_MODE unset, E2E_ENABLED=false — all must validate.

--- a/tests/unit/test-e2e-mode-command.sh
+++ b/tests/unit/test-e2e-mode-command.sh
@@ -207,6 +207,71 @@ assert_grep "PR_NUMBER empty-guard before substitution" \
 
 # ---------------------------------------------------------------------------
 echo ""
+echo "=== TC-E2E-MODE-012: F1 fix — decision block branches on E2E_MODE ==="
+# ---------------------------------------------------------------------------
+# Before fixup: decision-block FAIL message said "screenshot evidence" for
+# both browser and command mode, which would confuse the agent in
+# command mode (no browser, no screenshots).
+assert_grep "decision FAIL branch differentiates browser vs command" \
+  'case "\$\{?E2E_MODE.*browser\)' "$WRAPPER"
+assert_grep "command-mode FAIL message references log tail (not screenshots)" \
+  'log tail.*evidence|tail of /tmp/e2e-' "$WRAPPER"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-013: F2 fix — evidence marker requires SHA binding ==="
+# ---------------------------------------------------------------------------
+# Without SHA in the marker, stale evidence from an old commit could
+# satisfy a re-review of new code. The wrapper instructs agent to
+# emit and check the SHA-bearing form.
+assert_grep "wrapper marker spec includes sha=\"...\"" \
+  'e2e-evidence: complete sha=' "$WRAPPER"
+assert_grep "wrapper instructs agent to bind to PR_HEAD_SHA" \
+  'PR_HEAD_SHA' "$WRAPPER"
+assert_grep "stale-evidence guard step present" \
+  'stale-evidence|Stale-evidence' "$WRAPPER"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-014: F3 fix — parser only on EXIT_CODE ∈ {0, 124} ==="
+# ---------------------------------------------------------------------------
+# Running the parser on a hard-failure log produces confusing crashes
+# that mask the real failure. The prompt now gates parser invocation.
+assert_grep "Step 4 gates parser on EXIT_CODE 0 or 124" \
+  'EXIT_CODE.*-eq 0.*-eq 124' "$WRAPPER"
+assert_grep "Step 5 has log-tail fallback for non-{0,124} exits" \
+  'tail -50.*e2e-' "$WRAPPER"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-015: F4 fix — unbraced \$PR_NUMBER rejected ==="
+# ---------------------------------------------------------------------------
+# Unbraced form silently renders empty (PR_NUMBER not exported until
+# command-mode block, and the wrapper substitution only handles
+# braced ${PR_NUMBER}). Catches the typo at validation time.
+assert_validate_fails "unbraced \$PR_NUMBER in E2E_COMMAND rejected" \
+  "unbraced.*PR_NUMBER" \
+  E2E_ENABLED=true E2E_MODE=command \
+  'E2E_COMMAND=bash scripts/x.sh $PR_NUMBER' \
+  'E2E_COMMAND_EVIDENCE_PARSER=bash scripts/p.sh ${PR_NUMBER}'
+# Braced form continues to validate clean
+assert_validate_succeeds "braced \${PR_NUMBER} in E2E_COMMAND validates clean" \
+  E2E_ENABLED=true E2E_MODE=command \
+  'E2E_COMMAND=bash scripts/x.sh ${PR_NUMBER}' \
+  'E2E_COMMAND_EVIDENCE_PARSER=bash scripts/p.sh ${PR_NUMBER}'
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-E2E-MODE-016: command-mode exports PR_NUMBER + PR_HEAD_SHA ==="
+# ---------------------------------------------------------------------------
+# Parser scripts need PR_HEAD_SHA at runtime to embed it in the marker.
+assert_grep "wrapper exports PR_HEAD_SHA in command mode" \
+  'export PR_HEAD_SHA' "$WRAPPER"
+assert_grep "wrapper exports PR_NUMBER in command mode" \
+  'export PR_NUMBER' "$WRAPPER"
+
+# ---------------------------------------------------------------------------
+echo ""
 echo "=== TC-E2E-MODE-back-compat: absent-config path validates clean ==="
 # ---------------------------------------------------------------------------
 # E2E_ENABLED unset, E2E_MODE unset, E2E_ENABLED=false — all must validate.


### PR DESCRIPTION
## Summary

Closes #161. Adds `E2E_MODE=command` to the autonomous-review wrapper so backend pipelines / CLI tools / libraries can run a project-supplied verify command instead of being forced into the existing browser-driven Chrome-DevTools-MCP flow.

- New `E2E_MODE` field with three values: `none` (default), `browser` (existing logic, opt-in), `command` (new). `E2E_ENABLED=true` with `E2E_MODE` unset is fail-loud.
- New `E2E_COMMAND` / `E2E_COMMAND_PRE_HOOKS` / `E2E_COMMAND_TIMEOUT_SECONDS` / `E2E_COMMAND_EVIDENCE_PARSER` fields. Project supplies a verify command + an evidence parser. Wrapper substitutes `${PR_NUMBER}` placeholder at render time, agent invokes the command, validates the evidence-block marker `<!-- e2e-evidence: complete -->`, posts as PR comment.
- Browser-mode behavior unchanged; existing browser-mode projects must opt in by setting `E2E_MODE=browser` explicitly (catches the most common upgrade footgun).
- Pipeline doc authority rule satisfied: `docs/pipeline/review-agent-flow.md` updated in same PR.

## Why

Concrete trigger: a recent PR in a backend-pipeline consumer required a 30-60min E2E run (DDB row state + S3 artifact assertions + visual confirmation of a transcript). The existing wrapper had no way to dispatch this — review agent looped 3 times against operator-gated findings, dev agent self-deescalated by removing the `autonomous` label, operator ran the E2E manually. Next consumer in this shape should not need that ceremony.

Browser-mode equates "E2E" with "Chrome DevTools MCP UI smoke test". That doesn't fit backend pipelines, CLI tools, libraries, infra-as-code, or ML pipelines, where verification is "did the artifact land + assert its content shape", not "is this button on the page".

## What's in this PR

- **Implementation** (`autonomous-review.sh` +209/-21): `validate_e2e_config()` with 5 fail-loud branches; `--validate-config-only` flag (test affordance); derived `E2E_ACTIVE` flag; `case ${E2E_MODE:-none}` dispatch with `none`/`browser`/`command` branches; `${PR_NUMBER}` substitution with `:- ` defaults to survive `set -u` on optional fields.
- **Configuration** (`autonomous.conf.example` +54): three-mode explainer, all five new fields documented with cross-references.
- **Skill prompt** (`skills/autonomous-review/SKILL.md` +39): mode-aware checklist + procedure section, link to new reference.
- **Reference doc** (`skills/autonomous-review/references/e2e-command-mode.md` NEW): full project-side contract, exit-code semantics, evidence-block format, end-to-end onboarding example for a backend-pipeline consumer.
- **Pipeline doc** (`docs/pipeline/review-agent-flow.md` +40): "E2E mode dispatch" section + fail-loud rule.
- **Tests** (`tests/unit/test-e2e-mode-command.sh` NEW + `docs/test-cases/e2e-mode-command.md` NEW): 11 test cases (TC-001..011) covering fail-loud branches, prompt-block headers, `${PR_NUMBER}` substitution, `set -u` regression guard, case-sensitivity, "command-mode fields without command-mode" guard, back-compat absent-config.

## Out of scope (separate follow-up issue)

- Background / async long-running E2E with an `e2e-running` PR label, for >60min cases without blocking the agent session. The MVP runs synchronously inside the agent session.
- Render-time tests for `${PR_NUMBER}` substitution / `none`-branch empty output (requires extracting heredoc into a function or capturing rendered prompt — heavier refactor).
- Wrapper-side last-line validation of the evidence marker (currently trusts the agent).
- timeout-124 stale-artifact acceptance hardening (require artifacts to embed `PR_NUMBER` + nonce).

## Test plan

- [x] `bash -n skills/autonomous-dispatcher/scripts/autonomous-review.sh` clean
- [x] `bash tests/unit/test-e2e-mode-command.sh` — 27 PASS / 0 FAIL
- [x] `bash tests/unit/test-autonomous-review-prompt.sh` — 11 PASS / 0 FAIL (back-compat)
- [x] All `tests/unit/test-*.sh` — 840 PASS / 0 FAIL
- [x] Pre-push code review via `/pr-review-toolkit:review-pr` — 4 review agents (code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer); 2 Critical + 2 High findings addressed in fixup commit `cf44047` before push
- [x] Runtime confirmation of `set -u` regression fix (C1) via standalone bash repro
- [ ] Mergeable + CI green (will verify after push)
- [ ] Follow-up issues filed for deferred Medium gaps

## Pre-push code review summary

Run on commit `a67b40b` before pushing. All Critical/High findings fixed in fixup commit `cf44047`:

| Severity | Finding | Status |
|---|---|---|
| Critical | C1 — `set -u` crash on unset `E2E_COMMAND_PRE_HOOKS` | Fixed (`:- ` defaults + TC-E2E-MODE-011 regression test) |
| Critical | C2 — doc drift: claimed wrapper validates marker, actually agent does | Fixed (reworded `e2e-command-mode.md`, `autonomous.conf.example`) |
| High | H1 — `${PR_NUMBER}` substitution unguarded against empty | Fixed (fail-loud check) |
| High | H2 — operator can set E2E_COMMAND without E2E_MODE=command | Fixed (validation rejects, TC-E2E-MODE-010) |
| Medium | M1-M4 (4 findings) | Deferred to follow-up issue per scope |
| Low | typo "six-character" / various polish | Fixed inline |