### PR TITLE
docs: replace retired Gemini CLI with Antigravity CLI (agy) in user-facing docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Install all skills into any of 40+ supported coding agents:
 npx skills add zxkane/autonomous-dev-team
 ```
 
-Supports Claude Code, Cursor, Windsurf, Gemini CLI, Kiro CLI, and [more](https://skills.sh).
+Supports Claude Code, Cursor, Windsurf, Antigravity, Kiro CLI, and [more](https://skills.sh).
 
 ## Available Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@
 
 ## Development Workflow (TDD + Agent-Assisted)
 
-This project enforces a strict TDD development workflow through agent hooks. The workflow applies to all supported coding agents (Claude Code, Kiro CLI, Cursor, Windsurf, Gemini CLI, etc.).
+This project enforces a strict TDD development workflow through agent hooks. The workflow applies to all supported coding agents (Claude Code, Kiro CLI, Cursor, Windsurf, Antigravity, etc.).
 
 ### Mandatory Rules (Hook Enforced)
 
@@ -31,7 +31,7 @@ This project enforces a strict TDD development workflow through agent hooks. The
 4. **Code review before commit** — code-simplifier must run before committing (Claude Code only)
 5. **PR review before push** — pr-review agent must run before pushing (Claude Code only)
 
-> Hooks are supported in Claude Code and Kiro CLI. For agents without hook support (Cursor, Windsurf, Gemini CLI), follow each step manually — the discipline is the same.
+> Hooks are supported in Claude Code and Kiro CLI. For agents without hook support (Cursor, Windsurf), follow each step manually — the discipline is the same.
 
 > ⚠️ **This repo is self-hosting — never edit files in the main workdir; always use a worktree.** This checkout of `zxkane/autonomous-dev-team` is consumed by the autonomous dispatcher running on the same box: its `scripts/` symlink resolves into this repo's own `skills/autonomous-dispatcher/scripts/` tree, so the dispatcher executes these exact files via `scripts/autonomous-{dev,review}.sh`. **Any uncommitted change in the main workdir becomes live for every dispatched dev/review wrapper.** A half-finished edit can crash a wrapper mid-run — e.g. an incomplete per-side `AGENT_REVIEW_CMD` rebind aborts the review wrapper with `AGENT_REVIEW_CMD: unbound variable`, leaving the issue stuck in `reviewing` with no verdict and no re-dispatch.
 >

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ schedule.
   instance) via pluggable provider seams — see
   [GitLab support](#gitlab-support).
 - **Agent CLIs**: Claude Code, Codex CLI, Kiro CLI, opencode, Cursor Agent,
-  Gemini CLI, and most CLIs with a `-p <prompt>` non-interactive flag — see
-  [docs/agent-clis.md](docs/agent-clis.md).
+  Antigravity CLI (agy), and most CLIs with a `-p <prompt>` non-interactive
+  flag — see [docs/agent-clis.md](docs/agent-clis.md).
 
 ## Quick Start
 
@@ -30,7 +30,7 @@ npx skills add zxkane/autonomous-dev-team
 | **autonomous-common** | Shared workflow-enforcement hooks and agent-callable utility scripts |
 | **create-issue** | Structured issue creation with templates, autonomous label guidance, and workspace change attachment |
 
-Works with Claude Code, Cursor, Windsurf, Gemini CLI, Kiro CLI, and
+Works with Claude Code, Cursor, Windsurf, Antigravity, Kiro CLI, and
 [40+ agents](https://skills.sh). After installing, follow
 **[docs/installation.md](docs/installation.md)** for the post-install wiring
 (symlinks, plugins, `autonomous.conf`, labels) — it includes a copy-paste

--- a/docs/agent-clis.md
+++ b/docs/agent-clis.md
@@ -12,13 +12,19 @@ The pipeline spawns dev/review agents through a pluggable abstraction layer
 | Codex CLI | `codex` | `exec --json "<prompt>"` | `exec resume <thread-id>` (captured from JSON stream) | Full support |
 | Kiro CLI | `kiro-cli` | `chat --no-interactive [--agent <name>]` | (falls back to new) | Basic support |
 | Cursor Agent | `agent` | `-p "<prompt>"` | `--resume=<chat-id>` | Generic fallback (untested explicit branch) |
-| Gemini CLI | `gemini` | `--session-id <UUID> -p "<prompt>"` | `--resume <UUID>` | Full support |
+| Antigravity CLI | `agy` | `-p "<prompt>" --log-file <path>` (conversation UUID grepped from the log) | `--conversation <UUID>` | Full support |
 | opencode | `opencode` | `run --format json [PROMPT]` | `run --session <sessionID>` (captured from JSON stream) | Full support † |
 
-The `claude`, `codex`, `gemini`, `kiro`, and `opencode` rows have explicit
+The `claude`, `codex`, `agy`, `kiro`, and `opencode` rows have explicit
 adapters; the others run through the generic `<cli> -p <prompt>` fallback.
 Any CLI not listed should still work if it accepts a `-p <prompt>`
 non-interactive flag — the abstraction layer is intentionally permissive.
+
+> **Gemini CLI is retired upstream** and no longer has an adapter row here.
+> Antigravity CLI (`agy`) is the replacement for Gemini-family models — it
+> ships its own conversation-UUID session model (grepped from `--log-file`,
+> not the `--session-id`/`--resume` pair Gemini CLI used) and `--model`
+> validation against `agy models` (see the EXTRA_ARGS table below).
 
 ## Per-CLI required EXTRA_ARGS (post-#102 / #140)
 
@@ -31,7 +37,7 @@ snippet per CLI:
 |-----------|---------------------|---------------------|-----|
 | `claude` | R1 | (none — `--permission-mode` is structural) | claude's tool-trust knob is an existing structural flag |
 | `codex` | R3 | (none) | `exec --json` is structural; no operator-tunable trust default |
-| `gemini` | R2 / R2'' | `--approval-mode yolo --output-format stream-json` | Without yolo, every shell/write tool defaults to ask_user→deny in headless mode (silent fabrication failure mode) |
+| `agy` | — | (none — `--dangerously-skip-permissions --print-timeout "$AGENT_TIMEOUT"` are structural, hardcoded in the adapter) | Without `--dangerously-skip-permissions` headless mode blocks on every tool-use prompt (agy's counterpart to kiro's `--trust-all-tools`); `--print-timeout` overrides agy's internal 5m default cap |
 | `kiro` | R5 / R5' | `--trust-all-tools` | Stock kiro installs deny every coding tool in `--no-interactive` mode without the trust flag (silent fabrication failure mode) |
 | `opencode` | R4 | (none) | `run --format json` is structural; provider/model selector handled via `AGENT_DEV_MODEL` |
 

--- a/docs/cross-agent-hooks.md
+++ b/docs/cross-agent-hooks.md
@@ -17,7 +17,7 @@ What differs between agents is **how to declare which script runs when** — i.e
 | **Antigravity** | `.antigravity/hooks.json` | Identical to Claude Code (undocumented) | `Bash` | `2` | `install-antigravity-hooks.sh` (PR-11a) |
 | **Cursor** | `.cursor/hooks.json` | Claude-style, camelCase events, `version: 1` envelope | `Shell` (or pipe regex on cmd) | `2` | `install-cursor-hooks.sh` (PR-11b) |
 | **Kiro CLI / Amazon Q** | `.kiro/agents/<name>.json` | Agent definition; camelCase events; `timeout_ms` (ms not seconds) | `execute_bash`, `fs_write` (Write+Edit unified) | `2` | `install-kiro-hooks.sh` (PR-11b) |
-| **Gemini CLI** | `.gemini/settings.json` | `BeforeTool`/`AfterTool` events; provides `$CLAUDE_PROJECT_DIR` env compat alias | `run_shell_command`, `write_file`, `replace` | `2` | `install-gemini-hooks.sh` (PR-11b) |
+| **Gemini CLI** ⚠️ retired | `.gemini/settings.json` | `BeforeTool`/`AfterTool` events; provides `$CLAUDE_PROJECT_DIR` env compat alias | `run_shell_command`, `write_file`, `replace` | `2` | `install-gemini-hooks.sh` (PR-11b) — kept for historical installs; Gemini CLI has been discontinued upstream, use Antigravity CLI (`agy`) instead |
 | **Codex CLI** | `.codex/hooks.json` + `[features]codex_hooks=true` in `config.toml` | Claude-style (modeled verbatim) | `Bash`, `Write`, `Edit` (undocumented but inferred) | `2` | `install-codex-hooks.sh` (PR-11b) |
 | **Windsurf** | `.windsurf/hooks.json` | snake_case events that fold matcher info; **no matcher field** on entries | event encodes the kind: `pre_run_command` (Bash) / `pre_write_code` (Write+Edit merged) / etc. | `2` | `install-windsurf-hooks.sh` (PR-11c) |
 | **Kimi CLI** | `~/.kimi/config.toml` (or `.kimi/config.toml` with `--project`) | TOML, `[[hooks]]` array of tables | exact / regex (`RunShell`, `WriteFile`, `StrReplaceFile`) | `2` | `install-kimi-hooks.sh` (PR-11c) |
@@ -42,7 +42,7 @@ bash .claude/skills/autonomous-common/scripts/install-cursor-hooks.sh
 # Kiro CLI / Amazon Q (default agent name is "default"; override with --agent <name>)
 bash .claude/skills/autonomous-common/scripts/install-kiro-hooks.sh
 
-# Gemini CLI
+# Gemini CLI (retired upstream — see the matrix note above; use Antigravity instead)
 bash .claude/skills/autonomous-common/scripts/install-gemini-hooks.sh
 
 # Codex CLI (also enables [features] codex_hooks = true in .codex/config.toml)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -57,8 +57,8 @@ test -f scripts/autonomous.conf.example && echo "scripts OK"
 > agent-callable utility scripts referenced by the skills (e.g.,
 > `scripts/gh-as-user.sh`).
 
-If your IDE has no hook support (Cursor, Windsurf, Gemini CLI), skip this
-step — the skills still work; you just enforce the workflow manually.
+If your IDE has no hook support (Cursor, Windsurf), skip this step — the
+skills still work; you just enforce the workflow manually.
 
 ## Step 3 — Enable required Claude Code plugins
 
@@ -94,7 +94,7 @@ wrapper invocation. Fill in these required values:
 | `REPO_OWNER`, `REPO_NAME` | Yes | Split form of `REPO` | Used for App-token scoping (GitHub). |
 | `PROJECT_DIR` | Yes | Absolute path to the project root on the dispatcher box | Where the agent runs. |
 | `ISSUE_PROVIDER`, `CODE_HOST` | No (default `github`) | `github` or `gitlab` | The two provider seams (issue tracker / code host). See [gitlab-setup.md](gitlab-setup.md) for the GitLab lane. |
-| `AGENT_CMD` | No (default `claude`) | `claude`, `codex`, `kiro`, `gemini`, or `opencode` | The CLI used to spawn dev/review agents. See [agent-clis.md](agent-clis.md) for per-CLI notes and resume semantics. |
+| `AGENT_CMD` | No (default `claude`) | `claude`, `codex`, `kiro`, `agy`, or `opencode` | The CLI used to spawn dev/review agents. See [agent-clis.md](agent-clis.md) for per-CLI notes and resume semantics. |
 | `AGENT_DEV_MODEL`, `AGENT_REVIEW_MODEL` | No (default empty / `sonnet`) | Model name passed to the agent CLI | Empty = let the CLI pick. The review model defaults to `sonnet` to keep review costs predictable. |
 | `AGENT_REVIEW_AGENTS` | No (default empty) | Space-separated CLI list (e.g. `agy kiro`) | Run **multiple** independent review agents and gate the merge on unanimous agreement. See [agent-clis.md](agent-clis.md#multiple-review-agents). |
 | `AGENT_PERMISSION_MODE` | No (default `auto`) | `auto`, `plan`, or `bypassPermissions` | `bypassPermissions` grants the agent unrestricted shell access — only use in a trusted sandbox. |

--- a/skills/autonomous-common/SKILL.md
+++ b/skills/autonomous-common/SKILL.md
@@ -77,7 +77,7 @@ Claude Code only. The installer prompts for these; if installing manually, add t
 }
 ```
 
