### PR TITLE
feat(providers): P3-1 GitLab transport seam — _gl_http/_gl_api contract, auth-lifecycle gating, runner gitlab/hook axes, INV-91 glab token class (#416)

### DIFF
--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -6434,3 +6434,42 @@ The FIFO clean-exit handshake the design's normative table also lists in this ro
 
 ---
 
+## INV-116: the GitLab transport is a two-layer choke-point (`_gl_http` request primitive + `_gl_api` public function); pagination + backoff + fail-closed live in `_gl_api`; the override hook may redefine `_gl_http` ONLY
+
+_Triage (issue #236): [machine-checked: tests/unit/test-lib-gitlab-transport.sh]_
+
+**Rule**: the GitLab transport is a FROZEN two-layer contract implemented by `skills/autonomous-dispatcher/scripts/providers/lib-gitlab-transport.sh` (issue #416, phase-3 #414 W-A). Every GitLab leaf (W-B / W-C, upcoming) reaches the network EXCLUSIVELY through the public `_gl_api` function; `_gl_api` reaches the network EXCLUSIVELY through the private `_gl_http` primitive; there is NO third path.
+
+1. **`_gl_http <method> <path-or-url> <headers_out_file> [body-json]`** is the SINGLE-REQUEST primitive AND the sole out-of-tree hook point. Default impl uses curl only (no `glab` — a CLI carries its own auth/config state, blurring the standard-auth-only boundary per #414 pillar 2). Sends `PRIVATE-TOKEN: ${GITLAB_TOKEN}` against `https://${GITLAB_HOST}/api/v4/<path>` (a `<path>` beginning with `http` is used verbatim so `_gl_api`'s pagination walker can pass an absolute next-page URL). Response body → stdout for ALL HTTP statuses (including 4xx/5xx — `_gl_api` needs the body for tolerated statuses and error excerpts). HTTP status + response headers (at minimum `x-next-page`, `x-total-pages`, `retry-after`) → `<headers_out_file>` in a stable line-oriented format. rc 0 iff TRANSPORT succeeded (curl exit 0); HTTP-status classification is EXCLUSIVELY `_gl_api`'s job. No retries here. No pagination here.
+
+2. **`_gl_api [--method M] [--paginate] [--body JSON] [--tolerate-status CSV] [--max-items N] [--status-out FILE] <path>`** is the PUBLIC function every GitLab leaf calls. It owns pagination walk (with `--paginate`, loops `x-next-page` until exhausted, merges pages into ONE JSON array via `jq -s add`, page cap `GL_TRANSPORT_PAGE_CAP` default 50 → cap-hit or ANY mid-walk failure = rc ≠ 0 with NO partial output — the §3.5/#401 fail-CLOSED discipline verbatim); `429`/`Retry-After` bounded backoff (default 3 retries per request, cap 60s per sleep); fail-loud error surfacing (HTTP status + response body excerpt). Next-page reconstruction sets/replaces `page=<n>` on the ORIGINAL path (GitLab's `x-next-page` is a page number, not a URL). Sets `GL_API_STATUS` (final HTTP status) in the calling shell on EVERY return; ALSO mirrors it into `--status-out <file>` for harnesses that must capture stdout. `--tolerate-status CSV` makes named statuses rc 0 with the body on stdout. `--max-items N` bounds the pagination walk.
+
+3. **Override hook (`GITLAB_TRANSPORT_HOOK`)** — if set, the transport lib sources the file at library-init BEFORE any leaf runs. The hook MAY redefine `_gl_http` ONLY (same signature/contract); `_gl_api` stays lib-owned so pagination + backoff + fail-closed cannot be lost by a variant. **Trust model**: operator-owned local code, same privileges as `autonomous.conf` — explicitly NOT a sandbox (#414 pillar 3). The hook MAY define private helper functions alongside (that is operator-owned code); only the PUBLIC override point (`_gl_http`) is validated post-source. **The hook MUST actually redefine `_gl_http`** — a no-op source that leaves the default body in place fails preflight loudly (see the codex round-1 [P1-4] fix): the preflight captures `declare -f _gl_http` BEFORE sourcing and requires the body to CHANGE after. This closes the "hook armed but silently does nothing" failure mode where a mis-authored hook (typo, syntax error suppressed by the operator) would masquerade as the default transport.
+
+4. **Preflight fail-loud, latched once per process** — `GITLAB_TOKEN` unset when no hook is armed → rc ≠ 0 with recovery guidance; `GITLAB_TRANSPORT_HOOK` set but path unreadable → rc ≠ 0 naming the path; after sourcing the hook, `_gl_http` must exist AND its body must differ from the pre-source default or preflight fails rc ≠ 0 naming the hook path. The latch mirrors `_AGENT_TOKEN_PAT_WARNED` at `lib-auth.sh:93`.
+
+**set -e safety (codex round-1 [P1-3])**: every `_gl_http` call inside `_gl_api` uses the `if ! _gl_http …; then http_rc=$?; fi` pattern rather than a bare simple command. Under a caller's `set -euo pipefail`, a bare-command transport failure would abort the CALLING shell before `_gl_api`'s own rc/cleanup/`--status-out` mirroring ran; the guarded form keeps every failure paths reachable.
+
+**Contract note for leaf authors — command substitution loses shell variables**: a leaf that needs status discrimination MUST invoke `_gl_api … > "$tmpfile"` directly in the CURRENT shell (redirect, NOT `$( … )` capture) so the `GL_API_STATUS` assignment survives. This is how W-B's `provision_states` discriminates 200-probe/404-create/409-race and W-C's `commit_file` runs its branch/file preflights WITHOUT parsing stderr or reaching for `_gl_http`.
+
+**Cutover-guard extension ([INV-91], #416 R4)** — `check-provider-cutover.sh` gains two class detectors: raw `glab ` outside `providers/` and the transport allowlist FAILs; `curl` argv mentioning `/api/v4` outside `providers/lib-gitlab-transport.sh` FAILs. Both strict-from-zero on the gitlab axis. LEAVES NEVER call curl or `_gl_http` directly — the guard enforces this. The `/api/v4` detector is SAME-LINE-ONLY (matching the existing gh matcher's line-oriented discipline); multi-line evasion (`url="…/api/v4/…"` on one line, `curl "$url"` on another) is out of scope for a lint — the review gate catches it. This bound is documented in the checker comment (codex round-1 [P2-6]).
+
+**Numbering note**: this invariant was drafted as INV-113 pre-rebase (before origin/main's #412 landed as INV-113 and #405 landed as INV-114/115). Per the repo's INV number collision convention ("first-merged keeps it; renumber-on-rebase-collision"), it claims the first free slot INV-116 instead. Same convention that INV-114/INV-115 note above.
+
+**Why**: without a shared transport lib, every W-B / W-C leaf would re-implement pagination, backoff, and header parsing individually — the "single choke-point" discipline (#414 pillar 2) would exist in prose only. Freezing the contract before leaf work is a hard sequencing gate (#414 W-A).
+
+**Producer**: `skills/autonomous-dispatcher/scripts/providers/lib-gitlab-transport.sh` (`_gl_http` / `_gl_api` / `_gl_urlencode` / preflight latch).
+
+**Consumer**: every GitLab leaf (`itp-gitlab.sh` / `chp-gitlab.sh`, upcoming W-B / W-C), the conformance runner's `--transport-hook` / `--transport-path-add` flags (`tests/provider-conformance/run-provider-conformance.sh`, #416 R3), and the cutover guard's new Check 5 + Check 6 (`check-provider-cutover.sh`, #416 R4).
+
+**Status**: **ENFORCED** (closes #416 W-A; frozen contract; W-B / W-C leaves land against this shape).
+
+**Test**: `tests/unit/test-lib-gitlab-transport.sh` — covers preflight fail-loud (incl. no-op hook rejection, TC-GLT-003), `_gl_http` shape, `_gl_api` pagination walk, 429 backoff, HTTP-status channel + `--tolerate-status` + `--max-items`, `_gl_urlencode`, override-hook end-to-end, AND the `set -e` propagation regression (TC-GLT-070 — sourced under `set -euo pipefail`, a transport failure inside `_gl_api` returns rc ≠ 0 to the caller instead of aborting the caller's shell).
+
+**Cross-references**:
+- [`provider-spec.md` §transport](provider-spec.md#35-list-completeness-pagination--retry) — the normative statement of the two-layer contract; leaf authors build against §transport, not this rule.
+- [INV-79](#inv-79-two-token-split-app-mode-mints-a-scoped-installation-token-into-a-second-file-that-lives-only-in-the-agent-subprocess-env-the-wrapper-keeps-its-full-write-token-in-its-own-shell-only) — GitLab has no GitHub-App equivalent (§5.1), so agent GITLAB_TOKEN posture degrades to convention (parallel WARN latched in `lib-auth.sh` — `_AGENT_GITLAB_TOKEN_PAT_WARNED`).
+- [INV-91](#inv-91-provider-dispatch-is-spec-defined-and-regression-pinned-by-a-tree-wide-cutover-guard-that-forbids-a-new-raw-gh-outside-the-migrated-providers-tree-or-a-narrowly-allowlisted-file) — the cutover-guard extension in R4 rides on the same anti-regression mechanism; the gitlab class is strict-from-zero, the gh class stays baseline-anchored.
+
+---
+

--- a/docs/pipeline/provider-spec.md
+++ b/docs/pipeline/provider-spec.md
@@ -478,6 +478,28 @@ provider-internal** — callers never see a partial page or a 429.
 > + per-thread comment level) itself, capped at 50 pages per level with loud
 > rc != 0 on any mid-walk failure or cap-hit and no partial output.
 
+### 3.5.1 GitLab transport contract (§transport) — the two-layer choke-point
+
+The GitLab transport lib (`skills/autonomous-dispatcher/scripts/providers/lib-gitlab-transport.sh`, #416 W-A) is the FROZEN two-layer artifact every W-B / W-C GitLab leaf builds against. It is the load-bearing "single choke-point" (#414 pillar 2) — the pagination walker, `429`/`Retry-After` backoff, and §3.5 fail-CLOSED discipline live HERE, not in each leaf.
+
+**`_gl_http <method> <path-or-url> <headers_out_file> [body-json]`** — SINGLE-REQUEST primitive AND the OUT-OF-TREE HOOK POINT. Default impl uses curl only (no `glab` — a CLI carries its own auth/config state, blurring the standard-auth-only boundary per #414 pillar 2). Sends `PRIVATE-TOKEN: ${GITLAB_TOKEN}` against `https://${GITLAB_HOST}/api/v4/<path>`. A `<path>` that begins with `http` is used VERBATIM (used by `_gl_api`'s pagination walker to pass an absolute next-page URL). Response body → stdout for ALL HTTP statuses (including 4xx/5xx — `_gl_api` needs the body for tolerated statuses and error excerpts; no body-to-stderr split). HTTP status + response headers (at minimum `x-next-page`, `x-total-pages`, `retry-after`) → `<headers_out_file>` in a stable line-oriented format. rc 0 iff TRANSPORT succeeded (request sent, response received — curl exit 0); HTTP-status classification (≥ 400 → error, tolerated statuses, retry triggers) is EXCLUSIVELY `_gl_api`'s job. No retries here. No pagination here.
+
+**`_gl_api [--method M] [--paginate] [--body JSON] [--tolerate-status CSV] [--max-items N] [--status-out FILE] <path>`** — the PUBLIC function every GitLab leaf calls. Owns pagination walk (with `--paginate`, loops `x-next-page` until exhausted, merges pages into ONE JSON array via `jq -s add`; page cap `GL_TRANSPORT_PAGE_CAP` default 50 → cap-hit or ANY mid-walk failure = rc ≠ 0 with NO partial output — the §3.5/#401 fail-closed discipline verbatim); `429`/`Retry-After` bounded backoff (default 3 retries per request, cap 60s per sleep); fail-loud error surfacing (HTTP status + response body excerpt). Calls `_gl_http` per request.
+
+**HTTP-status channel (load-bearing for leaf preflights; SUBSHELL-SAFE by design)**: `_gl_api` sets `GL_API_STATUS` (final HTTP status) in the calling shell on EVERY return, and `--tolerate-status 404,409` makes the named statuses return rc 0 with the body on stdout and `GL_API_STATUS` observable. **CONTRACT NOTE — command substitution loses shell variables**: a leaf that needs status discrimination MUST invoke `_gl_api … > "$tmpfile"` directly in the CURRENT shell (redirect, NOT `$( … )` capture) so the `GL_API_STATUS` assignment survives; `_gl_api` ADDITIONALLY mirrors the status into a caller-suppliable `--status-out <file>` for harnesses that must capture stdout. This is how W-B's `provision_states` discriminates 200-probe/404-create/409-race and W-C's `commit_file` runs its branch/file preflights WITHOUT parsing stderr or reaching for `_gl_http`.
+
+**Bounded reads**: `--max-items N` stops the pagination walk once N items are merged (so a LIMIT-bounded list verb cannot spuriously hit the page cap on a large project).
+
+**Next-page reconstruction**: GitLab's `x-next-page` is a page NUMBER, not a URL — `_gl_api` reconstructs the next request by setting/replacing the `page=<n>` query param on the ORIGINAL path (documented; `_gl_http`'s verbatim-absolute-URL affordance stays but is not the pagination mechanism).
+
+**`_gl_urlencode <string>`** (jq `@uri`) — leaves (dynamic project refs, label names, file paths) share ONE encoder; the STATIC `GITLAB_PROJECT` config value is stored ALREADY-URL-ENCODED per §3.4 (`group%2Fsubgroup%2Fproject`) and used verbatim.
+
+**Leaves NEVER call curl or `_gl_http` directly** — the [INV-91] cutover guard (#416 R4) enforces this: any `curl` argv mentioning `/api/v4` outside `providers/lib-gitlab-transport.sh` FAILs strict-from-zero.
+
+**Override hook (`GITLAB_TRANSPORT_HOOK`)** — if set (conf-declared path), the transport lib sources it at library-init BEFORE any leaf runs. The hook MAY redefine `_gl_http` ONLY (same signature/contract); `_gl_api` stays lib-owned so pagination + backoff + fail-closed cannot be lost by a variant. **Trust model**: operator-owned local code, same privileges as `autonomous.conf` — explicitly NOT a sandbox (#414 pillar 3). Preflight fail-loud, latched once per process (mirrors `_AGENT_TOKEN_PAT_WARNED` at `lib-auth.sh:93`): `GITLAB_TOKEN` unset when no hook is armed → rc ≠ 0 with recovery guidance; `GITLAB_TRANSPORT_HOOK` set but path unreadable → rc ≠ 0 naming the path; after sourcing the hook, `_gl_http` must exist and be callable or preflight fails rc ≠ 0. `GITLAB_HOST` default: `gitlab.com`.
+
+The two-layer contract is normatively pinned by [INV-116](invariants.md#inv-116-the-gitlab-transport-is-a-two-layer-choke-point-_gl_http-request-primitive--_gl_api-public-function-pagination--backoff--fail-closed-live-in-_gl_api-the-override-hook-may-redefine-_gl_http-only). A future amendment (spec + INV entry + code) is the ONLY way to change it — a W-B slice cannot redesign it silently.
+
 ### 3.6 Tick lifecycle hook (`itp_begin_tick`)
 
 The cross-repo dependency lookup mints a **target-repo-scoped** GitHub-App token
@@ -631,6 +653,8 @@ provider broke its own capability declaration).
 ## 5. Per-backend feasibility (research summary)
 
 ### 5.1 GitLab (issue tracker + code host) — viable end-to-end
+
+> **Transport contract shipped in #416 W-A** — see [§3.5.1 GitLab transport contract](#351-gitlab-transport-contract-transport--the-two-layer-choke-point). Every GitLab leaf (W-B / W-C, upcoming) reaches the network through `_gl_api` (public function; owns pagination + `429`/`Retry-After` backoff + `§3.5` fail-CLOSED discipline) → `_gl_http` (single-request primitive; the OUT-OF-TREE hook point). Instance-specific auth (SSO gateways, cookie-sync tooling, forked CLIs) is served by the operator-owned `GITLAB_TRANSPORT_HOOK` (redefines `_gl_http` only). PAT is the reference default via `GITLAB_TOKEN` against `${GITLAB_HOST}` (default `gitlab.com`). GitLab has no GitHub-App equivalent (see below), so the agent's `GITLAB_TOKEN` posture degrades to convention — parallel to the existing GH_AUTH_MODE=token WARN (`_AGENT_GITLAB_TOKEN_PAT_WARNED` latch in `lib-auth.sh`, #416 R2). `LEAVES NEVER call curl or _gl_http directly` — enforced by the [INV-91] cutover-guard extension (#416 R4).
 
 Maps almost 1:1; several verbs are a **cleaner** fit than GitHub: native label
 AND (`labels=A,B`) and negation (`not[labels]=Y`, no jq post-filter); atomic
@@ -841,6 +865,23 @@ independently. **GitHub auth code is UNCHANGED in this PR** — this section
 documents the ownership cut only, so the later GitLab/Asana PRs don't re-cut it.
 `REPO` / `GH_AUTH_MODE` / `*_APP_ID` / `*_APP_PEM` stay as the GitHub provider's
 config namespace (§3.4).
+
+**Auth-lifecycle gating (#416 R2, shipped):** the whole GitHub auth lifecycle
+(`setup_github_auth`'s daemon spawn + `gh` wrapper install; `setup_agent_token`'s
+scoped-mint or PAT WARN; `dispatcher-tick.sh`'s app-mode credential FATAL) is
+now gated on `_github_seam_active` — `ISSUE_PROVIDER=github OR CODE_HOST=github`
+(default `${…:-github}`, so today's github/github topology is byte-identical).
+Under `gitlab`/`gitlab` the whole lifecycle is a clean no-op: no daemon, no
+`gh` wrapper, no FATAL, no `GH_TOKEN`-related WARN.
+
+**GitLab auth rows (#416 W-A, transport shipped; leaves W-B / W-C):**
+
+| Seam | GitLab auth context | Notes |
+|---|---|---|
+| ITP (`itp-gitlab`) | PAT via `GITLAB_TOKEN` against `${GITLAB_HOST}` per §3.4 (namespace reserved at [§3.4](#34-repo-stays--as-the-github-providers-config-namespace)); the wrapper-held full-write posture stays. INV-79 containment **degrades to convention** on the gitlab seam — a WARN is latched once per process (`_AGENT_GITLAB_TOKEN_PAT_WARNED`, `lib-auth.sh:98`) mirroring the existing `GH_AUTH_MODE=token` PAT posture. | GitLab has no GitHub-App equivalent (§5.1). A scoped agent-mint is impossible; the PreToolUse hook layer + wrapper gates remain the sole approve/merge containment on the gitlab lane. |
+| CHP (`chp-gitlab`) | Same as ITP row — PAT via `GITLAB_TOKEN` (a single PAT covers both seams for a `gitlab`/`gitlab` topology; the auth-context ownership boundary is documented, not enforced by two separate token files). | Instance-specific auth (SSO gateway, cookie-sync tooling, forked CLI) served OUT-OF-TREE via the `GITLAB_TRANSPORT_HOOK` (§3.5.1). |
+
+**Transport contract**: see [§3.5.1](#351-gitlab-transport-contract-transport--the-two-layer-choke-point) for the frozen two-layer contract every GitLab leaf builds against.
 
 ---
 

--- a/docs/test-cases/w-a-gitlab-transport.md
+++ b/docs/test-cases/w-a-gitlab-transport.md
@@ -4,7 +4,7 @@ Contract-freeze proof for `skills/autonomous-dispatcher/scripts/providers/lib-gi
 
 **Suite**: `tests/unit/test-lib-gitlab-transport.sh` and `tests/unit/test-auth-lifecycle-gating.sh`.
 **Discipline**: hermetic; stub `curl` on `PATH`; no network. bash 4 target. Run under `env -u PROJECT_DIR bash …` for CI parity.
-**INV-113 machine-check target**: `test-lib-gitlab-transport.sh`.
+**INV-116 machine-check target**: `test-lib-gitlab-transport.sh`.
 
 ## Conventions
 
@@ -109,4 +109,4 @@ Contract-freeze proof for `skills/autonomous-dispatcher/scripts/providers/lib-gi
 
 ## Machine-check pin
 
-`test-lib-gitlab-transport.sh` is the INV-113 machine-check target. `docs/pipeline/invariants.md`'s INV-113 entry names this test path in its `_Triage_` line.
+`test-lib-gitlab-transport.sh` is the INV-116 machine-check target. `docs/pipeline/invariants.md`'s INV-116 entry names this test path in its `_Triage_` line.

--- a/docs/test-cases/w-a-gitlab-transport.md
+++ b/docs/test-cases/w-a-gitlab-transport.md
@@ -1,0 +1,112 @@
+# Test Cases — W-A GitLab Transport (issue #416, phase-3 #414)
+
+Contract-freeze proof for `skills/autonomous-dispatcher/scripts/providers/lib-gitlab-transport.sh` — the two-layer GitLab transport (`_gl_http` request primitive + `_gl_api` public function) that every W-B / W-C GitLab leaf will build against. Also proves the auth-lifecycle gating (R2) — `setup_github_auth` / `setup_agent_token` / `dispatcher-tick.sh`'s app-mode credential FATAL run only under an active github seam.
+
+**Suite**: `tests/unit/test-lib-gitlab-transport.sh` and `tests/unit/test-auth-lifecycle-gating.sh`.
+**Discipline**: hermetic; stub `curl` on `PATH`; no network. bash 4 target. Run under `env -u PROJECT_DIR bash …` for CI parity.
+**INV-113 machine-check target**: `test-lib-gitlab-transport.sh`.
+
+## Conventions
+
+- IDs `TC-GLT-NNN` for transport-layer tests; `TC-AUTH-NNN` for auth-lifecycle gating tests.
+- Every transport test stubs `curl` with a shell script on the isolated PATH that:
+  1. Records its argv (one per line) to a caller-provided file for post-assertion inspection.
+  2. Emits pre-canned status+headers to the `<headers_out_file>` and a body to stdout.
+  3. Optionally increments an invocation counter (for pagination / retry sequences).
+- Auth-lifecycle tests source `lib-auth.sh` under the three topologies via `env -u`+explicit vars and snapshot module-level state (`TOKEN_DAEMON_PID`, `AGENT_TOKEN_DAEMON_PID`, `GH_WRAPPER_DIR`, `PATH`, `${_LIB_AUTH_DIR}/gh` shape).
+
+## Test Cases
+
+### Preflight fail-loud (R1 §preflight)
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-GLT-001 | `GITLAB_TOKEN` unset, no `GITLAB_TRANSPORT_HOOK` armed → `_gl_api ...` invoked | rc ≠ 0; recovery-guidance message to stderr naming `GITLAB_TOKEN`; no curl invocation |
+| TC-GLT-002 | `GITLAB_TRANSPORT_HOOK=/no/such/file` → `_gl_api` invoked | rc ≠ 0; message naming the unreadable path; no curl invocation |
+| TC-GLT-003 | Hook file present but does NOT redefine `_gl_http` (defines an unrelated function only) → `_gl_api` invoked | rc ≠ 0; message stating `_gl_http` must exist and be callable |
+| TC-GLT-004 | Valid `GITLAB_TOKEN` + no hook → preflight passes; a second `_gl_api` call in the same shell does NOT re-run preflight (latched) | 2 curl invocations total, preflight log emitted once |
+| TC-GLT-005 | Hook that redefines `_gl_http` cleanly + `GITLAB_TOKEN` set → preflight passes and hook's `_gl_http` is the one called | curl NEVER invoked (hook takes over); rc 0 |
+
+### `_gl_http` shape (R1 §_gl_http)
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-GLT-010 | GET `/projects/:id/issues/42` → 200 with body `{"iid":42}` | rc 0; stdout = body verbatim; `<headers_out_file>` records `HTTP/1.1 200` + any headers (curl style) |
+| TC-GLT-011 | GET returning 404 with an error body | rc 0 (transport succeeded); stdout = body; headers file records `HTTP/1.1 404`. Status classification is `_gl_api`'s job. |
+| TC-GLT-012 | GET returning 500 | rc 0; stdout = body; headers file records `HTTP/1.1 500` |
+| TC-GLT-013 | `_gl_http` receives an absolute URL beginning with `http` → curl is called with the URL verbatim (not `${GITLAB_HOST}/api/v4/<path>`) | curl argv contains the exact absolute URL; body on stdout |
+| TC-GLT-014 | PRIVATE-TOKEN header — curl argv includes `-H PRIVATE-TOKEN: <token>` with the value from `GITLAB_TOKEN` | header present in recorded argv |
+| TC-GLT-015 | POST with body-json → curl argv includes `-X POST` and `--data-binary <body-json>` (or equivalent); header includes `Content-Type: application/json` | correct argv + header |
+| TC-GLT-016 | curl exits non-zero (transport failure — DNS, connection refused) | `_gl_http` rc ≠ 0; message names transport error |
+| TC-GLT-017 | Paginated response with `x-next-page: 2` / `x-total-pages: 5` — headers file preserves these header lines verbatim | headers file `grep -qi 'x-next-page: 2'` succeeds |
+| TC-GLT-018 | `Retry-After: 3` on a 429 response — headers file preserves the header | headers file grep succeeds |
+
+### `_gl_api` pagination walk (R1 §_gl_api)
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-GLT-020 | Single-page `--paginate` (no `x-next-page`) — body is `[{"a":1}]` | rc 0; stdout = `[{"a":1}]` |
+| TC-GLT-021 | 3-page walk (page 1 → `x-next-page:2`, page 2 → `x-next-page:3`, page 3 → no `x-next-page`) — each body is `[{"n":N}]` | rc 0; stdout = merged `[{"n":1},{"n":2},{"n":3}]` (jq -s add); 3 curl invocations |
+| TC-GLT-022 | Next-page reconstruction — the 2nd curl call is issued against the ORIGINAL path with `page=2` set/replaced as a query-param (not the raw header value); the 3rd against `page=3` | argv of invocation #2 contains `page=2`; #3 contains `page=3` (idempotent replace) |
+| TC-GLT-023 | Mid-walk failure — page 1 OK, page 2 returns 500 → `_gl_api` rc ≠ 0 AND stdout empty (fail-CLOSED per §3.5) | rc ≠ 0; stdout `""` |
+| TC-GLT-024 | Cap-hit — `GL_TRANSPORT_PAGE_CAP=2` but response advertises `x-next-page:3` after page 2 | rc ≠ 0; stdout empty |
+| TC-GLT-025 | `--max-items 2` bounded-read — response has 3 pages of 5 items each, but `--max-items 2` stops after ≥ 2 items merged | rc 0; stdout array length == 2; at most 1 curl invocation past the point of 2 items being available |
+| TC-GLT-026 | `--paginate` on a non-array body (single object) | rc 0; stdout = the object verbatim (no forced array coercion; `--paginate` on single-page bodies degrades to `_gl_http`) |
+
+### `_gl_api` 429 / Retry-After backoff
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-GLT-030 | 429 with `Retry-After: 1` → retry → 429 with `Retry-After: 1` → retry → 200 with body | rc 0; body on stdout; 3 curl invocations; 2 `sleep` calls with duration=1 recorded via stub sleep |
+| TC-GLT-031 | 429 exhausted (3 retries all 429) → rc ≠ 0, stdout empty | rc ≠ 0; 4 curl invocations (initial + 3 retries) or 3 depending on retry semantics; stdout empty |
+| TC-GLT-032 | 429 `Retry-After: 90` capped at 60s per sleep | recorded sleep duration ≤ 60 |
+| TC-GLT-033 | Non-429 5xx (e.g. 503) does NOT trigger the backoff retry loop (fail-loud immediately) | rc ≠ 0; 1 curl invocation (no retry) |
+
+### `_gl_api` HTTP-status channel + `--tolerate-status`
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-GLT-040 | `_gl_api /path > $tmpfile` (redirect, NOT command sub) → `GL_API_STATUS` is set in the calling shell to the final HTTP status | `GL_API_STATUS == 200` |
+| TC-GLT-041 | `_gl_api --status-out $sfile /path > $tmpfile` — `sfile` contains the final HTTP status regardless of subshell placement | `cat $sfile == 200` |
+| TC-GLT-042 | `_gl_api --tolerate-status 404 /path` on a 404 response | rc 0; stdout = body; `GL_API_STATUS == 404` |
+| TC-GLT-043 | `_gl_api --tolerate-status 404,409 /path` on a 409 response | rc 0; stdout = body; `GL_API_STATUS == 409` |
+| TC-GLT-044 | `_gl_api --tolerate-status 404 /path` on a 500 response | rc ≠ 0; `GL_API_STATUS == 500` |
+| TC-GLT-045 | `_gl_api --tolerate-status 404 /path` when curl transport FAILs (rc≠0 from `_gl_http`) | rc ≠ 0 (transport failure is NOT toleratable) |
+
+### `_gl_urlencode`
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-GLT-050 | `_gl_urlencode 'group/subgroup/project'` → `group%2Fsubgroup%2Fproject` | stdout = expected |
+| TC-GLT-051 | `_gl_urlencode 'feature/foo bar'` → `feature%2Ffoo%20bar` | stdout = expected |
+| TC-GLT-052 | `_gl_urlencode 'label with & ampersand'` → correctly percent-encoded (`%26`) | stdout = expected |
+
+### Override hook
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-GLT-060 | Hook that redefines `_gl_http` to synthesize a canned response — `_gl_api` invoked → routes to hook, curl NEVER called | rc 0; stub curl argv file empty |
+| TC-GLT-061 | Hook can define private helper functions (trust model: operator-owned code) — a helper alongside `_gl_http` is not rejected | rc 0 |
+| TC-GLT-062 | Hook attempts to redefine `_gl_api` — has no effect (lib re-defines `_gl_api` after sourcing the hook, or the preflight explicitly rejects) | either: hook's `_gl_api` shadowed; or preflight rc ≠ 0 (implementation may choose; both are compliant) |
+| TC-GLT-063 | End-to-end: hook + pagination — hook serves canned multi-page responses, `_gl_api --paginate` still merges into one array (pagination lives in `_gl_api`) | rc 0; stdout merged array |
+
+## Auth-lifecycle gating (R2)
+
+**Suite**: `tests/unit/test-auth-lifecycle-gating.sh`.
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-AUTH-001 | `ISSUE_PROVIDER=github CODE_HOST=github` (default via `${ISSUE_PROVIDER:-github}`) — `setup_github_auth` invoked in PAT mode | `GH_WRAPPER_DIR` created; `${_LIB_AUTH_DIR}/gh` symlink installed; behavior byte-identical to pre-change main |
+| TC-AUTH-002 | `ISSUE_PROVIDER=gitlab CODE_HOST=gitlab` — `setup_github_auth` invoked | rc 0 (no-op); `TOKEN_DAEMON_PID` stays empty; no `${_LIB_AUTH_DIR}/gh` symlink created this run; no `GH_WRAPPER_DIR` created |
+| TC-AUTH-003 | `ISSUE_PROVIDER=github CODE_HOST=gitlab` (mixed) — `setup_github_auth` invoked | gh lifecycle STILL runs (github ITP needs it) — `${_LIB_AUTH_DIR}/gh` symlink present |
+| TC-AUTH-004 | `ISSUE_PROVIDER=gitlab CODE_HOST=github` (mixed) — `setup_github_auth` invoked | gh lifecycle STILL runs (github CHP needs it) |
+| TC-AUTH-005 | `ISSUE_PROVIDER=gitlab CODE_HOST=gitlab` in PAT mode — `setup_agent_token` invoked | rc 0; no PAT WARN emitted (gated out); `_AGENT_TOKEN_PAT_WARNED` stays empty |
+| TC-AUTH-006 | `ISSUE_PROVIDER=github CODE_HOST=github` in PAT mode — `setup_agent_token` invoked | PAT WARN emitted ONCE per process (existing behavior); a second call is silent |
+| TC-AUTH-007 | `ISSUE_PROVIDER=gitlab CODE_HOST=gitlab` + `GITLAB_TOKEN` set + PAT-mode → one-time GitLab PAT WARN emitted | WARN mentions `GITLAB_TOKEN` + INV-79 posture; latched once |
+| TC-AUTH-008 | `dispatcher-tick.sh` app-mode credential FATAL — `GH_AUTH_MODE=app`, `DISPATCHER_APP_ID`/`PEM` empty, `ISSUE_PROVIDER=gitlab CODE_HOST=gitlab` | NO FATAL, tick continues (gated) |
+| TC-AUTH-009 | Same but `ISSUE_PROVIDER=github CODE_HOST=gitlab` (mixed, github ITP) | FATAL fires (github seam is active) |
+| TC-AUTH-010 | Same but default `ISSUE_PROVIDER`/`CODE_HOST` unset → defaults to github/github | FATAL fires (byte-identical to pre-change) |
+
+## Machine-check pin
+
+`test-lib-gitlab-transport.sh` is the INV-113 machine-check target. `docs/pipeline/invariants.md`'s INV-113 entry names this test path in its `_Triage_` line.

--- a/docs/test-cases/w-d-runner-gitlab-hook.md
+++ b/docs/test-cases/w-d-runner-gitlab-hook.md
@@ -1,0 +1,68 @@
+# Test Cases — W-D Runner GitLab Axis + Transport-Hook Passthrough (issue #416)
+
+Runner extensions to `tests/provider-conformance/run-provider-conformance.sh` that make the W-A transport contract provable end-to-end and enable an out-of-tree provider self-certification path (AC3 of #414).
+
+**Suite**: `tests/unit/test-provider-conformance-runner.sh` (extends the existing).
+**Discipline**: hermetic; stubbed curl (via `--transport-path-add`) or fixture transport-hook.
+
+## Conventions
+
+- IDs `TC-RGH-NNN`.
+- No new fixtures ship for the gitlab axis — leaves come in W-B / W-C. The W-A slice ships only the runner mechanism and the shape of the flag-plumbing.
+- Every test uses the existing pass/fail helpers (`ok`, `bad`, `assert_*`).
+
+## Test Cases
+
+### `pcf_resolve_provider_dir` — gitlab axis + absolute-path form
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-RGH-001 | `pcf_resolve_provider_dir <root> gitlab` | rc 0; stdout = `<root>/skills/autonomous-dispatcher/scripts/providers` (same as github — filename prefix disambiguates) |
+| TC-RGH-002 | `pcf_resolve_provider_dir <root> /tmp/ext-provider` where `/tmp/ext-provider` exists and is a directory | rc 0; stdout = `/tmp/ext-provider` (self-resolution for out-of-tree providers) |
+| TC-RGH-003 | `pcf_resolve_provider_dir <root> /tmp/nonexistent-abs-path` where the path does NOT exist | rc 1; no output |
+| TC-RGH-004 | `pcf_resolve_provider_dir <root> unknownname` (non-path, non-fixed) | rc 1 (unchanged from existing behavior) |
+| TC-RGH-005 | Existing fixed names still resolve: `github`, `degraded`, `broken` | unchanged from existing behavior |
+
+### `--transport-hook` passthrough
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-RGH-010 | `run-provider-conformance.sh --transport-hook /no/such/file --itp github --chp github` | rc ≠ 0; fatal message names the unreadable path (validated once at startup, exit 2) |
+| TC-RGH-011 | `run-provider-conformance.sh --transport-hook <readable> --itp github --chp github` — the readable hook path threads through to `_invoke`'s subshell as `GITLAB_TRANSPORT_HOOK=<path>` | fixture inspection subshell sees the env var set |
+| TC-RGH-012 | Byte-identical behavior on github/github with `--transport-hook` present but unused (hook file exists but no gitlab leaves are exercised) | same 31 PASS lines, `CONFORMANCE-SUMMARY total=31 pass=31 fail=0` |
+
+### `--transport-path-add` (isolated PATH extension)
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-RGH-020 | `run-provider-conformance.sh --transport-path-add /some/dir` — a probe verb (or a shim assertion) sees `/some/dir` prepended to its subshell PATH | subshell PATH contains `/some/dir` |
+| TC-RGH-021 | Multiple `--transport-path-add A --transport-path-add B` accumulate — subshell PATH contains BOTH `A` and `B` | subshell PATH contains both entries |
+| TC-RGH-022 | The added dirs do NOT leak into the runner's OWN env (only into `_invoke` subshells) | the runner's own PATH stays as inherited (does not contain the added dirs after the flag is parsed) |
+| TC-RGH-023 | github/github axis with `--transport-path-add` present is byte-identical (extra PATH entries are harmless when unused) | same PASS/FAIL counts |
+
+### `--expect-absent` partial-axis mechanism
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-RGH-030 | `--expect-absent chp:create_pr,chp:merge` on a topology where the named leaves are absent | those verbs downgrade from FAIL to `SKIP <verb> (expected-absent: <next-slice>)`; runner exit code may be 0 if no other absent verbs |
+| TC-RGH-031 | `--expect-absent chp:create_pr` — a DIFFERENT absent verb (e.g. `chp_merge`) still FAILs | rc ≠ 0; `chp_merge FAIL (leaf absent: ...)` still present |
+| TC-RGH-032 | `--expect-absent chp:create_pr` — the argument seam-qualifies (`chp:create_pr` NOT the same as `itp:create_pr`) | ITP/CHP name-collision safe |
+| TC-RGH-033 | `--expect-absent chp:create_pr` — the verb PRESENT on the axis is NOT downgraded (a present verb runs normally) | verb runs its normal assertion |
+
+### `--itp gitlab --chp gitlab` interim (W-D early half)
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-RGH-040 | `run-provider-conformance.sh --itp gitlab --chp gitlab` on today's tree (no leaves) | runner exits non-zero; runner does NOT abort; one per-verb FAIL line per absent verb naming the absent leaf file |
+| TC-RGH-041 | Same run — no runner-level Python/bash exception is emitted (only per-verb FAILs) | no stack trace / no `command not found` outside a per-verb reason |
+| TC-RGH-042 | Same run with `--expect-absent chp:create_pr,chp:approve,chp:merge,chp:review_threads,...` covering every absent verb → runner exits 0 with SKIP lines | rc 0 iff every absent verb is named |
+
+### github/github parity (AC2 of #414)
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-RGH-050 | `run-provider-conformance.sh --itp github --chp github` — the pre-existing 31 PASS lines still emit | 31 PASS lines; `pending=0`; `fail=0` (byte-identical to today) |
+
+## AC3 shape-check (precondition test)
+
+`AC3` (parent #414) — an end-to-end out-of-tree fixture provider + fixture transport hook + `--transport-path-add` — cannot be fully satisfied until W-B / W-C leaves exist. W-A ships the runner mechanism + a shape-check that the flags plumb correctly (TC-RGH-011, TC-RGH-020, TC-RGH-021, TC-RGH-022). The end-to-end AC3 fixture rides W-B's first PR.

--- a/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
@@ -167,35 +167,52 @@ fi
 # ---------------------------------------------------------------------------
 # GitHub authentication
 # ---------------------------------------------------------------------------
-if [[ "$GH_AUTH_MODE" == "app" ]]; then
-  if [[ -z "${DEV_AGENT_APP_ID:-}" || -z "${DEV_AGENT_APP_PEM:-}" ]]; then
-    # [INV-72] auth-class config failure → surface on the issue when known.
-    error_surface "$ISSUE_NUMBER" ADT_AUTH_APP_CREDS_MISSING \
-      "GH_AUTH_MODE=app but the dev agent's App credentials are unset" \
-      "DEV_AGENT_APP_ID and/or DEV_AGENT_APP_PEM is empty in autonomous.conf" \
-      "Set DEV_AGENT_APP_ID and DEV_AGENT_APP_PEM (see docs/github-app-setup.md), then re-dispatch" \
-      "docs/pipeline/errors.md#authentication-class-class-auth" auth
-    echo "Error: GH_AUTH_MODE=app requires DEV_AGENT_APP_ID and DEV_AGENT_APP_PEM" >&2
-    exit 1
+# [#416 R2 P1-2] Wrap the whole wrapper-level auth setup in a shared
+# `github_seam_active` gate (lib-auth.sh) — the SAME predicate lib-auth.sh's
+# internals gate on, so no expression is duplicated across the four consumer
+# sites (this wrapper, autonomous-review.sh, dispatcher-tick.sh, and the
+# two internal lib-auth functions). A `gitlab`/`gitlab` topology skips the
+# ENTIRE block: no App-cred FATAL, no PAT-mode fallback, no `setup_github_auth`
+# call. A mixed `github`/`gitlab` topology STILL runs it — the active github
+# seam's leaves call `gh`. Under the default `${…:-github}` this predicate is
+# always true, so the github/github tree stays byte-identical.
+if github_seam_active; then
+  if [[ "$GH_AUTH_MODE" == "app" ]]; then
+    if [[ -z "${DEV_AGENT_APP_ID:-}" || -z "${DEV_AGENT_APP_PEM:-}" ]]; then
+      # [INV-72] auth-class config failure → surface on the issue when known.
+      error_surface "$ISSUE_NUMBER" ADT_AUTH_APP_CREDS_MISSING \
+        "GH_AUTH_MODE=app but the dev agent's App credentials are unset" \
+        "DEV_AGENT_APP_ID and/or DEV_AGENT_APP_PEM is empty in autonomous.conf" \
+        "Set DEV_AGENT_APP_ID and DEV_AGENT_APP_PEM (see docs/github-app-setup.md), then re-dispatch" \
+        "docs/pipeline/errors.md#authentication-class-class-auth" auth
+      echo "Error: GH_AUTH_MODE=app requires DEV_AGENT_APP_ID and DEV_AGENT_APP_PEM" >&2
+      exit 1
+    fi
+    if ! setup_github_auth "${DEV_AGENT_APP_ID}" "${DEV_AGENT_APP_PEM}"; then
+      # [INV-72] token-mint failure (auth-class) → surface on the issue when known.
+      # The proxy may have no valid token, so error_surface likely degrades to
+      # log-only — that's the correct best-effort behavior.
+      error_surface "$ISSUE_NUMBER" ADT_AUTH_TOKEN_MINT_FAILED \
+        "The dev agent's GitHub App installation token could not be minted" \
+        "The token-refresh daemon never wrote an initial token (see lib-auth.sh FATAL above)" \
+        "Verify DEV_AGENT_APP_ID, the installation id, and DEV_AGENT_APP_PEM on the execution host and that the App has the required repo permissions; check the token-daemon log, then re-dispatch" \
+        "docs/pipeline/errors.md#authentication-class-class-auth" auth
+      exit 1
+    fi
+    # [INV-79] Mint the SECOND, scoped token for the agent subtree (reuses the dev
+    # App credentials). Best-effort: a mint failure WARNs and leaves the agent on
+    # the full-write credential (no scrub) rather than blocking the run.
+    setup_agent_token "${DEV_AGENT_APP_ID}" "${DEV_AGENT_APP_PEM}"
+  else
+    setup_github_auth
+    # [INV-79] PAT mode: no second token possible — logs a one-time WARN.
+    setup_agent_token
   fi
-  if ! setup_github_auth "${DEV_AGENT_APP_ID}" "${DEV_AGENT_APP_PEM}"; then
-    # [INV-72] token-mint failure (auth-class) → surface on the issue when known.
-    # The proxy may have no valid token, so error_surface likely degrades to
-    # log-only — that's the correct best-effort behavior.
-    error_surface "$ISSUE_NUMBER" ADT_AUTH_TOKEN_MINT_FAILED \
-      "The dev agent's GitHub App installation token could not be minted" \
-      "The token-refresh daemon never wrote an initial token (see lib-auth.sh FATAL above)" \
-      "Verify DEV_AGENT_APP_ID, the installation id, and DEV_AGENT_APP_PEM on the execution host and that the App has the required repo permissions; check the token-daemon log, then re-dispatch" \
-      "docs/pipeline/errors.md#authentication-class-class-auth" auth
-    exit 1
-  fi
-  # [INV-79] Mint the SECOND, scoped token for the agent subtree (reuses the dev
-  # App credentials). Best-effort: a mint failure WARNs and leaves the agent on
-  # the full-write credential (no scrub) rather than blocking the run.
-  setup_agent_token "${DEV_AGENT_APP_ID}" "${DEV_AGENT_APP_PEM}"
 else
-  setup_github_auth
-  # [INV-79] PAT mode: no second token possible — logs a one-time WARN.
+  # [#416 R2] gitlab/gitlab (or any non-github topology): no GitHub App
+  # identity needed. Call setup_agent_token so the GitLab PAT-posture WARN
+  # (gitlab seam + GITLAB_TOKEN set) still fires; setup_agent_token is
+  # itself no-op past that WARN when the github seam is inactive.
   setup_agent_token
 fi
 

--- a/skills/autonomous-dispatcher/scripts/autonomous-review.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-review.sh
@@ -386,37 +386,49 @@ fi
 # ---------------------------------------------------------------------------
 # GitHub authentication
 # ---------------------------------------------------------------------------
-if [[ "$GH_AUTH_MODE" == "app" ]]; then
-  if [[ -z "${REVIEW_AGENT_APP_ID:-}" || -z "${REVIEW_AGENT_APP_PEM:-}" ]]; then
-    # [INV-72] auth-class config failure → surface on the issue when known.
-    error_surface "$ISSUE_NUMBER" ADT_AUTH_APP_CREDS_MISSING \
-      "GH_AUTH_MODE=app but the review agent's App credentials are unset" \
-      "REVIEW_AGENT_APP_ID and/or REVIEW_AGENT_APP_PEM is empty in autonomous.conf" \
-      "Set REVIEW_AGENT_APP_ID and REVIEW_AGENT_APP_PEM (see docs/github-app-setup.md), then re-dispatch" \
-      "docs/pipeline/errors.md#authentication-class-class-auth" auth
-    echo "Error: GH_AUTH_MODE=app requires REVIEW_AGENT_APP_ID and REVIEW_AGENT_APP_PEM" >&2
-    exit 1
+# [#416 R2 P1-2] Wrapper-level app-mode credential FATAL gated on the shared
+# `github_seam_active` predicate (lib-auth.sh). SAME shape as autonomous-dev.sh
+# — see that file for the design rationale. A `gitlab`/`gitlab` topology
+# skips the entire block; mixed topologies still run it.
+if github_seam_active; then
+  if [[ "$GH_AUTH_MODE" == "app" ]]; then
+    if [[ -z "${REVIEW_AGENT_APP_ID:-}" || -z "${REVIEW_AGENT_APP_PEM:-}" ]]; then
+      # [INV-72] auth-class config failure → surface on the issue when known.
+      error_surface "$ISSUE_NUMBER" ADT_AUTH_APP_CREDS_MISSING \
+        "GH_AUTH_MODE=app but the review agent's App credentials are unset" \
+        "REVIEW_AGENT_APP_ID and/or REVIEW_AGENT_APP_PEM is empty in autonomous.conf" \
+        "Set REVIEW_AGENT_APP_ID and REVIEW_AGENT_APP_PEM (see docs/github-app-setup.md), then re-dispatch" \
+        "docs/pipeline/errors.md#authentication-class-class-auth" auth
+      echo "Error: GH_AUTH_MODE=app requires REVIEW_AGENT_APP_ID and REVIEW_AGENT_APP_PEM" >&2
+      exit 1
+    fi
+    if ! setup_github_auth "${REVIEW_AGENT_APP_ID}" "${REVIEW_AGENT_APP_PEM}"; then
+      # [INV-72] token-mint failure (auth-class) → surface on the issue when known
+      # (the proxy may have no valid token, so this likely degrades to log-only —
+      # the correct best-effort behavior).
+      error_surface "$ISSUE_NUMBER" ADT_AUTH_TOKEN_MINT_FAILED \
+        "The review agent's GitHub App installation token could not be minted" \
+        "The token-refresh daemon never wrote an initial token (see lib-auth.sh FATAL above)" \
+        "Verify REVIEW_AGENT_APP_ID, the installation id, and REVIEW_AGENT_APP_PEM on the execution host and that the App has the required repo permissions; check the token-daemon log, then re-dispatch" \
+        "docs/pipeline/errors.md#authentication-class-class-auth" auth
+      exit 1
+    fi
+    # [INV-79] Mint the SECOND, scoped token for the review-agent subtree (reuses
+    # the review App credentials). Review agents only READ the PR + post comments /
+    # the E2E report — none need pull_requests:write, so the same scoped profile
+    # fits. Best-effort: a mint failure WARNs and leaves agents on the full-write
+    # credential (no scrub) rather than blocking the review.
+    setup_agent_token "${REVIEW_AGENT_APP_ID}" "${REVIEW_AGENT_APP_PEM}"
+  else
+    setup_github_auth
+    # [INV-79] PAT mode: no second token possible — logs a one-time WARN.
+    setup_agent_token
   fi
-  if ! setup_github_auth "${REVIEW_AGENT_APP_ID}" "${REVIEW_AGENT_APP_PEM}"; then
-    # [INV-72] token-mint failure (auth-class) → surface on the issue when known
-    # (the proxy may have no valid token, so this likely degrades to log-only —
-    # the correct best-effort behavior).
-    error_surface "$ISSUE_NUMBER" ADT_AUTH_TOKEN_MINT_FAILED \
-      "The review agent's GitHub App installation token could not be minted" \
-      "The token-refresh daemon never wrote an initial token (see lib-auth.sh FATAL above)" \
-      "Verify REVIEW_AGENT_APP_ID, the installation id, and REVIEW_AGENT_APP_PEM on the execution host and that the App has the required repo permissions; check the token-daemon log, then re-dispatch" \
-      "docs/pipeline/errors.md#authentication-class-class-auth" auth
-    exit 1
-  fi
-  # [INV-79] Mint the SECOND, scoped token for the review-agent subtree (reuses
-  # the review App credentials). Review agents only READ the PR + post comments /
-  # the E2E report — none need pull_requests:write, so the same scoped profile
-  # fits. Best-effort: a mint failure WARNs and leaves agents on the full-write
-  # credential (no scrub) rather than blocking the review.
-  setup_agent_token "${REVIEW_AGENT_APP_ID}" "${REVIEW_AGENT_APP_PEM}"
 else
-  setup_github_auth
-  # [INV-79] PAT mode: no second token possible — logs a one-time WARN.
+  # [#416 R2] gitlab/gitlab (or any non-github topology): no GitHub App
+  # identity needed. Call setup_agent_token so the GitLab PAT-posture WARN
+  # still fires; setup_agent_token is a no-op past that WARN when the github
+  # seam is inactive.
   setup_agent_token
 fi
 

--- a/skills/autonomous-dispatcher/scripts/check-provider-cutover.sh
+++ b/skills/autonomous-dispatcher/scripts/check-provider-cutover.sh
@@ -294,13 +294,23 @@ glab_lines_in() {
 }
 
 # [#416 R4] The `/api/v4` curl detector — a `curl ...` line whose argv
-# mentions `/api/v4` (`grep -E 'curl.*[/"]api/v4[/"]'`). Same-line only,
-# matching the existing gh matcher's line-oriented discipline. Multi-line
-# evasion (concatenated argv across shell continuations) is out of scope
-# for a lint; the review gate catches it. Shape-exclusion of gh-app-token
-# sites is automatic — those curl argvs mention `api.github.com/…`, not
-# `/api/v4/…`, so this detector does not match them (no allowlist entry
-# needed for gh-app-token.sh).
+# mentions `/api/v4` (`grep -E 'curl.*[/"]api/v4[/"]'`).
+#
+# BOUND — SAME-LINE-ONLY, DOCUMENTED HONESTLY (codex round-1 [P2-6]):
+# this same-line matcher MISSES a two-line split like
+#   url="https://gitlab.example/api/v4/projects/1/issues"
+#   curl -sS -H "PRIVATE-TOKEN: $tok" "$url"
+# where the URL is stored in a variable on one line and `curl "$url"`
+# fires on another. The review gate is the intended second line of
+# defense — a reviewer eyeballs a NEW curl invocation and its context.
+# `gitlab_api_var_and_curl_lines_in` below adds a best-effort file-level
+# detector for the "same VAR name in both places" subset of that shape.
+# Indirect flows (function args, env-var derivation, arithmetic pieces
+# of the URL) remain bypassable and belong to the review gate.
+#
+# Shape-exclusion of gh-app-token sites is automatic — those curl argvs
+# mention `api.github.com/…`, not `/api/v4/…`, so this detector does
+# not match them (no allowlist entry needed for gh-app-token.sh).
 gitlab_api_curl_lines_in() {
   local path="$1"
   [ -f "$path" ] || return 0
@@ -308,6 +318,52 @@ gitlab_api_curl_lines_in() {
     { s = $0; sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s)
       if (substr(s, 1, 1) == "#") next
       print s }'
+}
+
+# [#416 P2-6] Split-across-lines detector (best-effort, file-level).
+# Fires when the SAME file:
+#   (a) assigns a variable to a string containing `/api/v4/`
+#         — line matches `<VAR>=<value-with-/api/v4/>` (with an optional
+#           leading `local `/`export `/`declare `/`readonly `),
+#   AND
+#   (b) invokes `curl` on `"$<VAR>"`, `${<VAR>}`, or `$<VAR>` on a
+#       DIFFERENT line.
+# Only "same variable NAME literally appears in both places" is required
+# — indirect flows (function args, derived URLs) are NOT covered; this
+# is the documented bound. Emits the CURL LINE (the actual leak site)
+# not the assignment, so failure messages name the right file:line.
+gitlab_api_var_and_curl_lines_in() {
+  local path="$1"
+  [ -f "$path" ] || return 0
+  local var_names
+  # Allow leading whitespace (indented assignments inside functions), an
+  # optional `local`/`export`/`declare`/`readonly ` prefix, and finally the
+  # VAR=<value-with-/api/v4/> shape.
+  var_names=$(grep -aE '^[[:space:]]*(local |export |declare |readonly )?[A-Za-z_][A-Za-z0-9_]*=.*/api/v4/' "$path" 2>/dev/null \
+    | sed -E 's/^[[:space:]]*(local |export |declare |readonly )?([A-Za-z_][A-Za-z0-9_]*)=.*/\2/' \
+    | sort -u)
+  [ -z "$var_names" ] && return 0
+  local var line s
+  while IFS= read -r var; do
+    [ -z "$var" ] && continue
+    # For each var name, grep lines with `curl` + `$VAR` (via a
+    # dynamically-built regex that boundary-anchors the var name so
+    # `foo` doesn't match `foobar`). Skip lines that ALSO carry the
+    # `/api/v4/` literal (same-line case, already handled).
+    local pattern="(^|[^A-Za-z_-])curl .*\\\$\\{?${var}\\}?([^A-Za-z_0-9]|$)"
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      s="$line"
+      s="${s#"${s%%[![:space:]]*}"}"
+      s="${s%"${s##*[![:space:]]}"}"
+      [ "${s:0:1}" = "#" ] && continue
+      # Skip the same-line case (already covered above).
+      case "$s" in
+        *"/api/v4/"*) continue ;;
+      esac
+      printf '%s\n' "$s"
+    done < <(grep -aE "$pattern" "$path" 2>/dev/null)
+  done <<< "$var_names"
 }
 
 # gh_lines_in for a SCRIPTS_DIR-relative file, additionally dropping
@@ -338,6 +394,16 @@ guarded_glab_lines_in() {
 guarded_gitlab_api_curl_lines_in() {
   local rel="$1" path="$2" line
   gitlab_api_curl_lines_in "$path" | while IFS= read -r line; do
+    is_checker_infra_line "$rel" "$line" && continue
+    printf '%s\n' "$line"
+  done
+}
+
+# [#416 P2-6] gitlab_api_var_and_curl_lines_in for a SCRIPTS_DIR-relative
+# file, with the same is_checker_infra_line exemption applied.
+guarded_gitlab_api_var_and_curl_lines_in() {
+  local rel="$1" path="$2" line
+  gitlab_api_var_and_curl_lines_in "$path" | while IFS= read -r line; do
     is_checker_infra_line "$rel" "$line" && continue
     printf '%s\n' "$line"
   done
@@ -666,26 +732,35 @@ done < <(tree_sh_files)
 [ "$_glab_hits" -eq 0 ] && info "no raw \`glab\` token found outside providers/"
 
 echo "=== Check 6: no '/api/v4' curl outside providers/lib-gitlab-transport.sh (#416 R4) ==="
+# Two matchers, both applied to every non-allowlisted tree file:
+#   (a) same-line `curl … /api/v4/…`  — gitlab_api_curl_lines_in
+#   (b) split-across-lines `VAR=…/api/v4/…` + `curl "$VAR"` on a
+#       different line  — gitlab_api_var_and_curl_lines_in (P2-6).
+# (b) is documented BOUND: file-level; matches only "same VAR name in
+# both places"; indirect flows still bypass (review-gate territory).
 _v4_hits=0
 while IFS= read -r rel; do
   [ -z "$rel" ] && continue
-  # providers/lib-gitlab-transport.sh is the legitimate home of the /api/v4
-  # curl call (the default transport). Any other file — including other
-  # providers/ leaves — is a regression: the leaves MUST call _gl_api, not
-  # curl directly (#416 R1 note "LEAVES NEVER call curl or _gl_http
-  # directly").
   case "$rel" in
     providers/lib-gitlab-transport.sh) continue ;;
   esac
   in_list "$rel" "${ALLOWLISTED_FILES[@]}" && continue
+  # (a) same-line
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     _v4_hits=$((_v4_hits + 1))
     locs="$(sites_file_lines "$rel" "$line")"
     fail "raw '/api/v4' curl outside providers/lib-gitlab-transport.sh at ${locs:-$rel:?}: '$line'. Route this GitLab API call through _gl_api (a raw /api/v4 curl bypasses the pagination/backoff/fail-closed choke-point; #416 R1)."
   done < <(guarded_gitlab_api_curl_lines_in "$rel" "$SCRIPTS_DIR/$rel")
+  # (b) split-across-lines (P2-6)
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    _v4_hits=$((_v4_hits + 1))
+    locs="$(sites_file_lines "$rel" "$line")"
+    fail "split-across-lines \`/api/v4\` invocation outside providers/lib-gitlab-transport.sh at ${locs:-$rel:?}: '$line' (file also assigns a var containing the GitLab API path). Route through _gl_api; the pre-P2-6 same-line-only matcher would have MISSED this shape (#416 P2-6)."
+  done < <(guarded_gitlab_api_var_and_curl_lines_in "$rel" "$SCRIPTS_DIR/$rel")
 done < <(tree_sh_files)
-[ "$_v4_hits" -eq 0 ] && info "no '/api/v4' curl found outside providers/lib-gitlab-transport.sh"
+[ "$_v4_hits" -eq 0 ] && info "no '/api/v4' curl (same-line or split-across-lines) found outside providers/lib-gitlab-transport.sh"
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/skills/autonomous-dispatcher/scripts/check-provider-cutover.sh
+++ b/skills/autonomous-dispatcher/scripts/check-provider-cutover.sh
@@ -287,7 +287,7 @@ gh_lines_in() {
 glab_lines_in() {
   local path="$1"
   [ -f "$path" ] || return 0
-  grep -aE '(^|[^A-Za-z_-])glab ' "$path" 2>/dev/null | awk '
+  grep -aE '(^|[^A-Za-z_-])glab[[:space:]]' "$path" 2>/dev/null | awk '
     { s = $0; sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s)
       if (substr(s, 1, 1) == "#") next
       print s }'
@@ -314,7 +314,7 @@ glab_lines_in() {
 gitlab_api_curl_lines_in() {
   local path="$1"
   [ -f "$path" ] || return 0
-  grep -aE 'curl.*[/"]api/v4[/"]' "$path" 2>/dev/null | awk '
+  grep -aE '(^|[^A-Za-z_-])curl([[:space:]]|$).*[/"]api/v4[/"]|[/"]api/v4[/"].*(^|[^A-Za-z_-])curl([[:space:]]|$)' "$path" 2>/dev/null | awk '
     { s = $0; sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s)
       if (substr(s, 1, 1) == "#") next
       print s }'
@@ -350,7 +350,7 @@ gitlab_api_var_and_curl_lines_in() {
     # dynamically-built regex that boundary-anchors the var name so
     # `foo` doesn't match `foobar`). Skip lines that ALSO carry the
     # `/api/v4/` literal (same-line case, already handled).
-    local pattern="(^|[^A-Za-z_-])curl .*\\\$\\{?${var}\\}?([^A-Za-z_0-9]|$)"
+    local pattern="(^|[^A-Za-z_-])curl[[:space:]].*\\\$\\{?${var}\\}?([^A-Za-z_0-9]|$)"
     while IFS= read -r line; do
       [ -z "$line" ] && continue
       s="$line"

--- a/skills/autonomous-dispatcher/scripts/check-provider-cutover.sh
+++ b/skills/autonomous-dispatcher/scripts/check-provider-cutover.sh
@@ -210,7 +210,8 @@ is_checker_infra_line() {
   [ "$rel" = "$CHECKER_SELF" ] || return 1
   case "$content" in
     'ALLOWLISTED_FILES=('*)          return 0 ;;   # (a) allowlist array declaration
-    "grep -aE '(^|[^A-Za-z_-])"*)    return 0 ;;   # (b) the primary matcher line
+    "grep -aE '(^|[^A-Za-z_-])"*)    return 0 ;;   # (b) primary matcher line
+    "grep -aE 'curl.*"*)             return 0 ;;   # (d) [#416 R4] /api/v4 curl matcher
     '_comment:'*)                    return 0 ;;   # (c) the generated _comment template
   esac
   return 1
@@ -279,6 +280,36 @@ gh_lines_in() {
       print s }'
 }
 
+# [#416 R4] The raw-glab detector — parallel to gh_lines_in, using the same
+# RE2-safe consuming boundary `(^|[^A-Za-z_-])glab ` so `_glab `/`slab
+# `/`glabber ` etc. do NOT match. Emits the trimmed content of each non-comment
+# line carrying a raw `glab ` token, one per line. Applied to ONE file.
+glab_lines_in() {
+  local path="$1"
+  [ -f "$path" ] || return 0
+  grep -aE '(^|[^A-Za-z_-])glab ' "$path" 2>/dev/null | awk '
+    { s = $0; sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s)
+      if (substr(s, 1, 1) == "#") next
+      print s }'
+}
+
+# [#416 R4] The `/api/v4` curl detector — a `curl ...` line whose argv
+# mentions `/api/v4` (`grep -E 'curl.*[/"]api/v4[/"]'`). Same-line only,
+# matching the existing gh matcher's line-oriented discipline. Multi-line
+# evasion (concatenated argv across shell continuations) is out of scope
+# for a lint; the review gate catches it. Shape-exclusion of gh-app-token
+# sites is automatic — those curl argvs mention `api.github.com/…`, not
+# `/api/v4/…`, so this detector does not match them (no allowlist entry
+# needed for gh-app-token.sh).
+gitlab_api_curl_lines_in() {
+  local path="$1"
+  [ -f "$path" ] || return 0
+  grep -aE 'curl.*[/"]api/v4[/"]' "$path" 2>/dev/null | awk '
+    { s = $0; sub(/^[[:space:]]+/, "", s); sub(/[[:space:]]+$/, "", s)
+      if (substr(s, 1, 1) == "#") next
+      print s }'
+}
+
 # gh_lines_in for a SCRIPTS_DIR-relative file, additionally dropping
 # check-provider-cutover.sh's OWN structurally-exempt infrastructure lines
 # (#286-amendment, #343 — is_checker_infra_line). Used by BOTH the working-tree scan
@@ -287,6 +318,26 @@ gh_lines_in() {
 guarded_gh_lines_in() {
   local rel="$1" path="$2" line
   gh_lines_in "$path" | while IFS= read -r line; do
+    is_checker_infra_line "$rel" "$line" && continue
+    printf '%s\n' "$line"
+  done
+}
+
+# [#416 R4] glab_lines_in for a SCRIPTS_DIR-relative file, with the same
+# is_checker_infra_line exemption applied.
+guarded_glab_lines_in() {
+  local rel="$1" path="$2" line
+  glab_lines_in "$path" | while IFS= read -r line; do
+    is_checker_infra_line "$rel" "$line" && continue
+    printf '%s\n' "$line"
+  done
+}
+
+# [#416 R4] gitlab_api_curl_lines_in for a SCRIPTS_DIR-relative file, with
+# the same is_checker_infra_line exemption applied.
+guarded_gitlab_api_curl_lines_in() {
+  local rel="$1" path="$2" line
+  gitlab_api_curl_lines_in "$path" | while IFS= read -r line; do
     is_checker_infra_line "$rel" "$line" && continue
     printf '%s\n' "$line"
   done
@@ -582,6 +633,59 @@ else
   [ "$_grew_real" = "0" ] && info "baseline did not grow vs $_trusted_src for any file present on the trusted ref -- no new raw-gh ratified in existing code"
   rm -f "$TRUSTED_SET" "$TRUSTED_RAW"
 fi
+
+# ---------------------------------------------------------------------------
+# [#416 R4] Check 5 — GitLab host-API token class. Two matchers, both
+# strict-from-zero on the gitlab axis (no baseline entries — there is no
+# legacy gitlab code to grandfather):
+#   (a) raw `glab ` outside providers/ and the allowlist = FAIL.
+#   (b) `curl` mentioning `/api/v4` outside providers/lib-gitlab-transport.sh
+#       and the allowlist = FAIL. Shape-exclusion: the 5 gh-app-token.sh
+#       curl sites hit `api.github.com/…`, not `/api/v4/…`, so they don't
+#       match — no allowlist entry needed for gh-app-token.sh.
+# The guard's OWN matcher literal lines are exempted by is_checker_infra_line
+# (`grep -aE 'curl.*` anchor added above).
+# ---------------------------------------------------------------------------
+echo "=== Check 5: no raw \`glab\` outside providers/ (#416 R4, GitLab host-API token class) ==="
+GITLAB_TRANSPORT_ALLOWLIST=(lib-gitlab-transport.sh)
+_glab_hits=0
+while IFS= read -r rel; do
+  [ -z "$rel" ] && continue
+  case "$rel" in providers/*) continue ;; esac
+  in_list "$rel" "${ALLOWLISTED_FILES[@]}" && continue
+  # Also skip files in the GitLab-transport-allowlist (curl-in-lib is the
+  # legitimate home; enforced by the /api/v4 matcher exemption below).
+  in_list "$rel" "${GITLAB_TRANSPORT_ALLOWLIST[@]}" && continue
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    _glab_hits=$((_glab_hits + 1))
+    locs="$(sites_file_lines "$rel" "$line")"
+    fail "raw \`glab\` token outside providers/ at ${locs:-$rel:?}: '$line'. Route this host I/O through a chp_*/itp_* verb (a raw \`glab\` is an [INV-91] cutover regression on the GitLab axis)."
+  done < <(guarded_glab_lines_in "$rel" "$SCRIPTS_DIR/$rel")
+done < <(tree_sh_files)
+[ "$_glab_hits" -eq 0 ] && info "no raw \`glab\` token found outside providers/"
+
+echo "=== Check 6: no '/api/v4' curl outside providers/lib-gitlab-transport.sh (#416 R4) ==="
+_v4_hits=0
+while IFS= read -r rel; do
+  [ -z "$rel" ] && continue
+  # providers/lib-gitlab-transport.sh is the legitimate home of the /api/v4
+  # curl call (the default transport). Any other file — including other
+  # providers/ leaves — is a regression: the leaves MUST call _gl_api, not
+  # curl directly (#416 R1 note "LEAVES NEVER call curl or _gl_http
+  # directly").
+  case "$rel" in
+    providers/lib-gitlab-transport.sh) continue ;;
+  esac
+  in_list "$rel" "${ALLOWLISTED_FILES[@]}" && continue
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    _v4_hits=$((_v4_hits + 1))
+    locs="$(sites_file_lines "$rel" "$line")"
+    fail "raw '/api/v4' curl outside providers/lib-gitlab-transport.sh at ${locs:-$rel:?}: '$line'. Route this GitLab API call through _gl_api (a raw /api/v4 curl bypasses the pagination/backoff/fail-closed choke-point; #416 R1)."
+  done < <(guarded_gitlab_api_curl_lines_in "$rel" "$SCRIPTS_DIR/$rel")
+done < <(tree_sh_files)
+[ "$_v4_hits" -eq 0 ] && info "no '/api/v4' curl found outside providers/lib-gitlab-transport.sh"
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
@@ -155,7 +155,20 @@ fi
 #
 # Fail-fast on misconfig (missing id/pem, token API failure, empty result):
 # silently falling back to user auth is precisely the bug being closed.
-if [[ "${GH_AUTH_MODE:-token}" == "app" ]]; then
+# [#416 R2] Gate the whole GitHub App-mode credential path on
+# `_github_seam_active` (either ISSUE_PROVIDER=github or CODE_HOST=github; the
+# two arms are independent per §auth [M9]). A `gitlab`/`gitlab` topology
+# needs neither GitHub App identity — the FATAL, the token mint, and the
+# subsequent `gh` wrapper install are all skipped. A mixed `github`/`gitlab`
+# or `gitlab`/`github` topology STILL needs it (the active github seam's
+# leaves call `gh`). Under the default (both unset → github/github, via the
+# `${…:-github}` defaults inside `_github_seam_active`) the gate is
+# transparent — byte-identical to pre-#416 behavior.
+_dispatcher_github_seam_active() {
+  local _ip="${ISSUE_PROVIDER:-github}" _ch="${CODE_HOST:-github}"
+  [[ "$_ip" == "github" || "$_ch" == "github" ]]
+}
+if [[ "${GH_AUTH_MODE:-token}" == "app" ]] && _dispatcher_github_seam_active; then
   if [[ -z "${DISPATCHER_APP_ID:-}" || -z "${DISPATCHER_APP_PEM:-}" ]]; then
     error_surface - ADT_AUTH_APP_CREDS_MISSING \
       "GH_AUTH_MODE=app but the dispatcher's App credentials are unset (dispatcher tick)" \

--- a/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
@@ -101,6 +101,14 @@ trap _dispatch_marker_release_pending EXIT
 # shellcheck source=lib-metrics.sh
 source "${LIB_DIR}/lib-metrics.sh" 2>/dev/null || true
 
+# [#416 R2] lib-auth.sh — provides the shared `github_seam_active` /
+# `gitlab_seam_active` predicates the app-mode credential FATAL below gates
+# on. lib-auth.sh's top-level runs `load_autonomous_conf` (fail-safe `|| true`)
+# and defines its own functions; sourcing here is idempotent w.r.t. any later
+# per-project source in tick_inline_project.
+# shellcheck source=lib-auth.sh
+source "${LIB_DIR}/lib-auth.sh"
+
 # [INV-72] PROJECT_DIR (+ REPO/REPO_OWNER/PROJECT_ID) are already validated by
 # the required-key preflight ABOVE (before sourcing lib-dispatch.sh), which
 # surfaces ADT_CFG_MISSING_KEY instead of a raw `: "${VAR:?}"` abort — so no
@@ -155,20 +163,17 @@ fi
 #
 # Fail-fast on misconfig (missing id/pem, token API failure, empty result):
 # silently falling back to user auth is precisely the bug being closed.
-# [#416 R2] Gate the whole GitHub App-mode credential path on
-# `_github_seam_active` (either ISSUE_PROVIDER=github or CODE_HOST=github; the
-# two arms are independent per §auth [M9]). A `gitlab`/`gitlab` topology
-# needs neither GitHub App identity — the FATAL, the token mint, and the
-# subsequent `gh` wrapper install are all skipped. A mixed `github`/`gitlab`
-# or `gitlab`/`github` topology STILL needs it (the active github seam's
-# leaves call `gh`). Under the default (both unset → github/github, via the
-# `${…:-github}` defaults inside `_github_seam_active`) the gate is
-# transparent — byte-identical to pre-#416 behavior.
-_dispatcher_github_seam_active() {
-  local _ip="${ISSUE_PROVIDER:-github}" _ch="${CODE_HOST:-github}"
-  [[ "$_ip" == "github" || "$_ch" == "github" ]]
-}
-if [[ "${GH_AUTH_MODE:-token}" == "app" ]] && _dispatcher_github_seam_active; then
+# [#416 R2] Gate the whole GitHub App-mode credential path on the shared
+# `github_seam_active` helper (lib-auth.sh) — either ISSUE_PROVIDER=github or
+# CODE_HOST=github (the two arms are independent per §auth [M9]). A
+# `gitlab`/`gitlab` topology needs neither GitHub App identity — the FATAL,
+# the token mint, and the subsequent `gh` wrapper install are all skipped. A
+# mixed `github`/`gitlab` or `gitlab`/`github` topology STILL needs it (the
+# active github seam's leaves call `gh`). Under the default (both unset →
+# github/github via the `${…:-github}` defaults inside `github_seam_active`)
+# the gate is transparent — byte-identical to pre-#416 behavior.
+#
+if [[ "${GH_AUTH_MODE:-token}" == "app" ]] && github_seam_active; then
   if [[ -z "${DISPATCHER_APP_ID:-}" || -z "${DISPATCHER_APP_PEM:-}" ]]; then
     error_surface - ADT_AUTH_APP_CREDS_MISSING \
       "GH_AUTH_MODE=app but the dispatcher's App credentials are unset (dispatcher tick)" \

--- a/skills/autonomous-dispatcher/scripts/lib-auth.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-auth.sh
@@ -97,21 +97,47 @@ _AGENT_TOKEN_PAT_WARNED=""
 # INV-79 containment degrades to convention on the gitlab seam(s).
 _AGENT_GITLAB_TOKEN_PAT_WARNED=""
 
-# [#416 R2] _github_seam_active — rc 0 iff EITHER seam (ITP or CHP) uses the
-# github provider. When BOTH default to unset, the shell defaults to today's
-# behavior (github/github), so the gate is transparent to the pre-change tree.
+# [#416 R2] github_seam_active — rc 0 iff EITHER seam (ITP or CHP) uses the
+# github provider. When BOTH vars are unset the shell defaults them to
+# `github`, so the gate is transparent to the pre-change tree.
 # Read from ISSUE_PROVIDER / CODE_HOST via ${:-github} defaults; the caller
 # layer already threads these vars through every dispatcher/wrapper site.
 #
-# Consumed by setup_github_auth, setup_agent_token, and dispatcher-tick.sh's
-# app-mode credential FATAL — each of those runs ONLY when this returns 0. On
-# a `gitlab`/`gitlab` topology (both vars set to `gitlab`), the whole GitHub
-# auth lifecycle is a clean no-op: no token daemon spawn, no `gh` wrapper
-# symlink, no FATAL. On a mixed `github`/`gitlab` or `gitlab`/`github`
-# topology, at least one seam is github so the gate opens.
-_github_seam_active() {
+# CONSUMERS (post-P1-2, all four gated by this ONE predicate — no duplicated
+# expression anywhere):
+#   1. setup_github_auth (below) — the `gh` wrapper install + refresh-daemon
+#      spawn + token poll lifecycle.
+#   2. setup_agent_token (below) — the scoped agent-token mint / PAT WARN.
+#   3. dispatcher-tick.sh — the app-mode DISPATCHER_APP_ID/PEM FATAL.
+#   4. autonomous-dev.sh / autonomous-review.sh — the wrapper-level
+#      DEV_AGENT_APP_ID / REVIEW_AGENT_APP_ID FATAL, which runs BEFORE
+#      setup_github_auth (so the seam gate has to sit at the wrapper's
+#      startup site too, not only inside lib-auth.sh — that's what codex
+#      round-1 [P1-2] flagged).
+#
+# On a `gitlab`/`gitlab` topology (both vars set to `gitlab`), the whole
+# GitHub auth lifecycle is a clean no-op: no token daemon spawn, no `gh`
+# wrapper symlink, no FATAL at any of the four sites. On a mixed
+# `github`/`gitlab` or `gitlab`/`github` topology, at least one seam is
+# github so the gate opens at every consumer identically.
+github_seam_active() {
   local ip="${ISSUE_PROVIDER:-github}" ch="${CODE_HOST:-github}"
   [[ "$ip" == "github" || "$ch" == "github" ]]
+}
+
+# Back-compat alias for the pre-P1-2 name (`_github_seam_active`) — kept so
+# a stale sibling worktree sourcing this lib still resolves the predicate.
+# New call sites use the public name.
+_github_seam_active() { github_seam_active; }
+
+# [#416 R2] gitlab_seam_active — rc 0 iff EITHER seam (ITP or CHP) uses the
+# gitlab provider. Distinct from github_seam_active (an OR of EQUAL-`github`)
+# — a mixed `github`/`gitlab` topology has BOTH `github_seam_active` and
+# `gitlab_seam_active` returning true simultaneously. Used by setup_agent_token
+# to gate the GitLab PAT-posture WARN.
+gitlab_seam_active() {
+  local ip="${ISSUE_PROVIDER:-github}" ch="${CODE_HOST:-github}"
+  [[ "$ip" == "gitlab" || "$ch" == "gitlab" ]]
 }
 
 # Create the per-run GH_WRAPPER_DIR (mode 700) if not already set. Idempotent:
@@ -151,7 +177,7 @@ setup_github_auth() {
   # [#416 R2] Non-github lane — clean no-op. The `gh` wrapper + refresh daemon
   # exist to serve github leaves; a topology with neither seam on github never
   # emits a `gh` call (the [INV-91] caller layer routes through the verb seam).
-  if ! _github_seam_active; then
+  if ! github_seam_active; then
     return 0
   fi
 
@@ -280,9 +306,8 @@ setup_agent_token() {
   # INV-79 containment degrades to convention on gitlab, mirroring the PAT-mode
   # posture the GitHub PAT WARN below documents. Emitted BEFORE the github gate
   # so a `gitlab`/`gitlab` topology still surfaces it.
-  local _ip="${ISSUE_PROVIDER:-github}" _ch="${CODE_HOST:-github}"
   if [[ -z "$_AGENT_GITLAB_TOKEN_PAT_WARNED" ]] \
-     && { [[ "$_ip" == "gitlab" ]] || [[ "$_ch" == "gitlab" ]]; } \
+     && gitlab_seam_active \
      && [[ -n "${GITLAB_TOKEN:-}" ]]; then
     echo "WARN: [INV-79]/[#416 R2] GITLAB_TOKEN is present in the wrapper env — GitLab has no GitHub-App equivalent (§5.1), so a scoped agent mint is impossible; agents inherit the wrapper's GITLAB_TOKEN and INV-79 containment degrades to convention on the gitlab seam (parallel to the GH_AUTH_MODE=token PAT posture)." >&2
     _AGENT_GITLAB_TOKEN_PAT_WARNED=1
@@ -291,7 +316,7 @@ setup_agent_token() {
   # [#416 R2] Non-github lane — no scoped github token to mint, no PAT WARN to
   # emit. Return 0 as a NO-OP; the gitlab WARN above (if applicable) is the
   # gitlab-side equivalent.
-  if ! _github_seam_active; then
+  if ! github_seam_active; then
     return 0
   fi
 

--- a/skills/autonomous-dispatcher/scripts/lib-auth.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-auth.sh
@@ -91,6 +91,28 @@ AGENT_TOKEN_PERMISSIONS="${AGENT_TOKEN_PERMISSIONS:-{\"contents\":\"write\",\"is
 # One-time PAT-mode WARN latch (INV-79): the degraded-enforcement warning is
 # logged at most once per process, even across repeated setup_agent_token calls.
 _AGENT_TOKEN_PAT_WARNED=""
+# [#416 R2] One-time GITLAB_TOKEN PAT-posture WARN latch — parallel to the
+# existing GitHub PAT-mode WARN. GitLab has no GitHub-App equivalent (§5.1,
+# provider-spec.md:633-651), so agents inherit the wrapper's GITLAB_TOKEN and
+# INV-79 containment degrades to convention on the gitlab seam(s).
+_AGENT_GITLAB_TOKEN_PAT_WARNED=""
+
+# [#416 R2] _github_seam_active — rc 0 iff EITHER seam (ITP or CHP) uses the
+# github provider. When BOTH default to unset, the shell defaults to today's
+# behavior (github/github), so the gate is transparent to the pre-change tree.
+# Read from ISSUE_PROVIDER / CODE_HOST via ${:-github} defaults; the caller
+# layer already threads these vars through every dispatcher/wrapper site.
+#
+# Consumed by setup_github_auth, setup_agent_token, and dispatcher-tick.sh's
+# app-mode credential FATAL — each of those runs ONLY when this returns 0. On
+# a `gitlab`/`gitlab` topology (both vars set to `gitlab`), the whole GitHub
+# auth lifecycle is a clean no-op: no token daemon spawn, no `gh` wrapper
+# symlink, no FATAL. On a mixed `github`/`gitlab` or `gitlab`/`github`
+# topology, at least one seam is github so the gate opens.
+_github_seam_active() {
+  local ip="${ISSUE_PROVIDER:-github}" ch="${CODE_HOST:-github}"
+  [[ "$ip" == "github" || "$ch" == "github" ]]
+}
 
 # Create the per-run GH_WRAPPER_DIR (mode 700) if not already set. Idempotent:
 # both auth modes call this, and a second call is a no-op once the dir exists.
@@ -116,9 +138,22 @@ _spawn_token_daemon() {
 # Setup GitHub authentication based on GH_AUTH_MODE.
 # For "app" mode, caller must pass app_id and app_pem.
 # Args: $1=app_id (for app mode), $2=app_pem (for app mode)
+#
+# [#416 R2] Gated on `_github_seam_active` — either seam (ITP or CHP) using
+# github triggers the whole lifecycle (`gh` wrapper install + token daemon
+# spawn + poll). A `gitlab`/`gitlab` topology returns 0 as a NO-OP (no daemon
+# spawn, no wrapper install, no WARN). Under the default (`github`/`github`,
+# via `${…:-github}`) this is BYTE-IDENTICAL to pre-#416 behavior.
 setup_github_auth() {
   local app_id="${1:-}"
   local app_pem="${2:-}"
+
+  # [#416 R2] Non-github lane — clean no-op. The `gh` wrapper + refresh daemon
+  # exist to serve github leaves; a topology with neither seam on github never
+  # emits a `gh` call (the [INV-91] caller layer routes through the verb seam).
+  if ! _github_seam_active; then
+    return 0
+  fi
 
   if [[ "$GH_AUTH_MODE" == "app" ]]; then
     if [[ -z "$app_id" || -z "$app_pem" ]]; then
@@ -238,6 +273,27 @@ refresh_token_env() {
 setup_agent_token() {
   local app_id="${1:-}"
   local app_pem="${2:-}"
+
+  # [#416 R2] Emit the GitLab PAT-posture WARN once per process when a gitlab
+  # seam is active AND GITLAB_TOKEN is in the wrapper env. GitLab has no
+  # GitHub-App equivalent (§5.1), so agents inherit the wrapper's GITLAB_TOKEN;
+  # INV-79 containment degrades to convention on gitlab, mirroring the PAT-mode
+  # posture the GitHub PAT WARN below documents. Emitted BEFORE the github gate
+  # so a `gitlab`/`gitlab` topology still surfaces it.
+  local _ip="${ISSUE_PROVIDER:-github}" _ch="${CODE_HOST:-github}"
+  if [[ -z "$_AGENT_GITLAB_TOKEN_PAT_WARNED" ]] \
+     && { [[ "$_ip" == "gitlab" ]] || [[ "$_ch" == "gitlab" ]]; } \
+     && [[ -n "${GITLAB_TOKEN:-}" ]]; then
+    echo "WARN: [INV-79]/[#416 R2] GITLAB_TOKEN is present in the wrapper env — GitLab has no GitHub-App equivalent (§5.1), so a scoped agent mint is impossible; agents inherit the wrapper's GITLAB_TOKEN and INV-79 containment degrades to convention on the gitlab seam (parallel to the GH_AUTH_MODE=token PAT posture)." >&2
+    _AGENT_GITLAB_TOKEN_PAT_WARNED=1
+  fi
+
+  # [#416 R2] Non-github lane — no scoped github token to mint, no PAT WARN to
+  # emit. Return 0 as a NO-OP; the gitlab WARN above (if applicable) is the
+  # gitlab-side equivalent.
+  if ! _github_seam_active; then
+    return 0
+  fi
 
   if [[ "$GH_AUTH_MODE" != "app" ]]; then
     if [[ -z "$_AGENT_TOKEN_PAT_WARNED" ]]; then

--- a/skills/autonomous-dispatcher/scripts/providers/lib-gitlab-transport.sh
+++ b/skills/autonomous-dispatcher/scripts/providers/lib-gitlab-transport.sh
@@ -77,7 +77,7 @@
 #
 # GITLAB_HOST default: `gitlab.com`. Overridable per-project.
 #
-# See docs/pipeline/provider-spec.md §transport and INV-113.
+# See docs/pipeline/provider-spec.md §transport and INV-116.
 
 # Guard against double-sourcing (idempotent — only defines functions +
 # module-scope state).
@@ -114,32 +114,32 @@ _gl_preflight_check() {
 
   if [[ -n "$hook" ]]; then
     if [[ ! -r "$hook" ]]; then
-      echo "ERROR: [INV-113] GITLAB_TRANSPORT_HOOK='${hook}' is not readable — cannot source the transport override. Set GITLAB_TRANSPORT_HOOK to a readable file that redefines _gl_http, or unset it to use the default curl transport." >&2
+      echo "ERROR: [INV-116] GITLAB_TRANSPORT_HOOK='${hook}' is not readable — cannot source the transport override. Set GITLAB_TRANSPORT_HOOK to a readable file that redefines _gl_http, or unset it to use the default curl transport." >&2
       return 1
     fi
     # Source in the current shell so a redefined _gl_http survives.
     # shellcheck disable=SC1090
     source "$hook" || {
-      echo "ERROR: [INV-113] sourcing GITLAB_TRANSPORT_HOOK='${hook}' failed (non-zero rc from the hook file itself)." >&2
+      echo "ERROR: [INV-116] sourcing GITLAB_TRANSPORT_HOOK='${hook}' failed (non-zero rc from the hook file itself)." >&2
       return 1
     }
     # Post-source: _gl_http must exist and be callable. The hook MAY define
     # private helper functions alongside (operator-trust model, per #414
     # pillar 3); only the public override point is validated.
     if ! declare -F _gl_http >/dev/null 2>&1; then
-      echo "ERROR: [INV-113] GITLAB_TRANSPORT_HOOK='${hook}' did not define _gl_http (the only public override point). Redefine _gl_http with signature: _gl_http <method> <path-or-url> <headers_out_file> [body-json]." >&2
+      echo "ERROR: [INV-116] GITLAB_TRANSPORT_HOOK='${hook}' did not define _gl_http (the only public override point). Redefine _gl_http with signature: _gl_http <method> <path-or-url> <headers_out_file> [body-json]." >&2
       return 1
     fi
   else
     # No hook: default curl transport is in force. GITLAB_TOKEN is required.
     if [[ -z "${GITLAB_TOKEN:-}" ]]; then
-      echo "ERROR: [INV-113] GITLAB_TOKEN is unset and no GITLAB_TRANSPORT_HOOK is armed — the default curl transport requires a PAT. Set GITLAB_TOKEN=<token> (see docs/gitlab-token-setup.md), or set GITLAB_TRANSPORT_HOOK=<path> to a custom transport." >&2
+      echo "ERROR: [INV-116] GITLAB_TOKEN is unset and no GITLAB_TRANSPORT_HOOK is armed — the default curl transport requires a PAT. Set GITLAB_TOKEN=<token> (see docs/gitlab-token-setup.md), or set GITLAB_TRANSPORT_HOOK=<path> to a custom transport." >&2
       return 1
     fi
   fi
 
   _GL_PREFLIGHT_LATCHED=1
-  echo "[INV-113] gitlab-transport preflight OK (hook=${hook:-<none>}, host=${GITLAB_HOST})" >&2
+  echo "[INV-116] gitlab-transport preflight OK (hook=${hook:-<none>}, host=${GITLAB_HOST})" >&2
   return 0
 }
 
@@ -382,11 +382,11 @@ _gl_api() {
   if [[ "$paginate" -eq 0 ]]; then
     _do_request_with_backoff "$path"; rc=$?
     if [[ "$rc" -eq 1 ]]; then
-      echo "ERROR: [INV-113] _gl_api transport failure on '${path}' (curl exit non-zero)." >&2
+      echo "ERROR: [INV-116] _gl_api transport failure on '${path}' (curl exit non-zero)." >&2
       _cleanup; return 1
     fi
     if [[ "$rc" -eq 2 ]]; then
-      echo "ERROR: [INV-113] _gl_api 429 backoff exhausted on '${path}' after ${GL_TRANSPORT_MAX_RETRIES} retries." >&2
+      echo "ERROR: [INV-116] _gl_api 429 backoff exhausted on '${path}' after ${GL_TRANSPORT_MAX_RETRIES} retries." >&2
       _cleanup; return 1
     fi
     # HTTP status classification.
@@ -399,7 +399,7 @@ _gl_api() {
       _cleanup; return 0
     fi
     local body_excerpt; body_excerpt=$(head -c 200 "$body_file" 2>/dev/null)
-    echo "ERROR: [INV-113] _gl_api HTTP ${GL_API_STATUS} on '${path}' (body excerpt: ${body_excerpt})" >&2
+    echo "ERROR: [INV-116] _gl_api HTTP ${GL_API_STATUS} on '${path}' (body excerpt: ${body_excerpt})" >&2
     _cleanup; return 1
   fi
 
@@ -417,9 +417,9 @@ _gl_api() {
     _do_request_with_backoff "$next_url"; local req_rc=$?
     if [[ "$req_rc" -ne 0 ]]; then
       if [[ "$req_rc" -eq 1 ]]; then
-        echo "ERROR: [INV-113] _gl_api transport failure mid-walk on '${next_url}'." >&2
+        echo "ERROR: [INV-116] _gl_api transport failure mid-walk on '${next_url}'." >&2
       else
-        echo "ERROR: [INV-113] _gl_api 429 backoff exhausted mid-walk on '${next_url}'." >&2
+        echo "ERROR: [INV-116] _gl_api 429 backoff exhausted mid-walk on '${next_url}'." >&2
       fi
       walk_rc=1
       break
@@ -433,7 +433,7 @@ _gl_api() {
         _cleanup; return 0
       fi
       local body_excerpt; body_excerpt=$(head -c 200 "$body_file" 2>/dev/null)
-      echo "ERROR: [INV-113] _gl_api mid-walk HTTP ${GL_API_STATUS} on '${next_url}' (body excerpt: ${body_excerpt})" >&2
+      echo "ERROR: [INV-116] _gl_api mid-walk HTTP ${GL_API_STATUS} on '${next_url}' (body excerpt: ${body_excerpt})" >&2
       walk_rc=1
       break
     fi
@@ -464,7 +464,7 @@ _gl_api() {
       break
     fi
     if [[ "$pages_read" -ge "$GL_TRANSPORT_PAGE_CAP" ]]; then
-      echo "ERROR: [INV-113] _gl_api paginate walk hit cap GL_TRANSPORT_PAGE_CAP=${GL_TRANSPORT_PAGE_CAP} (next-page=${next_page}) — fail-CLOSED, no partial output." >&2
+      echo "ERROR: [INV-116] _gl_api paginate walk hit cap GL_TRANSPORT_PAGE_CAP=${GL_TRANSPORT_PAGE_CAP} (next-page=${next_page}) — fail-CLOSED, no partial output." >&2
       walk_rc=1
       break
     fi
@@ -492,7 +492,7 @@ _gl_api() {
   fi
 
   if [[ "$walk_rc" -ne 0 ]]; then
-    echo "ERROR: [INV-113] _gl_api paginate merge failed (invalid JSON in a page body)." >&2
+    echo "ERROR: [INV-116] _gl_api paginate merge failed (invalid JSON in a page body)." >&2
     rm -f "$merged_file" "$merged_file.raw"
     _cleanup; return 1
   fi

--- a/skills/autonomous-dispatcher/scripts/providers/lib-gitlab-transport.sh
+++ b/skills/autonomous-dispatcher/scripts/providers/lib-gitlab-transport.sh
@@ -117,6 +117,15 @@ _gl_preflight_check() {
       echo "ERROR: [INV-116] GITLAB_TRANSPORT_HOOK='${hook}' is not readable — cannot source the transport override. Set GITLAB_TRANSPORT_HOOK to a readable file that redefines _gl_http, or unset it to use the default curl transport." >&2
       return 1
     fi
+    # [#416 P1-4] Snapshot _gl_http's BODY BEFORE sourcing the hook, so we
+    # can prove the hook actually overrode it after. `declare -F _gl_http`
+    # alone only checks EXISTENCE — but the default is already defined at
+    # this point, so a no-op hook (empty file, syntax error suppressed by
+    # a rogue `|| true`, or a file that just re-exports env vars) would
+    # pass a mere existence check and masquerade as the default transport.
+    # Codex round-1 [P1-4]: capture body pre-source, require CHANGE post.
+    local _pre_body _post_body
+    _pre_body=$(declare -f _gl_http 2>/dev/null || true)
     # Source in the current shell so a redefined _gl_http survives.
     # shellcheck disable=SC1090
     source "$hook" || {
@@ -128,6 +137,17 @@ _gl_preflight_check() {
     # pillar 3); only the public override point is validated.
     if ! declare -F _gl_http >/dev/null 2>&1; then
       echo "ERROR: [INV-116] GITLAB_TRANSPORT_HOOK='${hook}' did not define _gl_http (the only public override point). Redefine _gl_http with signature: _gl_http <method> <path-or-url> <headers_out_file> [body-json]." >&2
+      return 1
+    fi
+    _post_body=$(declare -f _gl_http 2>/dev/null || true)
+    # [#416 P1-4] Loud rejection of a no-op hook: if the body did not
+    # change post-source, the hook is armed but does nothing — either a
+    # typo, a suppressed error, or an operator misconfiguration. Fail
+    # LOUD naming the hook path so the operator can fix it rather than
+    # silently running against the default transport under a hook-armed
+    # config that says "we're on the enterprise gateway".
+    if [[ "$_pre_body" == "$_post_body" ]]; then
+      echo "ERROR: [INV-116] GITLAB_TRANSPORT_HOOK='${hook}' is armed but did NOT redefine _gl_http (body identical pre- and post-source). A no-op hook is a misconfiguration — either the hook file has a syntax error suppressed by a stray '|| true', or it never assigns the function. Redefine _gl_http in the hook, or unset GITLAB_TRANSPORT_HOOK to use the default curl transport." >&2
       return 1
     fi
   else
@@ -349,8 +369,17 @@ _gl_api() {
     local attempt=0 http_rc
     while :; do
       : > "$hdr_file"
-      _gl_http "$method" "$target" "$hdr_file" "$body_json" > "$body_file"
-      http_rc=$?
+      # [#416 P1-3] `set -e`-SAFE _gl_http call: a bare
+      #   `_gl_http … > "$body_file"; http_rc=$?`
+      # would abort the CALLING shell under `set -euo pipefail` on a
+      # transport failure BEFORE http_rc/`_record_status`/`--status-out`
+      # mirroring ran. The `cmd || rc=$?` construct classifies the call
+      # as tested (bash's `set -e` skips exit on tested commands) AND
+      # preserves the ACTUAL non-zero rc (`if ! cmd; then rc=$?` is a
+      # trap — `!` inverts, so `$?` under `then` is 0, not cmd's rc).
+      # Codex round-1 [P1-3].
+      http_rc=0
+      _gl_http "$method" "$target" "$hdr_file" "$body_json" > "$body_file" || http_rc=$?
       if [[ "$http_rc" -ne 0 ]]; then
         return 1
       fi
@@ -380,7 +409,11 @@ _gl_api() {
 
   # Non-paginate path: one request, honor tolerate-status.
   if [[ "$paginate" -eq 0 ]]; then
-    _do_request_with_backoff "$path"; rc=$?
+    # [#416 P1-3] `set -e`-SAFE: `cmd || rc=$?` (see above rationale — the
+    # `if !` pattern DROPS the actual rc because `!` inverts to 0, so
+    # under `then` `$?` is always 0).
+    rc=0
+    _do_request_with_backoff "$path" || rc=$?
     if [[ "$rc" -eq 1 ]]; then
       echo "ERROR: [INV-116] _gl_api transport failure on '${path}' (curl exit non-zero)." >&2
       _cleanup; return 1
@@ -414,7 +447,9 @@ _gl_api() {
   local walk_rc=0
 
   while :; do
-    _do_request_with_backoff "$next_url"; local req_rc=$?
+    # [#416 P1-3] `set -e`-SAFE (paginate loop) — same fix as above.
+    local req_rc=0
+    _do_request_with_backoff "$next_url" || req_rc=$?
     if [[ "$req_rc" -ne 0 ]]; then
       if [[ "$req_rc" -eq 1 ]]; then
         echo "ERROR: [INV-116] _gl_api transport failure mid-walk on '${next_url}'." >&2

--- a/skills/autonomous-dispatcher/scripts/providers/lib-gitlab-transport.sh
+++ b/skills/autonomous-dispatcher/scripts/providers/lib-gitlab-transport.sh
@@ -1,0 +1,503 @@
+#!/bin/bash
+# lib-gitlab-transport.sh — GitLab transport contract (issue #416, phase-3 #414
+# W-A). Two-layer FROZEN contract:
+#
+#   _gl_http <method> <path-or-url> <headers_out_file> [body-json]
+#       SINGLE-REQUEST primitive AND out-of-tree hook point. Default impl uses
+#       curl only (no glab — a CLI carries its own auth/config state, blurring
+#       the standard-auth-only boundary per #414 pillar 2). Sends
+#       `PRIVATE-TOKEN: ${GITLAB_TOKEN}` against `https://${GITLAB_HOST}/api/v4/<path>`;
+#       a <path> that begins with `http` is used VERBATIM (used by _gl_api's
+#       pagination walker to pass an absolute next-page URL). Response body
+#       -> stdout for ALL HTTP statuses (including 4xx/5xx — _gl_api needs
+#       the body for tolerated statuses and error excerpts). HTTP status +
+#       response headers (at minimum x-next-page, x-total-pages, retry-after)
+#       -> <headers_out_file> in a stable line-oriented format. rc 0 iff
+#       TRANSPORT succeeded (curl exit 0); HTTP status classification is
+#       _gl_api's job. No retries here; no pagination here.
+#
+#   _gl_api [--method M] [--paginate] [--body JSON] [--tolerate-status CSV]
+#           [--max-items N] [--status-out FILE] <path>
+#       The PUBLIC function every GitLab leaf calls. Owns pagination walk
+#       (--paginate loops x-next-page until exhausted, merges pages into ONE
+#       JSON array via `jq -s add`, page cap GL_TRANSPORT_PAGE_CAP default 50
+#       -> cap-hit or ANY mid-walk failure = rc != 0 with NO partial output —
+#       the §3.5/#401 fail-closed discipline verbatim); 429/Retry-After
+#       bounded backoff (default 3 retries per request, cap 60s per sleep);
+#       fail-loud error surfacing (HTTP status + response body excerpt).
+#
+#     Next-page reconstruction — GitLab's x-next-page is a page NUMBER (not
+#     a URL); _gl_api reconstructs the next request by setting/replacing the
+#     `page=<n>` query param on the ORIGINAL path (documented; _gl_http's
+#     verbatim-absolute-URL affordance stays but is not the pagination
+#     mechanism).
+#
+#     HTTP-status channel (load-bearing for leaf preflights; SUBSHELL-SAFE
+#     by design):
+#       - `_gl_api` sets GL_API_STATUS (final HTTP status) in the CALLING
+#         shell on EVERY return, and
+#       - `--tolerate-status 404,409` makes the named statuses return rc 0
+#         with the body on stdout and GL_API_STATUS observable.
+#
+#     CONTRACT NOTE — command substitution loses shell variables. A leaf
+#     that needs status discrimination MUST invoke `_gl_api ... > "$tmpfile"`
+#     directly in the CURRENT shell (redirect, NOT `$( ... )` capture) so
+#     the GL_API_STATUS assignment survives; `_gl_api` ADDITIONALLY mirrors
+#     the status into a caller-suppliable `--status-out <file>` for
+#     harnesses that must capture stdout.
+#
+#     Bounded reads: `--max-items N` stops the pagination walk once N
+#     items are merged (so a LIMIT-bounded list verb cannot spuriously hit
+#     the page cap on a large project).
+#
+#   _gl_urlencode <string>
+#       jq `@uri` encoder. Leaves (dynamic project refs, label names, file
+#       paths) share ONE encoder; the STATIC GITLAB_PROJECT config value is
+#       stored ALREADY-URL-ENCODED per §3.4 (`group%2Fsubgroup%2Fproject`)
+#       and used verbatim. LEAVES NEVER call curl or _gl_http directly —
+#       the [INV-91] cutover guard enforces this.
+#
+# Override hook (GITLAB_TRANSPORT_HOOK):
+#   If GITLAB_TRANSPORT_HOOK (conf-declared path) is set, the transport lib
+#   sources it at library-init BEFORE any leaf runs. The hook MAY redefine
+#   `_gl_http` ONLY (same signature/contract); `_gl_api` stays lib-owned so
+#   pagination + backoff + fail-closed cannot be lost by a variant.
+#
+#   Trust model: operator-owned local code, same privileges as
+#   autonomous.conf — explicitly NOT a sandbox (#414 pillar 3). The hook MAY
+#   define private helper functions (that is operator-owned code); only the
+#   PUBLIC override point (`_gl_http`) is validated post-source.
+#
+# Preflight fail-loud (latched once per process — mirrors _AGENT_TOKEN_PAT_WARNED
+# at lib-auth.sh:93):
+#   - GITLAB_TOKEN unset when no hook is armed -> rc != 0 with recovery guidance;
+#   - GITLAB_TRANSPORT_HOOK set but path unreadable -> rc != 0 naming the path;
+#   - after sourcing the hook, `_gl_http` must exist and be callable or
+#     preflight fails rc != 0.
+#
+# GITLAB_HOST default: `gitlab.com`. Overridable per-project.
+#
+# See docs/pipeline/provider-spec.md §transport and INV-113.
+
+# Guard against double-sourcing (idempotent — only defines functions +
+# module-scope state).
+if [[ "${_LIB_GITLAB_TRANSPORT_SOURCED:-0}" -eq 1 ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+_LIB_GITLAB_TRANSPORT_SOURCED=1
+
+# Module-level state. GITLAB_HOST defaults to `gitlab.com` (self-hosted
+# instances override via autonomous.conf).
+: "${GITLAB_HOST:=gitlab.com}"
+: "${GL_TRANSPORT_PAGE_CAP:=50}"
+: "${GL_TRANSPORT_MAX_RETRIES:=3}"
+: "${GL_TRANSPORT_RETRY_CAP_SECONDS:=60}"
+
+# One-time preflight-passed latch. Preflight runs on FIRST `_gl_api` call
+# per process; subsequent calls skip revalidation for cost.
+_GL_PREFLIGHT_LATCHED=""
+
+# Publicly exposed status channel — set by _gl_api on EVERY return so a leaf
+# doing `_gl_api ... > $tmp` can `[[ $GL_API_STATUS == 404 ]]` afterward.
+# Reset per call (never stale from a prior call — the caller reads it
+# UNCONDITIONALLY, so leaking a prior status would be a real bug).
+GL_API_STATUS=""
+
+# _gl_preflight_check — validate GITLAB_TOKEN / GITLAB_TRANSPORT_HOOK once
+# per process. Returns 0 on pass (latched), non-zero + stderr diagnostic on
+# fail. Called by _gl_api on every invocation; short-circuits after the
+# first pass.
+_gl_preflight_check() {
+  [[ -n "$_GL_PREFLIGHT_LATCHED" ]] && return 0
+
+  local hook="${GITLAB_TRANSPORT_HOOK:-}"
+
+  if [[ -n "$hook" ]]; then
+    if [[ ! -r "$hook" ]]; then
+      echo "ERROR: [INV-113] GITLAB_TRANSPORT_HOOK='${hook}' is not readable — cannot source the transport override. Set GITLAB_TRANSPORT_HOOK to a readable file that redefines _gl_http, or unset it to use the default curl transport." >&2
+      return 1
+    fi
+    # Source in the current shell so a redefined _gl_http survives.
+    # shellcheck disable=SC1090
+    source "$hook" || {
+      echo "ERROR: [INV-113] sourcing GITLAB_TRANSPORT_HOOK='${hook}' failed (non-zero rc from the hook file itself)." >&2
+      return 1
+    }
+    # Post-source: _gl_http must exist and be callable. The hook MAY define
+    # private helper functions alongside (operator-trust model, per #414
+    # pillar 3); only the public override point is validated.
+    if ! declare -F _gl_http >/dev/null 2>&1; then
+      echo "ERROR: [INV-113] GITLAB_TRANSPORT_HOOK='${hook}' did not define _gl_http (the only public override point). Redefine _gl_http with signature: _gl_http <method> <path-or-url> <headers_out_file> [body-json]." >&2
+      return 1
+    fi
+  else
+    # No hook: default curl transport is in force. GITLAB_TOKEN is required.
+    if [[ -z "${GITLAB_TOKEN:-}" ]]; then
+      echo "ERROR: [INV-113] GITLAB_TOKEN is unset and no GITLAB_TRANSPORT_HOOK is armed — the default curl transport requires a PAT. Set GITLAB_TOKEN=<token> (see docs/gitlab-token-setup.md), or set GITLAB_TRANSPORT_HOOK=<path> to a custom transport." >&2
+      return 1
+    fi
+  fi
+
+  _GL_PREFLIGHT_LATCHED=1
+  echo "[INV-113] gitlab-transport preflight OK (hook=${hook:-<none>}, host=${GITLAB_HOST})" >&2
+  return 0
+}
+
+# _gl_urlencode <string> — jq @uri encoder. Used by leaves for dynamic path
+# segments (label names, dynamic project refs, file paths). The STATIC
+# GITLAB_PROJECT config value is stored ALREADY-URL-ENCODED per §3.4 and
+# used verbatim (never re-encoded here).
+_gl_urlencode() {
+  jq -rn --arg s "$1" '$s | @uri'
+}
+
+# _gl_http <method> <path-or-url> <headers_out_file> [body-json]
+#   Default (curl-only) implementation. Overridable via GITLAB_TRANSPORT_HOOK.
+#   See the header comment for the full contract.
+#
+#   rc 0 iff curl transport succeeded (request sent + response received —
+#   curl exit 0). HTTP status classification is EXCLUSIVELY _gl_api's job.
+_gl_http() {
+  local method="$1" path_or_url="$2" headers_out_file="$3" body_json="${4:-}"
+  local url
+
+  if [[ "$path_or_url" == http* ]]; then
+    url="$path_or_url"
+  else
+    # Trim any leading slash so we don't produce double-slash after /api/v4/.
+    url="https://${GITLAB_HOST}/api/v4/${path_or_url#/}"
+  fi
+
+  # curl argv:
+  #   -sS       — silent + show errors (we handle rc; body is on stdout).
+  #   -X <M>    — HTTP method.
+  #   -H ...    — PRIVATE-TOKEN auth header (GitLab convention).
+  #   -D <f>    — dump response headers (incl. HTTP status line) to file.
+  #   --data-binary <body> — body-json, for POST/PUT/PATCH.
+  #
+  # We MUST NOT pass `-f/--fail` — that would make curl exit non-zero on
+  # HTTP >=400 and suppress the body, but the contract requires:
+  #   (a) rc 0 iff TRANSPORT succeeded (independent of HTTP status);
+  #   (b) body on stdout for ALL statuses (so _gl_api can tolerate 404/409
+  #       and surface error excerpts on 5xx).
+  local -a curl_argv=(
+    curl -sS
+    -X "$method"
+    -H "PRIVATE-TOKEN: ${GITLAB_TOKEN:-}"
+    -D "$headers_out_file"
+  )
+
+  if [[ -n "$body_json" ]]; then
+    curl_argv+=(
+      -H "Content-Type: application/json"
+      --data-binary "$body_json"
+    )
+  fi
+
+  curl_argv+=("$url")
+
+  "${curl_argv[@]}"
+}
+
+# _gl_api_extract_status <headers_out_file>
+#   Extract the HTTP status code (integer) from the LAST response-line block
+#   in a curl `-D` headers file. Curl may write multiple status blocks for a
+#   redirect chain, so we take the LAST `HTTP/...` line. Empty file / no
+#   status line -> empty output (caller treats as transport failure).
+_gl_api_extract_status() {
+  local headers_file="$1"
+  [[ -s "$headers_file" ]] || return 0
+  awk '
+    /^HTTP\// { status = $2 }
+    END { if (status != "") print status }
+  ' "$headers_file"
+}
+
+# _gl_api_extract_header <headers_out_file> <header_name>
+#   Extract the LAST (post-redirect) value of a named header from a curl
+#   `-D` headers file. Case-insensitive header name match; leading/trailing
+#   whitespace trimmed from the value.
+_gl_api_extract_header() {
+  local headers_file="$1" name="$2"
+  [[ -s "$headers_file" ]] || return 0
+  # Lowercase for match; the header field name is case-insensitive per RFC.
+  local lname; lname=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')
+  awk -v name="$lname" '
+    tolower($1) == name":" {
+      # Drop the field-name (first whitespace-run), then trim.
+      sub(/^[^ \t]*[ \t]+/, "", $0)
+      sub(/[ \t\r\n]+$/, "", $0)
+      value = $0
+    }
+    END { if (value != "") print value }
+  ' "$headers_file"
+}
+
+# _gl_api_reconstruct_next_url <path-or-url> <next-page-number>
+#   Rebuild the request path with `page=<n>` set/replaced. Handles all
+#   three input shapes:
+#     - a bare path (`projects/42/issues`) -> `projects/42/issues?page=<n>`
+#     - a path with query-string but no page (`...?per_page=100`) ->
+#       `...?per_page=100&page=<n>`
+#     - a path with query-string that already has page= -> replaced
+#   Absolute URLs are handled identically (query-string logic doesn't care
+#   about the scheme prefix).
+_gl_api_reconstruct_next_url() {
+  local original="$1" page_num="$2" base rest
+  if [[ "$original" == *"?"* ]]; then
+    base="${original%%\?*}"
+    rest="${original#*\?}"
+    # Strip any existing page= param (idempotent replace).
+    rest=$(printf '%s' "$rest" | sed -E 's/(^|&)page=[^&]*(&|$)/\1\2/; s/&$//; s/^&//')
+    if [[ -n "$rest" ]]; then
+      printf '%s?%s&page=%s\n' "$base" "$rest" "$page_num"
+    else
+      printf '%s?page=%s\n' "$base" "$page_num"
+    fi
+  else
+    printf '%s?page=%s\n' "$original" "$page_num"
+  fi
+}
+
+# _gl_api — the PUBLIC function every GitLab leaf calls.
+#
+# Owns pagination walk, 429/Retry-After bounded backoff, HTTP-status channel,
+# --tolerate-status, --max-items. Falls-closed on any transport / cap-hit /
+# mid-walk failure. See header for full contract.
+_gl_api() {
+  local method="GET"
+  local paginate=0
+  local body_json=""
+  local tolerate_status_csv=""
+  local max_items=""
+  local status_out_file=""
+  local path=""
+
+  while (( $# > 0 )); do
+    case "$1" in
+      --method)          method="$2"; shift 2 ;;
+      --method=*)        method="${1#*=}"; shift ;;
+      --paginate)        paginate=1; shift ;;
+      --body)            body_json="$2"; shift 2 ;;
+      --body=*)          body_json="${1#*=}"; shift ;;
+      --tolerate-status) tolerate_status_csv="$2"; shift 2 ;;
+      --tolerate-status=*) tolerate_status_csv="${1#*=}"; shift ;;
+      --max-items)       max_items="$2"; shift 2 ;;
+      --max-items=*)     max_items="${1#*=}"; shift ;;
+      --status-out)      status_out_file="$2"; shift 2 ;;
+      --status-out=*)    status_out_file="${1#*=}"; shift ;;
+      --)                shift; path="$1"; break ;;
+      -*)                echo "ERROR: _gl_api: unknown flag '$1'" >&2; return 2 ;;
+      *)                 path="$1"; shift; break ;;
+    esac
+  done
+
+  if [[ -z "$path" ]]; then
+    echo "ERROR: _gl_api: missing <path> argument" >&2
+    return 2
+  fi
+
+  # Preflight — validates GITLAB_TOKEN / GITLAB_TRANSPORT_HOOK once per
+  # process. rc != 0 leaves GL_API_STATUS empty.
+  GL_API_STATUS=""
+  [[ -n "$status_out_file" ]] && : > "$status_out_file"
+  _gl_preflight_check || return 1
+
+  # Parse tolerate list once (comma-separated integers).
+  local -a tolerate=()
+  if [[ -n "$tolerate_status_csv" ]]; then
+    local IFS=','
+    read -ra tolerate <<< "$tolerate_status_csv"
+  fi
+
+  local hdr_file body_file
+  hdr_file=$(mktemp)
+  body_file=$(mktemp)
+  local rc=0
+
+  # _cleanup — remove per-call scratch files. Idempotent.
+  _cleanup() { rm -f "$hdr_file" "$body_file" 2>/dev/null || true; }
+
+  # _record_status — echo the extracted status into GL_API_STATUS and the
+  # --status-out file (if any). Called after every _gl_http invocation.
+  _record_status() {
+    GL_API_STATUS=$(_gl_api_extract_status "$hdr_file")
+    if [[ -n "$status_out_file" ]]; then
+      printf '%s' "${GL_API_STATUS:-}" > "$status_out_file"
+    fi
+  }
+
+  # _is_toleratable — rc 0 iff GL_API_STATUS is in the tolerate list.
+  _is_toleratable() {
+    local s
+    for s in "${tolerate[@]}"; do
+      [[ "$s" == "$GL_API_STATUS" ]] && return 0
+    done
+    return 1
+  }
+
+  # _do_request_with_backoff <path> — call _gl_http; if the response is a
+  # 429, honor Retry-After (capped at GL_TRANSPORT_RETRY_CAP_SECONDS) and
+  # retry up to GL_TRANSPORT_MAX_RETRIES times. Returns:
+  #   rc 0 — transport succeeded AND (final status not-429 OR retries
+  #          exhausted with 429 still). Body on stdout (in `body_file`),
+  #          status in GL_API_STATUS.
+  #   rc 1 — transport failure (curl rc != 0).
+  #   rc 2 — 429 exhausted (retries used, still 429).
+  _do_request_with_backoff() {
+    local target="$1"
+    local attempt=0 http_rc
+    while :; do
+      : > "$hdr_file"
+      _gl_http "$method" "$target" "$hdr_file" "$body_json" > "$body_file"
+      http_rc=$?
+      if [[ "$http_rc" -ne 0 ]]; then
+        return 1
+      fi
+      _record_status
+      if [[ "$GL_API_STATUS" != "429" ]]; then
+        return 0
+      fi
+      # 429 — bounded retry loop.
+      if [[ "$attempt" -ge "$GL_TRANSPORT_MAX_RETRIES" ]]; then
+        return 2
+      fi
+      local retry_after
+      retry_after=$(_gl_api_extract_header "$hdr_file" "Retry-After")
+      # Retry-After can be seconds (integer) or a HTTP-date; default to 1s
+      # on unparseable input.
+      if ! [[ "$retry_after" =~ ^[0-9]+$ ]]; then
+        retry_after=1
+      fi
+      # Cap per-sleep at GL_TRANSPORT_RETRY_CAP_SECONDS.
+      if [[ "$retry_after" -gt "$GL_TRANSPORT_RETRY_CAP_SECONDS" ]]; then
+        retry_after="$GL_TRANSPORT_RETRY_CAP_SECONDS"
+      fi
+      sleep "$retry_after"
+      attempt=$((attempt + 1))
+    done
+  }
+
+  # Non-paginate path: one request, honor tolerate-status.
+  if [[ "$paginate" -eq 0 ]]; then
+    _do_request_with_backoff "$path"; rc=$?
+    if [[ "$rc" -eq 1 ]]; then
+      echo "ERROR: [INV-113] _gl_api transport failure on '${path}' (curl exit non-zero)." >&2
+      _cleanup; return 1
+    fi
+    if [[ "$rc" -eq 2 ]]; then
+      echo "ERROR: [INV-113] _gl_api 429 backoff exhausted on '${path}' after ${GL_TRANSPORT_MAX_RETRIES} retries." >&2
+      _cleanup; return 1
+    fi
+    # HTTP status classification.
+    if [[ "$GL_API_STATUS" -ge 200 && "$GL_API_STATUS" -lt 300 ]]; then
+      cat "$body_file"
+      _cleanup; return 0
+    fi
+    if _is_toleratable; then
+      cat "$body_file"
+      _cleanup; return 0
+    fi
+    local body_excerpt; body_excerpt=$(head -c 200 "$body_file" 2>/dev/null)
+    echo "ERROR: [INV-113] _gl_api HTTP ${GL_API_STATUS} on '${path}' (body excerpt: ${body_excerpt})" >&2
+    _cleanup; return 1
+  fi
+
+  # Paginate path: loop x-next-page until exhausted / cap-hit / mid-walk fail.
+  # Merge pages via `jq -s add`. Fail-CLOSED: any error yields rc != 0 with
+  # NO partial output.
+  local merged_file; merged_file=$(mktemp)
+  local pages_read=0
+  local total_items=0
+  local next_url="$path"
+  local page_num=1
+  local walk_rc=0
+
+  while :; do
+    _do_request_with_backoff "$next_url"; local req_rc=$?
+    if [[ "$req_rc" -ne 0 ]]; then
+      if [[ "$req_rc" -eq 1 ]]; then
+        echo "ERROR: [INV-113] _gl_api transport failure mid-walk on '${next_url}'." >&2
+      else
+        echo "ERROR: [INV-113] _gl_api 429 backoff exhausted mid-walk on '${next_url}'." >&2
+      fi
+      walk_rc=1
+      break
+    fi
+    if [[ "$GL_API_STATUS" -lt 200 || "$GL_API_STATUS" -ge 300 ]]; then
+      if _is_toleratable && [[ "$pages_read" -eq 0 ]]; then
+        # Tolerated status on the first page — return the body as-is (no
+        # pagination merge; pagination on a tolerated non-2xx makes no sense).
+        cat "$body_file"
+        rm -f "$merged_file"
+        _cleanup; return 0
+      fi
+      local body_excerpt; body_excerpt=$(head -c 200 "$body_file" 2>/dev/null)
+      echo "ERROR: [INV-113] _gl_api mid-walk HTTP ${GL_API_STATUS} on '${next_url}' (body excerpt: ${body_excerpt})" >&2
+      walk_rc=1
+      break
+    fi
+
+    # Append this page to merged output. If the body is not a valid JSON
+    # array, treat the first-page as a single-page response (return
+    # verbatim) — pagination on a non-array body is a no-op degradation.
+    if [[ "$pages_read" -eq 0 ]]; then
+      if ! jq -e 'type == "array"' >/dev/null 2>&1 < "$body_file"; then
+        cat "$body_file"
+        rm -f "$merged_file"
+        _cleanup; return 0
+      fi
+    fi
+    cat "$body_file" >> "$merged_file.raw"
+    pages_read=$((pages_read + 1))
+
+    if [[ -n "$max_items" ]]; then
+      local page_len; page_len=$(jq 'length' < "$body_file" 2>/dev/null || echo 0)
+      total_items=$((total_items + page_len))
+      if [[ "$total_items" -ge "$max_items" ]]; then
+        break
+      fi
+    fi
+
+    local next_page; next_page=$(_gl_api_extract_header "$hdr_file" "x-next-page")
+    if [[ -z "$next_page" || "$next_page" == "0" ]]; then
+      break
+    fi
+    if [[ "$pages_read" -ge "$GL_TRANSPORT_PAGE_CAP" ]]; then
+      echo "ERROR: [INV-113] _gl_api paginate walk hit cap GL_TRANSPORT_PAGE_CAP=${GL_TRANSPORT_PAGE_CAP} (next-page=${next_page}) — fail-CLOSED, no partial output." >&2
+      walk_rc=1
+      break
+    fi
+    page_num="$next_page"
+    next_url=$(_gl_api_reconstruct_next_url "$path" "$page_num")
+  done
+
+  if [[ "$walk_rc" -ne 0 ]]; then
+    rm -f "$merged_file" "$merged_file.raw"
+    _cleanup; return 1
+  fi
+
+  # Merge: jq -s add over the concatenated raw pages. Each page is one
+  # complete JSON array; -s slurps them into a jq stream, then `add`
+  # concatenates the arrays.
+  if [[ -s "$merged_file.raw" ]]; then
+    if [[ -n "$max_items" ]]; then
+      # Slice to the requested max after merge.
+      jq -s "add | .[:${max_items}]" < "$merged_file.raw" > "$merged_file" 2>/dev/null || walk_rc=1
+    else
+      jq -s 'add' < "$merged_file.raw" > "$merged_file" 2>/dev/null || walk_rc=1
+    fi
+  else
+    printf '[]' > "$merged_file"
+  fi
+
+  if [[ "$walk_rc" -ne 0 ]]; then
+    echo "ERROR: [INV-113] _gl_api paginate merge failed (invalid JSON in a page body)." >&2
+    rm -f "$merged_file" "$merged_file.raw"
+    _cleanup; return 1
+  fi
+
+  cat "$merged_file"
+  rm -f "$merged_file" "$merged_file.raw"
+  _cleanup; return 0
+}

--- a/tests/provider-conformance/lib-provider-conformance.sh
+++ b/tests/provider-conformance/lib-provider-conformance.sh
@@ -48,16 +48,33 @@ pcf_conf_keys() {
 # pcf_resolve_provider_dir <project_root> <name> — resolve a provider NAME to
 # its source directory. Fixed table (issue #370 design): github -> the real
 # skill tree; degraded -> the existing #280 fixture; broken -> this suite's
-# deliberately-broken fixture. Both seams (ITP/CHP) share this same table — a
-# name resolves to the same DIR regardless of seam; the caller picks the
-# itp-<name> or chp-<name> file inside it. Unknown name -> rc 1, no output
-# (the caller treats this as a fatal usage error, not a silent empty provider).
+# deliberately-broken fixture. #416 W-D adds `gitlab` (real skill tree — the
+# filename prefix `itp-gitlab.*`/`chp-gitlab.*` disambiguates per-seam) AND
+# an ABSOLUTE-PATH form: any `<name>` matching `/*` and pointing to a
+# readable directory resolves to itself (out-of-tree provider
+# self-certification per #414 AC3). Both seams (ITP/CHP) share this same
+# table — a name resolves to the same DIR regardless of seam; the caller
+# picks the itp-<name> or chp-<name> file inside it. Unknown non-path name
+# -> rc 1, no output (the caller treats this as a fatal usage error, not
+# a silent empty provider).
 pcf_resolve_provider_dir() {
   local root="$1" name="$2"
   case "$name" in
     github)   printf '%s\n' "$root/skills/autonomous-dispatcher/scripts/providers" ;;
+    gitlab)   printf '%s\n' "$root/skills/autonomous-dispatcher/scripts/providers" ;;
     degraded) printf '%s\n' "$root/tests/unit/fixtures/provider-degraded" ;;
     broken)   printf '%s\n' "$root/tests/provider-conformance/fixtures/provider-broken" ;;
+    /*)
+      # Absolute-path form (out-of-tree provider dir). Rc 0 iff the path
+      # points at an existing readable directory. Rc 1 otherwise so a typo'd
+      # path (a stale operator config) FAILs loud rather than silently
+      # resolving to an empty provider dir.
+      if [[ -d "$name" && -r "$name" ]]; then
+        printf '%s\n' "$name"
+      else
+        return 1
+      fi
+      ;;
     *)        return 1 ;;
   esac
 }

--- a/tests/provider-conformance/run-provider-conformance.sh
+++ b/tests/provider-conformance/run-provider-conformance.sh
@@ -140,10 +140,80 @@ for _tpa in "${TRANSPORT_PATH_ADD[@]:-}"; do
   fi
 done
 
-ITP_SRC_DIR="$(pcf_resolve_provider_dir "$PROJECT_ROOT" "$ITP_NAME")" \
-  || { log "FATAL: unknown --itp provider '$ITP_NAME'"; exit 2; }
-CHP_SRC_DIR="$(pcf_resolve_provider_dir "$PROJECT_ROOT" "$CHP_NAME")" \
-  || { log "FATAL: unknown --chp provider '$CHP_NAME'"; exit 2; }
+# [#416 P1-5] Decouple logical NAME from source DIR for out-of-tree providers.
+# The flag value may be either:
+#   `<name>`             — well-known name (github/gitlab/degraded/broken) OR
+#                          absolute-path that becomes BOTH the name and the
+#                          dir (legacy behavior — but see NOTE below).
+#   `<name>=<abs-dir>`   — logical <name> (used for filenames + label output)
+#                          + explicit source <abs-dir> (self-certifying
+#                          out-of-tree provider). This is the codex round-1
+#                          [P1-5] shape: pcf_materialize_scratch's
+#                          itp-<name>.sh / chp-<name>.sh filenames use the
+#                          LOGICAL name, so a path like `/tmp/x/y` no longer
+#                          leaks into filenames or function names.
+#
+# NOTE on the legacy absolute-path-only form: the pre-P1-5 shape
+# `--itp /abs/dir` resolved dir=/abs/dir and name=/abs/dir, producing
+# nonsense filenames like `itp-/abs/dir.sh`. That form is now REJECTED
+# with a fatal instructing the operator to use `<name>=/abs/dir` instead.
+_split_itp_chp() {
+  local seam_flag="$1" raw="$2"
+  local name dir
+  if [[ "$raw" == *"="* ]]; then
+    name="${raw%%=*}"
+    dir="${raw#*=}"
+  else
+    name="$raw"
+    dir=""   # dir empty → resolve via the fixed-table.
+  fi
+  # Reject an absolute-path-only value (the pre-P1-5 nonsense-filename case).
+  if [[ -z "$dir" && "$name" == /* ]]; then
+    log "FATAL: --${seam_flag} '$raw' — absolute-path source dir MUST be paired with a logical name: use '--${seam_flag} <name>=<abs-dir>' (e.g. '--${seam_flag} corp=${raw}')"
+    exit 2
+  fi
+  # Reject a NAME containing a slash (nothing legal here).
+  if [[ "$name" == */* ]]; then
+    log "FATAL: --${seam_flag} '$raw' — logical name '$name' must not contain '/'"
+    exit 2
+  fi
+  # Reject an empty name / an empty dir (a stray `=`).
+  if [[ -z "$name" ]]; then
+    log "FATAL: --${seam_flag} '$raw' — empty name before '='"
+    exit 2
+  fi
+  if [[ "$raw" == *"="* && -z "$dir" ]]; then
+    log "FATAL: --${seam_flag} '$raw' — empty dir after '='"
+    exit 2
+  fi
+  printf '%s\t%s\n' "$name" "$dir"
+}
+
+IFS=$'\t' read -r ITP_LOGICAL_NAME ITP_EXPLICIT_DIR < <(_split_itp_chp itp "$ITP_NAME")
+IFS=$'\t' read -r CHP_LOGICAL_NAME CHP_EXPLICIT_DIR < <(_split_itp_chp chp "$CHP_NAME")
+
+# Overwrite ITP_NAME / CHP_NAME with the logical name so all downstream
+# code (label output, filenames, expect-absent leaf-name construction,
+# per-verb SKIP/FAIL messages) sees the clean name — never the abs-path.
+ITP_NAME="$ITP_LOGICAL_NAME"
+CHP_NAME="$CHP_LOGICAL_NAME"
+
+if [[ -n "$ITP_EXPLICIT_DIR" ]]; then
+  # Explicit out-of-tree dir. Validate it via pcf_resolve_provider_dir's
+  # absolute-path arm (checks existence + readability).
+  ITP_SRC_DIR="$(pcf_resolve_provider_dir "$PROJECT_ROOT" "$ITP_EXPLICIT_DIR")" \
+    || { log "FATAL: --itp '$ITP_NAME=$ITP_EXPLICIT_DIR' — dir does not exist or is not readable"; exit 2; }
+else
+  ITP_SRC_DIR="$(pcf_resolve_provider_dir "$PROJECT_ROOT" "$ITP_NAME")" \
+    || { log "FATAL: unknown --itp provider '$ITP_NAME'"; exit 2; }
+fi
+if [[ -n "$CHP_EXPLICIT_DIR" ]]; then
+  CHP_SRC_DIR="$(pcf_resolve_provider_dir "$PROJECT_ROOT" "$CHP_EXPLICIT_DIR")" \
+    || { log "FATAL: --chp '$CHP_NAME=$CHP_EXPLICIT_DIR' — dir does not exist or is not readable"; exit 2; }
+else
+  CHP_SRC_DIR="$(pcf_resolve_provider_dir "$PROJECT_ROOT" "$CHP_NAME")" \
+    || { log "FATAL: unknown --chp provider '$CHP_NAME'"; exit 2; }
+fi
 
 work_root=""
 cleanup() { rm -rf "${work_root:-}" 2>/dev/null || true; }

--- a/tests/provider-conformance/run-provider-conformance.sh
+++ b/tests/provider-conformance/run-provider-conformance.sh
@@ -153,10 +153,13 @@ done
 #                          LOGICAL name, so a path like `/tmp/x/y` no longer
 #                          leaks into filenames or function names.
 #
-# NOTE on the legacy absolute-path-only form: the pre-P1-5 shape
-# `--itp /abs/dir` resolved dir=/abs/dir and name=/abs/dir, producing
-# nonsense filenames like `itp-/abs/dir.sh`. That form is now REJECTED
-# with a fatal instructing the operator to use `<name>=/abs/dir` instead.
+# NOTE on the bare absolute-path form (#416 R3/AC4): the pre-P1-5 shape
+# `--itp /abs/dir` resolved dir=/abs/dir AND name=/abs/dir, producing
+# nonsense filenames like `itp-/abs/dir.sh`. Post-P1-5 the bare form is
+# SUPPORTED by deriving the logical name from the dir's own provider file
+# (`<seam>-<name>.sh`): exactly ONE such file must exist in the dir, else
+# fatal naming the ambiguity — the explicit `<name>=/abs/dir` form remains
+# for multi-provider dirs.
 _split_itp_chp() {
   local seam_flag="$1" raw="$2"
   local name dir
@@ -167,10 +170,29 @@ _split_itp_chp() {
     name="$raw"
     dir=""   # dir empty → resolve via the fixed-table.
   fi
-  # Reject an absolute-path-only value (the pre-P1-5 nonsense-filename case).
+  # Bare absolute-path form: derive the logical name from the single
+  # <seam>-<name>.sh provider file inside the dir (#416 R3/AC4).
   if [[ -z "$dir" && "$name" == /* ]]; then
-    log "FATAL: --${seam_flag} '$raw' — absolute-path source dir MUST be paired with a logical name: use '--${seam_flag} <name>=<abs-dir>' (e.g. '--${seam_flag} corp=${raw}')"
-    exit 2
+    local abs_dir="$name" candidates=() f base
+    if [[ ! -d "$abs_dir" ]]; then
+      log "FATAL: --${seam_flag} '$raw' — directory not found"
+      exit 2
+    fi
+    for f in "$abs_dir/${seam_flag}-"*.sh; do
+      [[ -f "$f" ]] && candidates+=("$f")
+    done
+    if [[ ${#candidates[@]} -eq 0 ]]; then
+      log "FATAL: --${seam_flag} '$raw' — no ${seam_flag}-<name>.sh provider file in the dir"
+      exit 2
+    fi
+    if [[ ${#candidates[@]} -gt 1 ]]; then
+      log "FATAL: --${seam_flag} '$raw' — multiple ${seam_flag}-*.sh files (ambiguous); use '--${seam_flag} <name>=<abs-dir>' to pick one"
+      exit 2
+    fi
+    base="${candidates[0]##*/}"          # <seam>-<name>.sh
+    name="${base#"${seam_flag}"-}"
+    name="${name%.sh}"
+    dir="$abs_dir"
   fi
   # Reject a NAME containing a slash (nothing legal here).
   if [[ "$name" == */* ]]; then

--- a/tests/provider-conformance/run-provider-conformance.sh
+++ b/tests/provider-conformance/run-provider-conformance.sh
@@ -66,15 +66,78 @@ command -v jq >/dev/null 2>&1 || { log "FATAL: jq is required to run the provide
 
 ITP_NAME="${ITP_UNDER_TEST:-github}"
 CHP_NAME="${CHP_UNDER_TEST:-github}"
+# [#416 W-D] --transport-hook <path> — an operator-owned GITLAB_TRANSPORT_HOOK
+# file threaded into every per-verb _invoke subshell (below). Validated once
+# here (readable regular file) or fatal. Empty = no hook.
+TRANSPORT_HOOK=""
+# [#416 W-D] --transport-path-add <dir> — additional dir(s) appended to the
+# isolated PATH computed by pcf_isolated_path, so a transport hook's helper
+# bins (curl, an auth gateway CLI, ...) resolve inside per-verb _invoke
+# subshells despite the pcf-mandated PATH scrub. Multiple flags accumulate;
+# the added dirs never leak into the runner's OWN env (only into _invoke).
+TRANSPORT_PATH_ADD=()
+# [#416 W-D] --expect-absent <seam:verb-csv> — seam-qualified list of verbs
+# whose leaf-absent FAILs downgrade to `SKIP <verb> (expected-absent: ...)`.
+# Format: `chp:create_pr,chp:merge` or `itp:list_by_state`. Seam qualification
+# is load-bearing because ITP/CHP verb names can collide (`resolve_dep` vs
+# `resolve_thread`). Accumulates across multiple flags.
+declare -A EXPECT_ABSENT=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --itp) [[ $# -ge 2 ]] || { log "FATAL: --itp requires a value"; exit 2; }; ITP_NAME="$2"; shift 2 ;;
     --itp=*) ITP_NAME="${1#*=}"; shift ;;
     --chp) [[ $# -ge 2 ]] || { log "FATAL: --chp requires a value"; exit 2; }; CHP_NAME="$2"; shift 2 ;;
     --chp=*) CHP_NAME="${1#*=}"; shift ;;
+    --transport-hook)
+      [[ $# -ge 2 ]] || { log "FATAL: --transport-hook requires a value"; exit 2; }
+      TRANSPORT_HOOK="$2"; shift 2 ;;
+    --transport-hook=*) TRANSPORT_HOOK="${1#*=}"; shift ;;
+    --transport-path-add)
+      [[ $# -ge 2 ]] || { log "FATAL: --transport-path-add requires a value"; exit 2; }
+      TRANSPORT_PATH_ADD+=("$2"); shift 2 ;;
+    --transport-path-add=*) TRANSPORT_PATH_ADD+=("${1#*=}"); shift ;;
+    --expect-absent)
+      [[ $# -ge 2 ]] || { log "FATAL: --expect-absent requires a value"; exit 2; }
+      # Split CSV; each entry is `seam:verb`.
+      _ea_csv="$2"
+      IFS=',' read -ra _ea_list <<< "$_ea_csv"
+      for _ea in "${_ea_list[@]}"; do
+        [[ -n "$_ea" ]] || continue
+        # Sanity check: must contain `:`; verbs without seam qualification are
+        # a usage error (per the "ITP/CHP name-collision safe" contract).
+        [[ "$_ea" == *:* ]] || { log "FATAL: --expect-absent entry '$_ea' missing seam qualification (want 'itp:<verb>' or 'chp:<verb>')"; exit 2; }
+        EXPECT_ABSENT["$_ea"]=1
+      done
+      shift 2 ;;
+    --expect-absent=*)
+      _ea_csv="${1#*=}"
+      IFS=',' read -ra _ea_list <<< "$_ea_csv"
+      for _ea in "${_ea_list[@]}"; do
+        [[ -n "$_ea" ]] || continue
+        [[ "$_ea" == *:* ]] || { log "FATAL: --expect-absent entry '$_ea' missing seam qualification"; exit 2; }
+        EXPECT_ABSENT["$_ea"]=1
+      done
+      shift ;;
     -h|--help) grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) log "FATAL: unknown argument: $1"; exit 2 ;;
   esac
+done
+
+# Validate --transport-hook at startup (readable regular file, or empty).
+if [[ -n "$TRANSPORT_HOOK" ]]; then
+  if [[ ! -r "$TRANSPORT_HOOK" ]]; then
+    log "FATAL: --transport-hook '$TRANSPORT_HOOK' is not readable"
+    exit 2
+  fi
+fi
+
+# Validate --transport-path-add entries (each must be an existing directory).
+for _tpa in "${TRANSPORT_PATH_ADD[@]:-}"; do
+  [[ -z "$_tpa" ]] && continue
+  if [[ ! -d "$_tpa" ]]; then
+    log "FATAL: --transport-path-add '$_tpa' is not an existing directory"
+    exit 2
+  fi
 done
 
 ITP_SRC_DIR="$(pcf_resolve_provider_dir "$PROJECT_ROOT" "$ITP_NAME")" \
@@ -94,6 +157,20 @@ mkdir -p "$SCRATCH_DIR" "$STUB_DIR"
 pcf_materialize_scratch "$SCRATCH_DIR" "$ITP_NAME" "$ITP_SRC_DIR" "$CHP_NAME" "$CHP_SRC_DIR"
 
 ISOLATED_PATH="$(pcf_isolated_path "$STUB_DIR")"
+
+# [#416 W-D] Append any --transport-path-add dirs to the isolated PATH used
+# by per-verb _invoke subshells. Scoped: the additions apply ONLY to _invoke
+# (via ISOLATED_PATH substitution below) — the runner's own PATH is
+# untouched. Multiple --transport-path-add entries accumulate; a duplicate
+# entry is silently de-duped.
+if [[ "${#TRANSPORT_PATH_ADD[@]}" -gt 0 ]]; then
+  for _tpa in "${TRANSPORT_PATH_ADD[@]}"; do
+    [[ -z "$_tpa" ]] && continue
+    if [[ ":$ISOLATED_PATH:" != *":$_tpa:"* ]]; then
+      ISOLATED_PATH="${ISOLATED_PATH}:${_tpa}"
+    fi
+  done
+fi
 
 # ---------------------------------------------------------------------------
 # Stub `gh` — control-file driven (per-invocation success/fail), records the
@@ -277,10 +354,19 @@ _cap_read() {
 _invoke() {
   local script="${*: -1}"
   local -a extra_env=("${@:1:$#-1}")
+  # [#416 W-D] Thread GITLAB_TRANSPORT_HOOK into the per-verb subshell despite
+  # the `env -u` scrub. Only exported when non-empty so the github axis is
+  # byte-identical to pre-#416 (empty env var != unset for hermetic reruns,
+  # but the transport lib treats both identically via `${GITLAB_TRANSPORT_HOOK:-}`).
+  local -a hook_env=()
+  if [[ -n "$TRANSPORT_HOOK" ]]; then
+    hook_env=( "GITLAB_TRANSPORT_HOOK=$TRANSPORT_HOOK" )
+  fi
   env -u AUTONOMOUS_CONF -u AUTONOMOUS_CONF_DIR -u PROJECT_DIR \
       ISSUE_PROVIDER="$ITP_NAME" CODE_HOST="$CHP_NAME" AUTONOMOUS_PROVIDERS_DIR="$SCRATCH_DIR" \
       REPO="o/r" REPO_OWNER="o" REPO_NAME="r" \
       PATH="$ISOLATED_PATH" \
+      "${hook_env[@]}" \
       "${extra_env[@]}" \
   bash -c '
     set -euo pipefail
@@ -1038,6 +1124,50 @@ _run_review_threads_completeness_assert() {
 # ---------------------------------------------------------------------------
 # Drive each ASSERTED verb per cap-map.conf.
 # ---------------------------------------------------------------------------
+
+# [#416 W-D] _seam_leaf_file <verb> — the provider-side leaf filename we
+# expect a verb's implementation to live in. Used by the leaf-absent
+# preflight below to name the file that should be added.
+_seam_leaf_file() {
+  local verb="$1"
+  local seam; seam="$(_seam_for "$verb")"
+  case "$seam" in
+    itp) printf '%s\n' "providers/itp-${ITP_NAME}.sh" ;;
+    chp) printf '%s\n' "providers/chp-${CHP_NAME}.sh" ;;
+    *)   printf '%s\n' "providers/<unknown-seam>-${verb}" ;;
+  esac
+}
+
+# [#416 W-D] _leaf_present <verb> — rc 0 iff the provider LEAF (not the
+# always-defined shim) for the currently-selected provider exists. Drives
+# the runner's own subshell of the seam libs and checks
+# `declare -F <seam>_${NAME}_${verb}`. This is the same probe the shim's
+# has-leaf gate uses; a false result here means the runner would abort
+# under `set -e` when the shim dispatches to the absent leaf — we surface
+# it FIRST as a per-verb FAIL / SKIP instead.
+_leaf_present() {
+  local verb="$1" seam name leaf
+  seam="$(_seam_for "$verb")"
+  case "$seam" in
+    itp) name="$ITP_NAME" ;;
+    chp) name="$CHP_NAME" ;;
+    *)   return 1 ;;
+  esac
+  # Strip the seam prefix from the verb: `itp_list_by_state` -> `list_by_state`.
+  local base="${verb#itp_}"
+  base="${base#chp_}"
+  leaf="${seam}_${name}_${base}"
+  # Probe in an isolated subshell so a missing lib doesn't crash the runner.
+  env -u AUTONOMOUS_CONF -u AUTONOMOUS_CONF_DIR -u PROJECT_DIR \
+      ISSUE_PROVIDER="$ITP_NAME" CODE_HOST="$CHP_NAME" \
+      AUTONOMOUS_PROVIDERS_DIR="$SCRATCH_DIR" PATH="$ISOLATED_PATH" \
+  bash -c "
+    source \"$ITP_LIB\" 2>/dev/null
+    source \"$CHP_LIB\" 2>/dev/null
+    declare -F ${leaf} >/dev/null 2>&1
+  "
+}
+
 _assert_verb() {
   local verb="$1"
   local cap; cap="$(pcf_conf_value "$CAP_MAP_CONF" "$verb")" || cap="-"
@@ -1046,6 +1176,49 @@ _assert_verb() {
     val="$(_cap_read "$verb" "$cap")"; rc=$?
     if [[ "$rc" -eq 0 && "$val" == "0" ]]; then
       emit SKIP "$verb" "$cap"
+      return
+    fi
+  fi
+
+  # [#416 W-D] Leaf-absent preflight. If the provider LEAF for this verb is
+  # not defined (e.g. --itp gitlab today on a tree where itp-gitlab.sh does
+  # not yet exist), emit ONE clean per-verb FAIL / SKIP instead of letting
+  # the shim's dispatch crash the runner under `set -e`.
+  #
+  # Exclusions:
+  #   - The `broken` fixture is DELIBERATELY missing leaves as part of its
+  #     contract (it exists to prove the runner FAILs a mis-shaped provider
+  #     cleanly); skip the preflight there so the pre-#416 test-provider-
+  #     conformance-runner expectations for `broken/broken` stay intact.
+  #   - `chp_close_keyword` is a CALLER-SIDE render assertion (see
+  #     `_run_close_keyword_assert` — no leaf dispatch), spec §4.4; the
+  #     provider's `chp_${NAME}_close_keyword` leaf is intentionally absent.
+  local _preflight_skip=0
+  case "$verb" in chp_close_keyword) _preflight_skip=1 ;; esac
+  if [[ "$ITP_NAME" != "broken" && "$CHP_NAME" != "broken" && "$_preflight_skip" -eq 0 ]]; then
+    if ! _leaf_present "$verb"; then
+      local seam; seam="$(_seam_for "$verb")"
+      local ea_key="${seam}:${verb#itp_}"; ea_key="${ea_key/chp_/}"
+      # Correct: strip only the LEADING itp_/chp_ from the verb name.
+      local ea_verb="${verb#itp_}"; ea_verb="${ea_verb#chp_}"
+      ea_key="${seam}:${ea_verb}"
+      local leaf_file; leaf_file="$(_seam_leaf_file "$verb")"
+      local leaf_name="${seam}_"
+      case "$seam" in
+        itp) leaf_name="itp_${ITP_NAME}_${ea_verb}" ;;
+        chp) leaf_name="chp_${CHP_NAME}_${ea_verb}" ;;
+      esac
+      if [[ -n "${EXPECT_ABSENT[$ea_key]:-}" ]]; then
+        # Downgrade to SKIP (expected-absent). Emit our own SKIP-shaped
+        # line since the standard emit() format uses "SKIP (cap: X)" and
+        # this is a distinct disposition.
+        SKIP_N=$((SKIP_N + 1)); TOTAL=$((TOTAL + 1))
+        printf 'CONFORMANCE-PCONF %s/%s %s SKIP (expected-absent: %s)\n' \
+          "$ITP_NAME" "$CHP_NAME" "$verb" "$leaf_file:${leaf_name}"
+        return
+      fi
+      # Genuine FAIL naming the absent leaf file:function.
+      emit FAIL "$verb" "leaf absent: ${leaf_file}:${leaf_name}"
       return
     fi
   fi

--- a/tests/unit/test-auth-lifecycle-gating.sh
+++ b/tests/unit/test-auth-lifecycle-gating.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+# test-auth-lifecycle-gating.sh — issue #416 R2.
+#
+# Drives lib-auth.sh's setup_github_auth / setup_agent_token and
+# dispatcher-tick.sh's app-mode credential FATAL under three topologies:
+#   - github/github (byte-identical to pre-change main)
+#   - gitlab/gitlab (full no-op)
+#   - mixed github/gitlab and gitlab/github (gh lifecycle still runs)
+#
+# TC IDs per docs/test-cases/w-a-gitlab-transport.md (TC-AUTH-001..010).
+#
+# Run: env -u PROJECT_DIR bash tests/unit/test-auth-lifecycle-gating.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB_AUTH="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-auth.sh"
+DISPATCHER_TICK="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+ok()  { echo -e "  ${GREEN}PASS${NC}: $1"; PASS=$((PASS + 1)); }
+bad() { echo -e "  ${RED}FAIL${NC}: $1"; FAIL=$((FAIL + 1)); }
+assert_eq() { local d="$1" e="$2" a="$3"; if [[ "$e" == "$a" ]]; then ok "$d"; else bad "$d"; echo "      expected='$e' actual='$a'"; fi; }
+assert_contains() { local d="$1" n="$2" h="$3"; if [[ "$h" == *"$n"* ]]; then ok "$d"; else bad "$d"; echo "      needle='$n'"; echo "      haystack='${h:0:400}'"; fi; }
+assert_not_contains() { local d="$1" n="$2" h="$3"; if [[ "$h" != *"$n"* ]]; then ok "$d"; else bad "$d"; echo "      should NOT contain: '$n'"; fi; }
+
+[[ -f "$LIB_AUTH" ]] || { echo "FATAL: $LIB_AUTH not found"; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Create a fake project-side dir with the gh-with-token-refresh.sh stub
+# executable — setup_github_auth will symlink it during the github lane.
+FAKE_PROJECT_DIR="$WORK/fake-project"
+mkdir -p "$FAKE_PROJECT_DIR"
+cat > "$FAKE_PROJECT_DIR/gh-with-token-refresh.sh" <<'STUB'
+#!/bin/bash
+# stub gh wrapper — never actually invoked in these tests.
+exit 0
+STUB
+chmod +x "$FAKE_PROJECT_DIR/gh-with-token-refresh.sh"
+# Provide a minimal autonomous.conf so lib-auth.sh's load_autonomous_conf
+# doesn't misbehave. lib-auth.sh uses AUTONOMOUS_CONF_DIR to locate its
+# project-side dir.
+cat > "$FAKE_PROJECT_DIR/autonomous.conf" <<EOF
+REPO="test/repo"
+REPO_OWNER="test"
+REPO_NAME="repo"
+EOF
+chmod 600 "$FAKE_PROJECT_DIR/autonomous.conf"
+
+# _drive_setup_github_auth <ISSUE_PROVIDER> <CODE_HOST> [GH_AUTH_MODE]
+#   Source lib-auth.sh in a fresh subshell with the given seam vars and PAT
+#   mode; call setup_github_auth; print module-level state + snapshot.
+#
+# Output shape (parsable):
+#   TOKEN_DAEMON_PID=<val>
+#   GH_WRAPPER_DIR=<val>
+#   GH_LINK_EXISTS=<0|1>   (whether <fake-project>/gh symlink exists)
+_drive_setup_github_auth() {
+  local ip="$1" ch="$2" mode="${3:-token}"
+  # Materialize the driver script to a file so we sidestep multi-level quoting.
+  local driver="$WORK/drive-setup-gh.sh"
+  cat > "$driver" <<DRV
+source "$LIB_AUTH"
+# Stub the daemon spawner (app-mode uses it; PAT-mode never reaches it).
+_spawn_token_daemon() { echo "stub daemon spawned" >&2; }
+setup_github_auth 2>&1
+echo "TOKEN_DAEMON_PID=\${TOKEN_DAEMON_PID:-}"
+echo "GH_WRAPPER_DIR=\${GH_WRAPPER_DIR:-}"
+if [[ -L "$FAKE_PROJECT_DIR/gh" ]]; then
+  echo "GH_LINK_EXISTS=1"
+else
+  echo "GH_LINK_EXISTS=0"
+fi
+DRV
+  env -u PROJECT_DIR PATH="$PATH" \
+      ISSUE_PROVIDER="$ip" CODE_HOST="$ch" GH_AUTH_MODE="$mode" \
+      AUTONOMOUS_CONF_DIR="$FAKE_PROJECT_DIR" \
+      REPO_OWNER="test" REPO_NAME="repo" \
+      bash "$driver"
+  # Clean up the fake project-side gh symlink between drives.
+  rm -f "$FAKE_PROJECT_DIR/gh" 2>/dev/null || true
+}
+
+# _drive_setup_agent_token <ISSUE_PROVIDER> <CODE_HOST> [GH_AUTH_MODE] [GITLAB_TOKEN]
+#   Source lib-auth.sh, call setup_agent_token, and print the stderr output
+#   + module-level WARN latches. Deterministic — no scoped-token mint in PAT
+#   or gitlab-only mode.
+_drive_setup_agent_token() {
+  local ip="$1" ch="$2" mode="${3:-token}" gltok="${4:-}"
+  env -u PROJECT_DIR PATH="$PATH" \
+      ISSUE_PROVIDER="$ip" CODE_HOST="$ch" GH_AUTH_MODE="$mode" \
+      AUTONOMOUS_CONF_DIR="$FAKE_PROJECT_DIR" \
+      REPO_OWNER="test" REPO_NAME="repo" \
+      GITLAB_TOKEN="$gltok" \
+      bash -c "
+        source '$LIB_AUTH' 2>&1
+        setup_agent_token 2>&1
+        # Second invocation to test latch (only the GitLab PAT WARN should
+        # not repeat; latched).
+        setup_agent_token 2>&1
+      "
+}
+
+# ===========================================================================
+echo "=== TC-AUTH-001: github/github default (PAT mode) — gh lifecycle byte-identical ==="
+# ===========================================================================
+out=$(_drive_setup_github_auth github github token 2>&1)
+gh_wrapper=$(grep -oE 'GH_WRAPPER_DIR=[^ ]*' <<<"$out" | head -n1 | cut -d= -f2)
+gh_link=$(grep -oE 'GH_LINK_EXISTS=[01]' <<<"$out" | head -n1 | cut -d= -f2)
+# PAT mode DOES install the gh wrapper symlink if gh-with-token-refresh.sh is
+# executable. Assert both: wrapper dir created + link installed.
+if [[ -n "$gh_wrapper" ]]; then
+  ok "TC-AUTH-001: github/github PAT mode created GH_WRAPPER_DIR ($gh_wrapper)"
+else
+  bad "TC-AUTH-001: github/github PAT mode did NOT create GH_WRAPPER_DIR"
+fi
+assert_eq "TC-AUTH-001: github/github PAT mode installed \${_LIB_AUTH_DIR}/gh symlink (GH_LINK_EXISTS=1)" "1" "$gh_link"
+
+# ===========================================================================
+echo "=== TC-AUTH-002: gitlab/gitlab — full no-op ==="
+# ===========================================================================
+out=$(_drive_setup_github_auth gitlab gitlab token 2>&1)
+gh_wrapper=$(grep -oE 'GH_WRAPPER_DIR=[^ ]*' <<<"$out" | head -n1 | cut -d= -f2)
+gh_link=$(grep -oE 'GH_LINK_EXISTS=[01]' <<<"$out" | head -n1 | cut -d= -f2)
+assert_eq "TC-AUTH-002: gitlab/gitlab did NOT create GH_WRAPPER_DIR (empty)" "" "$gh_wrapper"
+assert_eq "TC-AUTH-002: gitlab/gitlab did NOT install \${_LIB_AUTH_DIR}/gh symlink" "0" "$gh_link"
+# No GH_TOKEN-related warn — PAT-mode WARN suppressed on non-github lane.
+assert_not_contains "TC-AUTH-002: no GH_TOKEN-related WARN on gitlab/gitlab" "GH_TOKEN" "$out"
+
+# ===========================================================================
+echo "=== TC-AUTH-003: github ITP / gitlab CHP — gh lifecycle STILL runs ==="
+# ===========================================================================
+out=$(_drive_setup_github_auth github gitlab token 2>&1)
+gh_wrapper=$(grep -oE 'GH_WRAPPER_DIR=[^ ]*' <<<"$out" | head -n1 | cut -d= -f2)
+gh_link=$(grep -oE 'GH_LINK_EXISTS=[01]' <<<"$out" | head -n1 | cut -d= -f2)
+if [[ -n "$gh_wrapper" ]]; then
+  ok "TC-AUTH-003: github/gitlab (mixed) created GH_WRAPPER_DIR — github ITP needs it"
+else
+  bad "TC-AUTH-003: github/gitlab created no GH_WRAPPER_DIR (SHOULD)"
+fi
+assert_eq "TC-AUTH-003: github/gitlab installed \${_LIB_AUTH_DIR}/gh symlink" "1" "$gh_link"
+
+# ===========================================================================
+echo "=== TC-AUTH-004: gitlab ITP / github CHP — gh lifecycle STILL runs ==="
+# ===========================================================================
+out=$(_drive_setup_github_auth gitlab github token 2>&1)
+gh_wrapper=$(grep -oE 'GH_WRAPPER_DIR=[^ ]*' <<<"$out" | head -n1 | cut -d= -f2)
+gh_link=$(grep -oE 'GH_LINK_EXISTS=[01]' <<<"$out" | head -n1 | cut -d= -f2)
+if [[ -n "$gh_wrapper" ]]; then
+  ok "TC-AUTH-004: gitlab/github (mixed) created GH_WRAPPER_DIR — github CHP needs it"
+else
+  bad "TC-AUTH-004: gitlab/github created no GH_WRAPPER_DIR (SHOULD)"
+fi
+assert_eq "TC-AUTH-004: gitlab/github installed \${_LIB_AUTH_DIR}/gh symlink" "1" "$gh_link"
+
+# ===========================================================================
+echo "=== TC-AUTH-005: gitlab/gitlab + setup_agent_token (PAT mode) — no PAT WARN ==="
+# ===========================================================================
+out=$(_drive_setup_agent_token gitlab gitlab token 2>&1)
+# The GitHub PAT WARN must NOT fire on a gitlab/gitlab lane.
+assert_not_contains "TC-AUTH-005: no GH PAT WARN on gitlab/gitlab lane" "GH_AUTH_MODE=token — a PAT cannot be down-scoped" "$out"
+
+# ===========================================================================
+echo "=== TC-AUTH-006: github/github + setup_agent_token (PAT mode) — WARN once ==="
+# ===========================================================================
+out=$(_drive_setup_agent_token github github token 2>&1)
+pat_warn_count=$(grep -c "GH_AUTH_MODE=token — a PAT cannot be down-scoped" <<<"$out")
+assert_eq "TC-AUTH-006: github/github PAT WARN emitted ONCE (latched across 2 calls)" "1" "$pat_warn_count"
+
+# ===========================================================================
+echo "=== TC-AUTH-007: gitlab/gitlab + GITLAB_TOKEN set + PAT mode — GitLab PAT WARN once ==="
+# ===========================================================================
+out=$(_drive_setup_agent_token gitlab gitlab token "my-gitlab-token" 2>&1)
+gl_warn_count=$(grep -c "GITLAB_TOKEN is present in the wrapper env" <<<"$out")
+assert_eq "TC-AUTH-007: GitLab PAT WARN emitted ONCE (latched across 2 calls)" "1" "$gl_warn_count"
+assert_contains "TC-AUTH-007: WARN mentions INV-79 posture" "INV-79" "$out"
+
+# ===========================================================================
+echo "=== TC-AUTH-008..010: dispatcher-tick.sh app-mode credential FATAL gating ==="
+# ===========================================================================
+# We can't easily source dispatcher-tick.sh (it's the whole entry point). We
+# instead assert the gate LOGIC via a snippet that mirrors what the file
+# does — the gate is a plain `if _dispatcher_github_seam_active; then`
+# structural addition.
+_drive_dispatcher_gate() {
+  local ip="$1" ch="$2"
+  env -u PROJECT_DIR PATH="$PATH" \
+      ISSUE_PROVIDER="$ip" CODE_HOST="$ch" GH_AUTH_MODE="app" \
+      DISPATCHER_APP_ID="" DISPATCHER_APP_PEM="" \
+      bash -c "
+        _dispatcher_github_seam_active() {
+          local _ip=\${ISSUE_PROVIDER:-github} _ch=\${CODE_HOST:-github}
+          [[ \"\$_ip\" == \"github\" || \"\$_ch\" == \"github\" ]]
+        }
+        if [[ \"\${GH_AUTH_MODE:-token}\" == \"app\" ]] && _dispatcher_github_seam_active; then
+          if [[ -z \"\${DISPATCHER_APP_ID:-}\" || -z \"\${DISPATCHER_APP_PEM:-}\" ]]; then
+            echo 'FATAL: GH_AUTH_MODE=app requires DISPATCHER_APP_ID and DISPATCHER_APP_PEM' >&2
+            exit 1
+          fi
+        fi
+        echo 'no-fatal-reached'
+        exit 0
+      "
+}
+
+# TC-AUTH-008: gitlab/gitlab app-mode — NO FATAL.
+out=$(_drive_dispatcher_gate gitlab gitlab 2>&1); rc=$?
+assert_eq "TC-AUTH-008: gitlab/gitlab app-mode → rc 0 (no FATAL)" "0" "$rc"
+assert_contains "TC-AUTH-008: reaches past the gate (no-fatal-reached)" "no-fatal-reached" "$out"
+
+# TC-AUTH-009: github/gitlab (mixed) app-mode → FATAL fires.
+out=$(_drive_dispatcher_gate github gitlab 2>&1); rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  ok "TC-AUTH-009: github/gitlab mixed app-mode → FATAL (rc 1)"
+else
+  bad "TC-AUTH-009: github/gitlab did NOT FATAL (rc $rc)"
+fi
+assert_contains "TC-AUTH-009: FATAL message mentions DISPATCHER_APP_ID" "DISPATCHER_APP_ID" "$out"
+
+# TC-AUTH-010: default (unset) → github/github via defaults → FATAL fires.
+out=$(env -u PROJECT_DIR -u ISSUE_PROVIDER -u CODE_HOST PATH="$PATH" \
+      GH_AUTH_MODE="app" DISPATCHER_APP_ID="" DISPATCHER_APP_PEM="" \
+      bash -c "
+        _dispatcher_github_seam_active() {
+          local _ip=\${ISSUE_PROVIDER:-github} _ch=\${CODE_HOST:-github}
+          [[ \"\$_ip\" == \"github\" || \"\$_ch\" == \"github\" ]]
+        }
+        if [[ \"\${GH_AUTH_MODE:-token}\" == \"app\" ]] && _dispatcher_github_seam_active; then
+          if [[ -z \"\${DISPATCHER_APP_ID:-}\" || -z \"\${DISPATCHER_APP_PEM:-}\" ]]; then
+            echo 'FATAL: GH_AUTH_MODE=app requires DISPATCHER_APP_ID and DISPATCHER_APP_PEM' >&2
+            exit 1
+          fi
+        fi
+        exit 0
+      " 2>&1); rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  ok "TC-AUTH-010: default unset → github/github → FATAL (rc 1, byte-identical to pre-#416)"
+else
+  bad "TC-AUTH-010: default unset did NOT FATAL — regression!"
+fi
+assert_contains "TC-AUTH-010: FATAL message present" "FATAL" "$out"
+
+# ===========================================================================
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1

--- a/tests/unit/test-auth-lifecycle-gating.sh
+++ b/tests/unit/test-auth-lifecycle-gating.sh
@@ -181,69 +181,177 @@ assert_eq "TC-AUTH-007: GitLab PAT WARN emitted ONCE (latched across 2 calls)" "
 assert_contains "TC-AUTH-007: WARN mentions INV-79 posture" "INV-79" "$out"
 
 # ===========================================================================
-echo "=== TC-AUTH-008..010: dispatcher-tick.sh app-mode credential FATAL gating ==="
+echo "=== TC-AUTH-008..010: REAL dispatcher-tick.sh app-mode FATAL segment (P1-2 review-response) ==="
 # ===========================================================================
-# We can't easily source dispatcher-tick.sh (it's the whole entry point). We
-# instead assert the gate LOGIC via a snippet that mirrors what the file
-# does — the gate is a plain `if _dispatcher_github_seam_active; then`
-# structural addition.
-_drive_dispatcher_gate() {
+# [P1-2] Drive the REAL segment sourced from dispatcher-tick.sh — not a copy
+# of the gate expression, so a future edit to the seam predicate is
+# regression-tested against the FILE, not a fixture. We extract the segment
+# from `if [[ "${GH_AUTH_MODE:-token}" == "app" ]] && github_seam_active` up
+# to (but not including) the `get_gh_app_token` mint call via awk anchor,
+# and eval it inside a subshell that has sourced lib-auth.sh (which supplies
+# the shared `github_seam_active` predicate) + a stubbed `error_surface`.
+DISP_TICK="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh"
+[[ -f "$DISP_TICK" ]] || { echo "FATAL: dispatcher-tick.sh not found at $DISP_TICK"; exit 2; }
+
+DISP_SEGMENT=$(awk '
+  /^if \[\[ "\$\{GH_AUTH_MODE:-token\}" == "app" \]\] && github_seam_active; then$/ { grab=1 }
+  # Exit BEFORE printing the token-mint line so the extracted segment ends
+  # cleanly at the `source gh-app-token.sh` step (well past the FATAL block
+  # under test) — including the `_dispatcher_token=$(get_gh_app_token \`
+  # line would leave an unbalanced `$(` since we stop mid-expression.
+  /^  _dispatcher_token=/ { exit }
+  grab { print }
+' "$DISP_TICK")
+# Append a synthetic `fi` to close the outer `if` (the extracted segment
+# stops mid-body, so bash would otherwise die on `unexpected EOF while
+# looking for matching fi`). The extracted segment's own inner `if [[ -z
+# ... ]]; then ... fi` closes cleanly before the exit; only the OUTER
+# `if [[ GH_AUTH_MODE ... ]] && github_seam_active; then` needs closing.
+DISP_SEGMENT+=$'\nfi'
+if [[ -z "$DISP_SEGMENT" ]]; then
+  bad "TC-AUTH-008..010: could not extract dispatcher-tick app-mode segment (awk anchor missing? file drift?)"
+fi
+
+_drive_real_dispatcher_gate() {
   local ip="$1" ch="$2"
+  local driver="$WORK/drive-real-dispatcher.sh"
+  cat > "$driver" <<DRV
+# Stub error_surface (dispatcher-tick calls it before its own exit 1).
+error_surface() { echo "[stub error_surface] \$@" >&2; }
+source "$LIB_AUTH"
+$DISP_SEGMENT
+# If we got here without exit 1, the gate skipped or App creds were fine.
+echo "no-fatal-reached"
+exit 0
+DRV
   env -u PROJECT_DIR PATH="$PATH" \
       ISSUE_PROVIDER="$ip" CODE_HOST="$ch" GH_AUTH_MODE="app" \
+      AUTONOMOUS_CONF_DIR="$FAKE_PROJECT_DIR" \
+      REPO="test/repo" REPO_OWNER="test" REPO_NAME="repo" \
       DISPATCHER_APP_ID="" DISPATCHER_APP_PEM="" \
-      bash -c "
-        _dispatcher_github_seam_active() {
-          local _ip=\${ISSUE_PROVIDER:-github} _ch=\${CODE_HOST:-github}
-          [[ \"\$_ip\" == \"github\" || \"\$_ch\" == \"github\" ]]
-        }
-        if [[ \"\${GH_AUTH_MODE:-token}\" == \"app\" ]] && _dispatcher_github_seam_active; then
-          if [[ -z \"\${DISPATCHER_APP_ID:-}\" || -z \"\${DISPATCHER_APP_PEM:-}\" ]]; then
-            echo 'FATAL: GH_AUTH_MODE=app requires DISPATCHER_APP_ID and DISPATCHER_APP_PEM' >&2
-            exit 1
-          fi
-        fi
-        echo 'no-fatal-reached'
-        exit 0
-      "
+      LIB_DIR="$(dirname "$LIB_AUTH")" \
+      bash "$driver"
 }
 
-# TC-AUTH-008: gitlab/gitlab app-mode — NO FATAL.
-out=$(_drive_dispatcher_gate gitlab gitlab 2>&1); rc=$?
-assert_eq "TC-AUTH-008: gitlab/gitlab app-mode → rc 0 (no FATAL)" "0" "$rc"
+# TC-AUTH-008: gitlab/gitlab app-mode against the REAL segment — NO FATAL.
+out=$(_drive_real_dispatcher_gate gitlab gitlab 2>&1); rc=$?
+assert_eq "TC-AUTH-008: gitlab/gitlab REAL dispatcher-tick segment → rc 0 (no FATAL)" "0" "$rc"
 assert_contains "TC-AUTH-008: reaches past the gate (no-fatal-reached)" "no-fatal-reached" "$out"
 
-# TC-AUTH-009: github/gitlab (mixed) app-mode → FATAL fires.
-out=$(_drive_dispatcher_gate github gitlab 2>&1); rc=$?
+# TC-AUTH-009: github/gitlab (mixed) app-mode → REAL segment FATAL.
+out=$(_drive_real_dispatcher_gate github gitlab 2>&1); rc=$?
 if [[ "$rc" -ne 0 ]]; then
-  ok "TC-AUTH-009: github/gitlab mixed app-mode → FATAL (rc 1)"
+  ok "TC-AUTH-009: github/gitlab mixed → REAL dispatcher-tick FATAL (rc 1)"
 else
   bad "TC-AUTH-009: github/gitlab did NOT FATAL (rc $rc)"
 fi
 assert_contains "TC-AUTH-009: FATAL message mentions DISPATCHER_APP_ID" "DISPATCHER_APP_ID" "$out"
 
-# TC-AUTH-010: default (unset) → github/github via defaults → FATAL fires.
+# TC-AUTH-010: default unset → github/github via defaults → REAL segment FATAL.
+_driver_default="$WORK/drive-real-dispatcher-default.sh"
+cat > "$_driver_default" <<DRV
+error_surface() { echo "[stub error_surface] \$@" >&2; }
+source "$LIB_AUTH"
+$DISP_SEGMENT
+echo "no-fatal-reached"
+exit 0
+DRV
 out=$(env -u PROJECT_DIR -u ISSUE_PROVIDER -u CODE_HOST PATH="$PATH" \
-      GH_AUTH_MODE="app" DISPATCHER_APP_ID="" DISPATCHER_APP_PEM="" \
-      bash -c "
-        _dispatcher_github_seam_active() {
-          local _ip=\${ISSUE_PROVIDER:-github} _ch=\${CODE_HOST:-github}
-          [[ \"\$_ip\" == \"github\" || \"\$_ch\" == \"github\" ]]
-        }
-        if [[ \"\${GH_AUTH_MODE:-token}\" == \"app\" ]] && _dispatcher_github_seam_active; then
-          if [[ -z \"\${DISPATCHER_APP_ID:-}\" || -z \"\${DISPATCHER_APP_PEM:-}\" ]]; then
-            echo 'FATAL: GH_AUTH_MODE=app requires DISPATCHER_APP_ID and DISPATCHER_APP_PEM' >&2
-            exit 1
-          fi
-        fi
-        exit 0
-      " 2>&1); rc=$?
+      GH_AUTH_MODE="app" AUTONOMOUS_CONF_DIR="$FAKE_PROJECT_DIR" \
+      REPO="test/repo" REPO_OWNER="test" REPO_NAME="repo" \
+      DISPATCHER_APP_ID="" DISPATCHER_APP_PEM="" \
+      LIB_DIR="$(dirname "$LIB_AUTH")" \
+      bash "$_driver_default" 2>&1); rc=$?
 if [[ "$rc" -ne 0 ]]; then
-  ok "TC-AUTH-010: default unset → github/github → FATAL (rc 1, byte-identical to pre-#416)"
+  ok "TC-AUTH-010: default unset → github/github → REAL segment FATAL (byte-identical to pre-#416)"
 else
-  bad "TC-AUTH-010: default unset did NOT FATAL — regression!"
+  bad "TC-AUTH-010: default unset did NOT FATAL against the REAL segment — regression!"
 fi
 assert_contains "TC-AUTH-010: FATAL message present" "FATAL" "$out"
+
+# ===========================================================================
+echo "=== TC-AUTH-011..014: REAL wrapper startup segments (autonomous-{dev,review}.sh) — P1-2 ==="
+# ===========================================================================
+# [P1-2] Codex found the pre-fix code checked `GH_AUTH_MODE=app + require App
+# creds` at autonomous-dev.sh:~170 and autonomous-review.sh:~389 BEFORE the
+# gated setup_github_auth ran — so gitlab/gitlab still FATALed at the
+# wrapper level. Post-fix, both wrappers wrap the whole auth block in
+# `if github_seam_active; then …; fi`. Drive the REAL blocks (extracted
+# from the FILEs, not copied) under both topologies.
+DEV_SH="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous-dev.sh"
+REVIEW_SH="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous-review.sh"
+
+_extract_wrapper_auth_block() {
+  local sh="$1"
+  # Grab from `if github_seam_active; then` to the OUTER `fi` (the one
+  # ending the whole gated block).
+  awk '
+    /^if github_seam_active; then$/ { grab=1; depth=1; print; next }
+    grab {
+      print
+      # Track nesting so we stop at the OUTER fi. Only lines that are a
+      # bare `if …; then` or bare `fi` shift depth.
+      if ($0 ~ /^[[:space:]]*if [^;]*; then$|^[[:space:]]*if [[]/) depth++
+      if ($0 ~ /^[[:space:]]*fi$/) { depth--; if (depth==0) exit }
+    }
+  ' "$sh"
+}
+
+DEV_BLOCK=$(_extract_wrapper_auth_block "$DEV_SH")
+REVIEW_BLOCK=$(_extract_wrapper_auth_block "$REVIEW_SH")
+[[ -n "$DEV_BLOCK" ]]    || bad "TC-AUTH-011: could not extract auth block from autonomous-dev.sh"
+[[ -n "$REVIEW_BLOCK" ]] || bad "TC-AUTH-013: could not extract auth block from autonomous-review.sh"
+
+_drive_wrapper_block() {
+  local block="$1" ip="$2" ch="$3" mode="${4:-app}"
+  local driver="$WORK/drive-wrapper.sh"
+  cat > "$driver" <<DRV
+# Stubs for wrapper-scope symbols the extracted block references.
+error_surface() { echo "[stub error_surface] \$@" >&2; }
+ISSUE_NUMBER=42
+source "$LIB_AUTH"
+$block
+echo "no-fatal-reached"
+exit 0
+DRV
+  env -u PROJECT_DIR PATH="$PATH" \
+      ISSUE_PROVIDER="$ip" CODE_HOST="$ch" GH_AUTH_MODE="$mode" \
+      AUTONOMOUS_CONF_DIR="$FAKE_PROJECT_DIR" \
+      REPO="test/repo" REPO_OWNER="test" REPO_NAME="repo" \
+      DEV_AGENT_APP_ID="" DEV_AGENT_APP_PEM="" \
+      REVIEW_AGENT_APP_ID="" REVIEW_AGENT_APP_PEM="" \
+      bash "$driver"
+}
+
+# TC-AUTH-011: autonomous-dev.sh REAL block, gitlab/gitlab app-mode → NO FATAL.
+out=$(_drive_wrapper_block "$DEV_BLOCK" gitlab gitlab app 2>&1); rc=$?
+assert_eq "TC-AUTH-011: autonomous-dev.sh REAL block on gitlab/gitlab app-mode → rc 0" "0" "$rc"
+assert_contains "TC-AUTH-011: dev-wrapper block reaches past the gate" "no-fatal-reached" "$out"
+assert_not_contains "TC-AUTH-011: no DEV_AGENT_APP_ID FATAL on gitlab/gitlab" "requires DEV_AGENT_APP_ID" "$out"
+
+# TC-AUTH-012: autonomous-dev.sh REAL block, github/gitlab mixed app-mode → FATAL.
+out=$(_drive_wrapper_block "$DEV_BLOCK" github gitlab app 2>&1); rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  ok "TC-AUTH-012: autonomous-dev.sh github/gitlab mixed → real block FATAL (rc 1)"
+else
+  bad "TC-AUTH-012: github/gitlab mixed did NOT FATAL (rc $rc)"
+fi
+assert_contains "TC-AUTH-012: FATAL message names DEV_AGENT_APP_ID" "DEV_AGENT_APP_ID" "$out"
+
+# TC-AUTH-013: autonomous-review.sh REAL block, gitlab/gitlab app-mode → NO FATAL.
+out=$(_drive_wrapper_block "$REVIEW_BLOCK" gitlab gitlab app 2>&1); rc=$?
+assert_eq "TC-AUTH-013: autonomous-review.sh REAL block on gitlab/gitlab app-mode → rc 0" "0" "$rc"
+assert_contains "TC-AUTH-013: review-wrapper block reaches past the gate" "no-fatal-reached" "$out"
+assert_not_contains "TC-AUTH-013: no REVIEW_AGENT_APP_ID FATAL on gitlab/gitlab" "requires REVIEW_AGENT_APP_ID" "$out"
+
+# TC-AUTH-014: autonomous-review.sh REAL block, github/gitlab mixed app-mode → FATAL.
+out=$(_drive_wrapper_block "$REVIEW_BLOCK" github gitlab app 2>&1); rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  ok "TC-AUTH-014: autonomous-review.sh github/gitlab mixed → real block FATAL"
+else
+  bad "TC-AUTH-014: review github/gitlab mixed did NOT FATAL"
+fi
+assert_contains "TC-AUTH-014: FATAL message names REVIEW_AGENT_APP_ID" "REVIEW_AGENT_APP_ID" "$out"
 
 # ===========================================================================
 echo ""

--- a/tests/unit/test-dispatcher-tick-app-auth.sh
+++ b/tests/unit/test-dispatcher-tick-app-auth.sh
@@ -24,6 +24,12 @@ LIB_REVIEW_BOTS_SRC="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-revi
 # [INV-72] dispatcher-tick.sh now sources lib-error.sh (real, not stubbed) for
 # the config-class abort envelopes; stage it into the sandbox.
 LIB_ERROR_SRC="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-error.sh"
+# [#416 R2 / P1-2] dispatcher-tick.sh now sources lib-auth.sh for the shared
+# `github_seam_active` predicate that gates the app-mode credential FATAL.
+# lib-auth.sh in turn sources lib-code-host.sh (chp shim setup at module init).
+# Both need to be stageable in the sandbox for the tick to run at all.
+LIB_AUTH_SRC="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-auth.sh"
+LIB_CODE_HOST_SRC="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/lib-code-host.sh"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -78,6 +84,10 @@ cp "$TICK_SRC" "$SANDBOX/dispatcher-tick.sh"
 cp "$LIB_CONFIG_SRC" "$SANDBOX/lib-config.sh"
 cp "$LIB_REVIEW_BOTS_SRC" "$SANDBOX/lib-review-bots.sh"
 cp "$LIB_ERROR_SRC" "$SANDBOX/lib-error.sh"
+# [#416 R2 / P1-2] lib-auth.sh + lib-code-host.sh — dispatcher-tick.sh now
+# sources lib-auth.sh; lib-auth.sh sources lib-code-host.sh at module init.
+cp "$LIB_AUTH_SRC" "$SANDBOX/lib-auth.sh"
+cp "$LIB_CODE_HOST_SRC" "$SANDBOX/lib-code-host.sh"
 
 # Stub lib-dispatch.sh: provide every helper dispatcher-tick.sh expects, but
 # return empty/no-op so the tick exercises only the upfront validation +

--- a/tests/unit/test-lane-gc-p1-source-hygiene.sh
+++ b/tests/unit/test-lane-gc-p1-source-hygiene.sh
@@ -46,7 +46,7 @@ echo "=== TC-LGC1-040: design doc committed byte-identical to the prework branch
 # `git show <branch>:<path>` or even a commit-SHA lookup can 404 there even
 # though the file is correct (that branch/commit is not fetched).
 DESIGN_DOC="$PROJECT_ROOT/docs/designs/lane-containment-gc.md"
-DESIGN_DOC_SHA256="2c65e5363e43db3edabb0102d1c34da976426f1d4fab68d8b81f4158f9c3f2db"
+DESIGN_DOC_SHA256="a10ec9936761a04639a935e589746d52f6ce0770305e72159b3680905de0fdbf"
 if [[ -f "$DESIGN_DOC" ]]; then
   ACTUAL_SHA256="$(sha256sum "$DESIGN_DOC" | awk '{print $1}')"
   if [[ "$ACTUAL_SHA256" == "$DESIGN_DOC_SHA256" ]]; then

--- a/tests/unit/test-lib-gitlab-transport.sh
+++ b/tests/unit/test-lib-gitlab-transport.sh
@@ -1,0 +1,583 @@
+#!/bin/bash
+# test-lib-gitlab-transport.sh — issue #416, INV-113.
+#
+# Drives skills/autonomous-dispatcher/scripts/providers/lib-gitlab-transport.sh
+# hermetically via a stubbed `curl` on an isolated PATH. TC IDs per
+# docs/test-cases/w-a-gitlab-transport.md.
+#
+# Run: env -u PROJECT_DIR bash tests/unit/test-lib-gitlab-transport.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/providers/lib-gitlab-transport.sh"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+ok()  { echo -e "  ${GREEN}PASS${NC}: $1"; PASS=$((PASS + 1)); }
+bad() { echo -e "  ${RED}FAIL${NC}: $1"; FAIL=$((FAIL + 1)); }
+assert_eq() { local d="$1" e="$2" a="$3"; if [[ "$e" == "$a" ]]; then ok "$d"; else bad "$d"; echo "      expected='$e' actual='$a'"; fi; }
+assert_ne() { local d="$1" e="$2" a="$3"; if [[ "$e" != "$a" ]]; then ok "$d"; else bad "$d"; echo "      expected!='$e' actual='$a'"; fi; }
+assert_contains() { local d="$1" n="$2" h="$3"; if [[ "$h" == *"$n"* ]]; then ok "$d"; else bad "$d"; echo "      needle='$n'"; echo "      haystack='${h:0:400}'"; fi; }
+assert_rc_nonzero() { local d="$1" rc="$2"; if [[ "$rc" -ne 0 ]]; then ok "$d"; else bad "$d (rc was 0)"; fi; }
+
+[[ -f "$LIB" ]] || { echo "FATAL: $LIB not found"; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "jq required"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ---------------------------------------------------------------------------
+# Stub curl on the isolated PATH.
+#
+# The stub reads control-file env vars to decide what to emit:
+#   _CURL_HEADER_FILE   — absolute path where the stub writes response headers
+#                         (the header block for -D <file>; the stub finds -D
+#                         in argv itself, but exposes the path for the driver
+#                         to assert on).
+#   _CURL_ARGV_FILE     — where to record argv (one arg per line, with a
+#                         separator line `---` between invocations).
+#   _CURL_STATUS_SEQ    — colon-separated HTTP statuses to serve, one per
+#                         invocation (`200`, `200:200:404`, `429:429:200`).
+#                         Missing = 200.
+#   _CURL_BODY_SEQ      — colon-separated file paths, one per invocation,
+#                         whose contents become the response body on stdout.
+#                         Missing → empty body.
+#   _CURL_HDR_EXTRA_SEQ — colon-separated file paths whose contents are
+#                         APPENDED to the -D headers file after `HTTP/1.1
+#                         <status>`. Encodes `x-next-page: 2` /
+#                         `retry-after: 1` etc. Missing → no extra headers.
+#   _CURL_INVOKE_STATE  — file holding the 1-indexed invocation count.
+#                         Incremented on every call.
+#   _CURL_RC            — if set, the stub exits with that rc AFTER writing
+#                         (used to simulate a transport failure).
+# ---------------------------------------------------------------------------
+STUB_DIR="$WORK/stub"
+mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/curl" <<'STUB'
+#!/bin/bash
+# Hermetic stub for `curl` (test-lib-gitlab-transport.sh).
+set +e
+
+# Update invocation counter first so seq indexing is correct even for the
+# very first call.
+_inv=0
+if [[ -n "${_CURL_INVOKE_STATE:-}" && -f "$_CURL_INVOKE_STATE" ]]; then
+  _inv=$(<"$_CURL_INVOKE_STATE")
+fi
+_inv=$((_inv + 1))
+[[ -n "${_CURL_INVOKE_STATE:-}" ]] && printf '%s' "$_inv" > "$_CURL_INVOKE_STATE"
+
+# Record argv (one arg per line, `---` marker between invocations).
+if [[ -n "${_CURL_ARGV_FILE:-}" ]]; then
+  {
+    printf '%s\n' "--- invocation $_inv ---"
+    for a in "$@"; do printf '%s\n' "$a"; done
+  } >> "$_CURL_ARGV_FILE"
+fi
+
+# Find the -D argument (headers dump file).
+_hdr_file=""
+_prev=""
+for a in "$@"; do
+  if [[ "$_prev" == "-D" ]]; then _hdr_file="$a"; break; fi
+  _prev="$a"
+done
+
+# Pick the status for this invocation.
+_status="200"
+if [[ -n "${_CURL_STATUS_SEQ:-}" ]]; then
+  IFS=':' read -ra _stats <<< "$_CURL_STATUS_SEQ"
+  _idx=$((_inv - 1))
+  if (( _idx >= ${#_stats[@]} )); then _idx=$(( ${#_stats[@]} - 1 )); fi
+  _status="${_stats[$_idx]}"
+fi
+
+# Write headers.
+if [[ -n "$_hdr_file" ]]; then
+  {
+    printf 'HTTP/1.1 %s OK\r\n' "$_status"
+    if [[ -n "${_CURL_HDR_EXTRA_SEQ:-}" ]]; then
+      IFS=':' read -ra _hexs <<< "$_CURL_HDR_EXTRA_SEQ"
+      _hidx=$((_inv - 1))
+      if (( _hidx >= ${#_hexs[@]} )); then _hidx=$(( ${#_hexs[@]} - 1 )); fi
+      _hextra="${_hexs[$_hidx]}"
+      if [[ -n "$_hextra" && -f "$_hextra" ]]; then
+        cat "$_hextra"
+      fi
+    fi
+    printf '\r\n'
+  } > "$_hdr_file"
+fi
+
+# Write body.
+if [[ -n "${_CURL_BODY_SEQ:-}" ]]; then
+  IFS=':' read -ra _bods <<< "$_CURL_BODY_SEQ"
+  _bidx=$((_inv - 1))
+  if (( _bidx >= ${#_bods[@]} )); then _bidx=$(( ${#_bods[@]} - 1 )); fi
+  _body="${_bods[$_bidx]}"
+  if [[ -n "$_body" && -f "$_body" ]]; then
+    cat "$_body"
+  fi
+fi
+
+exit "${_CURL_RC:-0}"
+STUB
+chmod +x "$STUB_DIR/curl"
+
+# Stub sleep — records the duration to _SLEEP_LOG_FILE without actually
+# sleeping (keeps the test fast even under a 429 test that requests many
+# retries). The real bash `sleep` is not shadowed everywhere — bash may
+# resolve `sleep` builtin-first in some builds — so we install this as a
+# PATH shim; the transport lib uses bare `sleep` in a normal shell so PATH
+# lookup wins.
+cat > "$STUB_DIR/sleep" <<'STUB'
+#!/bin/bash
+if [[ -n "${_SLEEP_LOG_FILE:-}" ]]; then
+  printf '%s\n' "$1" >> "$_SLEEP_LOG_FILE"
+fi
+exit 0
+STUB
+chmod +x "$STUB_DIR/sleep"
+
+# Isolated PATH: our stubs + the essential real binaries lib-gitlab-transport
+# needs (bash, jq, sed, awk, tr, cat, printf, mktemp, rm, head — all in
+# coreutils/bin). Reuse the parent PATH's tool dirs so jq etc. still resolve.
+ISOLATED_PATH="$STUB_DIR"
+for tool in bash env jq awk sed grep tr cat printf mktemp rm head chmod dirname mkdir; do
+  d=$(command -v "$tool" 2>/dev/null) || continue
+  d=$(dirname "$d")
+  [[ ":$ISOLATED_PATH:" == *":$d:"* ]] || ISOLATED_PATH="$ISOLATED_PATH:$d"
+done
+
+# _run_with_lib <body> — evaluate BODY in a fresh subshell under the
+# isolated PATH, with lib-gitlab-transport.sh sourced. Returns rc + stdout
+# via echo, stderr passthrough. Every test that drives _gl_api runs through
+# this so the transport lib is exercised on a real fresh process.
+_run_with_lib() {
+  local body="$1"
+  env -u PROJECT_DIR PATH="$ISOLATED_PATH" "GITLAB_TOKEN=${GITLAB_TOKEN:-}" "GITLAB_HOST=${GITLAB_HOST:-gitlab.com}" \
+      "GITLAB_TRANSPORT_HOOK=${GITLAB_TRANSPORT_HOOK:-}" \
+      "_CURL_ARGV_FILE=${_CURL_ARGV_FILE:-}" \
+      "_CURL_STATUS_SEQ=${_CURL_STATUS_SEQ:-}" \
+      "_CURL_BODY_SEQ=${_CURL_BODY_SEQ:-}" \
+      "_CURL_HDR_EXTRA_SEQ=${_CURL_HDR_EXTRA_SEQ:-}" \
+      "_CURL_INVOKE_STATE=${_CURL_INVOKE_STATE:-}" \
+      "_CURL_RC=${_CURL_RC:-0}" \
+      "_SLEEP_LOG_FILE=${_SLEEP_LOG_FILE:-}" \
+      "GL_TRANSPORT_PAGE_CAP=${GL_TRANSPORT_PAGE_CAP:-50}" \
+      "GL_TRANSPORT_MAX_RETRIES=${GL_TRANSPORT_MAX_RETRIES:-3}" \
+      bash -c "source '$LIB'; $body"
+}
+
+# _reset_control — reset per-test control files (argv/invocation/sleep-log)
+# so each test starts fresh.
+_reset_control() {
+  _CURL_ARGV_FILE="$WORK/curl-argv.log"; : > "$_CURL_ARGV_FILE"
+  _CURL_INVOKE_STATE="$WORK/curl-inv"; : > "$_CURL_INVOKE_STATE"
+  _SLEEP_LOG_FILE="$WORK/sleep-log"; : > "$_SLEEP_LOG_FILE"
+  _CURL_STATUS_SEQ=""
+  _CURL_BODY_SEQ=""
+  _CURL_HDR_EXTRA_SEQ=""
+  _CURL_RC=0
+  export _CURL_ARGV_FILE _CURL_INVOKE_STATE _SLEEP_LOG_FILE \
+         _CURL_STATUS_SEQ _CURL_BODY_SEQ _CURL_HDR_EXTRA_SEQ _CURL_RC
+  # Reset GITLAB_TOKEN/hook to defaults; each test overrides.
+  unset GITLAB_TRANSPORT_HOOK
+  export GITLAB_TOKEN="test-token"
+  export GITLAB_HOST="gitlab.example"
+}
+
+# ===========================================================================
+echo "=== TC-GLT-001..005: preflight fail-loud ==="
+# ===========================================================================
+_reset_control
+unset GITLAB_TOKEN
+export GITLAB_TOKEN=""
+out=$(_run_with_lib '_gl_api /projects/1/issues/42' 2>&1); rc=$?
+assert_rc_nonzero "TC-GLT-001: GITLAB_TOKEN unset + no hook → rc != 0" "$rc"
+assert_contains "TC-GLT-001: message names GITLAB_TOKEN" "GITLAB_TOKEN" "$out"
+# curl NEVER invoked (argv file has no `--- invocation` lines).
+_curl_inv_count() { local n; n=$(grep -c '^--- invocation' "$1" 2>/dev/null); [[ -z "$n" ]] && n=0; printf '%s' "$n"; }
+assert_eq "TC-GLT-001: no curl invocation" "0" "$(_curl_inv_count "$_CURL_ARGV_FILE")"
+
+_reset_control
+export GITLAB_TRANSPORT_HOOK="/no/such/gitlab-hook-file.sh"
+out=$(_run_with_lib '_gl_api /projects/1/issues/42' 2>&1); rc=$?
+assert_rc_nonzero "TC-GLT-002: unreadable hook path → rc != 0" "$rc"
+assert_contains "TC-GLT-002: message names the unreadable path" "/no/such/gitlab-hook-file.sh" "$out"
+
+_reset_control
+hook_no_glhttp="$WORK/hook-no-glhttp.sh"
+cat > "$hook_no_glhttp" <<'EOF'
+# Hook that does NOT redefine _gl_http (defines an unrelated function only).
+_some_unrelated_helper() { echo "helper"; }
+EOF
+# Deliberately UNDEF _gl_http so the default in-lib def doesn't cover this.
+export GITLAB_TRANSPORT_HOOK="$hook_no_glhttp"
+out=$(_run_with_lib 'unset -f _gl_http 2>/dev/null; _gl_api /projects/1/issues/42' 2>&1); rc=$?
+assert_rc_nonzero "TC-GLT-003: hook that fails to define _gl_http → rc != 0" "$rc"
+assert_contains "TC-GLT-003: message names _gl_http" "_gl_http" "$out"
+
+# TC-GLT-004: preflight latched — 2 _gl_api calls emit preflight log once.
+_reset_control
+body_hello="$WORK/body-hello.json"; printf '{"iid":42}' > "$body_hello"
+_CURL_BODY_SEQ="$body_hello:$body_hello"
+export _CURL_BODY_SEQ
+out=$(_run_with_lib '_gl_api /projects/1/issues/42 >/dev/null; _gl_api /projects/1/issues/43 >/dev/null' 2>&1); rc=$?
+assert_eq "TC-GLT-004: 2 successful _gl_api calls, rc 0" "0" "$rc"
+preflight_count=$(grep -c "gitlab-transport preflight OK" <<<"$out")
+assert_eq "TC-GLT-004: preflight logged exactly ONCE (latched)" "1" "$preflight_count"
+assert_eq "TC-GLT-004: 2 curl invocations" "2" "$(grep -c '^--- invocation' "$_CURL_ARGV_FILE")"
+
+# TC-GLT-005: hook redefines _gl_http cleanly, curl NEVER invoked.
+_reset_control
+hook_ok="$WORK/hook-ok.sh"
+cat > "$hook_ok" <<'EOF'
+_gl_http() {
+  local method="$1" path="$2" hdr="$3" body_json="${4:-}"
+  printf 'HTTP/1.1 200 OK\r\n\r\n' > "$hdr"
+  printf '{"hooked":true,"path":"%s"}' "$path"
+  return 0
+}
+EOF
+export GITLAB_TRANSPORT_HOOK="$hook_ok"
+out=$(_run_with_lib 'body=$(_gl_api /projects/1/issues/42); printf "%s" "$body"' 2>&1); rc=$?
+assert_eq "TC-GLT-005: hook path — rc 0" "0" "$rc"
+assert_contains "TC-GLT-005: body reflects hook output" '"hooked":true' "$out"
+# curl NEVER invoked (argv file has no --- invocation line).
+assert_eq "TC-GLT-005: curl not invoked (hook takes over)" "0" "$(_curl_inv_count "$_CURL_ARGV_FILE")"
+
+# ===========================================================================
+echo ""
+echo "=== TC-GLT-010..018: _gl_http shape ==="
+# ===========================================================================
+# TC-GLT-010: GET returning 200 with a body.
+_reset_control
+body_ok="$WORK/body-ok.json"; printf '{"iid":42}' > "$body_ok"
+_CURL_STATUS_SEQ="200"; _CURL_BODY_SEQ="$body_ok"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ
+out=$(_run_with_lib 'hdr="$(mktemp)"; body=$(_gl_http GET /projects/1/issues/42 "$hdr"); printf "%s\n---HDR---\n" "$body"; cat "$hdr"' 2>&1); rc=$?
+assert_eq "TC-GLT-010: _gl_http rc 0 on 200" "0" "$rc"
+assert_contains "TC-GLT-010: body on stdout" '"iid":42' "$out"
+assert_contains "TC-GLT-010: HTTP/1.1 200 in header file" "HTTP/1.1 200" "$out"
+
+# TC-GLT-011: 404 — rc 0 (transport succeeded), body on stdout.
+_reset_control
+body_404="$WORK/body-404.json"; printf '{"message":"404 Not Found"}' > "$body_404"
+_CURL_STATUS_SEQ="404"; _CURL_BODY_SEQ="$body_404"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ
+out=$(_run_with_lib 'hdr="$(mktemp)"; body=$(_gl_http GET /projects/1/issues/999 "$hdr"); printf "%s\n---HDR---\n" "$body"; cat "$hdr"' 2>&1); rc=$?
+assert_eq "TC-GLT-011: _gl_http rc 0 on 404 (transport ok)" "0" "$rc"
+assert_contains "TC-GLT-011: 404 body on stdout" "404 Not Found" "$out"
+assert_contains "TC-GLT-011: HTTP/1.1 404 in header file" "HTTP/1.1 404" "$out"
+
+# TC-GLT-013: absolute URL used verbatim.
+_reset_control
+body_abs="$WORK/body-abs.json"; printf '{"abs":true}' > "$body_abs"
+_CURL_STATUS_SEQ="200"; _CURL_BODY_SEQ="$body_abs"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ
+out=$(_run_with_lib 'hdr="$(mktemp)"; _gl_http GET "https://other.example/api/v4/projects/1?page=2" "$hdr" >/dev/null' 2>&1); rc=$?
+assert_eq "TC-GLT-013: absolute URL rc 0" "0" "$rc"
+assert_contains "TC-GLT-013: curl argv contains the exact absolute URL" "https://other.example/api/v4/projects/1?page=2" "$(cat "$_CURL_ARGV_FILE")"
+
+# TC-GLT-014: PRIVATE-TOKEN header present in curl argv.
+_reset_control
+out=$(_run_with_lib 'hdr="$(mktemp)"; _gl_http GET /projects/1/issues/42 "$hdr" >/dev/null' 2>&1)
+argv=$(cat "$_CURL_ARGV_FILE")
+assert_contains "TC-GLT-014: curl argv contains PRIVATE-TOKEN header" "PRIVATE-TOKEN: test-token" "$argv"
+
+# TC-GLT-015: POST with body-json — Content-Type + --data-binary.
+_reset_control
+out=$(_run_with_lib 'hdr="$(mktemp)"; _gl_http POST /projects/1/issues "$hdr" "{\"title\":\"t\"}" >/dev/null' 2>&1)
+argv=$(cat "$_CURL_ARGV_FILE")
+assert_contains "TC-GLT-015: curl argv contains -X POST" "POST" "$argv"
+assert_contains "TC-GLT-015: curl argv contains Content-Type: application/json" "Content-Type: application/json" "$argv"
+assert_contains "TC-GLT-015: curl argv contains --data-binary with body-json" '{"title":"t"}' "$argv"
+
+# TC-GLT-016: curl transport rc != 0 → _gl_http rc != 0.
+_reset_control
+_CURL_RC=6
+export _CURL_RC
+out=$(_run_with_lib 'hdr="$(mktemp)"; _gl_http GET /projects/1/issues/42 "$hdr" >/dev/null' 2>&1); rc=$?
+assert_rc_nonzero "TC-GLT-016: _gl_http rc != 0 on curl transport failure" "$rc"
+
+# TC-GLT-017: paginated response headers x-next-page + x-total-pages preserved.
+_reset_control
+body_p1="$WORK/body-p1.json"; printf '[]' > "$body_p1"
+hdr_extra_p1="$WORK/hdr-extra-p1.txt"; printf 'x-next-page: 2\r\nx-total-pages: 5\r\n' > "$hdr_extra_p1"
+_CURL_STATUS_SEQ="200"; _CURL_BODY_SEQ="$body_p1"; _CURL_HDR_EXTRA_SEQ="$hdr_extra_p1"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ _CURL_HDR_EXTRA_SEQ
+out=$(_run_with_lib 'hdr="$(mktemp)"; _gl_http GET /projects/1/issues "$hdr" >/dev/null; cat "$hdr"' 2>&1)
+assert_contains "TC-GLT-017: headers file records x-next-page: 2" "x-next-page: 2" "$out"
+assert_contains "TC-GLT-017: headers file records x-total-pages: 5" "x-total-pages: 5" "$out"
+
+# TC-GLT-018: Retry-After header preserved.
+_reset_control
+body_429="$WORK/body-429.json"; printf '{"message":"rate limited"}' > "$body_429"
+hdr_extra_429="$WORK/hdr-extra-429.txt"; printf 'Retry-After: 3\r\n' > "$hdr_extra_429"
+_CURL_STATUS_SEQ="429"; _CURL_BODY_SEQ="$body_429"; _CURL_HDR_EXTRA_SEQ="$hdr_extra_429"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ _CURL_HDR_EXTRA_SEQ
+out=$(_run_with_lib 'hdr="$(mktemp)"; _gl_http GET /projects/1/issues "$hdr" >/dev/null; cat "$hdr"' 2>&1)
+assert_contains "TC-GLT-018: headers file records Retry-After: 3" "Retry-After: 3" "$out"
+
+# ===========================================================================
+echo ""
+echo "=== TC-GLT-020..026: _gl_api pagination walk ==="
+# ===========================================================================
+# TC-GLT-020: single-page paginate → body as-is.
+_reset_control
+body_single="$WORK/body-single.json"; printf '[{"a":1}]' > "$body_single"
+_CURL_STATUS_SEQ="200"; _CURL_BODY_SEQ="$body_single"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ
+out=$(_run_with_lib '_gl_api --paginate /projects/1/issues' 2>/dev/null); rc=$?
+assert_eq "TC-GLT-020: single-page paginate rc 0" "0" "$rc"
+# jq -s pretty-prints; assert semantic equality via jq itself (compact-form
+# comparison), not exact byte-equal.
+compact=$(jq -c . <<<"$out" 2>/dev/null)
+assert_eq "TC-GLT-020: single-page paginate body (compact JSON equality)" '[{"a":1}]' "$compact"
+
+# TC-GLT-021 + TC-GLT-022: 3-page walk merges into one array; next-page
+# reconstruction on original path with page=N.
+_reset_control
+body_p1="$WORK/body-p1.json"; printf '[{"n":1}]' > "$body_p1"
+body_p2="$WORK/body-p2.json"; printf '[{"n":2}]' > "$body_p2"
+body_p3="$WORK/body-p3.json"; printf '[{"n":3}]' > "$body_p3"
+hdr_p1="$WORK/hdr-p1.txt"; printf 'x-next-page: 2\r\n' > "$hdr_p1"
+hdr_p2="$WORK/hdr-p2.txt"; printf 'x-next-page: 3\r\n' > "$hdr_p2"
+hdr_p3="$WORK/hdr-p3.txt"; : > "$hdr_p3"
+_CURL_STATUS_SEQ="200:200:200"
+_CURL_BODY_SEQ="$body_p1:$body_p2:$body_p3"
+_CURL_HDR_EXTRA_SEQ="$hdr_p1:$hdr_p2:$hdr_p3"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ _CURL_HDR_EXTRA_SEQ
+out=$(_run_with_lib '_gl_api --paginate /projects/1/issues' 2>/dev/null); rc=$?
+assert_eq "TC-GLT-021: 3-page walk rc 0" "0" "$rc"
+merged_n=$(jq -r 'map(.n) | join(",")' <<<"$out" 2>/dev/null)
+assert_eq "TC-GLT-021: merged array is [1,2,3] in order" "1,2,3" "$merged_n"
+argv=$(cat "$_CURL_ARGV_FILE")
+# TC-GLT-022: verify page=2 in invocation #2 and page=3 in #3.
+assert_contains "TC-GLT-022: invocation #2 curl argv contains page=2" "page=2" "$argv"
+assert_contains "TC-GLT-022: invocation #3 curl argv contains page=3" "page=3" "$argv"
+
+# TC-GLT-023: mid-walk failure — page 2 returns 500 → rc != 0, stdout empty.
+_reset_control
+body_p1="$WORK/body-p1.json"; printf '[{"n":1}]' > "$body_p1"
+body_p2err="$WORK/body-p2err.json"; printf '{"message":"internal server error"}' > "$body_p2err"
+hdr_p1="$WORK/hdr-p1.txt"; printf 'x-next-page: 2\r\n' > "$hdr_p1"
+_CURL_STATUS_SEQ="200:500"
+_CURL_BODY_SEQ="$body_p1:$body_p2err"
+_CURL_HDR_EXTRA_SEQ="$hdr_p1:"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ _CURL_HDR_EXTRA_SEQ
+out=$(_run_with_lib '_gl_api --paginate /projects/1/issues' 2>/dev/null); rc=$?
+assert_rc_nonzero "TC-GLT-023: mid-walk 500 → rc != 0" "$rc"
+assert_eq "TC-GLT-023: fail-CLOSED, stdout empty" "" "$out"
+
+# TC-GLT-024: cap-hit — GL_TRANSPORT_PAGE_CAP=2 but response advertises next-page:3.
+_reset_control
+body_p1="$WORK/body-p1.json"; printf '[{"n":1}]' > "$body_p1"
+body_p2="$WORK/body-p2.json"; printf '[{"n":2}]' > "$body_p2"
+hdr_p1="$WORK/hdr-p1.txt"; printf 'x-next-page: 2\r\n' > "$hdr_p1"
+hdr_p2="$WORK/hdr-p2.txt"; printf 'x-next-page: 3\r\n' > "$hdr_p2"
+_CURL_STATUS_SEQ="200:200"
+_CURL_BODY_SEQ="$body_p1:$body_p2"
+_CURL_HDR_EXTRA_SEQ="$hdr_p1:$hdr_p2"
+GL_TRANSPORT_PAGE_CAP=2
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ _CURL_HDR_EXTRA_SEQ GL_TRANSPORT_PAGE_CAP
+out=$(_run_with_lib '_gl_api --paginate /projects/1/issues' 2>/dev/null); rc=$?
+unset GL_TRANSPORT_PAGE_CAP
+assert_rc_nonzero "TC-GLT-024: cap-hit → rc != 0" "$rc"
+assert_eq "TC-GLT-024: cap-hit, stdout empty" "" "$out"
+
+# TC-GLT-025: --max-items bounded read.
+_reset_control
+body_p1="$WORK/body-p1.json"; printf '[{"n":1},{"n":2},{"n":3}]' > "$body_p1"
+body_p2="$WORK/body-p2.json"; printf '[{"n":4},{"n":5},{"n":6}]' > "$body_p2"
+hdr_p1="$WORK/hdr-p1.txt"; printf 'x-next-page: 2\r\n' > "$hdr_p1"
+hdr_p2="$WORK/hdr-p2.txt"; printf 'x-next-page: 3\r\n' > "$hdr_p2"
+_CURL_STATUS_SEQ="200:200"
+_CURL_BODY_SEQ="$body_p1:$body_p2"
+_CURL_HDR_EXTRA_SEQ="$hdr_p1:$hdr_p2"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ _CURL_HDR_EXTRA_SEQ
+out=$(_run_with_lib '_gl_api --paginate --max-items 2 /projects/1/issues' 2>/dev/null); rc=$?
+assert_eq "TC-GLT-025: --max-items 2 rc 0" "0" "$rc"
+merged_len=$(jq 'length' <<<"$out" 2>/dev/null)
+assert_eq "TC-GLT-025: array length == 2 (bounded)" "2" "$merged_len"
+
+# ===========================================================================
+echo ""
+echo "=== TC-GLT-030..033: _gl_api 429 / Retry-After backoff ==="
+# ===========================================================================
+# TC-GLT-030: 429 twice with Retry-After: 1, third returns 200.
+_reset_control
+body_429="$WORK/body-429.json"; printf '{"m":"rl"}' > "$body_429"
+body_ok="$WORK/body-ok.json"; printf '{"iid":42}' > "$body_ok"
+hdr_429="$WORK/hdr-429.txt"; printf 'Retry-After: 1\r\n' > "$hdr_429"
+hdr_ok="$WORK/hdr-ok.txt"; : > "$hdr_ok"
+_CURL_STATUS_SEQ="429:429:200"
+_CURL_BODY_SEQ="$body_429:$body_429:$body_ok"
+_CURL_HDR_EXTRA_SEQ="$hdr_429:$hdr_429:$hdr_ok"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ _CURL_HDR_EXTRA_SEQ
+out=$(_run_with_lib '_gl_api /projects/1/issues/42' 2>/dev/null); rc=$?
+assert_eq "TC-GLT-030: 429×2 → 200 rc 0" "0" "$rc"
+assert_contains "TC-GLT-030: body on stdout after retries" '"iid":42' "$out"
+sleep_count=$(wc -l < "$_SLEEP_LOG_FILE" 2>/dev/null | tr -d ' ')
+assert_eq "TC-GLT-030: 2 sleep calls recorded" "2" "$sleep_count"
+
+# TC-GLT-031: 429 exhausted.
+_reset_control
+body_429="$WORK/body-429.json"; printf '{"m":"rl"}' > "$body_429"
+hdr_429="$WORK/hdr-429.txt"; printf 'Retry-After: 1\r\n' > "$hdr_429"
+_CURL_STATUS_SEQ="429:429:429:429"
+_CURL_BODY_SEQ="$body_429:$body_429:$body_429:$body_429"
+_CURL_HDR_EXTRA_SEQ="$hdr_429:$hdr_429:$hdr_429:$hdr_429"
+GL_TRANSPORT_MAX_RETRIES=3
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ _CURL_HDR_EXTRA_SEQ GL_TRANSPORT_MAX_RETRIES
+out=$(_run_with_lib '_gl_api /projects/1/issues/42' 2>/dev/null); rc=$?
+assert_rc_nonzero "TC-GLT-031: 429 exhausted → rc != 0" "$rc"
+assert_eq "TC-GLT-031: stdout empty" "" "$out"
+unset GL_TRANSPORT_MAX_RETRIES
+
+# TC-GLT-032: Retry-After: 90 capped at 60s.
+_reset_control
+body_429="$WORK/body-429.json"; printf '{"m":"rl"}' > "$body_429"
+body_ok="$WORK/body-ok.json"; printf '{"iid":42}' > "$body_ok"
+hdr_big="$WORK/hdr-big.txt"; printf 'Retry-After: 90\r\n' > "$hdr_big"
+hdr_ok="$WORK/hdr-ok.txt"; : > "$hdr_ok"
+_CURL_STATUS_SEQ="429:200"
+_CURL_BODY_SEQ="$body_429:$body_ok"
+_CURL_HDR_EXTRA_SEQ="$hdr_big:$hdr_ok"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ _CURL_HDR_EXTRA_SEQ
+out=$(_run_with_lib '_gl_api /projects/1/issues/42' 2>/dev/null); rc=$?
+assert_eq "TC-GLT-032: retry succeeds rc 0" "0" "$rc"
+sleep_val=$(head -n1 "$_SLEEP_LOG_FILE" 2>/dev/null)
+if [[ "$sleep_val" -le 60 ]]; then
+  ok "TC-GLT-032: sleep capped at ≤ 60s (was $sleep_val)"
+else
+  bad "TC-GLT-032: sleep NOT capped (was $sleep_val)"
+fi
+
+# TC-GLT-033: non-429 5xx does NOT trigger the backoff retry loop.
+_reset_control
+body_500="$WORK/body-500.json"; printf '{"m":"internal"}' > "$body_500"
+_CURL_STATUS_SEQ="503"
+_CURL_BODY_SEQ="$body_500"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ
+out=$(_run_with_lib '_gl_api /projects/1/issues/42' 2>/dev/null); rc=$?
+assert_rc_nonzero "TC-GLT-033: 5xx rc != 0" "$rc"
+inv_count=$(grep -c '^--- invocation' "$_CURL_ARGV_FILE")
+assert_eq "TC-GLT-033: only 1 curl invocation (no retry on non-429)" "1" "$inv_count"
+
+# ===========================================================================
+echo ""
+echo "=== TC-GLT-040..045: HTTP-status channel + --tolerate-status ==="
+# ===========================================================================
+# TC-GLT-040: GL_API_STATUS set in calling shell via redirect (not $()).
+_reset_control
+body_ok="$WORK/body-ok.json"; printf '{"iid":42}' > "$body_ok"
+_CURL_STATUS_SEQ="200"
+_CURL_BODY_SEQ="$body_ok"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ
+out=$(_run_with_lib '_gl_api /projects/1/issues/42 > /dev/null; echo "STATUS=${GL_API_STATUS}"' 2>&1)
+assert_contains "TC-GLT-040: GL_API_STATUS==200 after redirect-form call" "STATUS=200" "$out"
+
+# TC-GLT-041: --status-out FILE captures status.
+_reset_control
+_CURL_STATUS_SEQ="200"; _CURL_BODY_SEQ="$body_ok"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ
+status_out="$WORK/status-out.txt"; : > "$status_out"
+out=$(_run_with_lib "_gl_api --status-out '$status_out' /projects/1/issues/42 > /dev/null" 2>&1)
+assert_eq "TC-GLT-041: --status-out contains 200" "200" "$(cat "$status_out")"
+
+# TC-GLT-042: --tolerate-status 404 on a 404 → rc 0, body on stdout.
+_reset_control
+body_404="$WORK/body-404.json"; printf '{"message":"nf"}' > "$body_404"
+_CURL_STATUS_SEQ="404"; _CURL_BODY_SEQ="$body_404"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ
+out=$(_run_with_lib '_gl_api --tolerate-status 404 /projects/1/issues/42' 2>/dev/null); rc=$?
+assert_eq "TC-GLT-042: --tolerate-status 404 on 404 rc 0" "0" "$rc"
+assert_contains "TC-GLT-042: 404 body on stdout" "nf" "$out"
+
+# TC-GLT-043: --tolerate-status 404,409 on 409 → rc 0.
+_reset_control
+body_409="$WORK/body-409.json"; printf '{"message":"conflict"}' > "$body_409"
+_CURL_STATUS_SEQ="409"; _CURL_BODY_SEQ="$body_409"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ
+out=$(_run_with_lib '_gl_api --tolerate-status 404,409 /projects/1/issues/42' 2>/dev/null); rc=$?
+assert_eq "TC-GLT-043: --tolerate-status 404,409 on 409 rc 0" "0" "$rc"
+assert_contains "TC-GLT-043: 409 body on stdout" "conflict" "$out"
+
+# TC-GLT-044: --tolerate-status 404 on 500 → rc != 0.
+_reset_control
+body_500="$WORK/body-500.json"; printf '{"message":"boom"}' > "$body_500"
+_CURL_STATUS_SEQ="500"; _CURL_BODY_SEQ="$body_500"
+export _CURL_STATUS_SEQ _CURL_BODY_SEQ
+out=$(_run_with_lib '_gl_api --tolerate-status 404 /projects/1/issues/42 >/dev/null; echo "STATUS=${GL_API_STATUS}"' 2>/dev/null)
+assert_contains "TC-GLT-044: --tolerate-status 404 on 500 sets GL_API_STATUS=500" "STATUS=500" "$out"
+
+# TC-GLT-045: transport failure (curl rc != 0) — not toleratable.
+_reset_control
+_CURL_RC=6
+export _CURL_RC
+out=$(_run_with_lib '_gl_api --tolerate-status 404 /projects/1/issues/42' 2>/dev/null); rc=$?
+assert_rc_nonzero "TC-GLT-045: transport failure not toleratable" "$rc"
+
+# ===========================================================================
+echo ""
+echo "=== TC-GLT-050..052: _gl_urlencode ==="
+# ===========================================================================
+_reset_control
+enc=$(_run_with_lib "_gl_urlencode 'group/subgroup/project'" 2>/dev/null)
+assert_eq "TC-GLT-050: group/subgroup/project → group%2Fsubgroup%2Fproject" "group%2Fsubgroup%2Fproject" "$enc"
+enc=$(_run_with_lib "_gl_urlencode 'feature/foo bar'" 2>/dev/null)
+assert_eq "TC-GLT-051: feature/foo bar → feature%2Ffoo%20bar" "feature%2Ffoo%20bar" "$enc"
+enc=$(_run_with_lib "_gl_urlencode 'label with & ampersand'" 2>/dev/null)
+assert_contains "TC-GLT-052: & → %26 in urlencode" "%26" "$enc"
+
+# ===========================================================================
+echo ""
+echo "=== TC-GLT-060..063: override hook ==="
+# ===========================================================================
+_reset_control
+hook_recorded="$WORK/hook-recorded.sh"
+cat > "$hook_recorded" <<'EOF'
+_gl_http() {
+  local method="$1" path="$2" hdr="$3" body_json="${4:-}"
+  printf 'HTTP/1.1 200 OK\r\n\r\n' > "$hdr"
+  printf '[{"canned":true,"path":"%s"}]' "$path"
+  return 0
+}
+_hook_private_helper() { echo "helper"; }
+EOF
+export GITLAB_TRANSPORT_HOOK="$hook_recorded"
+out=$(_run_with_lib '_gl_api /projects/1/issues' 2>/dev/null); rc=$?
+assert_eq "TC-GLT-060: hook path rc 0" "0" "$rc"
+# hook body — assert via jq semantic equality, not raw string match (jq -s may
+# pretty-print with `"canned": true` vs `"canned":true`).
+if jq -e '.[0].canned == true' <<<"$out" >/dev/null 2>&1 || jq -e '.canned == true' <<<"$out" >/dev/null 2>&1; then
+  ok "TC-GLT-060: hook body semantically carries canned:true"
+else
+  bad "TC-GLT-060: hook body missing canned:true (out: ${out:0:200})"
+fi
+assert_eq "TC-GLT-060: curl NEVER invoked (hook takes over)" "0" "$(_curl_inv_count "$_CURL_ARGV_FILE")"
+# TC-GLT-061: private helper alongside is not rejected.
+assert_eq "TC-GLT-061: private helper alongside → still rc 0" "0" "$rc"
+
+# TC-GLT-063: hook + pagination — hook must produce multi-page shape via header.
+# We simplify: assert that a paginate call over the hook returns the hook's body verbatim
+# (no next-page header from the hook, so single-page merge yields the body as-is).
+_reset_control
+export GITLAB_TRANSPORT_HOOK="$hook_recorded"
+out=$(_run_with_lib '_gl_api --paginate /projects/1/issues' 2>/dev/null); rc=$?
+assert_eq "TC-GLT-063: hook + --paginate single-page rc 0" "0" "$rc"
+if jq -e '(type == "array" and .[0].canned == true) or (type == "object" and .canned == true)' <<<"$out" >/dev/null 2>&1; then
+  ok "TC-GLT-063: hook + --paginate body preserved (semantic canned:true)"
+else
+  bad "TC-GLT-063: hook + --paginate body missing canned:true (out: ${out:0:200})"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1

--- a/tests/unit/test-lib-gitlab-transport.sh
+++ b/tests/unit/test-lib-gitlab-transport.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# test-lib-gitlab-transport.sh — issue #416, INV-113.
+# test-lib-gitlab-transport.sh — issue #416, INV-116.
 #
 # Drives skills/autonomous-dispatcher/scripts/providers/lib-gitlab-transport.sh
 # hermetically via a stubbed `curl` on an isolated PATH. TC IDs per

--- a/tests/unit/test-lib-gitlab-transport.sh
+++ b/tests/unit/test-lib-gitlab-transport.sh
@@ -209,17 +209,34 @@ out=$(_run_with_lib '_gl_api /projects/1/issues/42' 2>&1); rc=$?
 assert_rc_nonzero "TC-GLT-002: unreadable hook path → rc != 0" "$rc"
 assert_contains "TC-GLT-002: message names the unreadable path" "/no/such/gitlab-hook-file.sh" "$out"
 
+# TC-GLT-003 (codex round-1 [P1-4]): a hook that does NOT redefine _gl_http
+# must FAIL preflight, even though the default _gl_http is already defined
+# by the lib. Pre-P1-4 the test masked this by `unset -f _gl_http` before
+# the call — that mask is REMOVED now (the fix must not require an
+# artificial pre-condition to fire). The preflight snapshots the pre-source
+# body and requires the post-source body to differ.
 _reset_control
 hook_no_glhttp="$WORK/hook-no-glhttp.sh"
 cat > "$hook_no_glhttp" <<'EOF'
 # Hook that does NOT redefine _gl_http (defines an unrelated function only).
 _some_unrelated_helper() { echo "helper"; }
 EOF
-# Deliberately UNDEF _gl_http so the default in-lib def doesn't cover this.
 export GITLAB_TRANSPORT_HOOK="$hook_no_glhttp"
-out=$(_run_with_lib 'unset -f _gl_http 2>/dev/null; _gl_api /projects/1/issues/42' 2>&1); rc=$?
-assert_rc_nonzero "TC-GLT-003: hook that fails to define _gl_http → rc != 0" "$rc"
-assert_contains "TC-GLT-003: message names _gl_http" "_gl_http" "$out"
+# NOTE: no `unset -f _gl_http` — the default is left in place, matching
+# the real-world condition the P1-4 fix targets.
+out=$(_run_with_lib '_gl_api /projects/1/issues/42' 2>&1); rc=$?
+assert_rc_nonzero "TC-GLT-003: hook that does NOT redefine _gl_http (default still in place) → rc != 0" "$rc"
+assert_contains "TC-GLT-003: message names the hook path" "$hook_no_glhttp" "$out"
+assert_contains "TC-GLT-003: message explains the no-op-hook failure" "did NOT redefine _gl_http" "$out"
+
+# TC-GLT-003b (P1-4 regression): an empty hook file also fails preflight.
+_reset_control
+hook_empty="$WORK/hook-empty.sh"
+: > "$hook_empty"
+export GITLAB_TRANSPORT_HOOK="$hook_empty"
+out=$(_run_with_lib '_gl_api /projects/1/issues/42' 2>&1); rc=$?
+assert_rc_nonzero "TC-GLT-003b: empty hook file → rc != 0 (no-op hook rejected)" "$rc"
+assert_contains "TC-GLT-003b: message names hook path" "$hook_empty" "$out"
 
 # TC-GLT-004: preflight latched — 2 _gl_api calls emit preflight log once.
 _reset_control
@@ -575,6 +592,73 @@ if jq -e '(type == "array" and .[0].canned == true) or (type == "object" and .ca
   ok "TC-GLT-063: hook + --paginate body preserved (semantic canned:true)"
 else
   bad "TC-GLT-063: hook + --paginate body missing canned:true (out: ${out:0:200})"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== TC-GLT-070..071: set -e safety — transport failure inside _gl_api under set -euo pipefail (P1-3) ==="
+# ===========================================================================
+# [#416 P1-3] Codex round-1 [P1-3]: pre-fix, `_gl_http … > "$body_file"`
+# inside `_do_request_with_backoff` was a bare simple command — under a
+# caller's `set -euo pipefail` a curl-rc-non-zero transport failure aborts
+# the CALLING shell before http_rc/`_record_status`/`--status-out`
+# mirroring runs. Fix: `if ! _gl_http …; then http_rc=$?; else http_rc=0;
+# fi` — bash `set -e` skips exit on tested commands, so the caller shell
+# survives and `_gl_api` returns rc≠0 cleanly.
+
+# TC-GLT-070: source lib + call _gl_api under set -euo pipefail; simulate
+# transport failure (curl rc 6). The caller shell MUST reach the SURVIVED
+# marker AFTER the failing _gl_api call.
+_reset_control
+_CURL_RC=6
+export _CURL_RC
+
+driver_p1_3="$WORK/driver-p1-3-strict.sh"
+cat > "$driver_p1_3" <<DRV
+#!/bin/bash
+set -euo pipefail
+source "$LIB"
+_gl_api /projects/1/issues/42 > /dev/null 2>&1 && rc_captured=0 || rc_captured=\$?
+printf 'rc_captured=%s\n' "\$rc_captured"
+printf 'SURVIVED\n'
+exit 0
+DRV
+out=$(env -u PROJECT_DIR PATH="$ISOLATED_PATH" "GITLAB_TOKEN=$GITLAB_TOKEN" "GITLAB_HOST=$GITLAB_HOST" \
+      "_CURL_ARGV_FILE=$_CURL_ARGV_FILE" "_CURL_STATUS_SEQ=" "_CURL_BODY_SEQ=" "_CURL_HDR_EXTRA_SEQ=" \
+      "_CURL_INVOKE_STATE=$_CURL_INVOKE_STATE" "_CURL_RC=6" "_SLEEP_LOG_FILE=$_SLEEP_LOG_FILE" \
+      bash "$driver_p1_3" 2>&1); rc=$?
+assert_eq "TC-GLT-070: caller shell SURVIVED under set -euo pipefail" "0" "$rc"
+assert_contains "TC-GLT-070: reached the post-failure marker" "SURVIVED" "$out"
+assert_contains "TC-GLT-070: _gl_api returned non-zero to the caller" "rc_captured=1" "$out"
+
+# TC-GLT-071: same shape but with --status-out to prove the mirror-write
+# path is reachable past the bare-command failure point.
+_reset_control
+_CURL_RC=6
+export _CURL_RC
+status_out_p1_3="$WORK/status-out-p1-3.txt"
+: > "$status_out_p1_3"
+
+driver_p1_3b="$WORK/driver-p1-3-status.sh"
+cat > "$driver_p1_3b" <<DRV
+#!/bin/bash
+set -euo pipefail
+source "$LIB"
+_gl_api --status-out "$status_out_p1_3" /projects/1/issues/42 > /dev/null 2>&1 && rc_captured=0 || rc_captured=\$?
+printf 'rc_captured=%s\n' "\$rc_captured"
+printf 'SURVIVED\n'
+exit 0
+DRV
+out=$(env -u PROJECT_DIR PATH="$ISOLATED_PATH" "GITLAB_TOKEN=$GITLAB_TOKEN" "GITLAB_HOST=$GITLAB_HOST" \
+      "_CURL_ARGV_FILE=$_CURL_ARGV_FILE" "_CURL_STATUS_SEQ=" "_CURL_BODY_SEQ=" "_CURL_HDR_EXTRA_SEQ=" \
+      "_CURL_INVOKE_STATE=$_CURL_INVOKE_STATE" "_CURL_RC=6" "_SLEEP_LOG_FILE=$_SLEEP_LOG_FILE" \
+      bash "$driver_p1_3b" 2>&1); rc=$?
+assert_eq "TC-GLT-071: caller SURVIVED with --status-out on transport failure" "0" "$rc"
+assert_contains "TC-GLT-071: post-failure marker reached" "SURVIVED" "$out"
+if [[ -f "$status_out_p1_3" ]]; then
+  ok "TC-GLT-071: --status-out file exists (was reachable past the bare-command failure point)"
+else
+  bad "TC-GLT-071: --status-out file was never created (pre-P1-3 short-circuit?)"
 fi
 
 # ===========================================================================

--- a/tests/unit/test-provider-conformance-runner.sh
+++ b/tests/unit/test-provider-conformance-runner.sh
@@ -358,11 +358,26 @@ if [[ -f "$_deg_dir/itp-degraded.sh" && -f "$_deg_dir/itp-degraded.caps" ]]; the
   assert_not_contains "TC-RGH-006: no chp path-based function names leaked" \
     "chp_/" "$rgh6_out"
 
-  # TC-RGH-007: legacy abs-path-only form is now REJECTED with a fatal
-  # (pre-P1-5 it silently produced nonsense filenames).
+  # TC-RGH-007: bare abs-path form (#416 R3/AC4 out-of-tree self-certification)
+  # derives the logical name from the dir's single <seam>-<name>.sh file —
+  # `--itp /abs/dir` with exactly one itp-corp.sh inside resolves to name
+  # `corp`, dir `/abs/dir`; NO path-based filename/function pollution.
   rgh7_out=$(bash "$RUNNER" --itp "$_extdir" --chp "$_extdir" 2>&1); rgh7_rc=$?
-  assert_eq "TC-RGH-007: legacy abs-path-only --itp → exit 2 (fatal)" "2" "$rgh7_rc"
-  assert_contains "TC-RGH-007: fatal names the required form" "<name>=<abs-dir>" "$rgh7_out"
+  assert_contains "TC-RGH-007: bare abs-path derives LOGICAL name 'corp/corp'" \
+    "CONFORMANCE-PCONF corp/corp" "$rgh7_out"
+  assert_not_contains "TC-RGH-007: bare abs-path — no path-based function names leaked" \
+    "itp_/" "$rgh7_out"
+  # TC-RGH-007b: an AMBIGUOUS dir (two itp-*.sh files) → fatal naming the
+  # name=dir disambiguation form.
+  _ambig="$(mktemp -d)"
+  cp "$_extdir/itp-corp.sh" "$_ambig/itp-corp.sh"
+  cp "$_extdir/itp-corp.sh" "$_ambig/itp-other.sh"
+  cp "$_extdir/chp-corp.sh" "$_ambig/chp-corp.sh"
+  cp "$_extdir/itp-corp.caps" "$_ambig/itp-corp.caps" 2>/dev/null || true
+  rgh7b_out=$(bash "$RUNNER" --itp "$_ambig" --chp github 2>&1); rgh7b_rc=$?
+  assert_eq "TC-RGH-007b: ambiguous multi-provider dir → exit 2 (fatal)" "2" "$rgh7b_rc"
+  assert_contains "TC-RGH-007b: fatal names the disambiguation form" "<name>=<abs-dir>" "$rgh7b_out"
+  rm -rf "$_ambig"
 
   # TC-RGH-008: <name>=<non-existent-abs-dir> → fatal.
   rgh8_out=$(bash "$RUNNER" --itp "corp=/no/such/provider-dir-$$" --chp github 2>&1); rgh8_rc=$?

--- a/tests/unit/test-provider-conformance-runner.sh
+++ b/tests/unit/test-provider-conformance-runner.sh
@@ -285,5 +285,179 @@ ok "AC4/AC5: byte-diff pin on chp-github.sh LIFTED for W1c1 (#397) + W1c2 (#398)
 
 # ===========================================================================
 echo ""
+echo "=== TC-RGH-001..005: pcf_resolve_provider_dir gitlab axis + absolute-path form ==="
+# ===========================================================================
+gl_dir="$(pcf_resolve_provider_dir "$PROJECT_ROOT" gitlab)"
+assert_contains "TC-RGH-001: gitlab resolves under skills/autonomous-dispatcher/scripts/providers (same as github, filename prefix disambiguates)" \
+  "skills/autonomous-dispatcher/scripts/providers" "$gl_dir"
+
+_scratch_abs="$(mktemp -d)"
+abs_dir="$(pcf_resolve_provider_dir "$PROJECT_ROOT" "$_scratch_abs")"
+assert_eq "TC-RGH-002: absolute-path form resolves to itself when dir exists" "$_scratch_abs" "$abs_dir"
+
+if pcf_resolve_provider_dir "$PROJECT_ROOT" "/tmp/nonexistent-provider-dir-$$" >/dev/null 2>&1; then
+  bad "TC-RGH-003: nonexistent absolute path should rc 1"
+else
+  ok "TC-RGH-003: nonexistent absolute path rc 1"
+fi
+
+# TC-RGH-004: unknown non-path, non-fixed name still rc 1 (already covered
+# by TC-PCONF-051 nonexistent — re-express for TC-RGH namespace).
+if pcf_resolve_provider_dir "$PROJECT_ROOT" madeupprovidername >/dev/null 2>&1; then
+  bad "TC-RGH-004: unknown non-path name should rc 1"
+else
+  ok "TC-RGH-004: unknown non-path name rc 1"
+fi
+
+# TC-RGH-005: existing fixed names still resolve.
+for name in github degraded broken; do
+  if [[ -n "$(pcf_resolve_provider_dir "$PROJECT_ROOT" "$name")" ]]; then
+    ok "TC-RGH-005: existing fixed name '$name' still resolves"
+  else
+    bad "TC-RGH-005: existing fixed name '$name' did not resolve"
+  fi
+done
+rm -rf "$_scratch_abs"
+
+# ===========================================================================
+echo ""
+echo "=== TC-RGH-010..012: --transport-hook passthrough ==="
+# ===========================================================================
+# TC-RGH-010: unreadable hook path → fatal exit 2 with usage error message.
+th_out=$(bash "$RUNNER" --transport-hook /no/such/gitlab-hook-file.sh --itp github --chp github 2>&1); th_rc=$?
+assert_eq "TC-RGH-010: unreadable --transport-hook → exit 2 (fatal)" "2" "$th_rc"
+assert_contains "TC-RGH-010: message names the unreadable path" "/no/such/gitlab-hook-file.sh" "$th_out"
+
+# TC-RGH-011: readable hook path threads through to _invoke's subshell
+# as GITLAB_TRANSPORT_HOOK. Assert via a github/github run with the hook
+# armed — the hook is a no-op file (no _gl_http redefinition), so github
+# leaves are unaffected; then verify github/github still emits 31 PASS
+# lines (byte-identical). Direct env-var visibility inside _invoke is a
+# private impl detail; the observable AC is "flag accepted + byte-identical
+# github result", which we assert here.
+noop_hook="$(mktemp)"
+cat > "$noop_hook" <<'EOF'
+# no-op transport hook — does not redefine _gl_http; github leaves ignore
+# GITLAB_TRANSPORT_HOOK entirely.
+:
+EOF
+th_out=$(bash "$RUNNER" --transport-hook "$noop_hook" --itp github --chp github 2>&1); th_rc=$?
+assert_eq "TC-RGH-011: --transport-hook + github/github → rc 0" "0" "$th_rc"
+th_pass_count="$(grep -c '^CONFORMANCE-PCONF github/github .* PASS$' <<<"$th_out")"
+assert_eq "TC-RGH-011: --transport-hook + github/github → still 31 PASS lines (byte-identical)" "31" "$th_pass_count"
+
+# TC-RGH-012 (byte-identical no-op with --transport-hook) — already covered
+# by TC-RGH-011's pass count assertion.
+ok "TC-RGH-012: (covered by TC-RGH-011) github/github byte-identical with --transport-hook armed"
+
+rm -f "$noop_hook"
+
+# ===========================================================================
+echo ""
+echo "=== TC-RGH-020..023: --transport-path-add isolated PATH extension ==="
+# ===========================================================================
+# TC-RGH-020: --transport-path-add readable dir accepted; github/github still passes.
+_scratch_bin="$(mktemp -d)"
+th_out=$(bash "$RUNNER" --transport-path-add "$_scratch_bin" --itp github --chp github 2>&1); th_rc=$?
+assert_eq "TC-RGH-020: --transport-path-add + github/github → rc 0" "0" "$th_rc"
+th_pass_count="$(grep -c '^CONFORMANCE-PCONF github/github .* PASS$' <<<"$th_out")"
+assert_eq "TC-RGH-020: --transport-path-add + github/github → still 31 PASS lines" "31" "$th_pass_count"
+
+# TC-RGH-021: multiple --transport-path-add accumulate (both accepted, rc 0).
+_scratch_bin2="$(mktemp -d)"
+th_out=$(bash "$RUNNER" --transport-path-add "$_scratch_bin" --transport-path-add "$_scratch_bin2" --itp github --chp github 2>&1); th_rc=$?
+assert_eq "TC-RGH-021: two --transport-path-add entries → rc 0" "0" "$th_rc"
+
+# TC-RGH-022: added dirs do NOT leak into the runner's own env.
+# Assert by checking the RUNNER'S OWN PATH ($PATH we started with) has NOT
+# been mutated post-hoc — since the flags are consumed and dirs are only
+# appended to ISOLATED_PATH (which lives in the subshells).
+_orig_path="$PATH"
+th_out=$(bash "$RUNNER" --transport-path-add "$_scratch_bin" --itp github --chp github 2>&1); th_rc=$?
+assert_eq "TC-RGH-022: runner's own PATH unchanged (not mutated)" "$_orig_path" "$PATH"
+
+# TC-RGH-023: covered by TC-RGH-020 (github/github byte-identical when flag armed).
+ok "TC-RGH-023: (covered by TC-RGH-020) github/github byte-identical with --transport-path-add"
+
+# TC-RGH-024: --transport-path-add /nonexistent → fatal exit 2.
+th_out=$(bash "$RUNNER" --transport-path-add /no/such/dir-for-transport-$$ --itp github --chp github 2>&1); th_rc=$?
+assert_eq "TC-RGH-024: --transport-path-add /nonexistent → exit 2" "2" "$th_rc"
+
+rm -rf "$_scratch_bin" "$_scratch_bin2"
+
+# ===========================================================================
+echo ""
+echo "=== TC-RGH-030..033: --expect-absent partial-axis mechanism ==="
+# ===========================================================================
+# TC-RGH-030: --expect-absent downgrades leaf-absent FAILs to SKIP on gitlab axis.
+th_out=$(bash "$RUNNER" --itp gitlab --chp gitlab --expect-absent chp:create_pr,chp:merge 2>&1); th_rc=$?
+# Two verbs downgrade to SKIP, other absent verbs still FAIL → rc != 0.
+if [[ "$th_rc" -ne 0 ]]; then
+  ok "TC-RGH-030: --expect-absent with SOME verbs unnamed → rc != 0 (other absent verbs still FAIL)"
+else
+  bad "TC-RGH-030: expected rc != 0 (other absent verbs), got rc 0"
+fi
+assert_contains "TC-RGH-030: chp_create_pr downgraded to SKIP (expected-absent: ...)" \
+  "chp_create_pr SKIP (expected-absent: providers/chp-gitlab.sh:chp_gitlab_create_pr)" "$th_out"
+assert_contains "TC-RGH-030: chp_merge downgraded to SKIP" \
+  "chp_merge SKIP (expected-absent: providers/chp-gitlab.sh:chp_gitlab_merge)" "$th_out"
+
+# TC-RGH-031: --expect-absent chp:create_pr → OTHER absent verbs still FAIL.
+th_out=$(bash "$RUNNER" --itp gitlab --chp gitlab --expect-absent chp:create_pr 2>&1); th_rc=$?
+assert_contains "TC-RGH-031: chp_merge still FAILs when only chp_create_pr expected-absent" \
+  "chp_merge FAIL leaf absent" "$th_out"
+
+# TC-RGH-032: --expect-absent seam-qualifies (itp:X != chp:X).
+# We rely on the CSV parse rejecting an entry without `:` (fatal exit 2).
+th_out=$(bash "$RUNNER" --itp gitlab --chp gitlab --expect-absent create_pr 2>&1); th_rc=$?
+assert_eq "TC-RGH-032: --expect-absent without seam qualification → exit 2 (fatal)" "2" "$th_rc"
+
+# ===========================================================================
+echo ""
+echo "=== TC-RGH-040..042: --itp gitlab --chp gitlab interim (W-D early half) ==="
+# ===========================================================================
+# TC-RGH-040: gitlab/gitlab on today's tree — non-zero exit, one FAIL per absent verb.
+gl_out=$(bash "$RUNNER" --itp gitlab --chp gitlab 2>&1); gl_rc=$?
+if [[ "$gl_rc" -ne 0 ]]; then
+  ok "TC-RGH-040: --itp gitlab --chp gitlab (no leaves) → rc != 0"
+else
+  bad "TC-RGH-040: expected rc != 0, got 0"
+fi
+gl_leafabs_count="$(grep -c 'FAIL leaf absent:' <<<"$gl_out")"
+if [[ "$gl_leafabs_count" -ge 20 ]]; then
+  ok "TC-RGH-040: 20+ per-verb 'FAIL leaf absent' lines emitted ($gl_leafabs_count)"
+else
+  bad "TC-RGH-040: expected ≥ 20 FAIL leaf absent lines, got $gl_leafabs_count"
+fi
+
+# TC-RGH-041: runner did NOT abort — has a CONFORMANCE-SUMMARY line.
+assert_contains "TC-RGH-041: runner completed (has SUMMARY line)" "CONFORMANCE-SUMMARY" "$gl_out"
+
+# TC-RGH-042: --expect-absent covering every absent verb → rc 0.
+# Build the full absent-verb list by extracting them from the FAIL output.
+# For robustness, name every verb we know is absent on today's tree.
+_all_absent=""
+while IFS= read -r line; do
+  # Grab lines like "CONFORMANCE-PCONF gitlab/gitlab <verb> FAIL leaf absent"
+  if [[ "$line" =~ CONFORMANCE-PCONF\ gitlab/gitlab\ ([a-z_]+)\ FAIL\ leaf\ absent ]]; then
+    verb="${BASH_REMATCH[1]}"
+    seam="${verb%%_*}"
+    base="${verb#itp_}"; base="${base#chp_}"
+    _all_absent="${_all_absent}${seam}:${base},"
+  fi
+done <<<"$gl_out"
+_all_absent="${_all_absent%,}"
+gl_out2=$(bash "$RUNNER" --itp gitlab --chp gitlab --expect-absent "$_all_absent" 2>&1); gl2_rc=$?
+assert_eq "TC-RGH-042: --expect-absent covering every absent verb → rc 0" "0" "$gl2_rc"
+
+# ===========================================================================
+echo ""
+echo "=== TC-RGH-050: github/github parity (byte-identical) — 31 PASS still holds ==="
+# ===========================================================================
+th_pass_count="$(grep -c '^CONFORMANCE-PCONF github/github .* PASS$' <<<"$gh_out")"
+assert_eq "TC-RGH-050: github/github byte-identical (31 PASS lines)" "31" "$th_pass_count"
+
+# ===========================================================================
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [[ "$FAIL" -eq 0 ]] && exit 0 || exit 1

--- a/tests/unit/test-provider-conformance-runner.sh
+++ b/tests/unit/test-provider-conformance-runner.sh
@@ -321,6 +321,65 @@ rm -rf "$_scratch_abs"
 
 # ===========================================================================
 echo ""
+echo "=== TC-RGH-006..009: name=/abs/dir out-of-tree provider (P1-5 review-response) ==="
+# ===========================================================================
+# [#416 P1-5] Codex round-1 [P1-5]: the pre-fix runner passed an absolute
+# path directly as ITP_NAME/CHP_NAME, so pcf_materialize_scratch built
+# nonsense filenames like `itp-/tmp/x.sh` and function names like
+# `itp_/tmp/x_verb`. Post-fix the flag shape is `--itp <name>=/abs/dir`,
+# decoupling logical NAME (used in filenames) from source DIR.
+
+# Build a REAL fixture out-of-tree provider dir with a working itp_corp.sh
+# leaf that mirrors the degraded provider's shape for a couple of verbs.
+# The runner should be invocable against it via `--itp corp=/tmp/…` and
+# emit `itp_corp_<verb>` function references, not `itp_/tmp/…_<verb>`.
+_extdir="$(mktemp -d)"
+_deg_dir="$PROJECT_ROOT/tests/unit/fixtures/provider-degraded"
+if [[ -f "$_deg_dir/itp-degraded.sh" && -f "$_deg_dir/itp-degraded.caps" ]]; then
+  # Copy the degraded ITP verbatim into the ext dir, renamed to `corp`,
+  # rewriting function names `itp_degraded_*` → `itp_corp_*` and the
+  # `_ITP_NAME=degraded` sentinel if present.
+  sed 's/itp_degraded_/itp_corp_/g; s/_ITP_NAME=degraded/_ITP_NAME=corp/g' \
+    "$_deg_dir/itp-degraded.sh" > "$_extdir/itp-corp.sh"
+  cp "$_deg_dir/itp-degraded.caps" "$_extdir/itp-corp.caps"
+  # Same for chp (so `--chp corp=…` also has something to resolve).
+  sed 's/chp_degraded_/chp_corp_/g; s/_CHP_NAME=degraded/_CHP_NAME=corp/g' \
+    "$_deg_dir/chp-degraded.sh" > "$_extdir/chp-corp.sh"
+  cp "$_deg_dir/chp-degraded.caps" "$_extdir/chp-corp.caps"
+
+  # TC-RGH-006: name=/abs/dir accepted; runner produces `CONFORMANCE-PCONF
+  # corp/corp <verb> …` lines (logical name, NOT the abs path).
+  rgh6_out=$(bash "$RUNNER" --itp "corp=$_extdir" --chp "corp=$_extdir" 2>&1); rgh6_rc=$?
+  assert_contains "TC-RGH-006: label uses LOGICAL name 'corp/corp' (not the abs path)" \
+    "CONFORMANCE-PCONF corp/corp" "$rgh6_out"
+  # And crucially — no `itp_/tmp/` or `chp_/tmp/` function-name pollution.
+  assert_not_contains "TC-RGH-006: no path-based function names leaked" \
+    "itp_/" "$rgh6_out"
+  assert_not_contains "TC-RGH-006: no chp path-based function names leaked" \
+    "chp_/" "$rgh6_out"
+
+  # TC-RGH-007: legacy abs-path-only form is now REJECTED with a fatal
+  # (pre-P1-5 it silently produced nonsense filenames).
+  rgh7_out=$(bash "$RUNNER" --itp "$_extdir" --chp "$_extdir" 2>&1); rgh7_rc=$?
+  assert_eq "TC-RGH-007: legacy abs-path-only --itp → exit 2 (fatal)" "2" "$rgh7_rc"
+  assert_contains "TC-RGH-007: fatal names the required form" "<name>=<abs-dir>" "$rgh7_out"
+
+  # TC-RGH-008: <name>=<non-existent-abs-dir> → fatal.
+  rgh8_out=$(bash "$RUNNER" --itp "corp=/no/such/provider-dir-$$" --chp github 2>&1); rgh8_rc=$?
+  assert_eq "TC-RGH-008: name=/nonexistent → exit 2 (fatal)" "2" "$rgh8_rc"
+
+  # TC-RGH-009: empty name / empty dir on either side of '=' → fatal.
+  rgh9_out=$(bash "$RUNNER" --itp "=$_extdir" --chp github 2>&1); rgh9_rc=$?
+  assert_eq "TC-RGH-009a: empty name before '=' → exit 2" "2" "$rgh9_rc"
+  rgh9b_out=$(bash "$RUNNER" --itp "corp=" --chp github 2>&1); rgh9b_rc=$?
+  assert_eq "TC-RGH-009b: empty dir after '=' → exit 2" "2" "$rgh9b_rc"
+else
+  ok "TC-RGH-006..009: skipped — degraded fixture not found (unexpected in this repo)"
+fi
+rm -rf "$_extdir"
+
+# ===========================================================================
+echo ""
 echo "=== TC-RGH-010..012: --transport-hook passthrough ==="
 # ===========================================================================
 # TC-RGH-010: unreadable hook path → fatal exit 2 with usage error message.

--- a/tests/unit/test-provider-cutover.sh
+++ b/tests/unit/test-provider-cutover.sh
@@ -860,6 +860,30 @@ else
 fi
 
 # ===========================================================================
+echo "=== TC-CUTOVER-GLAB-001b: TAB-separated 'glab<TAB>issue list' FAILs (#416 review round 2) ==="
+# ===========================================================================
+S="$(fresh_scratch glab001b)"
+printf '\nglab_tab() { glab\tissue list; }\n' >> "$S/autonomous-dev.sh"
+out="$(bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" 2>&1)"; rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q "raw \`glab\` token" <<<"$out"; then
+  ok "TC-CUTOVER-GLAB-001b: tab-separated raw 'glab' → FAIL (whitespace-class boundary)"
+else
+  bad "TC-CUTOVER-GLAB-001b: tab-separated 'glab' NOT caught (rc=$rc)"
+fi
+
+# ===========================================================================
+echo "=== TC-CUTOVER-GLAB-001c: split-line /api/v4 var + TAB-separated curl FAILs (#416 review round 2) ==="
+# ===========================================================================
+S="$(fresh_scratch glab001c)"
+printf '\nu="https://gitlab.example.com/api/v4/projects/1"\ncurl\t"$u"\n' >> "$S/autonomous-dev.sh"
+out="$(bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" 2>&1)"; rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  ok "TC-CUTOVER-GLAB-001c: split-line /api/v4 var consumed by tab-separated curl → FAIL"
+else
+  bad "TC-CUTOVER-GLAB-001c: tab-separated curl of an /api/v4 var NOT caught (rc=$rc)"
+fi
+
+# ===========================================================================
 echo "=== TC-CUTOVER-GLAB-002: 'glab' in a comment does NOT trip ==="
 # ===========================================================================
 S="$(fresh_scratch glab002)"

--- a/tests/unit/test-provider-cutover.sh
+++ b/tests/unit/test-provider-cutover.sh
@@ -847,6 +847,99 @@ else
 fi
 
 # ===========================================================================
+echo "=== TC-CUTOVER-GLAB-001: injected raw 'glab issue create' in scratch autonomous-dev.sh FAILs (#416 R4) ==="
+# ===========================================================================
+S="$(fresh_scratch glab001)"
+# shellcheck disable=SC2016
+printf '\nglab_direct() { glab issue create --title inj; }\n' >> "$S/autonomous-dev.sh"
+out="$(bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" 2>&1)"; rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q "raw \`glab\` token" <<<"$out"; then
+  ok "TC-CUTOVER-GLAB-001: raw 'glab' in caller layer → FAIL naming the site"
+else
+  bad "TC-CUTOVER-GLAB-001: injected raw 'glab' NOT caught (rc=$rc)"
+fi
+
+# ===========================================================================
+echo "=== TC-CUTOVER-GLAB-002: 'glab' in a comment does NOT trip ==="
+# ===========================================================================
+S="$(fresh_scratch glab002)"
+# shellcheck disable=SC2016
+printf '\n# This comment mentions glab in prose — must not trip the detector.\n' >> "$S/autonomous-dev.sh"
+if bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" >/dev/null 2>&1; then
+  ok "TC-CUTOVER-GLAB-002: prose 'glab' in a comment line does NOT trip"
+else
+  bad "TC-CUTOVER-GLAB-002: comment prose 'glab' tripped the lint (should not)"
+fi
+
+# ===========================================================================
+echo "=== TC-CUTOVER-GLAB-003: 'glabber' / '_glab' / '-glab' do NOT trip (word-boundary) ==="
+# ===========================================================================
+S="$(fresh_scratch glab003)"
+# shellcheck disable=SC2016
+printf '\nfake_fn() { local _glab=1; echo "$_glab glabber -glab"; }\n' >> "$S/autonomous-dev.sh"
+if bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" >/dev/null 2>&1; then
+  ok "TC-CUTOVER-GLAB-003: word-boundary rejects '_glab' / 'glabber' / '-glab'"
+else
+  bad "TC-CUTOVER-GLAB-003: word-boundary letter false-positive"
+fi
+
+# ===========================================================================
+echo "=== TC-CUTOVER-GLAB-NEG: the 5 gh-app-token.sh curl argvs PASS (shape-exclusion) ==="
+# ===========================================================================
+S="$(fresh_scratch glabneg)"
+# The gh-app-token.sh curl argvs mention api.github.com endpoints — no /api/v4.
+# Verify NO regression on the clean scratch copy (Check 6 emits its "no /api/v4
+# curl found" line and rc 0). This asserts that the shape-exclusion holds
+# without any allowlist widening.
+if bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" 2>&1 | grep -q "no '/api/v4' curl found outside providers/lib-gitlab-transport.sh"; then
+  ok "TC-CUTOVER-GLAB-NEG: shape-exclusion — 5 gh-app-token.sh curl sites PASS (api.github.com != /api/v4)"
+else
+  bad "TC-CUTOVER-GLAB-NEG: Check 6 unexpected FAIL on clean scratch"
+fi
+
+# Explicit sanity: inject a canonical gh-app-token.sh-shape curl argv into a
+# scratch file that is NOT allowlisted and verify it still passes (does NOT
+# match the /api/v4 detector — proves the shape-exclusion is content-based,
+# not file-scoped).
+S="$(fresh_scratch glabnegcurl)"
+# shellcheck disable=SC2016
+printf '\ntest_gh_style_curl() {\n  curl -s -H "Authorization: bearer $tok" -H "Accept: application/vnd.github+json" "https://api.github.com/orgs/foo/repos"\n}\n' >> "$S/autonomous-dev.sh"
+# gh_lines_in will not fire because there is no `gh ` token here (only `curl`).
+# But the /api/v4 detector must not either.
+if bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" 2>&1 | grep -q "no '/api/v4' curl found outside providers/lib-gitlab-transport.sh"; then
+  ok "TC-CUTOVER-GLAB-NEG-CURL: api.github.com curl argv passes /api/v4 detector cleanly"
+else
+  bad "TC-CUTOVER-GLAB-NEG-CURL: api.github.com curl argv tripped the /api/v4 detector (shape-exclusion broken)"
+fi
+
+# ===========================================================================
+echo "=== TC-CUTOVER-GLAB-004: injected '/api/v4' curl in scratch autonomous-dev.sh FAILs ==="
+# ===========================================================================
+S="$(fresh_scratch glab004)"
+# shellcheck disable=SC2016
+printf '\nfake_gitlab_curl() {\n  curl -s -H "PRIVATE-TOKEN: $tok" "https://gitlab.com/api/v4/projects/1/issues"\n}\n' >> "$S/autonomous-dev.sh"
+out="$(bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" 2>&1)"; rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q "raw '/api/v4' curl outside" <<<"$out"; then
+  ok "TC-CUTOVER-GLAB-004: raw /api/v4 curl in a caller-layer file → FAIL"
+else
+  bad "TC-CUTOVER-GLAB-004: /api/v4 curl NOT caught (rc=$rc)"
+fi
+
+# ===========================================================================
+echo "=== TC-CUTOVER-GLAB-005: '/api/v4' curl inside providers/lib-gitlab-transport.sh PASSES ==="
+# ===========================================================================
+S="$(fresh_scratch glab005)"
+# The scratch fresh_scratch copies providers/ recursively — including
+# lib-gitlab-transport.sh with its curl call. Verify it passes without
+# error. (Any hit inside providers/lib-gitlab-transport.sh is legitimately
+# skipped by Check 6.)
+if bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" >/dev/null 2>&1; then
+  ok "TC-CUTOVER-GLAB-005: /api/v4 curl inside providers/lib-gitlab-transport.sh is legitimate (Check 6 skips it)"
+else
+  bad "TC-CUTOVER-GLAB-005: lib-gitlab-transport.sh tripped Check 6 (should be the legitimate home)"
+fi
+
+# ===========================================================================
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [[ "$FAIL" -eq 0 ]] && exit 0 || exit 1

--- a/tests/unit/test-provider-cutover.sh
+++ b/tests/unit/test-provider-cutover.sh
@@ -891,7 +891,7 @@ S="$(fresh_scratch glabneg)"
 # Verify NO regression on the clean scratch copy (Check 6 emits its "no /api/v4
 # curl found" line and rc 0). This asserts that the shape-exclusion holds
 # without any allowlist widening.
-if bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" 2>&1 | grep -q "no '/api/v4' curl found outside providers/lib-gitlab-transport.sh"; then
+if bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" 2>&1 | grep -q "no '/api/v4' curl (same-line or split-across-lines) found outside providers/lib-gitlab-transport.sh"; then
   ok "TC-CUTOVER-GLAB-NEG: shape-exclusion — 5 gh-app-token.sh curl sites PASS (api.github.com != /api/v4)"
 else
   bad "TC-CUTOVER-GLAB-NEG: Check 6 unexpected FAIL on clean scratch"
@@ -906,7 +906,7 @@ S="$(fresh_scratch glabnegcurl)"
 printf '\ntest_gh_style_curl() {\n  curl -s -H "Authorization: bearer $tok" -H "Accept: application/vnd.github+json" "https://api.github.com/orgs/foo/repos"\n}\n' >> "$S/autonomous-dev.sh"
 # gh_lines_in will not fire because there is no `gh ` token here (only `curl`).
 # But the /api/v4 detector must not either.
-if bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" 2>&1 | grep -q "no '/api/v4' curl found outside providers/lib-gitlab-transport.sh"; then
+if bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" 2>&1 | grep -q "no '/api/v4' curl (same-line or split-across-lines) found outside providers/lib-gitlab-transport.sh"; then
   ok "TC-CUTOVER-GLAB-NEG-CURL: api.github.com curl argv passes /api/v4 detector cleanly"
 else
   bad "TC-CUTOVER-GLAB-NEG-CURL: api.github.com curl argv tripped the /api/v4 detector (shape-exclusion broken)"
@@ -937,6 +937,70 @@ if bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" >/dev/null 2>&1; then
   ok "TC-CUTOVER-GLAB-005: /api/v4 curl inside providers/lib-gitlab-transport.sh is legitimate (Check 6 skips it)"
 else
   bad "TC-CUTOVER-GLAB-005: lib-gitlab-transport.sh tripped Check 6 (should be the legitimate home)"
+fi
+
+# ===========================================================================
+echo "=== TC-CUTOVER-GLAB-BOUND-001: split-across-lines /api/v4 (var+curl) IS caught (#416 P2-6) ==="
+# ===========================================================================
+# [#416 P2-6] Pre-P2-6 the /api/v4 detector was same-line-only; a
+# two-line shape
+#   url="https://gitlab.example/api/v4/projects/1/issues"
+#   curl -sS -H "PRIVATE-TOKEN: $tok" "$url"
+# would slip past. Post-P2-6 the file-level detector fires on
+# "same VAR name assigned to /api/v4/ AND used in a curl invocation on
+# a different line".
+S="$(fresh_scratch glabp26)"
+# shellcheck disable=SC2016
+cat >> "$S/autonomous-dev.sh" <<'EOF'
+
+fake_gitlab_split_curl() {
+  url="https://gitlab.example.com/api/v4/projects/1/issues"
+  curl -sS -H "PRIVATE-TOKEN: $tok" "$url"
+}
+EOF
+out="$(bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" 2>&1)"; rc=$?
+if [[ "$rc" -ne 0 ]] && grep -q "split-across-lines" <<<"$out"; then
+  ok "TC-CUTOVER-GLAB-BOUND-001: split VAR + curl \"\$VAR\" caught by the P2-6 detector"
+else
+  bad "TC-CUTOVER-GLAB-BOUND-001: split shape NOT caught (rc=$rc); output: ${out:0:400}"
+fi
+
+# ===========================================================================
+echo "=== TC-CUTOVER-GLAB-BOUND-002: DOCUMENTED BOUND — indirect flow bypasses (review-gate territory) ==="
+# ===========================================================================
+# [#416 P2-6] The P2-6 detector matches ONLY "same VAR name in both places".
+# Indirect flows (function arg passing, env-var derivation) are still
+# bypassable and belong to the review gate — this TC documents that bound
+# and asserts the honest description is present in the checker comment.
+S="$(fresh_scratch glabp26b)"
+# shellcheck disable=SC2016
+cat >> "$S/autonomous-dev.sh" <<'EOF'
+
+fake_indirect_flow() {
+  build_url() { echo "https://gitlab.example.com/api/v4/projects/1"; }
+  # Indirect: derived from function output, not a same-name assignment.
+  target=$(build_url)
+  curl -sS -H "PRIVATE-TOKEN: $tok" "$target"
+}
+EOF
+# Above: `build_url` assigns nothing named `target`; the `target=…` line
+# uses command substitution rather than a literal-string assignment. This
+# shape is EXPECTED to bypass the file-level detector — DOCUMENTED bound.
+if bash "$CHECK" --scripts-dir "$S" --baseline "$BASELINE" >/dev/null 2>&1; then
+  ok "TC-CUTOVER-GLAB-BOUND-002: indirect-flow bypass documented (P2-6 file-level detector does NOT cover this — review-gate territory)"
+else
+  # A pass-through here would mean the guard got smarter than documented,
+  # which is fine — but we don't fail the test either way (bound is honest).
+  ok "TC-CUTOVER-GLAB-BOUND-002: indirect-flow shape also caught (stricter than the documented bound — still acceptable)"
+fi
+
+# Comment/doc-honesty grep: the checker must state the bound in a nearby
+# comment so a future reader knows what the detector DOES and DOESN'T do.
+if grep -q "BOUND — SAME-LINE-ONLY, DOCUMENTED HONESTLY" "$CHECK" \
+   && grep -Pzq '(?s)Indirect flows.*belong to the review gate' "$CHECK"; then
+  ok "TC-CUTOVER-GLAB-BOUND-002-DOC: checker comment states the bound honestly (P2-6 requirement)"
+else
+  bad "TC-CUTOVER-GLAB-BOUND-002-DOC: checker comment does not document the same-line-only bound + indirect-flow limitation"
 fi
 
 # ===========================================================================


### PR DESCRIPTION
Implements #416 (phase-3 P3-1 under #414): the GitLab transport seam — the frozen two-layer contract every later GitLab leaf builds on — plus auth-lifecycle gating, conformance-runner gitlab/out-of-tree axes with `--transport-hook`/`--expect-absent`, and the [INV-91] guard extension for the GitLab host-API token class.

## What's in
- **`providers/lib-gitlab-transport.sh`** — `_gl_http` (curl-only single-request primitive; the out-of-tree hook point; body on stdout for ALL statuses, status+headers to file, rc = transport success only) + `_gl_api` (public leaf-facing fn: page-number pagination walk w/ `GL_TRANSPORT_PAGE_CAP` fail-closed, 429/`Retry-After` bounded backoff, `GL_API_STATUS` in calling shell + `--status-out FILE`, `--tolerate-status CSV`, `--max-items N`) + `_gl_urlencode` + `GITLAB_TRANSPORT_HOOK` sourcing (override `_gl_http` only; no-op hooks rejected; operator-trust model, not a sandbox) + latched fail-loud preflight. set-e-safe under callers' `set -euo pipefail`.
- **Auth-lifecycle gating** — `github_seam_active()` shared helper; `setup_github_auth`/`setup_agent_token`/dispatcher-tick + BOTH wrapper-level `GH_AUTH_MODE=app` FATALs gated on (ISSUE_PROVIDER=github OR CODE_HOST=github). github/github byte-parity proven; gitlab/gitlab full no-op; mixed github-ITP/gitlab-CHP keeps the gh lifecycle. `GITLAB_TOKEN` PAT-posture WARN parallel to the existing [INV-79] PAT-mode WARN.
- **Conformance runner (W-D early)** — `gitlab` axis resolves to the real skill tree; out-of-tree provider dirs via name-decoupled dir form; `--transport-hook` + `--transport-path-add` threaded through `_invoke`'s env-scrub; `--expect-absent seam:verb` downgrades named leaf-absent FAILs to SKIP (the partial-axis mechanism for P3-2/P3-3 interim states).
- **[INV-91] guard extension** — raw `glab ` word-boundary + same-line `/api/v4`-curl outside providers/ + transport lib = FAIL, strict-from-zero; the 5 `gh-app-token.sh` curl sites pass by shape-exclusion (api.github.com, no allowlist entry); best-effort split-line detector + honestly-documented bound; gh baseline byte-unchanged.
- **Docs (Pipeline Documentation Authority)** — provider-spec §transport (the normative frozen contract), §auth GitLab rows, §5.1 forward-ref; invariants.md INV-113 w/ triage tag; two test-cases docs.

## Verification (all `env -u PROJECT_DIR`, on this branch)
- `test-lib-gitlab-transport.sh` 76/0 · `test-auth-lifecycle-gating.sh` 29/0 · `test-provider-conformance-runner.sh` 94/0 · `test-provider-cutover.sh` 78/0
- `run-provider-conformance.sh --itp github --chp github` → 31 PASS / 0 pending (byte-parity, #414 AC2)
- `check-provider-cutover.sh` → PASS (baseline unchanged)
- Full unit sweep: zero regressions (test-lane-gc-p1-source-hygiene.sh's 1 FAIL reproduces identically on origin/main — pre-existing, not this branch)

## Post-install
Adds only `lib-*.sh`/`providers/*` files — **no entry-point script, no consumer installer re-run** (skill-tree `readlink -f` resolution).

Part of #414 (P3-1). Unblocks #417 (P3-2) and #418 (P3-3).

Closes #416