### PR TITLE
docs(workflow): forbid main-workdir edits; mandate worktree to protect the live dispatcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,13 @@ This project enforces a strict TDD development workflow through agent hooks. The
 
 > Hooks are supported in Claude Code and Kiro CLI. For agents without hook support (Cursor, Windsurf, Gemini CLI), follow each step manually — the discipline is the same.
 
+> ⚠️ **This repo is self-hosting — never edit files in the main workdir; always use a worktree.** This checkout of `zxkane/autonomous-dev-team` is consumed by the autonomous dispatcher running on the same box: its `scripts/` symlink resolves into this repo's own `skills/autonomous-dispatcher/scripts/` tree, so the dispatcher executes these exact files via `scripts/autonomous-{dev,review}.sh`. **Any uncommitted change in the main workdir becomes live for every dispatched dev/review wrapper.** A half-finished edit can crash a wrapper mid-run — e.g. an incomplete per-side `AGENT_REVIEW_CMD` rebind aborts the review wrapper with `AGENT_REVIEW_CMD: unbound variable`, leaving the issue stuck in `reviewing` with no verdict and no re-dispatch.
+>
+> Therefore:
+> - **All work MUST happen in a git worktree** — `git worktree add .worktrees/<branch> -b <branch>`, edit there, PR from there.
+> - **Never modify, stage, or leave dirty any tracked file in the main workdir.** The only writes ever made directly to the main workdir are syncs of committed state (`git pull` / `git reset --hard origin/main`).
+> - This is stricter than the generic "develop in a worktree" rule (#1 above): here it protects the **live dispatcher**, not just commit hygiene.
+
 ### Pipeline Documentation Authority
 
 `docs/pipeline/*.md` (`state-machine.md`, `invariants.md`, `dispatcher-flow.md`, `dev-agent-flow.md`, `review-agent-flow.md`, `handoffs.md`) is the **spec** for the dispatcher / dev wrapper / review wrapper subsystem. Any code change to those wrappers MUST update the corresponding pipeline doc in the **same PR**.


### PR DESCRIPTION
## Summary

This checkout of `zxkane/autonomous-dev-team` is **self-hosting**: the autonomous dispatcher runs on the same box and executes `scripts/autonomous-{dev,review}.sh`, which symlink into this repo's own `skills/autonomous-dispatcher/scripts/` tree. So **any uncommitted edit in the main workdir is live for every dispatched dev/review wrapper.**

This was just demonstrated: a half-finished per-side `AGENT_REVIEW_CMD` rebind left dirty in the main workdir crashed the review wrapper with `AGENT_REVIEW_CMD: unbound variable` (`set -u` abort on line 37 of `autonomous-review.sh`), stranding an issue in the `reviewing` state with no verdict and no re-dispatch. The committed `origin/main` was fine — only the local dirty workdir was broken.

## Change

Adds a **Mandatory Rules** callout to `CLAUDE.md`:
- All work MUST happen in a git worktree; PR from there.
- Never modify / stage / leave dirty any tracked file in the main workdir.
- The only direct writes to the main workdir are syncs of committed state (`git pull` / `git reset --hard origin/main`).

This is stricter than the generic "develop in a worktree" rule — here it protects the **live dispatcher**, not just commit hygiene.

## Scope

Docs-only (7 lines, `CLAUDE.md`). No wrapper code touched, so the Pipeline Docs Gate does not apply.

## Testing

N/A — prose-only. Manual review: topology description verified against the actual `scripts/ -> skills/autonomous-dispatcher/scripts` symlink; security-scanned for private-repo / instance-id / cross-repo refs (clean).