### PR TITLE
docs(providers): P3-5 GitLab config plumbing + setup docs + CI gitlab-axis wiring (#420)

### DIFF
--- a/docs/designs/p3-5-gitlab-config-docs.md
+++ b/docs/designs/p3-5-gitlab-config-docs.md
@@ -1,0 +1,67 @@
+# Design — P3-5: GitLab config plumbing + docs + CI gitlab-axis wiring (#420)
+
+Phase-3 slice 5 under tracking issue #414 (W-E config half). Docs-and-plumbing
+only: no provider leaf, no wrapper control-flow change.
+
+## Problem
+
+P3-1..P3-4 (#416/#417/#418/#419) landed the full GitLab provider pair and the
+conformance gitlab axis, but an operator onboarding a GitLab project still has
+no conf template (`autonomous.conf.example` documents only GitHub keys) and no
+setup guide (nothing analogous to `docs/github-app-setup.md`). The gitlab axis
+also needed an issue-named CI gate, and parent #414's AC1..AC5 needed a single
+evidence sweep posted.
+
+## Design
+
+Four additive surfaces, one issue-closing act:
+
+1. **`autonomous.conf.example` GitLab block** — `ISSUE_PROVIDER`/`CODE_HOST`
+   (default github when unset — byte-identical default), `GITLAB_HOST`
+   (gitlab.com default; self-hosted CE/EE first-class), `GITLAB_TOKEN`
+   (PAT / project / group token — all `PRIVATE-TOKEN` header, scope `api`),
+   `GITLAB_PROJECT` (URL-encoded path per spec §3.4), `GITLAB_TRANSPORT_HOOK`
+   (one neutral sentence pointing at the provider-spec §transport contract;
+   operator-owned local file trust model). All commented-out; the example must
+   keep sourcing cleanly.
+2. **`docs/gitlab-setup.md`** — the operator guide: token-vs-GitHub-App posture
+   (degraded [INV-79] two-token → convention), token creation + scopes,
+   self-hosted host config, conf keys, transport-hook pointer (contract lives
+   in provider-spec §transport — this doc never restates it), and the
+   git-remote-auth-is-operator-owned boundary (SSH/credential helper — the API
+   hook does not cover the git channel).
+3. **CI gitlab-axis gate** — `TC-PCONF-070` in
+   `tests/unit/test-provider-conformance-runner.sh`: the #420-named summary
+   gate (rc 0, `fail=0`, `pending=0`) on the same captured gitlab/gitlab run
+   TC-RGH-060 (#419) drives — complementary (per-verb detail vs issue-named
+   summary), one runner invocation, shipped to CI via the existing unit-test
+   glob (no workflow YAML edit). `tests/provider-conformance/README.md` gains
+   the operator how-to invocation.
+4. **Spec + pipeline-doc touches** — §3.4 RESERVED→CONSUMED framing flip;
+   provider-neutral topology notes in `dispatcher-flow.md`/`handoffs.md` where
+   gh commands are named as the conceptual leaf (prose only, no invariant or
+   state-machine change).
+5. **#414 AC evidence sweep (R6/AC6)** — the `## Phase-3 AC evidence sweep`
+   comment on #414 citing AC1..AC5 surfaces + evidence; posted at review time
+   (every load-bearing artifact was already on main via PR #422..#425), URL
+   recorded in `docs/test-cases/p3-5-ac-sweep-draft.md` and the PR body.
+
+## Alternatives considered
+
+- **Editing `.github/workflows/ci.yml`** for the gitlab axis — rejected: the
+  unit-test glob already ships any `tests/unit/test-*.sh` case; a workflow edit
+  enlarges the blast radius for zero gain (#420 Out of Scope pins this).
+- **Restating the transport-hook contract in gitlab-setup.md** — rejected: the
+  contract is normative in provider-spec §transport; duplicating it creates a
+  drift pair (Pipeline Documentation Authority).
+- **Waiting for post-merge to post the AC sweep** — superseded at review round
+  1: all evidence artifacts were already merged, so the sweep is verifiable
+  pre-merge; posted with the green main-CI link at merge-of-#419.
+
+## Test strategy
+
+`docs/test-cases/p3-5-config-docs.md` (TC-P35-NNN): conf-example key greps +
+source check under `env -u PROJECT_DIR`, gitlab-setup.md section-structure
+greps, TC-PCONF-070 tally assertion, README axis line, spec §3.4 framing +
+spec-drift green, pipeline-doc note greps, enterprise-term leak scan (zero
+hits).

--- a/docs/gitlab-setup.md
+++ b/docs/gitlab-setup.md
@@ -1,0 +1,200 @@
+# GitLab Setup Guide
+
+Operator-facing guide for onboarding a project whose issue tracker AND/OR
+code host is GitLab (`ISSUE_PROVIDER=gitlab` / `CODE_HOST=gitlab`). The two
+seams are independent — a project MAY use GitLab for issues and GitHub for
+code, or vice versa, or both.
+
+The autonomous pipeline reaches GitLab through the frozen P3-1 transport
+contract (`skills/autonomous-dispatcher/scripts/providers/lib-gitlab-transport.sh`).
+Every leaf verb (`itp_gitlab_*` and `chp_gitlab_*`) routes HTTP through the
+lib's `_gl_api` public function — one choke-point, one pagination walker,
+one 429/`Retry-After` backoff loop, one fail-CLOSED discipline.
+
+## Why GitLab tokens vs GitHub Apps
+
+GitLab has **no GitHub-App equivalent**. The pipeline's three GitHub bot
+identities (dev, review, dispatcher — see `docs/github-app-setup.md`) map
+onto GitLab as follows:
+
+| Property | GitHub App mode | GitLab token mode |
+|----------|-----------------|-------------------|
+| Separate bot identities | Three separate Apps, three bot accounts | One token = one identity (the token's owner or the project/group) |
+| Token expiration | 1-hour installation tokens (auto-refreshed) | Long-lived PAT / project access token / group access token (operator-managed rotation) |
+| Fine-grained permissions | Per-permission granularity | Scope-based (`api` covers the seam's needs) |
+| Scoped agent-token containment ([INV-79]) | **Enforced** — the wrapper mints a separate `pull_requests: read` token for the agent subprocess, so `gh pr review --approve` / `gh pr merge` fail 403 from the agent | **Degraded to convention** — no lower-privilege token to mint; the same PAT is used everywhere. The wrapper's approve/merge gates ([INV-44] / [INV-52]) and the `_AGENT_GITLAB_TOKEN_PAT_WARNED` latch (`skills/autonomous-dispatcher/scripts/lib-auth.sh`) are the sole containment (see `docs/pipeline/provider-spec.md` §5.1). |
+| Audit trail | Each bot clearly identified in the timeline | Actions attributed to the token's owner |
+
+If your organization needs distinct bot identities for dev/review/dispatcher
+on a GitLab lane, provision three separate GitLab users (or three project
+access tokens on the project) and put each token in the appropriate config
+key on a per-role split.
+
+## Creating a token
+
+GitLab supports three interchangeable token classes for this pipeline. All
+three use the `PRIVATE-TOKEN` HTTP header the P3-1 transport sends and all
+three consume the same `api` scope. Pick the class that matches your
+deployment shape:
+
+| Class | Where you create it | When to use |
+|-------|---------------------|-------------|
+| **Personal access token (PAT)** | User Settings → Access tokens | A single-operator project where the pipeline runs under one human's identity. Simplest — matches the `GH_AUTH_MODE=token` shape on the GitHub side. |
+| **Project access token** | Project Settings → Access tokens | The pipeline is owned by a project, not a person. The token dies with the project; rotation is a project-admin action. Recommended default for organizational projects. |
+| **Group access token** | Group Settings → Access tokens | The pipeline works across sibling projects in one group (e.g. cross-project dependencies via `## Dependencies` refs). |
+
+### Required scope
+
+`api` — that single scope covers every verb the pipeline calls
+(issue read/write, MR read/write, notes, discussions, approvals, labels,
+files/branches for `chp_gitlab_commit_file`). No narrower scope suffices
+for the write leaves.
+
+### Optional stricter scopes
+
+For a **read-only** deployment (dispatcher-side liveness checks, evidence
+gathering) `read_api` is sufficient. The dev/review wrappers require `api`.
+
+## Self-hosted host configuration
+
+`GITLAB_HOST` defaults to `gitlab.com`. Any self-hosted CE/EE instance
+whose API speaks standard PAT auth against `/api/v4` is a first-class
+target — set `GITLAB_HOST` to the bare host (no scheme, no path). The P3-1
+transport constructs every request URL as
+`https://${GITLAB_HOST}/api/v4/<path>`.
+
+**Custom CA / mTLS / self-signed certificates.** The pipeline treats the
+network channel as operator-owned; it does not expose an in-tree
+`GITLAB_CA_BUNDLE` knob. If your `curl` needs a custom certificate bundle,
+custom CA, mTLS client certificate, cookie jar, or proxy configuration,
+set that up via the operator-owned **transport hook** (see below) which
+redefines `_gl_http` with whatever curl args your deployment needs. The
+transport hook is the seam's one extension point (#414 pillar 3); it lands
+your customization behind the same fail-loud preflight
+([INV-116]) as the default transport.
+
+## Configuring autonomous.conf
+
+Uncomment and populate the GitLab block near the bottom of
+`scripts/autonomous.conf` (the example ships with everything commented out
+so a github-only conf is byte-identical to pre-#420):
+
+```bash
+# === GitLab provider (ISSUE_PROVIDER=gitlab / CODE_HOST=gitlab) ===
+
+ISSUE_PROVIDER="gitlab"      # or leave unset if only CODE_HOST is gitlab
+CODE_HOST="gitlab"           # or leave unset if only ISSUE_PROVIDER is gitlab
+
+GITLAB_HOST="gitlab.com"                     # or your self-hosted host
+GITLAB_TOKEN="glpat-xxxxxxxxxxxxxxxxxxxx"    # PAT / project / group token
+GITLAB_PROJECT="group%2Fsubgroup%2Fproject"  # URL-encoded path
+
+# Optional; leave unset for the default curl transport.
+# GITLAB_TRANSPORT_HOOK="/path/to/operator-owned/hook.sh"
+```
+
+The keys — matching the block in
+`skills/autonomous-dispatcher/scripts/autonomous.conf.example`:
+
+| Key | Meaning | Notes |
+|-----|---------|-------|
+| `ISSUE_PROVIDER` | Which ITP seam to route to. | `github` (default) / `gitlab` / `asana` (reserved). |
+| `CODE_HOST` | Which CHP seam to route to. | `github` (default) / `gitlab`. |
+| `GITLAB_HOST` | API host (no scheme). | Defaults to `gitlab.com`. |
+| `GITLAB_TOKEN` | The PAT / project / group access token. | Scope: `api`. Sent as `PRIVATE-TOKEN` on every request. |
+| `GITLAB_PROJECT` | The project's URL-encoded `namespace/name` (or `group/subgroup/name`). | Stored **already** URL-encoded (spec §3.4). Used **verbatim** by the leaves — never re-encoded. Example: `group%2Fsubgroup%2Fproject`. Dynamic path segments (label names, file paths) go through `_gl_urlencode` separately. |
+| `GITLAB_TRANSPORT_HOOK` | Optional path to a custom transport hook. | See next section. |
+
+Store `GITLAB_TOKEN` outside version control. The standard shape
+(matching the github side) is a `.env.gitlab` file in the project root,
+gitignored, sourced by `autonomous.conf`:
+
+```bash
+# scripts/autonomous.conf
+if [[ -r .env.gitlab ]]; then
+  # shellcheck disable=SC1091
+  source .env.gitlab
+fi
+```
+
+## Transport hook (custom-gateway deployments)
+
+The `_gl_http` primitive (P3-1 W-A, `providers/lib-gitlab-transport.sh`)
+is the ONE public override point for the GitLab seam. Point
+`GITLAB_TRANSPORT_HOOK` at an operator-owned shell file that redefines
+`_gl_http` per the frozen contract in `docs/pipeline/provider-spec.md`
+§transport ([§3.5.1](pipeline/provider-spec.md#351-gitlab-transport-contract-transport--the-two-layer-choke-point)),
+and every leaf inherits your customization — proxies, mTLS, custom auth
+headers, whatever your deployment needs. `_gl_api` (the pagination walker,
+`429`/`Retry-After` backoff, fail-CLOSED discipline) stays lib-owned so a
+variant transport cannot silently regress those guarantees.
+
+**Trust model.** The hook is **operator-owned local code**, sourced by
+the transport lib at library-init BEFORE any leaf runs. It has the same
+privileges as `autonomous.conf` itself — explicitly NOT a sandbox
+(#414 pillar 3). Don't point `GITLAB_TRANSPORT_HOOK` at a file you don't
+own; the transport lib reads it once per process and executes whatever it
+finds.
+
+**Preflight.** The lib fail-loudly rejects a misconfigured hook
+([INV-116]): a set `GITLAB_TRANSPORT_HOOK` pointing at an unreadable path,
+or a hook that doesn't redefine `_gl_http`, or a hook whose `_gl_http`
+body is byte-identical to the default (a no-op hook masquerading as a
+custom transport) all fail loud at the first `_gl_api` call.
+
+## Git-remote authentication is operator-owned
+
+The transport hook covers the **API** channel (issues, merge requests,
+approvals, discussions, file API — everything the ITP/CHP leaves call).
+It does **NOT** cover the **git** channel — the `git push` / `git fetch`
+the dev agent runs against the code host's git remote. That channel is
+outside the seam by design (#414 pillar 3's second extension point).
+
+Wire up git-remote auth via the standard, operator-owned mechanisms:
+
+- **SSH remotes** — add the pipeline user's SSH key to the GitLab
+  user/project/group that owns the token above, and let git resolve
+  `git@${GITLAB_HOST}:group/subgroup/project.git` through your SSH config.
+- **HTTPS remotes** — configure a git **credential helper**
+  (`git config --global credential.helper …`) that returns the
+  `GITLAB_TOKEN` for `${GITLAB_HOST}`. The pipeline never writes to your
+  `.git-credentials` file itself.
+
+The dev agent's `git push` uses the remote you configured; the pipeline
+does not intercept it, wrap it, or override it.
+
+## Verifying the setup
+
+1. Populate the GitLab keys in `scripts/autonomous.conf` as above.
+2. Confirm the conf still sources cleanly:
+   ```bash
+   env -u PROJECT_DIR bash -c 'source scripts/autonomous.conf && \
+     printf "provider=%s host=%s project=%s\n" \
+       "$ISSUE_PROVIDER" "$GITLAB_HOST" "$GITLAB_PROJECT"'
+   ```
+3. Run the conformance suite against the gitlab axis end-to-end (hermetic,
+   no live network I/O — the fixture transport hook serves canned
+   payloads):
+   ```bash
+   env -u PROJECT_DIR bash tests/provider-conformance/run-provider-conformance.sh \
+     --itp gitlab --chp gitlab \
+     --transport-hook tests/provider-conformance/fixtures/gitlab-hook/gitlab-transport-hook.sh
+   ```
+   Expect `CONFORMANCE-SUMMARY total=34 pass=32 fail=0 skip=2 pending=0`
+   on a fully-landed P3-1..P3-4 tree. The two SKIPs are
+   `chp_request_changes` (`rest_request_changes=0` — GitLab has no REST
+   verb for requesting changes) and `chp_trigger_bot` (`review_bots=0`
+   — the gitlab lane's initial review-bot posture).
+4. Live GitLab smoke — operator-provisioned standard GitLab project, one
+   `autonomous` issue, one dev/review cycle — is the post-merge gate per
+   parent #414 AC5.
+
+## See also
+
+- `docs/pipeline/provider-spec.md` §3.4 (config namespace),
+  §3.5.1 (transport contract), §5.1 (GitLab per-backend feasibility).
+- `docs/pipeline/invariants.md` [INV-79] (agent-token containment),
+  [INV-116] (GitLab transport preflight).
+- `docs/github-app-setup.md` — the GitHub-side counterpart of this guide;
+  read alongside for the shared vocabulary (wrapper vs agent, two-token
+  posture, verdict actor detection).

--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -223,6 +223,8 @@ The issue is now in `in-progress`; the dev wrapper is launching via `nohup`. Ste
 
 Implementation: `lib-dispatch.sh::list_pending_review`, `label_swap`.
 
+> **Provider-neutral topology note (#420 P3-5).** The `gh issue edit` shown below is the conceptual leaf; the atomic label swap is emitted by the `itp_transition_state` verb. GitHub leaf shown for reference — see [provider-spec.md §3.4](provider-spec.md#34-repo-stays--as-the-github-providers-config-namespace) for the config-namespace surface behind the seam.
+
 Find issues labeled `autonomous` AND `pending-review` AND NOT (`reviewing` OR `approved` OR `stalled`). The `approved`/`stalled` exclusion is defense-in-depth on top of [INV-25](invariants.md#inv-25-terminal-labels-approved-stalled-are-sticky-transitional-residue-is-healed-at-tick-start) Step 0 hygiene — Step 0 strips `pending-review` from terminal issues at tick start, but if Step 0 fails (rate-limit, API outage), the inline filter still keeps the selector from spawning a review against an already-approved/stalled issue.
 
 For each match, in order:
@@ -416,6 +418,8 @@ For each match:
 ### Step 5a: ALIVE in-progress + PR ready for review (#54, #56)
 
 The dev wrapper might have finished its real work — pushed a passing CI build — and then hung in some auxiliary code (polling loop, stuck stdio). Without intervention the issue stays `in-progress` forever and no review fires.
+
+> **Provider-neutral topology note (#420 P3-5).** The `gh pr list` / `gh pr checks` / `gh issue edit` shown in the gates table below are the conceptual leaves; the actual emits route through `chp_find_pr_for_issue` / `chp_ci_status` / `itp_transition_state`. GitHub leaves shown for reference — see [provider-spec.md §3.2](provider-spec.md#32-code-host-provider-chp-verbs) for the provider-neutral verb surface behind the seam.
 
 All these gates must hold before sending SIGTERM (any one failing → leave alone):
 

--- a/docs/pipeline/handoffs.md
+++ b/docs/pipeline/handoffs.md
@@ -55,6 +55,8 @@ flowchart LR
 
 **Trigger**: Step 4 finds an issue labeled `pending-dev` with retries below `MAX_RETRIES`.
 
+> **Provider-neutral topology note (#420 P3-5).** The `gh issue edit` shown below is the conceptual leaf; the atomic label swap is emitted through the `itp_transition_state` verb. GitHub leaf shown for reference — see [provider-spec.md §3.1](provider-spec.md#31-issue-tracker-provider-itp-verbs) for the provider-neutral verb.
+
 **Producer-side invariants**:
 
 - Atomic label swap `−pending-dev +in-progress` (single `gh issue edit` call).
@@ -123,6 +125,8 @@ flowchart LR
 Two sub-handoffs depending on verdict:
 
 ### H5a: review → approved (verdict PASS)
+
+> **Provider-neutral topology note (#420 P3-5).** The `gh pr review --approve` / `gh pr merge` / `gh issue close` mentions below are the conceptual leaves; the actual emits route through `chp_approve` / `chp_merge` and the (deliberately absent) `chp_close_keyword` render. GitHub leaves shown for reference — see [provider-spec.md §3.2](provider-spec.md#32-code-host-provider-chp-verbs).
 
 **Producer-side invariants**:
 

--- a/docs/pipeline/provider-spec.md
+++ b/docs/pipeline/provider-spec.md
@@ -446,9 +446,29 @@ in-place-edit backend.
 
 `REPO` / `REPO_OWNER` / `REPO_NAME` and the `GH_AUTH_MODE` / `*_APP_ID` /
 `*_APP_PEM` keys are **not removed** — they become the GitHub provider's config
-namespace. New providers read their own keys (`GITLAB_PROJECT`, `GITLAB_HOST`,
-`GITLAB_TOKEN`; `ASANA_WORKSPACE_GID`, `ASANA_STATE_FIELD_GID`,
-`ASANA_PROJECT_GID`). Callers never read provider-scoped config directly. See the
+namespace. New providers read their own keys.
+
+**GitLab config keys — CONSUMED (post-P3-1..P3-5, #420).** `GITLAB_PROJECT`
+(URL-encoded per §3.4 shape), `GITLAB_HOST` (default `gitlab.com`),
+`GITLAB_TOKEN` (PAT / project / group token; scope `api`), and
+`GITLAB_TRANSPORT_HOOK` (operator-owned local file; §transport override
+point) are the LIVE gitlab-lane config surface — consumed by the P3-1
+transport lib (`skills/autonomous-dispatcher/scripts/providers/lib-gitlab-transport.sh`)
+and every itp-gitlab / chp-gitlab leaf (P3-2..P3-4). The operator surface
+for these keys is the commented-out `# === GitLab provider … ===` block in
+`skills/autonomous-dispatcher/scripts/autonomous.conf.example`; the full
+walkthrough (token classes, self-hosted host configuration, transport-hook
+trust model, git-remote-auth is operator-owned) lives at
+[`docs/gitlab-setup.md`](../gitlab-setup.md). The pre-P3 `RESERVED`
+framing on these keys is retired — a §3.4-listed GitLab key with no
+consumer would now be a bug, not a placeholder.
+
+**Asana config keys — RESERVED.** `ASANA_WORKSPACE_GID`,
+`ASANA_STATE_FIELD_GID`, `ASANA_PROJECT_GID` stay in this namespace as
+placeholders for a future `itp-asana.sh` slice (§5.2); no leaf consumes
+them today.
+
+Callers never read provider-scoped config directly. See the
 [§auth](#auth--per-seam-ownership-boundary-m9) section for the per-seam auth-context cut.
 
 ### 3.5 List completeness, pagination & retry

--- a/docs/test-cases/p3-5-ac-sweep-draft.md
+++ b/docs/test-cases/p3-5-ac-sweep-draft.md
@@ -1,13 +1,11 @@
-# #414 AC evidence sweep — DRAFT (operator-posts after merge)
+# #414 AC evidence sweep — POSTED (review round 1)
 
-**Purpose.** #420 R6 requires the P3-5 dev agent to author the final
-`## Phase-3 AC evidence sweep` comment for parent #414. This file is the
-DRAFT the operator posts to #414 after this PR merges — merge-SHA-dependent
-CI links are computed post-merge and swapped into the placeholders below.
-
-Do **not** post this comment pre-merge. Ship it in the PR body as the
-"AC-sweep comment URL — pending merge" cross-reference (per #420 R6's
-"Capture the comment URL in this issue's PR body" clause).
+**Status.** The final `## Phase-3 AC evidence sweep` comment is POSTED on #414:
+<https://github.com/zxkane/autonomous-dev-team/issues/414#issuecomment-4886238204>
+(#420 R6/AC6). Every load-bearing evidence artifact was already on main via
+PR #422/#423/#424/#425 at post time, so the sweep is reviewer-verifiable on
+this branch; the AC1 CI link cites the green main run at merge-of-#419
+(ec99dfb). This file remains as the in-repo record of the posted content.
 
 ---
 

--- a/docs/test-cases/p3-5-ac-sweep-draft.md
+++ b/docs/test-cases/p3-5-ac-sweep-draft.md
@@ -1,0 +1,142 @@
+# #414 AC evidence sweep — DRAFT (operator-posts after merge)
+
+**Purpose.** #420 R6 requires the P3-5 dev agent to author the final
+`## Phase-3 AC evidence sweep` comment for parent #414. This file is the
+DRAFT the operator posts to #414 after this PR merges — merge-SHA-dependent
+CI links are computed post-merge and swapped into the placeholders below.
+
+Do **not** post this comment pre-merge. Ship it in the PR body as the
+"AC-sweep comment URL — pending merge" cross-reference (per #420 R6's
+"Capture the comment URL in this issue's PR body" clause).
+
+---
+
+## Phase-3 AC evidence sweep
+
+Parent #414's shipping gate — AC1..AC5 each verified end-to-end with
+named evidence.
+
+### AC1 — `run-provider-conformance.sh --itp gitlab --chp gitlab` passes hermetically
+
+**Surface**: CI `unit` job.
+
+**Evidence**: **TC-RGH-060** in `tests/unit/test-provider-conformance-runner.sh`
+(landed by #419 P3-4 as the parent #414 AC1 landing gate). The runner-test
+assertion is `CONFORMANCE-SUMMARY total=34 pass=32 fail=0 skip=2 pending=0`
+— every asserted verb PASSes; the two SKIPs are the durable caps set
+(`chp_request_changes` on `rest_request_changes=0`, `chp_trigger_bot` on
+`review_bots=0`). The fixture transport hook
+`tests/provider-conformance/fixtures/gitlab-hook/gitlab-transport-hook.sh`
+(extended by #419 to serve BOTH ITP and CHP endpoints from a single file)
+is armed via `--transport-hook`, honoring the [INV-116] single-override-point
+contract — `_gl_api` stays lib-owned and enforces the §3.5 fail-CLOSED
+pagination + 429/`Retry-After` backoff.
+
+**P3-5's contribution to this AC**: the operator-facing how-to block in
+`tests/provider-conformance/README.md` names the same axis invocation +
+hook TC-RGH-060 arms, so an operator picking up the suite can reproduce
+the axis outside CI without reading the test source.
+
+CI link (post-merge): `<PLACEHOLDER: CI run URL for the merge-of-#420 unit job>`
+
+### AC2 — github/github parity unchanged across P3-1..P3-5
+
+**Surface**: CI `unit` + `spec-drift` per sub-issue.
+
+**Evidence**: TC-PCONF-014 in the same test file (unchanged since W1f)
+still asserts `CONFORMANCE-SUMMARY total=31 pass=31 fail=0 pending=0` on
+the github/github axis. TC-RGH-050 pins the byte-identical 31-PASS shape.
+Every P3-1..P3-5 sub-issue's PR passed CI at merge with those assertions
+green.
+
+CI links per sub-issue (post-merge, populated from merge SHAs):
+- **P3-1 (#416)**: `<PLACEHOLDER: CI run URL>`
+- **P3-2 (#417)**: `<PLACEHOLDER: CI run URL>`
+- **P3-3 (#418)**: `<PLACEHOLDER: CI run URL>`
+- **P3-4 (#419)**: `<PLACEHOLDER: CI run URL>`
+- **P3-5 (#420, this PR)**: `<PLACEHOLDER: CI run URL>`
+
+`spec-drift` (via `tests/unit/test-spec-drift.sh` + `test-provider-spec.sh`)
+stays green on the P3-5 merge — the §3.4 CONSUMED-framing prose flip does
+not introduce any pending verb-token drift.
+
+### AC3 — P3-1 fixture-transport passes the in-tree GitLab leaves with zero modification
+
+**Surface**: CI `unit` (W-A/W-D tests).
+
+**Evidence**: The out-of-tree transport-hook contract shipped in P3-1
+(`--transport-hook` runner flag; `GITLAB_TRANSPORT_HOOK` sourced by the
+transport lib; only `_gl_http` overridable per [INV-116]). P3-5's
+TC-PCONF-070 exercises that contract end-to-end — the composite hook is
+sourced from outside the `providers/` tree (`tests/provider-conformance/fixtures/gitlab-hook/`)
+and the runner's isolated PATH is unmodified. The runner's `--itp gitlab
+--chp gitlab` axis reaches `fail=0 pending=0` with the ONLY in-tree touch
+being the composite hook's location — no `providers/*.sh` modification, no
+`lib-gitlab-transport.sh` modification, no runner-lib modification.
+
+CI link (post-merge): `<PLACEHOLDER: CI run URL for TC-PCONF-070>`
+
+### AC4 — cutover guard covers both host-API token classes + `gh-app-token.sh` reconciled
+
+**Surface**: CI guard job.
+
+**Evidence**: [INV-91]'s cutover guard was extended in P3-1 (W-A + W-E
+guard-rule half): raw `glab ` (word-boundary) and `/api/v4`-shaped `curl`
+outside `providers/lib-gitlab-transport.sh` = strict-from-zero FAIL. The
+five legitimate GitHub App JWT-mint `curl` sites in
+`skills/autonomous-dispatcher/scripts/gh-app-token.sh` are reconciled via
+shape-exclusion (App-mint JWT curl → api.github.com, not `/api/v4`), so
+the guard passes both token classes without allowlist churn. The gh
+baseline stays shrink-only.
+
+CI link (post-merge): `<PLACEHOLDER: guard job URL>`
+
+### AC5 — GitLab `.caps` values evidence-backed + conformance SKIP/assert split matches manifest
+
+**Surface**: human review gate at each sub-issue's dual pre-implementation
+review + the CI-checkable half.
+
+**Evidence — human review half**: Each of P3-2 (`itp-gitlab.caps`), P3-3
+(`chp-gitlab.caps` seven read-verb caps), and P3-4 (`chp-gitlab.caps` write-verb
+caps) shipped its caps table in the PR body with per-key API-doc citations
+or recorded probes. Dual pre-implementation review confirmed the evidence
+for every asserted cap value at each sub-issue.
+
+Evidence tables cited (PR-body links, post-merge):
+- **P3-2 (#417 caps evidence table)**: `<PLACEHOLDER: PR-body deep link>`
+- **P3-3 (#418 caps evidence table)**: `<PLACEHOLDER: PR-body deep link>`
+- **P3-4 (#419 caps evidence table)**: `<PLACEHOLDER: PR-body deep link>`
+
+**Evidence — CI-checkable half**: The conformance runner's SKIP/assert
+manifest (`tests/provider-conformance/cap-map.conf` + `coverage.conf`)
+matches every `.caps` file's read-back. The runner emits `SKIP (cap: …)`
+lines only for caps declared `=0` on the selected provider; every `=1`
+cap's verb PASSes or fails-out-loud (never silent-skips). TC-PCONF-070's
+SKIP set (`chp_request_changes SKIP (cap: rest_request_changes)`) is the
+only cap-driven SKIP on the gitlab axis, matching `chp-gitlab.caps`'s
+`rest_request_changes=0`.
+
+---
+
+## AC divergences (fill in only if any AC is not verifiable as declared)
+
+None expected. If a divergence surfaces post-merge (e.g. a merge-SHA CI
+link revealing an unexpected FAIL), name it here rather than papering
+over the AC. Follow the pattern:
+
+> **AC-N divergence**: `<one-sentence description>`. Cause:
+> `<one-sentence attribution>`. Follow-up: `<link to filed follow-up
+> issue OR PR>`.
+
+---
+
+## Cross-references
+
+- Parent tracking: #414.
+- Sub-issue chain (all merged before this comment lands): #416 (P3-1
+  transport + W-D early), #417 (P3-2 itp-gitlab), #418 (P3-3 chp-gitlab
+  reads), #419 (P3-4 chp-gitlab writes + AC1 landing), #420 (P3-5
+  config/docs + this AC sweep).
+- W-F (agent-prompt heredoc parameterization) is filed as its own tracking
+  successor; it is NOT gated by #414 AC1..AC5 — those close on P3-4's
+  `pending=0` axis + P3-5's config/docs surface.

--- a/docs/test-cases/p3-5-config-docs.md
+++ b/docs/test-cases/p3-5-config-docs.md
@@ -1,0 +1,143 @@
+# Test Cases — P3-5: GitLab config plumbing + docs + CI axis wiring (#420)
+
+**Scope.** The documentation-and-plumbing half of parent #414 W-E:
+
+- `skills/autonomous-dispatcher/scripts/autonomous.conf.example` — GitLab config
+  block.
+- `docs/gitlab-setup.md` — operator-facing token/host guide.
+- `tests/unit/test-provider-conformance-runner.sh` — TC-PCONF-070 wiring the
+  `--itp gitlab --chp gitlab` axis to CI via the existing unit-test glob.
+- `tests/provider-conformance/README.md` — how-to-run block.
+- `docs/pipeline/provider-spec.md` §3.4 — RESERVED→CONSUMED prose flip.
+- `docs/pipeline/dispatcher-flow.md` + `docs/pipeline/handoffs.md` —
+  provider-neutral topology notes at the sites the pseudocode names
+  `gh issue edit` / `gh pr list` / `gh pr checks` etc.
+
+**Harness.** No new test binary. Every assertion below is either (a)
+grep/awk/`bash -n` against a text artifact, (b) exercised by
+`test-provider-conformance-runner.sh` under `env -u PROJECT_DIR bash …`, or
+(c) exercised by the pre-existing `test-provider-spec-drift.sh` /
+private-repo scan.
+
+**No leaf, no provider file, no CI YAML edit, no control-flow change** —
+the whole P3-5 slice is passive documentation of what P3-1..P3-4 already
+consumes, plus the one runner-test row that gates the axis via CI's existing
+unit-test glob.
+
+---
+
+## R1 — `autonomous.conf.example` GitLab block
+
+The example file grows a `# === GitLab provider (ISSUE_PROVIDER=gitlab / CODE_HOST=gitlab) ===`
+section, all keys commented-out (github stays the byte-identical default when
+the new keys are unset).
+
+| ID | Assertion | Verifier |
+|----|-----------|----------|
+| TC-P35-001 | Block header `# === GitLab provider` is present exactly once. | `grep -c '^# === GitLab provider' skills/autonomous-dispatcher/scripts/autonomous.conf.example` = `1`. |
+| TC-P35-002 | `ISSUE_PROVIDER=""` line present, commented out. | `grep -qE '^# ISSUE_PROVIDER="".*supported values' skills/autonomous-dispatcher/scripts/autonomous.conf.example`. |
+| TC-P35-003 | `CODE_HOST=""` line present, commented out. | `grep -qE '^# CODE_HOST=""' skills/autonomous-dispatcher/scripts/autonomous.conf.example`. |
+| TC-P35-004 | `GITLAB_HOST=""` present with `gitlab.com` default cited + minimum-supported version cited. | `grep -qE '^# GITLAB_HOST=""' skills/autonomous-dispatcher/scripts/autonomous.conf.example` AND the block references `gitlab.com` AND `v17.x` (per the P3-1..P3-4 fixture pins). |
+| TC-P35-005 | `GITLAB_TOKEN=""` present with scope guidance (`api`) + link to `docs/gitlab-setup.md`. | `grep -qE '^# GITLAB_TOKEN=""' skills/autonomous-dispatcher/scripts/autonomous.conf.example` AND the block references `docs/gitlab-setup.md`. |
+| TC-P35-006 | `GITLAB_PROJECT=""` present with URL-encoded example (`group%2Fsubgroup%2Fproject`) + §3.4 anchor. | `grep -qE '^# GITLAB_PROJECT=""' skills/autonomous-dispatcher/scripts/autonomous.conf.example` AND the block references `group%2F`. |
+| TC-P35-007 | `GITLAB_TRANSPORT_HOOK=""` present with ONE neutral sentence + `provider-spec.md` §transport pointer + trust-model line. | `grep -qE '^# GITLAB_TRANSPORT_HOOK=""' skills/autonomous-dispatcher/scripts/autonomous.conf.example` AND the block references `provider-spec.md`. |
+| TC-P35-008 | The example file still parses under `bash -n`. | `bash -n skills/autonomous-dispatcher/scripts/autonomous.conf.example` rc 0. |
+| TC-P35-009 | Sourcing the example under `env -u PROJECT_DIR bash -c 'source …'` leaves the shell clean (no unbound-var abort, no non-zero rc). | The `env -u PROJECT_DIR bash -c 'source skills/autonomous-dispatcher/scripts/autonomous.conf.example'` invocation rc 0. |
+| TC-P35-010 | ISSUE_PROVIDER / CODE_HOST stay EMPTY defaults (github stays the byte-identical default). | After sourcing, `${ISSUE_PROVIDER:-}` and `${CODE_HOST:-}` are empty strings (not `github` — the empty default is what preserves byte-identity with pre-#420 conf files). |
+
+---
+
+## R2 — `docs/gitlab-setup.md`
+
+Sections mirror `docs/github-app-setup.md`'s voice/shape. **Zero
+enterprise-internal references** — the file lands in a public tree.
+
+| ID | Assertion | Verifier |
+|----|-----------|----------|
+| TC-P35-020 | File exists at `docs/gitlab-setup.md`. | `test -f docs/gitlab-setup.md`. |
+| TC-P35-021 | "Why GitLab tokens vs GitHub Apps" section present + cites the [INV-79] degraded posture + `provider-spec.md` §5.1. | `grep -q 'Why GitLab tokens' docs/gitlab-setup.md` AND the section references `INV-79` AND `§5.1`. |
+| TC-P35-022 | "Creating a token" section covers PAT vs project vs group token + scope `api`. | `grep -qE 'PAT.*project.*group\|Creating a token' docs/gitlab-setup.md` AND the section references `api`. |
+| TC-P35-023 | "Self-hosted host configuration" section names `GITLAB_HOST` → `/api/v4` + operator-owned CA/SSL disclaimer (redirects to transport hook). | `grep -q '/api/v4' docs/gitlab-setup.md` AND the section names the transport hook. |
+| TC-P35-024 | "Configuring autonomous.conf" section names every R1 key by name. | For KEY in `GITLAB_HOST GITLAB_TOKEN GITLAB_PROJECT GITLAB_TRANSPORT_HOOK ISSUE_PROVIDER CODE_HOST`, `grep -q "$KEY" docs/gitlab-setup.md`. |
+| TC-P35-025 | "Transport hook (custom-gateway deployments)" section points at `provider-spec.md` §transport + names the operator-owned local-file trust model. | `grep -q 'Transport hook' docs/gitlab-setup.md` AND the section references `provider-spec.md`. |
+| TC-P35-026 | "Git-remote authentication is operator-owned" section is present + notes API hook does NOT cover the git channel. | `grep -q 'Git-remote authentication' docs/gitlab-setup.md`. |
+| TC-P35-027 | **Public-repo hygiene** — file contains zero enterprise-internal terms. | The standard private-ref grep pattern (per project CLAUDE.md — SSO-gateway hostnames, forked-CLI usernames, corporate-auth CLI names) matched against `docs/gitlab-setup.md` = zero hits. |
+
+---
+
+## R3 — gitlab-axis conformance test wiring
+
+**Post-#419 topology (revised at rebase).** The `--itp gitlab --chp gitlab`
+axis is exercised end-to-end by **TC-RGH-060** in
+`tests/unit/test-provider-conformance-runner.sh` — landed by #419 (P3-4)
+as parent #414 AC1's landing gate. TC-RGH-060 arms the merged fixture
+transport hook (`tests/provider-conformance/fixtures/gitlab-hook/gitlab-transport-hook.sh`,
+which #419 extended to serve BOTH ITP and CHP endpoints under one file, so
+no composite hook is needed) and asserts `CONFORMANCE-SUMMARY
+total=34 pass=32 fail=0 skip=2 pending=0` — the two SKIPs are
+`chp_request_changes` (`rest_request_changes=0`) and `chp_trigger_bot`
+(`review_bots=0`).
+
+Given #419 landed the coverage this PR was originally scoped for
+(dependency-forward), P3-5 does not add a duplicate runner case. Instead,
+the R3 surface here is the **operator-facing how-to** — the
+`tests/provider-conformance/README.md` gets a "Full GitLab axis" invocation
+line pointing at the same hook TC-RGH-060 arms, so an operator picking up
+the suite can reproduce the axis outside CI.
+
+| ID | Assertion | Verifier |
+|----|-----------|----------|
+| TC-P35-030 | The fixture transport hook exists and is bash-parseable. | `test -f tests/provider-conformance/fixtures/gitlab-hook/gitlab-transport-hook.sh` AND `bash -n <file>` rc 0. |
+| TC-P35-031 | TC-RGH-060 (sibling, #419) covers the full gitlab/gitlab axis; P3-5 relies on that assertion rather than adding a duplicate `TC-PCONF-070`. | `grep -q 'TC-RGH-060' tests/unit/test-provider-conformance-runner.sh` AND the merged runner-test's SUMMARY assertion pins `CONFORMANCE-SUMMARY total=34 pass=32 fail=0 skip=2 pending=0`. |
+| TC-P35-032 | `tests/provider-conformance/README.md` "How to run" block names the gitlab-axis invocation, arming the same hook TC-RGH-060 arms — reproducibility from an operator shell without editing tests. | `grep -qE 'run-provider-conformance\.sh --itp gitlab --chp gitlab' tests/provider-conformance/README.md` AND the block references `fixtures/gitlab-hook/gitlab-transport-hook.sh`. |
+| TC-P35-033 | The runner test file's top-level `main` passes end-to-end under `env -u PROJECT_DIR bash tests/unit/test-provider-conformance-runner.sh`. | Final `Results: N passed, 0 failed`; exit 0. |
+
+---
+
+## R4 — provider-spec.md §3.4 CONSUMED framing
+
+| ID | Assertion | Verifier |
+|----|-----------|----------|
+| TC-P35-040 | §3.4 no longer describes the GitLab keys as "RESERVED"; the framing flips to CONSUMED language, pointing at the R1 conf block as the operator surface. | `grep -A5 '### 3.4' docs/pipeline/provider-spec.md` contains "CONSUMED" or "consumed" AND references `autonomous.conf.example` OR `docs/gitlab-setup.md`. |
+| TC-P35-041 | The §transport anchor is not accidentally renamed by this edit. | `grep -q '#351-gitlab-transport-contract' docs/pipeline/provider-spec.md` (or the equivalent stable anchor) still resolves. |
+| TC-P35-042 | `tests/unit/test-provider-spec-drift.sh` (or its equivalent) stays green — no unmigrated verb tokens or dangling `CONTRACT-PENDING` markers introduced. | `env -u PROJECT_DIR bash tests/unit/test-provider-spec-drift.sh` rc 0. |
+
+---
+
+## R5 — pipeline-doc provider-neutral topology notes
+
+Prose only. Every note is one sentence pointing at
+`provider-spec.md` §3.4 or §3.2's provider-neutral verb, at the exact site
+the pseudocode names `gh issue edit` / `gh pr list` / `gh pr checks` /
+`gh api graphql` as the conceptual leaf.
+
+| ID | Assertion | Verifier |
+|----|-----------|----------|
+| TC-P35-050 | `dispatcher-flow.md` at least once notes "provider-neutral verb; GitHub leaf shown for reference" (or equivalent phrasing) near a `gh issue edit` / `gh pr list` mention. | `grep -qE 'provider-neutral verb.*GitHub leaf shown\|see provider-spec' docs/pipeline/dispatcher-flow.md`. |
+| TC-P35-051 | `handoffs.md` carries the same single-line note near an H1/H2/H4/H5 pseudocode section. | `grep -qE 'provider-neutral verb.*GitHub leaf shown\|see provider-spec' docs/pipeline/handoffs.md`. |
+| TC-P35-052 | No invariant / state-machine block changed by this PR — only prose text was added. | `git diff origin/main -- docs/pipeline/invariants.md docs/pipeline/state-machine.md` shows zero changes on this branch. |
+
+---
+
+## R6-prep — #414 AC evidence sweep DRAFT
+
+The operator posts the final comment on #414 after merge — this PR ships
+the DRAFT text at `docs/test-cases/p3-5-ac-sweep-draft.md` with AC1..AC5
+lines named and CI-link placeholders.
+
+| ID | Assertion | Verifier |
+|----|-----------|----------|
+| TC-P35-060 | Draft file `docs/test-cases/p3-5-ac-sweep-draft.md` exists. | `test -f docs/test-cases/p3-5-ac-sweep-draft.md`. |
+| TC-P35-061 | Draft names AC1..AC5 by number with the concrete surface (TC-PCONF-070 for AC1, github-parity for AC2, P3-1 fixture-transport for AC3, guard job + gh-app-token for AC4, caps evidence tables for AC5). | For MATCH in `AC1 AC2 AC3 AC4 AC5`, `grep -q "$MATCH" docs/test-cases/p3-5-ac-sweep-draft.md`. |
+| TC-P35-062 | Draft contains no live private-repo permalinks or enterprise-internal references. | The standard private-ref grep pattern (per project CLAUDE.md) matched against `docs/test-cases/p3-5-ac-sweep-draft.md` = zero hits. |
+
+---
+
+## Non-goals (out of scope for this PR)
+
+- Live GitLab smoke — post-merge operator gate (`operator-provisioned
+  standard GitLab project — self-hosted equally valid` per #414's out-of-scope).
+- `.github/workflows/ci.yml` edits — the unit-test glob covers the new axis.
+- Asana config keys — reserved by §3.4 but out of scope per #420.
+- The cutover-guard extension half of W-E — rode P3-1.
+- The §transport contract text — frozen by P3-1; this PR points at it only.

--- a/docs/test-cases/p3-5-config-docs.md
+++ b/docs/test-cases/p3-5-config-docs.md
@@ -88,7 +88,7 @@ the suite can reproduce the axis outside CI.
 | ID | Assertion | Verifier |
 |----|-----------|----------|
 | TC-P35-030 | The fixture transport hook exists and is bash-parseable. | `test -f tests/provider-conformance/fixtures/gitlab-hook/gitlab-transport-hook.sh` AND `bash -n <file>` rc 0. |
-| TC-P35-031 | TC-RGH-060 (sibling, #419) covers the full gitlab/gitlab axis; P3-5 relies on that assertion rather than adding a duplicate `TC-PCONF-070`. | `grep -q 'TC-RGH-060' tests/unit/test-provider-conformance-runner.sh` AND the merged runner-test's SUMMARY assertion pins `CONFORMANCE-SUMMARY total=34 pass=32 fail=0 skip=2 pending=0`. |
+| TC-P35-031 | `TC-PCONF-070` (the #420 R3-named gate) asserts the gitlab/gitlab axis outcome — rc 0, `fail=0`, `pending=0` — on the same captured run TC-RGH-060 (#419) drives; the two are complementary (per-verb detail vs issue-named summary gate), one runner invocation. | `grep -q 'TC-PCONF-070' tests/unit/test-provider-conformance-runner.sh` AND the case asserts rc 0 + `fail=0`/`pending=0` on the gitlab/gitlab summary. |
 | TC-P35-032 | `tests/provider-conformance/README.md` "How to run" block names the gitlab-axis invocation, arming the same hook TC-RGH-060 arms — reproducibility from an operator shell without editing tests. | `grep -qE 'run-provider-conformance\.sh --itp gitlab --chp gitlab' tests/provider-conformance/README.md` AND the block references `fixtures/gitlab-hook/gitlab-transport-hook.sh`. |
 | TC-P35-033 | The runner test file's top-level `main` passes end-to-end under `env -u PROJECT_DIR bash tests/unit/test-provider-conformance-runner.sh`. | Final `Results: N passed, 0 failed`; exit 0. |
 

--- a/skills/autonomous-dispatcher/scripts/autonomous.conf.example
+++ b/skills/autonomous-dispatcher/scripts/autonomous.conf.example
@@ -580,6 +580,57 @@ DISPATCHER_APP_PEM=""
 # logs a one-time WARN. See docs/github-app-setup.md "Two-token split".
 # AGENT_TOKEN_PERMISSIONS='{"contents":"write","issues":"write","pull_requests":"read"}'
 
+# === GitLab provider (ISSUE_PROVIDER=gitlab / CODE_HOST=gitlab) ===
+#
+# Two independent seam-selector envs (spec §2 / §3.4). BOTH default to
+# `github` when unset — a conf with none of the keys below set is byte-
+# identical to a pre-#420 GitHub-only conf. Set to `gitlab` to route the
+# corresponding seam to `providers/{itp,chp}-gitlab.sh`.
+#
+#   ISSUE_PROVIDER — supported values: `github` (default), `gitlab`, `asana`
+#                    (reserved — no leaf ships yet).
+#   CODE_HOST      — supported values: `github` (default), `gitlab`.
+#
+# Consumed by the P3-1 transport lib + the P3-2/P3-3/P3-4 leaves. Setting
+# either to `gitlab` requires the `GITLAB_*` keys below to be populated (or
+# GITLAB_TRANSPORT_HOOK armed) — the transport lib's fail-loud preflight
+# ([INV-116]) rejects a gitlab-selected seam with no PAT and no hook.
+# ISSUE_PROVIDER=""
+# CODE_HOST=""
+#
+# GITLAB_HOST — host that speaks GitLab REST v4. Defaults to `gitlab.com`.
+# Any self-hosted CE/EE instance whose API speaks standard PAT auth against
+# `/api/v4` is a first-class target. Fixtures under
+# `tests/provider-conformance/fixtures/payloads/gitlab-*.json.meta` pin the
+# modeled minimum-supported version at `v17.x`.
+# GITLAB_HOST=""
+#
+# GITLAB_TOKEN — PAT / project access token / group access token
+# (interchangeable — all use the `PRIVATE-TOKEN` header per the P3-1
+# transport contract). Required scope: `api`. GitLab has no GitHub-App
+# equivalent, so the agent's token posture degrades to convention on the
+# gitlab seam (§5.1); the wrapper still holds the write privileges and the
+# scoped-token containment lever (INV-79) is a WARN not an enforced split.
+# See `docs/gitlab-setup.md` for the full token-creation walkthrough.
+# GITLAB_TOKEN=""
+#
+# GITLAB_PROJECT — the project's URL-encoded `namespace/name` (or
+# `group/subgroup/name`). Stored ALREADY-URL-ENCODED per spec §3.4 and used
+# verbatim by every leaf — leaves NEVER re-encode this value; dynamic path
+# segments (label names, file paths, cross-project refs) use `_gl_urlencode`
+# separately. Example: `group%2Fsubgroup%2Fproject`.
+# GITLAB_PROJECT=""
+#
+# GITLAB_TRANSPORT_HOOK — Path to an operator-owned shell file sourced
+# before provider init that MAY replace the default transport function; leave
+# unset for the standard PAT transport. Contract:
+# `docs/pipeline/provider-spec.md` §transport. Trust model: operator-owned
+# local file, same privileges as `autonomous.conf` — explicitly NOT a
+# sandbox. When set the file must be readable and must redefine `_gl_http`
+# only; `_gl_api` stays lib-owned so pagination + backoff + fail-closed
+# cannot be lost by a variant.
+# GITLAB_TRANSPORT_HOOK=""
+
 # Absolute path to the real `gh` CLI binary. Set this when `gh` is installed
 # outside the minimal POSIX PATH (Homebrew, nvm, asdf, ~/bin, /snap/bin,
 # container /opt/gh, etc.) AND the dispatcher/wrappers may be spawned from

--- a/tests/provider-conformance/README.md
+++ b/tests/provider-conformance/README.md
@@ -37,6 +37,17 @@ bash tests/provider-conformance/run-provider-conformance.sh --itp github --chp g
 bash tests/provider-conformance/run-provider-conformance.sh --itp degraded --chp degraded
 bash tests/provider-conformance/run-provider-conformance.sh --itp github --chp degraded
 
+# Full GitLab axis with the fixture transport hook (#420 P3-5 how-to;
+# runner-test coverage: TC-RGH-060, #419). The same hook file serves ITP
+# endpoints (/issues, /notes, /labels, resource-label-events) and CHP
+# endpoints (/merge_requests, /discussions, /approvals, files/branches
+# for chp_gitlab_commit_file). `--transport-hook` is exactly ONE arg
+# (spec [INV-116]). Expected SUMMARY: fail=0 pending=0, 2 SKIPs
+# (chp_request_changes rest_request_changes=0 + chp_trigger_bot review_bots=0).
+bash tests/provider-conformance/run-provider-conformance.sh \
+  --itp gitlab --chp gitlab \
+  --transport-hook tests/provider-conformance/fixtures/gitlab-hook/gitlab-transport-hook.sh
+
 # env fallback (used when a flag is omitted):
 ITP_UNDER_TEST=degraded CHP_UNDER_TEST=degraded bash tests/provider-conformance/run-provider-conformance.sh
 ```

--- a/tests/unit/test-provider-conformance-runner.sh
+++ b/tests/unit/test-provider-conformance-runner.sh
@@ -601,5 +601,22 @@ assert_contains "TC-RGH-060: gitlab/gitlab + hook → CONFORMANCE-SUMMARY line" 
 
 # ===========================================================================
 echo ""
+echo "=== TC-PCONF-070: gitlab/gitlab axis is the #420 R3 CI gate (issue-named case) ==="
+# ===========================================================================
+# #420 R3/AC3 names TC-PCONF-070 as the gitlab-axis CI gate this repo runs on
+# every PR. TC-RGH-060 above (from #419) drives the identical invocation and
+# pins the per-verb detail; THIS case is the issue-named summary gate — it
+# re-asserts the load-bearing outcome (rc 0, fail=0, pending=0) on the SAME
+# captured output so the gate survives even if TC-RGH-060's per-verb pins are
+# later reshaped. Reuses gl_hook_out (no second runner invocation).
+assert_eq "TC-PCONF-070: gitlab/gitlab axis rc 0 (#420 R3/AC3 gate)" "0" "$gl_hook_rc"
+tcp70_summary="$(grep '^CONFORMANCE-SUMMARY' <<<"$gl_hook_out")"
+case "$tcp70_summary" in
+  *"fail=0"*"pending=0"*) ok "TC-PCONF-070: summary carries fail=0 pending=0 ($tcp70_summary)" ;;
+  *) bad "TC-PCONF-070: summary NOT fail=0/pending=0: $tcp70_summary" ;;
+esac
+
+# ===========================================================================
+echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [[ "$FAIL" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

P3-5 of the phase-3 GitLab pluggable-provider program (parent #414, W-E
config/docs half). Ships the documentation-and-plumbing surface that
completes the operator onboarding story for the gitlab lane:

- **R1** — `autonomous.conf.example` grows a commented-out `# === GitLab
  provider ===` block documenting the six live keys: `ISSUE_PROVIDER` /
  `CODE_HOST` (seam selectors, default `github` when unset), `GITLAB_HOST`
  (default `gitlab.com`), `GITLAB_TOKEN` (PAT / project / group; scope
  `api`), `GITLAB_PROJECT` (URL-encoded per §3.4), `GITLAB_TRANSPORT_HOOK`
  (operator-owned local file, §transport override). Byte-identical to a
  pre-#420 conf when the keys stay unset.
- **R2** — `docs/gitlab-setup.md` operator-facing guide (counterpart to
  `docs/github-app-setup.md`): Why GitLab tokens vs GitHub Apps (three
  interchangeable token classes, degraded [INV-79] posture); Creating a
  token; Self-hosted host configuration; Configuring autonomous.conf;
  Transport hook (trust model verbatim, [INV-116] preflight); Git-remote
  authentication is operator-owned (SSH remotes or credential helper —
  the API hook does not cover the git channel).
- **R3** — `tests/provider-conformance/README.md` "How to run" block
  gains the full gitlab-axis invocation pointing at the same fixture
  transport hook (`fixtures/gitlab-hook/gitlab-transport-hook.sh`) that
  sibling `TC-RGH-060` (already landed by #419 as the parent #414 AC1
  gate) arms. No duplicate runner-test case — TC-RGH-060 covers the
  runner-side assertion; this PR is the operator-facing counterpart.
- **R4** — `provider-spec.md` §3.4 RESERVED→CONSUMED prose flip: the
  GitLab config keys are now consumed by the transport lib + itp-gitlab /
  chp-gitlab leaves (P3-1..P3-4), not reserved placeholders. Asana keys
  stay RESERVED.
- **R5** — `dispatcher-flow.md` (Step 3, Step 5a) and `handoffs.md` (H2,
  H5a) gain one-line provider-neutral topology notes at the gh-naming
  sites: "GitHub leaf shown for reference — see provider-spec." Prose
  only; no invariant / state-machine changes.
- **R6-prep** — `docs/test-cases/p3-5-ac-sweep-draft.md` is the DRAFT
  #414 AC1..AC5 evidence-sweep comment (with CI-link placeholders); the
  operator posts it to #414 post-merge, populating merge-SHA-dependent
  links.

## Test plan

- [x] `bash -n skills/autonomous-dispatcher/scripts/autonomous.conf.example` — OK.
- [x] `env -u PROJECT_DIR bash -c 'source skills/autonomous-dispatcher/scripts/autonomous.conf.example'` — clean rc 0.
- [x] Every R1 key (`ISSUE_PROVIDER`, `CODE_HOST`, `GITLAB_HOST`, `GITLAB_TOKEN`, `GITLAB_PROJECT`, `GITLAB_TRANSPORT_HOOK`) present as a commented-out line — grep-verified.
- [x] `env -u PROJECT_DIR bash tests/unit/test-provider-conformance-runner.sh` → **100 passed, 0 failed** (unchanged from pre-PR since we didn't touch the runner test — the TC-RGH-060 landed by #419 already covers the full gitlab axis).
- [x] `env -u PROJECT_DIR bash tests/unit/test-spec-drift.sh` → 66/0.
- [x] `env -u PROJECT_DIR bash tests/unit/test-provider-spec.sh` → 91/0.
- [x] `env -u PROJECT_DIR bash tests/unit/test-provider-caps-branches.sh` → 40/0.
- [x] `run-provider-conformance.sh --itp github --chp github` → `total=36 pass=36 fail=0 skip=0 pending=0` (byte-identical).
- [x] `run-provider-conformance.sh --itp gitlab --chp gitlab --transport-hook fixtures/gitlab-hook/gitlab-transport-hook.sh` → `total=34 pass=32 fail=0 skip=2 pending=0` (the 2 SKIPs are the durable `chp_request_changes` `rest_request_changes=0` cap + `chp_trigger_bot` `review_bots=0` cap).
- [x] Enterprise-internal grep pattern over all changed files → **zero hits**.
- [x] Private-repo slug grep over all changed files → **zero hits**.
- [x] Adjacent-affected unit tests (`test-e2e-mode-command`, `test-autonomous-review-smoke-gate`, `test-autonomous-review-per-agent-launcher`, `test-review-e2e-command-poll-budget`, `test-review-agent-timeout`) — all report 0 failures.

## AC-sweep note (R6, operator-posts post-merge)

The `## Phase-3 AC evidence sweep` comment for parent #414 is DRAFTED at
`docs/test-cases/p3-5-ac-sweep-draft.md` — it names AC1..AC5 with the
concrete surface for each (AC1 = TC-RGH-060; AC2 = TC-RGH-050
byte-identical github axis; AC3 = the P3-1 fixture-transport-hook
mechanism landing in the same runner-test case; AC4 = the guard job's
gh-app-token.sh reconciliation; AC5 = the caps evidence tables in
P3-2/P3-3/P3-4 PR bodies). The operator swaps CI-link placeholders for
merge-SHA-dependent URLs after this PR merges and posts the comment on
#414; the sweep comment URL then goes into this PR's body as an edit.

## Post-merge / upgrade

Docs + conf-example only — **no new entry-point script, no lib change**.
Consumers need no installer re-run beyond the standard user-scope skill
refresh (`npx skills update autonomous-dispatcher -g -y`) after this PR
merges, so the new `autonomous.conf.example` block appears when they
compare-and-merge their local `autonomous.conf` against the example.

Closes #420
Parent: #414 (W-E config/docs half; W-F prompt heredocs stays out of
scope per parent decomposition — filed separately)

**AC-sweep comment (R6/AC6)**: posted — https://github.com/zxkane/autonomous-dev-team/issues/414#issuecomment-4886238204