### PR TITLE
fix(hooks): verify-completion.sh fails closed when review threads exceed one page (#412)

### DIFF
--- a/docs/designs/verify-completion-pagination-guard.md
+++ b/docs/designs/verify-completion-pagination-guard.md
@@ -1,0 +1,60 @@
+# verify-completion.sh — fail-closed truncation guard (#412)
+
+## Problem
+
+`skills/autonomous-common/hooks/verify-completion.sh` issues two raw
+`gh api graphql` reads with `reviewThreads(first: 100)` and no awareness of
+further pages. On a PR with >100 review threads, unresolved threads beyond
+page 1 are invisible: `check_unresolved_reviews` under-counts and the Stop
+hook can stop blocking while real unresolved threads remain — a silent
+truncation, the same hazard class the CHP seam closed in #401 (W1f).
+
+## Constraints (why not a cursor walk)
+
+- A full pagination loop here would duplicate the cursor-walk logic that
+  already lives in `chp_review_threads` (#401) — two implementations of the
+  same GraphQL walk to keep in sync.
+- Hooks are deliberately dependency-free: they do not source the CHP/ITP
+  provider libs, and that boundary stays.
+- This Stop hook is a bounded advisory (Claude Code force-ends the turn
+  after 8 consecutive no-progress blocks); no merge decision keys on its
+  count. The proportionate fix is loud-on-truncation, not full completeness.
+
+## Design
+
+Add `pageInfo { hasNextPage }` to both GraphQL queries. In
+`check_unresolved_reviews`, check `hasNextPage` FIRST:
+
+- `hasNextPage == true` → the hook cannot prove all threads are resolved.
+  Emit the sentinel `truncated` instead of a count. The caller blocks with a
+  distinct message: the PR has >100 review threads, the hook cannot verify
+  completeness, verify manually (`gh pr view --web`). The message claims no
+  specific count (it cannot know one).
+- `hasNextPage == false` (or `pageInfo` absent — old-shape responses) →
+  behavior is byte-identical to today: numeric count, existing block
+  message on >0, no block on 0.
+- GraphQL query failure (`.data == null`) keeps today's fail-open
+  `echo "0"` — changing the failure posture is out of scope (#412 body).
+
+The sentinel check must precede the numeric `-gt` comparison in the caller:
+bash `[[ -gt ]]` arithmetic-evaluates its operands, so `"truncated"` resolves
+as an unset-variable lookup → 0 → `0 -gt 0` → false, **silently, rc 0**. A
+missed sentinel would not error under `set -e` — it would silently un-block,
+the exact failure this guard exists to prevent.
+
+`get_unresolved_review_details` gets the same `pageInfo { hasNextPage }`
+field added for query-shape parity (R1), but its output path is unreachable
+in the truncated case — the caller blocks on the sentinel before requesting
+details.
+
+## Accepted trade-off
+
+A >100-thread PR whose threads are ALL resolved is blocked up to the 8-round
+Stop-hook cap, then force-released with a warning. Bounded annoyance in an
+extreme-outlier scenario, in exchange for eliminating a silent false-unblock.
+
+## Test surface
+
+`tests/unit/test-verify-completion-pagination.sh` — hermetic (PATH-stubbed
+`gh` + `git`), drives the real hook end-to-end. See
+`docs/test-cases/verify-completion-pagination-guard.md`.

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -6340,3 +6340,26 @@ _Triage (issue #236): [machine-checked: tests/unit/test-lib-review-codex.sh, tes
 
 ---
 
+## INV-113: verify-completion.sh fails closed when the reviewThreads page is truncated — hasNextPage:true yields the `truncated` sentinel and a blocking message, never a page-1 count
+
+_Triage (issue #236): [machine-checked: tests/unit/test-verify-completion-pagination.sh]_
+
+**Rule**: the Stop hook's unresolved-review-thread check (`check_unresolved_reviews` in `skills/autonomous-common/hooks/verify-completion.sh`) reads a single `reviewThreads(first: 100)` page by design — a cursor walk here would duplicate the CHP seam's `chp_review_threads` logic (#401) outside the seam, and hooks stay provider-lib-free. Both GraphQL queries therefore request `pageInfo { hasNextPage }`, and when it is `true` the function MUST print the sentinel `truncated` instead of a count; the caller MUST handle that sentinel BEFORE the numeric `-gt` comparison and block with a distinct message (PR has >100 review threads, hook cannot verify completeness, verify manually) that claims no specific count. `hasNextPage:false` and pageInfo-less (old-shape) responses are byte-identical to the pre-#412 behavior, and a failed GraphQL read keeps its pre-existing fail-open `echo "0"` (explicitly out of scope for #412).
+
+**Sentinel-before-`-gt` is load-bearing**: bash `[[ ]]` arithmetic-evaluates `-gt` operands, so `[[ "truncated" -gt 0 ]]` resolves the string as an unset-variable lookup → 0 → false, **silently, rc 0** — a missed sentinel would not error under `set -e`; it would silently un-block, which is exactly the false-unblock this invariant exists to prevent. The guard must stay ahead of the numeric comparison.
+
+**Why**: pre-#412 the two reads carried `reviewThreads(first: 100)` with no page awareness — on a PR with >100 review threads, unresolved threads beyond page 1 were invisible and the completion gate silently stopped blocking (the hook-side sibling of the silent-truncation class #401 / #347 W1f closed in the CHP seam). The accepted trade-off: a >100-thread PR whose threads are ALL resolved is blocked up to the Stop-hook block cap and then force-released with a warning — bounded annoyance in an extreme-outlier scenario, in exchange for eliminating a silent false-unblock.
+
+**Producer**: `check_unresolved_reviews` (the sentinel) and the CI-passed branch of `verify-completion.sh` (the sentinel-first block).
+
+**Consumer**: the dev agent's Stop-time completion attempt — the truncation block directs it (or the operator) to manual verification instead of letting it finish with unverifiable thread state.
+
+**Status**: **ENFORCED** (closes #412).
+
+**Test**: `tests/unit/test-verify-completion-pagination.sh` — TC-VCP-001/001b/001c (truncated + all page-1 threads resolved still blocks with the truncation message and no fabricated count; **proven to FAIL pre-fix**), TC-VCP-002 (sentinel wins even when page 1 has unresolved threads), TC-VCP-003/004 (single-page behavior byte-preserved), TC-VCP-005 (query-failure fail-open unchanged), TC-VCP-006a/b (pageInfo-less old shape degrades to single-page), TC-VCP-007 (source-shape pin: both queries carry `pageInfo { hasNextPage }`). Test plan: `docs/test-cases/verify-completion-pagination-guard.md`.
+
+**Cross-references**:
+- [INV-94](#inv-94-chp_count_reviews_by_login-is-a-single-choke-point-leaf-with-capture-check-sum-pagination) / the §3.5 completeness family — the no-silent-caps posture this hook-side guard extends to the one raw GraphQL read outside the provider seam.
+
+---
+

--- a/docs/test-cases/verify-completion-pagination-guard.md
+++ b/docs/test-cases/verify-completion-pagination-guard.md
@@ -1,0 +1,19 @@
+# Test cases — verify-completion.sh fail-closed truncation guard (#412)
+
+Hermetic: `gh`, `git`, and `jq`-availability are controlled via a PATH-front
+stub dir; the real hook script runs unmodified end-to-end (stdin fed,
+exit code + stderr asserted). All fixtures satisfy the hook's preconditions:
+non-main branch, PR number found, CI `completed`/`success` (so control flow
+reaches the unresolved-thread check).
+
+| ID | Fixture | Expect |
+|---|---|---|
+| TC-VCP-001 | `hasNextPage:true`, page-1 threads ALL resolved | exit 2 (block); stderr carries the truncation message (mentions >100 threads / cannot verify), NOT the numeric "unresolved review thread(s)" message |
+| TC-VCP-002 | `hasNextPage:true`, page-1 has 2 unresolved threads | exit 2 (block); truncation message (sentinel wins before counting) |
+| TC-VCP-003 | `hasNextPage:false`, 0 unresolved (all resolved/outdated) | exit 0, no block — byte-preserved current behavior |
+| TC-VCP-004 | `hasNextPage:false`, 2 unresolved threads | exit 2; EXISTING "Unresolved Review Comments" message with count 2 — byte-preserved current behavior |
+| TC-VCP-005 | GraphQL failure (`gh api graphql` exits 1 / `.data == null`) | exit 0 — today's fail-open posture unchanged (out of scope to change) |
+| TC-VCP-006 | Response WITHOUT `pageInfo` at all (old-shape defensive) | treated as single page; same as TC-VCP-003/004 by unresolved count |
+| TC-VCP-007 | Source-shape pin (no fixture — greps the hook source) | both `reviewThreads` queries carry `pageInfo { hasNextPage }` (grep-count parity; covers the details query too, R1) |
+
+Run: `env -u PROJECT_DIR bash tests/unit/test-verify-completion-pagination.sh`

--- a/skills/autonomous-common/hooks/README.md
+++ b/skills/autonomous-common/hooks/README.md
@@ -47,7 +47,7 @@ IDEs without hook support (Cursor, Windsurf, Gemini CLI, etc.) rely on skill ins
 | `check-rebase-before-push.sh` | PreToolUse | Bash | Blocks push if branch is behind origin/main |
 | `post-git-action-clear.sh` | PostToolUse | Bash | Clears state after git actions |
 | `post-git-push.sh` | PostToolUse | Bash | Post-push reminder for CI/E2E |
-| `verify-completion.sh` | Stop | All | Blocks task completion until CI/E2E pass |
+| `verify-completion.sh` | Stop | All | Blocks task completion until CI/E2E pass and review threads resolve; fails closed on >100-thread PRs (single-page read cannot verify completeness, #412) |
 | `lib.sh` | Library | N/A | Shared utility functions |
 | `state-manager.sh` | Library | N/A | Workflow state management |
 

--- a/skills/autonomous-common/hooks/verify-completion.sh
+++ b/skills/autonomous-common/hooks/verify-completion.sh
@@ -50,6 +50,11 @@ output_block_response() {
 }
 
 # Function to check unresolved review threads
+# Prints a count, or the sentinel "truncated" when the thread list exceeds one
+# page (#412): the query reads a single 100-thread page by design (a cursor
+# walk would duplicate the CHP seam's chp_review_threads logic), so when
+# pageInfo.hasNextPage is true the hook cannot prove all threads are resolved
+# and must fail CLOSED — the caller keeps blocking with a truncation message.
 check_unresolved_reviews() {
   if [[ -z "$pr_number" ]]; then
     echo "0"
@@ -68,13 +73,20 @@ check_unresolved_reviews() {
   local repo="${repo_info##*/}"
 
   # Query unresolved review threads using GraphQL
-  local query='query($owner: String!, $repo: String!, $pr_number: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $pr_number) { reviewThreads(first: 100) { nodes { isResolved isOutdated comments(first: 1) { nodes { author { login } } } } } } } }'
+  local query='query($owner: String!, $repo: String!, $pr_number: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $pr_number) { reviewThreads(first: 100) { pageInfo { hasNextPage } nodes { isResolved isOutdated comments(first: 1) { nodes { author { login } } } } } } } }'
 
   local result
   result=$(gh api graphql -f query="$query" -f owner="$owner" -f repo="$repo" -F pr_number="$pr_number" 2>/dev/null || echo '{"data":null}')
 
   if [[ $(echo "$result" | jq -r '.data') == "null" ]]; then
     echo "0"
+    return
+  fi
+
+  # Fail closed on truncation (#412): more pages exist, so any count from
+  # page 1 alone could under-count. Report the sentinel instead of a number.
+  if [[ $(echo "$result" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false') == "true" ]]; then
+    echo "truncated"
     return
   fi
 
@@ -97,7 +109,7 @@ get_unresolved_review_details() {
   local owner="${repo_info%%/*}"
   local repo="${repo_info##*/}"
 
-  local query='query($owner: String!, $repo: String!, $pr_number: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $pr_number) { reviewThreads(first: 100) { nodes { isResolved isOutdated path comments(first: 1) { nodes { author { login } body } } } } } } }'
+  local query='query($owner: String!, $repo: String!, $pr_number: Int!) { repository(owner: $owner, name: $repo) { pullRequest(number: $pr_number) { reviewThreads(first: 100) { pageInfo { hasNextPage } nodes { isResolved isOutdated path comments(first: 1) { nodes { author { login } body } } } } } } }'
 
   local result
   result=$(gh api graphql -f query="$query" -f owner="$owner" -f repo="$repo" -F pr_number="$pr_number" 2>/dev/null || echo '{"data":null}')
@@ -142,6 +154,25 @@ fi
 if [[ "$status" == "completed" && "$conclusion" == "success" ]]; then
   # Check for unresolved review comments
   unresolved_count=$(check_unresolved_reviews)
+
+  # Truncation sentinel must be handled BEFORE the numeric comparison: bash
+  # [[ -gt ]] arithmetic-evaluates the string to 0 (unset-variable lookup),
+  # so a missed sentinel silently un-blocks — no error under set -e. Fail
+  # closed: the hook cannot verify completeness, so it must not claim the
+  # threads are resolved.
+  if [[ "$unresolved_count" == "truncated" ]]; then
+    output_block_response "## ⛔ BLOCKED - Review Threads Exceed One Page
+
+PR #$pr_number has more than 100 review threads. This hook reads a single
+page and cannot verify that every thread is resolved.
+
+### Required Steps:
+1. Verify all review threads are resolved manually: \`gh pr view $pr_number --web\`
+2. Resolve any remaining conversations
+3. Retry task completion
+
+**Cannot verify review-thread completion automatically on this PR.**"
+  fi
 
   if [[ "$unresolved_count" -gt 0 ]]; then
     review_details=$(get_unresolved_review_details)

--- a/tests/unit/fixtures/verify-completion/threads-no-pageinfo-resolved.json
+++ b/tests/unit/fixtures/verify-completion/threads-no-pageinfo-resolved.json
@@ -1,0 +1,1 @@
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":true,"isOutdated":false,"path":"src/a.sh","comments":{"nodes":[{"author":{"login":"reviewer"},"body":"looks good"}]}}]}}}}}

--- a/tests/unit/fixtures/verify-completion/threads-no-pageinfo-unresolved.json
+++ b/tests/unit/fixtures/verify-completion/threads-no-pageinfo-unresolved.json
@@ -1,0 +1,1 @@
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"isOutdated":false,"path":"src/a.sh","comments":{"nodes":[{"author":{"login":"reviewer"},"body":"fix this"}]}},{"isResolved":false,"isOutdated":false,"path":"src/b.sh","comments":{"nodes":[{"author":{"login":"reviewer"},"body":"and this"}]}}]}}}}}

--- a/tests/unit/fixtures/verify-completion/threads-single-page-resolved.json
+++ b/tests/unit/fixtures/verify-completion/threads-single-page-resolved.json
@@ -1,0 +1,1 @@
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":true,"isOutdated":false,"path":"src/a.sh","comments":{"nodes":[{"author":{"login":"reviewer"},"body":"looks good"}]}},{"isResolved":false,"isOutdated":true,"path":"src/old.sh","comments":{"nodes":[{"author":{"login":"reviewer"},"body":"outdated one"}]}}]}}}}}

--- a/tests/unit/fixtures/verify-completion/threads-single-page-unresolved.json
+++ b/tests/unit/fixtures/verify-completion/threads-single-page-unresolved.json
@@ -1,0 +1,1 @@
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false},"nodes":[{"isResolved":false,"isOutdated":false,"path":"src/a.sh","comments":{"nodes":[{"author":{"login":"reviewer"},"body":"fix this"}]}},{"isResolved":false,"isOutdated":false,"path":"src/b.sh","comments":{"nodes":[{"author":{"login":"reviewer"},"body":"and this"}]}}]}}}}}

--- a/tests/unit/fixtures/verify-completion/threads-truncated-all-resolved.json
+++ b/tests/unit/fixtures/verify-completion/threads-truncated-all-resolved.json
@@ -1,0 +1,1 @@
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":true},"nodes":[{"isResolved":true,"isOutdated":false,"path":"src/a.sh","comments":{"nodes":[{"author":{"login":"reviewer"},"body":"looks good"}]}},{"isResolved":true,"isOutdated":false,"path":"src/b.sh","comments":{"nodes":[{"author":{"login":"reviewer"},"body":"done"}]}}]}}}}}

--- a/tests/unit/fixtures/verify-completion/threads-truncated-unresolved.json
+++ b/tests/unit/fixtures/verify-completion/threads-truncated-unresolved.json
@@ -1,0 +1,1 @@
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":true},"nodes":[{"isResolved":false,"isOutdated":false,"path":"src/a.sh","comments":{"nodes":[{"author":{"login":"reviewer"},"body":"fix this"}]}},{"isResolved":false,"isOutdated":false,"path":"src/b.sh","comments":{"nodes":[{"author":{"login":"reviewer"},"body":"and this"}]}}]}}}}}

--- a/tests/unit/test-verify-completion-pagination.sh
+++ b/tests/unit/test-verify-completion-pagination.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# test-verify-completion-pagination.sh — #412 fail-closed truncation guard for
+# the verify-completion.sh Stop hook.
+#
+# The hook's two GraphQL reads use `reviewThreads(first: 100)`. Pre-#412 they
+# had no awareness of further pages, so a PR with >100 review threads could
+# silently under-count unresolved threads and stop blocking (false
+# completion-unblock). The fix requests `pageInfo { hasNextPage }` and FAILS
+# CLOSED: hasNextPage:true ⇒ the hook cannot prove completeness ⇒ keep
+# blocking with a distinct truncation message (never a fabricated count).
+#
+# Hermetic: `gh` and `git` are PATH-front stubs; the REAL hook runs end-to-end
+# (stdin fed, exit code + stderr asserted). Fixtures satisfy the hook's
+# preconditions — non-main branch, PR found, CI completed/success — so control
+# flow reaches the unresolved-thread check. TC IDs: TC-VCP-001..007
+# (docs/test-cases/verify-completion-pagination-guard.md).
+#
+# Run: env -u PROJECT_DIR bash tests/unit/test-verify-completion-pagination.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="$PROJECT_ROOT/skills/autonomous-common/hooks/verify-completion.sh"
+FIXTURES="$SCRIPT_DIR/fixtures/verify-completion"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { PASS=$((PASS+1)); echo -e "${GREEN}PASS${NC}: $1"; }
+fail() { FAIL=$((FAIL+1)); echo -e "${RED}FAIL${NC}: $1"; }
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+STUB_BIN="$TMPDIR_TEST/bin"
+FAKE_PROJECT="$TMPDIR_TEST/project"
+mkdir -p "$STUB_BIN" "$FAKE_PROJECT"
+
+# --- git stub: the hook only calls `git branch --show-current`. The
+# state-manager path resolves the project root via CLAUDE_PROJECT_DIR (set
+# below), so no other git behavior is needed.
+cat > "$STUB_BIN/git" <<'EOF'
+#!/bin/bash
+if [[ "${1:-}" == "branch" ]]; then
+  echo "fix/feature-branch"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$STUB_BIN/git"
+
+# --- gh stub: dispatch on subcommand. GraphQL responses come from the fixture
+# named in _MOCK_GRAPHQL_FIXTURE; _MOCK_GRAPHQL_FAIL=1 simulates a failed read
+# (the hook's `|| echo '{"data":null}'` fallback then applies).
+cat > "$STUB_BIN/gh" <<'EOF'
+#!/bin/bash
+case "${1:-}" in
+  pr)
+    case "${2:-}" in
+      view)   echo "42" ;;
+      checks) echo "[]" ;;   # no e2e job → hook exits 0 after review gate
+    esac
+    ;;
+  run)
+    echo '[{"status":"completed","conclusion":"success"}]'
+    ;;
+  repo)
+    echo "zxkane/testrepo"
+    ;;
+  api)
+    if [[ "${_MOCK_GRAPHQL_FAIL:-0}" == "1" ]]; then
+      exit 1
+    fi
+    cat "$_MOCK_GRAPHQL_FIXTURE"
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$STUB_BIN/gh"
+
+# run_hook <fixture-file|-> [fail]
+# Runs the real hook with stubbed PATH; captures rc + stderr.
+HOOK_RC=0
+HOOK_STDERR=""
+run_hook() {
+  local fixture="$1" failmode="${2:-0}"
+  local errfile="$TMPDIR_TEST/stderr"
+  set +e
+  echo '{}' | env PATH="$STUB_BIN:$PATH" \
+    CLAUDE_PROJECT_DIR="$FAKE_PROJECT" \
+    _MOCK_GRAPHQL_FIXTURE="$fixture" \
+    _MOCK_GRAPHQL_FAIL="$failmode" \
+    bash "$HOOK" >/dev/null 2>"$errfile"
+  HOOK_RC=$?
+  set -e
+  HOOK_STDERR="$(cat "$errfile")"
+}
+
+set -e
+
+# ---------------------------------------------------------------------------
+# TC-VCP-001: hasNextPage:true + page-1 all resolved → BLOCK with truncation
+# message (the regression this issue exists for: pre-fix this exits 0).
+# ---------------------------------------------------------------------------
+run_hook "$FIXTURES/threads-truncated-all-resolved.json"
+if [[ "$HOOK_RC" -eq 2 ]]; then
+  pass "TC-VCP-001: truncated+all-resolved page blocks (rc=2)"
+else
+  fail "TC-VCP-001: expected rc=2, got rc=$HOOK_RC (silent false-unblock)"
+fi
+if echo "$HOOK_STDERR" | grep -qi "more than 100 review threads" \
+   && echo "$HOOK_STDERR" | grep -qi "cannot verify"; then
+  pass "TC-VCP-001b: truncation message present"
+else
+  fail "TC-VCP-001b: truncation message missing; stderr: $(echo "$HOOK_STDERR" | head -3)"
+fi
+if echo "$HOOK_STDERR" | grep -q "unresolved review thread(s)"; then
+  fail "TC-VCP-001c: must not claim a numeric unresolved count it cannot know"
+else
+  pass "TC-VCP-001c: no fabricated numeric count in truncation message"
+fi
+
+# ---------------------------------------------------------------------------
+# TC-VCP-002: hasNextPage:true + page-1 has unresolved → still the truncation
+# block (sentinel wins before counting; count would be a lie anyway).
+# ---------------------------------------------------------------------------
+run_hook "$FIXTURES/threads-truncated-unresolved.json"
+if [[ "$HOOK_RC" -eq 2 ]] && echo "$HOOK_STDERR" | grep -qi "more than 100 review threads"; then
+  pass "TC-VCP-002: truncated+unresolved blocks with truncation message"
+else
+  fail "TC-VCP-002: expected rc=2 + truncation message, got rc=$HOOK_RC"
+fi
+
+# ---------------------------------------------------------------------------
+# TC-VCP-003: hasNextPage:false, 0 unresolved (resolved + outdated only) →
+# no block, exits 0 — current behavior byte-preserved.
+# ---------------------------------------------------------------------------
+run_hook "$FIXTURES/threads-single-page-resolved.json"
+if [[ "$HOOK_RC" -eq 0 ]]; then
+  pass "TC-VCP-003: single page all-resolved does not block (rc=0)"
+else
+  fail "TC-VCP-003: expected rc=0, got rc=$HOOK_RC; stderr: $(echo "$HOOK_STDERR" | head -3)"
+fi
+
+# ---------------------------------------------------------------------------
+# TC-VCP-004: hasNextPage:false, 2 unresolved → existing numeric block message.
+# ---------------------------------------------------------------------------
+run_hook "$FIXTURES/threads-single-page-unresolved.json"
+if [[ "$HOOK_RC" -eq 2 ]] && echo "$HOOK_STDERR" | grep -q "2 unresolved review thread(s)"; then
+  pass "TC-VCP-004: single page unresolved keeps existing count message"
+else
+  fail "TC-VCP-004: expected rc=2 + '2 unresolved review thread(s)', got rc=$HOOK_RC"
+fi
+
+# ---------------------------------------------------------------------------
+# TC-VCP-005: GraphQL read fails → today's fail-open (rc=0). Changing that
+# posture is explicitly out of scope for #412.
+# ---------------------------------------------------------------------------
+run_hook "-" 1
+if [[ "$HOOK_RC" -eq 0 ]]; then
+  pass "TC-VCP-005: GraphQL failure keeps fail-open rc=0 (unchanged posture)"
+else
+  fail "TC-VCP-005: expected rc=0 on query failure, got rc=$HOOK_RC"
+fi
+
+# ---------------------------------------------------------------------------
+# TC-VCP-006: response without pageInfo (old shape) → treated as single page.
+# ---------------------------------------------------------------------------
+run_hook "$FIXTURES/threads-no-pageinfo-unresolved.json"
+if [[ "$HOOK_RC" -eq 2 ]] && echo "$HOOK_STDERR" | grep -q "2 unresolved review thread(s)"; then
+  pass "TC-VCP-006a: pageInfo-less unresolved response → numeric block"
+else
+  fail "TC-VCP-006a: expected rc=2 + numeric message, got rc=$HOOK_RC"
+fi
+run_hook "$FIXTURES/threads-no-pageinfo-resolved.json"
+if [[ "$HOOK_RC" -eq 0 ]]; then
+  pass "TC-VCP-006b: pageInfo-less resolved response → no block"
+else
+  fail "TC-VCP-006b: expected rc=0, got rc=$HOOK_RC"
+fi
+
+# ---------------------------------------------------------------------------
+# TC-VCP-007: source-shape — BOTH GraphQL queries in the hook carry
+# pageInfo { hasNextPage } (R1 covers the details query too).
+# ---------------------------------------------------------------------------
+query_count=$(grep -c "reviewThreads(first: 100)" "$HOOK" || true)
+pageinfo_count=$(grep -c "pageInfo { hasNextPage }" "$HOOK" || true)
+if [[ "$query_count" -ge 2 && "$pageinfo_count" -eq "$query_count" ]]; then
+  pass "TC-VCP-007: all $query_count reviewThreads queries request pageInfo { hasNextPage }"
+else
+  fail "TC-VCP-007: $pageinfo_count/$query_count queries carry pageInfo { hasNextPage }"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Closes #412 with the re-scoped **fail-closed truncation guard** (see the issue's "Scope decision" section — a full cursor walk was rejected as duplicating the CHP seam's `chp_review_threads` logic outside the seam).

Both `verify-completion.sh` GraphQL reads now request `reviewThreads(first: 100) { pageInfo { hasNextPage } ... }`. When `hasNextPage` is `true`, `check_unresolved_reviews()` emits the sentinel `truncated` instead of a count, and the Stop hook blocks with a distinct message (PR has >100 review threads, hook cannot verify completeness, verify manually) — never a fabricated count. The sentinel is handled **before** the numeric `-gt` comparison, which is load-bearing: bash `[[ -gt ]]` arithmetic-evaluates the string to 0 (unset-variable lookup), so a missed sentinel would silently un-block rather than error.

Single-page behavior is byte-preserved; pageInfo-less (old-shape) responses degrade to single-page; the pre-existing fail-open posture on GraphQL query failure is unchanged (explicitly out of scope per the issue).

## Requirements coverage

- **R1** — both queries carry `pageInfo { hasNextPage }`; `hasNextPage:true` ⇒ blocking regardless of the page-1 count (TC-VCP-001/002/007).
- **R2** — distinct truncation message; states >100 threads + cannot verify + points at `gh pr view --web`; claims no numeric count (TC-VCP-001b/001c).
- **R3** — `hasNextPage:false` byte-preserved (TC-VCP-003/004); query failure keeps today's fail-open `echo "0"` (TC-VCP-005); pageInfo-less old shape degrades to single-page (TC-VCP-006a/b).

## Acceptance criteria

- **AC1** (truncated + all page-1 resolved ⇒ still blocks, truncation message): TC-VCP-001/001b/001c — **proven to fail pre-fix** (rc=0 silent false-unblock on the pre-fix hook). Surface: CI `unit`.
- **AC2** (`hasNextPage:false` reproduces current behavior exactly): TC-VCP-003/004/006a/006b. Surface: CI `unit`.

## Pipeline docs

New **INV-113** in `docs/pipeline/invariants.md` (with the `_Triage (issue #236): [machine-checked: …]_` tag) documents the fail-closed rule, the sentinel-before-`-gt` hazard, and the accepted trade-off (an all-resolved >100-thread PR is blocked up to the Stop-hook block cap, then force-released with a warning — bounded annoyance vs. silent false-unblock).

## Testing

- New hermetic `tests/unit/test-verify-completion-pagination.sh` (TC-VCP-001..007): PATH-front `gh`/`git` stubs drive the REAL hook end-to-end; fixtures satisfy all preconditions (non-main branch, PR found, CI success) so control flow reaches the thread check. No network, no repo state, no fixed /tmp paths.
- Full unit suite: 0 failed suites in the worktree. `test-spec-drift.sh` 66/66 (INV-113 triage tag validated). `shellcheck -S error` clean.
- Design doc: `docs/designs/verify-completion-pagination-guard.md`; test plan: `docs/test-cases/verify-completion-pagination-guard.md`.

## Post-install / upgrade

No new entry-point script and no new `lib-*.sh` — this edits the existing `verify-completion.sh` hook (already wired via `.claude/settings.json`). `npx skills update autonomous-common -g` alone refreshes consumers.