-> IDEs without hook support (Cursor, Windsurf, Gemini CLI) skip both the installer and the symlinks — the skills work without hooks, but workflow steps must be followed manually.
+> IDEs without hook support (Cursor, Windsurf) skip both the installer and the symlinks — the skills work without hooks, but workflow steps must be followed manually.
 
 ## What's here
 

--- a/skills/autonomous-common/hooks/README.md
+++ b/skills/autonomous-common/hooks/README.md
@@ -29,7 +29,7 @@ Kiro CLI supports hooks. Adapt the Claude Code hook configuration for Kiro's hoo
 
 ## Other IDEs
 
-IDEs without hook support (Cursor, Windsurf, Gemini CLI, etc.) rely on skill instructions for workflow enforcement. Follow each step in the autonomous-dev skill manually.
+IDEs without hook support (Cursor, Windsurf, etc.) rely on skill instructions for workflow enforcement. Follow each step in the autonomous-dev skill manually.
 
 ## Hook Reference
 

--- a/skills/autonomous-dev/SKILL.md
+++ b/skills/autonomous-dev/SKILL.md
@@ -102,7 +102,7 @@ Triggered when running inside the `scripts/autonomous-dev.sh` wrapper. The workf
 
 ## Cross-Platform Notes
 
-This skill works across IDEs that support skills.sh. Map generic verbs in this doc to your IDE's tools (Claude Code's Bash → terminal in Cursor, etc.). Hook-based enforcement is available on Claude Code and Kiro CLI; on Cursor / Windsurf / Gemini CLI, follow each step manually — the discipline is the same.
+This skill works across IDEs that support skills.sh. Map generic verbs in this doc to your IDE's tools (Claude Code's Bash → terminal in Cursor, etc.). Hook-based enforcement is available on Claude Code and Kiro CLI; on Cursor / Windsurf, follow each step manually — the discipline is the same.
 
 For the full IDE table + verb-to-tool map, see [`references/cross-platform.md`](references/cross-platform.md).
 


