### PR TITLE
ci: wire check-provider-cutover.sh into ci.yml strict mode (#295)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,13 +137,30 @@ jobs:
     name: Spec Drift
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth: 0 so the provider-cutover guard's strict monotonicity check
+      # (--require-trusted-ref, below) can resolve origin/main (the current tip of
+      # main, which carries the trusted cutover-baseline.json) and read its baseline.
+      # A shallow (depth-1) checkout has no origin/main, and under
+      # --require-trusted-ref an unresolvable trusted ref FAILs closed (#286 P1#1 — a
+      # permissive skip would let a PR add a raw-gh + regenerate the baseline and
+      # self-ratify). check-spec-drift.sh below is unaffected by depth.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
 
       # (a) regenerate the state-machine.md mermaid region from transitions.json
       #     and fail on any diff; (b) guard/action mapping + label-write
       #     completeness. Same checker the unit test (test-spec-drift.sh) drives.
       - name: Check spec/code drift
         run: bash skills/autonomous-dispatcher/scripts/check-spec-drift.sh
+
+      # Provider-cutover ratchet guard ([INV-91]): no NEW raw `gh` may re-enter the
+      # provider-neutral caller layer outside providers/. Run in strict mode
+      # (--require-trusted-ref) so a missing/unreadable trusted baseline FAILs closed
+      # rather than silently passing. Credential-free (jq + coreutils); same checker
+      # the unit test (test-provider-cutover.sh) drives.
+      - name: Check provider cutover (no new raw gh in caller layer)
+        run: bash skills/autonomous-dispatcher/scripts/check-provider-cutover.sh --require-trusted-ref
 
   hermetic-shellcheck:
     name: Hermetic / ShellCheck + workflow lint
@@ -188,6 +205,9 @@ jobs:
             skills/autonomous-dispatcher/scripts/gen-state-machine.sh \
             skills/autonomous-dispatcher/scripts/check-spec-drift.sh \
             tests/unit/test-spec-drift.sh \
+            skills/autonomous-dispatcher/scripts/check-provider-cutover.sh \
+            tests/unit/test-provider-cutover.sh \
+            tests/unit/test-provider-caps-branches.sh \
             tests/e2e/run-agent-smoke.sh \
             tests/e2e/run-metrics-report.sh \
             tests/e2e/run-error-envelope-e2e.sh \


### PR DESCRIPTION
## Summary

Implements #295 — wires the existing provider-cutover ratchet guard (`check-provider-cutover.sh`, [INV-91], landed in #294) into CI. This is the maintainer follow-up that #286 deliberately deferred (the autonomous agent's GitHub App token lacks `workflow` scope and cannot push `.github/workflows/`).

## Changes (only `.github/workflows/ci.yml`, +20 lines)

- **spec-drift job**: add `fetch-depth: 0` to the `actions/checkout` step (so the guard's strict monotonicity Check 4 can resolve `origin/main` — the current tip of `main`, which carries the trusted `cutover-baseline.json`), and add a step running `check-provider-cutover.sh --require-trusted-ref` (strict / fail-closed — a missing/unreadable trusted baseline FAILs rather than silently self-ratifying, closing #286 P1#1).
- **hermetic-shellcheck job**: add `check-provider-cutover.sh` + `tests/unit/test-provider-cutover.sh` + `tests/unit/test-provider-caps-branches.sh` to the `shellcheck -S error` file list.

## Why spec-drift / why fetch-depth: 0

`spec-drift` is already the credential-free static-lint job, so the guard co-locates there without a redundant checkout. `fetch-depth: 0` is the robust idiom for making `origin/main` resolvable; it does **not** change `check-spec-drift.sh` (which is working-tree-only).

## Verification (local)

- ✅ clean tree → `cutover-guard: PASS`
- ✅ injected new `gh pr view` in a scratch lib-dispatch.sh → FAIL exit 1, names `file:line`
- ✅ `shellcheck -S error` clean on the 3 newly-listed files
- ✅ ci.yml valid YAML
- ✅ self-ratification bypass (add raw-gh + regenerate baseline) is caught by strict Check 4

## Review

codex-equivalent adversarial review: **APPROVE-WITH-NITS**, 0 P1/P2, 3 P3 nits. The highest-risk point — `actions/checkout@v4 + fetch-depth: 0` actually making `origin/main` resolvable on both PR and push events — was verified against the action's source (`getRefSpecForAllHistory` → `+refs/heads/*:refs/remotes/origin/*`). P3#1 (comment wording "merge base" → "tip") adopted; P3#2/#3 are non-blocking optimizations left as-is.

## Security

Static command, no `${{ github.event.* }}` interpolation; credential-free job; checkout still SHA-pinned. No injection / supply-chain surface introduced.

Closes #295