### PR DESCRIPTION
Docs-only sweep: Gemini CLI has been discontinued upstream — replace it with Antigravity CLI (`agy`) in every user-facing doc that lists supported agent CLIs / no-hook-support IDEs.

## What's in
- `README.md`, `AGENTS.md`, `CLAUDE.md`, `docs/installation.md`: "Gemini CLI" → "Antigravity" in agent-CLI and hook-support lists.
- `docs/agent-clis.md`: added `agy` as a first-class support-matrix row (session model: `--log-file` conversation-UUID capture + `--conversation` resume — distinct from Gemini's `--session-id`/`--resume` pair) with its structural `EXTRA_ARGS` entry (`--dangerously-skip-permissions --print-timeout`); dropped the `gemini` row; added a retirement note.
- `docs/cross-agent-hooks.md`: marked the Gemini CLI hook-installer matrix entry retired (kept for historical installs, points readers to `agy`).
- `skills/autonomous-common/{SKILL.md,hooks/README.md}`, `skills/autonomous-dev/SKILL.md`: dropped Gemini CLI from the no-hook-support IDE lists.

## What's NOT touched
No code/adapter/test changes — `adapters/gemini.sh`, `lib-agent.sh`'s gemini branch, `install-gemini-hooks.sh`, and `AGENT_CMD=gemini` all keep working exactly as before for anyone with an existing deployment. This PR only steers new users and docs toward `agy`, which already has a complete, independent adapter (Antigravity 2.0).

## Verification
- `grep -rn "Gemini CLI" README.md docs/agent-clis.md docs/installation.md` → 0 hits (the 2 remaining `docs/agent-clis.md` mentions are the intentional retirement note).
- Private-repo/enterprise-term leak scan on all 9 changed files → clean.