### PR TITLE
feat(dispatcher): preflight the GitHub CLI minimum version before a tick runs

### DIFF
--- a/docs/pipeline/dispatcher-flow.md
+++ b/docs/pipeline/dispatcher-flow.md
@@ -143,9 +143,19 @@ The self-heal is **scoped narrowly** — only the two directly-executed scripts.
 
 Defense in depth: the same heal also runs in every `install-*-hooks.sh` via `lib-installer.sh::ensure_dispatcher_scripts_executable`, so consumers re-running the installer get the heal even if their installed skill version still has the broken mode (the skills CLI's `computedHash` is content-only, not mode-aware).
 
+## Pre-step: `gh` CLI minimum-version validation
+
+Implementation: `dispatcher-tick.sh`, immediately after the `EXECUTION_BACKEND` check and before `REVIEW_BOTS` — same slot, same reasoning: a broken dependency must never reach a side effect.
+
+The GitHub-provider ITP/CHP leaves (`providers/itp-github.sh`, `providers/chp-github.sh`) call `gh api --paginate --slurp` to fetch issue/PR comments. `--slurp` was added in gh v2.48.0 (2024-04-17); on an older (or absent) `gh`, the call prints `unknown flag: --slurp` to stderr and the pipeline returns empty. Left unchecked, that empty result surfaces much later and opaquely — e.g. a `-ge` integer comparison over an empty retry count trips `set -euo pipefail` and aborts the tick mid-run, well past Step 4, with Step 5 (stale detection) never executing that tick.
+
+`gh_version_ok "$GH_MIN_VERSION"` (`providers/lib-github-transport.sh`, `GH_MIN_VERSION="2.48.0"` — the same `gh --version` capability probe self-sourced by both `providers/itp-github.sh` and `providers/chp-github.sh`, mirroring the `lib-gitlab-transport.sh` pattern, and reachable from `dispatcher-tick.sh` because `lib-dispatch.sh` transitively sources the GitHub ITP/CHP leaves) parses the first `X.Y.Z` token out of `gh --version`'s first line and numeric-sorts it (`sort -V`) against the minimum. Gated on `github_seam_active` (`lib-auth.sh`) — a `gitlab`/`gitlab` topology never calls `gh` and must not be blocked by a `gh` version it doesn't need. Kept under `providers/` (not the provider-neutral caller layer) because it is itself a raw `gh` invocation, subject to the same [INV-91] cutover-guard scan as every other GitHub-CLI call site.
+
+**Failure mode**: a missing `gh`, an unparseable `--version` output, or a version below the minimum aborts the ENTIRE tick rc≠0 with the `ADT_CFG_GH_VERSION_TOO_OLD` [INV-72] error envelope, surfaced as a dispatcher alert. No `gh` API call happens before this check runs (`gh --version` itself is a local, no-network invocation).
+
 ## Pre-step: `ISSUE_FILTER` / `ISSUE_SCAN_LIMIT` validation (issue #436, [INV-121])
 
-Implementation: `dispatcher-tick.sh`, immediately after the `EXECUTION_BACKEND`/`REVIEW_BOTS` upfront checks and **before** the GitHub App token mint (the next pre-step below) — same slot, same reasoning: a poisoned config must never reach a side effect.
+Implementation: `dispatcher-tick.sh`, immediately after the `EXECUTION_BACKEND`/`gh`-version/`REVIEW_BOTS` upfront checks and **before** the GitHub App token mint (the next pre-step below) — same slot, same reasoning: a poisoned config must never reach a side effect.
 
 `issue_filter_validate "${ISSUE_FILTER:-}"` (`lib-issue-filter.sh`, sourced transitively via `lib-dispatch.sh`) runs three checks in order, any of which fails closed:
 

--- a/docs/pipeline/errors.md
+++ b/docs/pipeline/errors.md
@@ -53,6 +53,7 @@ The `error_envelope` / `error_surface` helpers live in
 | `ADT_CFG_EXECUTION_BACKEND_INVALID` | `EXECUTION_BACKEND` has an unrecognized value | The dispatcher's `EXECUTION_BACKEND` is not `local` or `remote-aws-ssm` | Set `EXECUTION_BACKEND` to `local` or `remote-aws-ssm` in `dispatcher.conf`/`autonomous.conf` | dispatcher-alert |
 | `ADT_CFG_ISSUE_FILTER_INVALID` | `ISSUE_FILTER` failed validation | The filter is malformed (compiler error), references a reserved pipeline-state/`autonomous` label, or contains an `assignee:` atom against a provider whose caps lack `assignees=1` ([INV-121]) | Fix `ISSUE_FILTER` in `autonomous.conf`/`dispatcher.conf` per the grammar in `autonomous.conf.example`, then re-dispatch | dispatcher-alert |
 | `ADT_CFG_ISSUE_SCAN_LIMIT_INVALID` | `ISSUE_SCAN_LIMIT` has an invalid value | The value is not a positive integer | Set `ISSUE_SCAN_LIMIT` to a positive integer (or unset for the default 100) in `autonomous.conf`/`dispatcher.conf`, then re-dispatch | dispatcher-alert |
+| `ADT_CFG_GH_VERSION_TOO_OLD` | The `gh` CLI on the execution host is missing or older than the minimum required version | The GitHub-provider ITP/CHP leaves call `gh api --paginate --slurp`; `--slurp` was added in gh v2.48.0, and an older/absent `gh` fails that call silently, surfacing much later as an opaque abort mid-tick | Upgrade `gh` to >= 2.48.0 on the execution host, then re-dispatch | dispatcher-alert |
 
 ## Authentication class (`class: auth`)
 

--- a/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
+++ b/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh
@@ -134,6 +134,25 @@ case "${EXECUTION_BACKEND:-local}" in
     ;;
 esac
 
+# Validate the GitHub CLI version upfront, same slot and reasoning as
+# EXECUTION_BACKEND above: the GitHub-provider ITP/CHP leaves (providers/
+# itp-github.sh, providers/chp-github.sh — gh_version_ok / GH_MIN_VERSION /
+# GH_INSTALLED_VERSION live in the shared providers/lib-github-transport.sh,
+# transitively sourced via lib-dispatch.sh above) depend on the '--slurp'
+# pagination flag, and an older CLI fails that call silently deep inside
+# Step 3/4 instead of here, aborting the tick opaquely well past any label
+# transition. Gated on `github_seam_active` — a gitlab/gitlab topology never
+# calls the GitHub CLI and must not be blocked by its version (or absence).
+if github_seam_active && ! gh_version_ok "$GH_MIN_VERSION"; then
+  error_surface - ADT_CFG_GH_VERSION_TOO_OLD \
+    "The GitHub CLI on PATH is missing or older than the minimum required version (dispatcher tick)" \
+    "The installed CLI reported '${GH_INSTALLED_VERSION}'; the GitHub provider requires the CLI to be >= ${GH_MIN_VERSION} for the '--slurp' pagination flag (added in GitHub CLI v2.48.0)" \
+    "Upgrade the GitHub CLI to >= ${GH_MIN_VERSION} on the execution host, then the next tick proceeds" \
+    "docs/pipeline/errors.md#configuration-class-class-config"
+  echo "[dispatcher-tick] FATAL: the GitHub CLI is missing or older than the minimum required version ${GH_MIN_VERSION} (got '${GH_INSTALLED_VERSION}'). The '--slurp' pagination flag requires version >= 2.48.0. Upgrade before the next tick." >&2
+  exit 1
+fi
+
 # Validate REVIEW_BOTS upfront for the same reason: a typo (e.g.
 # REVIEW_BOTS="q codx") would let the tick swap labels to `reviewing` and
 # spawn the review wrapper, which then exits 1 at startup — burning a

--- a/skills/autonomous-dispatcher/scripts/providers/chp-github.sh
+++ b/skills/autonomous-dispatcher/scripts/providers/chp-github.sh
@@ -30,6 +30,20 @@
 #   chp_github_close_keyword
 # (chp_caps reads the .caps manifest in the dispatcher, not a function here.)
 
+# TRANSPORT-LIB SELF-SOURCE: `gh_version_ok` (the `--slurp` capability check
+# some leaves below preflight on) lives in `lib-github-transport.sh` (a
+# sibling file in `providers/`, shared with itp-github.sh — mirrors the
+# lib-gitlab-transport.sh self-source pattern, #416). Guarded on `declare -F
+# gh_version_ok`: a unit test with a test-local stub, or the sibling
+# itp-github.sh already sourcing it, must not be clobbered by a re-source.
+if ! declare -F gh_version_ok >/dev/null 2>&1; then
+  _CHP_GITHUB_SELF="${BASH_SOURCE[0]:-$0}"
+  _CHP_GITHUB_DIR="$(cd "$(dirname "$(readlink -f "$_CHP_GITHUB_SELF")")" && pwd)"
+  # shellcheck source=lib-github-transport.sh
+  [[ -f "${_CHP_GITHUB_DIR}/lib-github-transport.sh" ]] && \
+    source "${_CHP_GITHUB_DIR}/lib-github-transport.sh"
+fi
+
 # ---------------------------------------------------------------------------
 # W1c1 (#397) PR-read leaf machinery, shared by chp_github_find_pr_for_issue
 # and chp_github_pr_list.

--- a/skills/autonomous-dispatcher/scripts/providers/itp-github.sh
+++ b/skills/autonomous-dispatcher/scripts/providers/itp-github.sh
@@ -33,6 +33,22 @@
 #   itp_github_label_event_ts                                       [#323 OBSERVE]
 # (itp_caps reads the .caps manifest in the dispatcher, not a function here.)
 
+# TRANSPORT-LIB SELF-SOURCE: `gh_version_ok` (the `--slurp` capability check
+# `itp_github_list_comments` below preflights on) lives in
+# `lib-github-transport.sh` (a sibling file in `providers/`, shared with
+# chp-github.sh — mirrors the lib-gitlab-transport.sh self-source pattern,
+# #416). Guarded on `declare -F gh_version_ok`: a unit test with a test-local
+# stub, or the sibling chp-github.sh already sourcing it, must not be
+# clobbered by a re-source. Resolve via `readlink -f` of this file's own
+# BASH_SOURCE so a symlinked skill-tree resolves the real sibling.
+if ! declare -F gh_version_ok >/dev/null 2>&1; then
+  _ITP_GITHUB_SELF="${BASH_SOURCE[0]:-$0}"
+  _ITP_GITHUB_DIR="$(cd "$(dirname "$(readlink -f "$_ITP_GITHUB_SELF")")" && pwd)"
+  # shellcheck source=lib-github-transport.sh
+  [[ -f "${_ITP_GITHUB_DIR}/lib-github-transport.sh" ]] && \
+    source "${_ITP_GITHUB_DIR}/lib-github-transport.sh"
+fi
+
 # ---------------------------------------------------------------------------
 # W1a abstract state-read contracts (#371, #347 phase-2). Unlike the other ITP
 # leaves in this file (byte-identical gh-argv pass-throughs, #281), these three

--- a/skills/autonomous-dispatcher/scripts/providers/lib-github-transport.sh
+++ b/skills/autonomous-dispatcher/scripts/providers/lib-github-transport.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# lib-github-transport.sh — GitHub CLI capability check, shared by
+# itp-github.sh and chp-github.sh (mirrors the lib-gitlab-transport.sh
+# self-source pattern, #416).
+#
+# Both GitHub provider leaves (itp-github.sh's list-comments leaf,
+# chp-github.sh's incidental-read leaves) shell out to `gh api --paginate
+# --slurp`. `--slurp` was added in GitHub CLI v2.48.0 (2024-04-17) — on an
+# older `gh`, the call prints "unknown flag: --slurp" to stderr and the
+# pipeline returns empty, which fails much later and opaquely (e.g. a `-ge`
+# integer comparison over an empty retry count trips `set -euo pipefail` and
+# aborts the dispatcher tick mid-run).
+#
+# Double-source guard (idempotent — only defines a function + module-scope
+# state), mirroring lib-gitlab-transport.sh's `_LIB_GITLAB_TRANSPORT_SOURCED`
+# sentinel. The self-source blocks in itp-github.sh / chp-github.sh additionally
+# gate on `declare -F gh_version_ok` so a unit test's test-local stub (or the
+# sibling leaf's earlier source) is never clobbered.
+if [[ "${_LIB_GITHUB_TRANSPORT_SOURCED:-0}" -eq 1 ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+_LIB_GITHUB_TRANSPORT_SOURCED=1
+
+GH_MIN_VERSION="2.48.0"
+
+# GH_INSTALLED_VERSION — populated by gh_version_ok(); the raw first line of
+# `gh --version` (or "<not found>"), for callers that want it in a FATAL
+# message without invoking `gh --version` a second time.
+GH_INSTALLED_VERSION=""
+
+# gh_version_ok MIN_VERSION — 0 if `gh --version`'s parsed version is >=
+# MIN_VERSION, 1 otherwise (including "gh not on PATH" / unparseable output).
+# Uses `sort -V` (numeric-aware version sort, GNU/uutils/BSD-portable) rather
+# than a bespoke field-by-field comparator. Sets GH_INSTALLED_VERSION as a
+# side effect (single `gh --version` invocation for the whole preflight).
+gh_version_ok() {
+  local min_version="$1" installed first
+  installed="$(gh --version 2>/dev/null | head -1)"
+  GH_INSTALLED_VERSION="${installed:-<not found>}"
+  installed="$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' <<<"$installed" | head -1)"
+  [[ -n "$installed" ]] || return 1
+  first="$(printf '%s\n%s\n' "$min_version" "$installed" | sort -V | head -1)"
+  [[ "$first" == "$min_version" ]]
+}

--- a/skills/autonomous-dispatcher/scripts/providers/lib-github-transport.sh
+++ b/skills/autonomous-dispatcher/scripts/providers/lib-github-transport.sh
@@ -28,17 +28,51 @@ GH_MIN_VERSION="2.48.0"
 # message without invoking `gh --version` a second time.
 GH_INSTALLED_VERSION=""
 
-# gh_version_ok MIN_VERSION — 0 if `gh --version`'s parsed version is >=
+# _gh_transport_binary — echo the `gh` binary to invoke, honoring the same
+# `REAL_GH` escape hatch gh-with-token-refresh.sh resolves (#92): an
+# executable `REAL_GH` is used directly (installs outside the minimal
+# non-interactive PATH — cron/systemd/SSM — that never sourced rc files);
+# otherwise fall back to the bare `gh` name so a normal PATH lookup applies.
+# This precheck runs standalone, BEFORE dispatcher-tick.sh's auth/wrapper
+# setup installs the token-refresh proxy, so it must resolve independently
+# rather than assume the proxy is already on PATH.
+_gh_transport_binary() {
+  if [[ -n "${REAL_GH:-}" && -x "$REAL_GH" ]]; then
+    printf '%s\n' "$REAL_GH"
+  else
+    printf 'gh\n'
+  fi
+}
+
+# _gh_version_ge MIN INSTALLED — 0 if INSTALLED (an "X.Y.Z" string) is >=
+# MIN, 1 otherwise. Numeric per-component comparison (major, then minor,
+# then patch) — portable across GNU/BSD/macOS/uutils, unlike `sort -V`
+# (not part of POSIX/BSD sort; a host without GNU coreutils would silently
+# misreport every version as "too old" when the -V flag itself errors).
+_gh_version_ge() {
+  local min="$1" installed="$2"
+  local -a min_parts installed_parts
+  IFS='.' read -r -a min_parts <<<"$min"
+  IFS='.' read -r -a installed_parts <<<"$installed"
+  local i
+  for i in 0 1 2; do
+    local m="${min_parts[$i]:-0}" v="${installed_parts[$i]:-0}"
+    (( v > m )) && return 0
+    (( v < m )) && return 1
+  done
+  return 0
+}
+
+# gh_version_ok MIN_VERSION — 0 if the resolved gh binary's `--version` is >=
 # MIN_VERSION, 1 otherwise (including "gh not on PATH" / unparseable output).
-# Uses `sort -V` (numeric-aware version sort, GNU/uutils/BSD-portable) rather
-# than a bespoke field-by-field comparator. Sets GH_INSTALLED_VERSION as a
-# side effect (single `gh --version` invocation for the whole preflight).
+# Sets GH_INSTALLED_VERSION as a side effect (single `gh --version`
+# invocation for the whole preflight).
 gh_version_ok() {
-  local min_version="$1" installed first
-  installed="$(gh --version 2>/dev/null | head -1)"
+  local min_version="$1" bin installed
+  bin="$(_gh_transport_binary)"
+  installed="$("$bin" --version 2>/dev/null | head -1)"
   GH_INSTALLED_VERSION="${installed:-<not found>}"
   installed="$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' <<<"$installed" | head -1)"
   [[ -n "$installed" ]] || return 1
-  first="$(printf '%s\n%s\n' "$min_version" "$installed" | sort -V | head -1)"
-  [[ "$first" == "$min_version" ]]
+  _gh_version_ge "$min_version" "$installed"
 }

--- a/tests/unit/test-dispatcher-tick-app-auth.sh
+++ b/tests/unit/test-dispatcher-tick-app-auth.sh
@@ -100,6 +100,11 @@ cat > "$SANDBOX/lib-dispatch.sh" <<'EOF'
 MAX_RETRIES="${MAX_RETRIES:-3}"
 MAX_CONCURRENT="${MAX_CONCURRENT:-5}"
 
+# gh-version precheck helpers (see lib-dispatch.sh): this sandbox's auth-block
+# tests don't exercise the gh-version gate, so always report OK.
+GH_MIN_VERSION="2.48.0"
+gh_version_ok() { return 0; }
+
 count_active() { echo 0; }
 list_new_issues() { echo '[]'; }
 list_pending_review() { echo '[]'; }

--- a/tests/unit/test-dispatcher-tick-gh-version.sh
+++ b/tests/unit/test-dispatcher-tick-gh-version.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+# test-dispatcher-tick-gh-version.sh — Unit tests for the gh-CLI minimum
+# version fail-fast precheck added to dispatcher-tick.sh.
+#
+# Why: `itp_github_list_comments` (providers/itp-github.sh) shells out to
+# `gh api --paginate --slurp`. `--slurp` was added in gh v2.48.0 — an older
+# `gh` on PATH prints "unknown flag: --slurp" and the pipeline returns empty,
+# which downstream (e.g. count_retries' `-ge` integer comparison) trips
+# `set -euo pipefail` and aborts the tick mid-run, well past Step 4, with
+# Step 5 (stale detection) never running. The precheck catches this upfront,
+# before any gh API call, instead of failing opaquely deep in the tick.
+#
+# Strategy: same as test-dispatcher-tick-review-bots.sh — a `gh` shim on
+# PATH reporting a version, a sandbox autonomous.conf, run dispatcher-tick.sh,
+# assert rc/output.
+#
+# Run: bash tests/unit/test-dispatcher-tick-gh-version.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TICK="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/dispatcher-tick.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      needle='$needle'"
+    echo "      haystack='${haystack:0:500}'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      should not contain: '$needle'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+PROJECT_DIR_FAKE="$TMPROOT/proj"
+mkdir -p "$PROJECT_DIR_FAKE/scripts"
+
+BIN="$TMPROOT/bin"
+mkdir -p "$BIN"
+
+# write_gh_stub VERSION_STRING — a `gh` on PATH whose `--version` output
+# matches the real CLI's format, and which records every call so the test
+# can assert the precheck never invokes it for anything else.
+write_gh_stub() {
+  local version="$1"
+  cat > "$BIN/gh" <<EOF
+#!/bin/bash
+if [[ "\$1" == "--version" ]]; then
+  echo "gh version ${version} (2025-01-01)"
+  exit 0
+fi
+echo "GH_CALLED \$*" >> "$TMPROOT/gh-calls"
+exit 0
+EOF
+  chmod +x "$BIN/gh"
+}
+
+write_conf() {
+  cat > "$TMPROOT/autonomous.conf" <<EOF
+PROJECT_ID="testproj"
+REPO="owner/repo"
+REPO_OWNER="owner"
+REPO_NAME="repo"
+PROJECT_DIR="$PROJECT_DIR_FAKE"
+MAX_CONCURRENT=5
+MAX_RETRIES=3
+REVIEW_BOTS=""
+EOF
+}
+
+run_tick() {
+  : > "$TMPROOT/gh-calls"
+  PATH="$BIN:$PATH" \
+  AUTONOMOUS_CONF="$TMPROOT/autonomous.conf" \
+  bash "$TICK" 2>&1
+}
+
+run_tick_rc() {
+  PATH="$BIN:$PATH" AUTONOMOUS_CONF="$TMPROOT/autonomous.conf" \
+    bash "$TICK" >/dev/null 2>&1
+  echo $?
+}
+
+write_conf
+
+# ---------------------------------------------------------------------------
+echo "=== TC-DT-GHV-01: gh below the minimum version aborts the tick rc != 0 ==="
+# ---------------------------------------------------------------------------
+write_gh_stub "2.46.0"
+output=$(run_tick)
+rc=$(run_tick_rc)
+
+if [[ "$rc" -ne 0 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: tick exits non-zero on gh 2.46.0 (rc=$rc)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: tick should exit non-zero on gh 2.46.0 (got rc=0)"
+  FAIL=$((FAIL + 1))
+fi
+
+assert_contains "stderr names the installed version"  "2.46.0"    "$output"
+assert_contains "stderr names the minimum version"     "2.48.0"    "$output"
+assert_contains "stderr mentions --slurp"               "--slurp"  "$output"
+assert_contains "envelope code present" "ADT_CFG_GH_VERSION_TOO_OLD" "$output"
+
+gh_calls_file="$TMPROOT/gh-calls"
+if [[ -s "$gh_calls_file" ]]; then
+  echo -e "  ${RED}FAIL${NC}: gh was called (beyond --version) before precheck failure:"
+  sed 's/^/      /' "$gh_calls_file"
+  FAIL=$((FAIL + 1))
+else
+  echo -e "  ${GREEN}PASS${NC}: gh not called beyond --version — precheck aborts before any API call"
+  PASS=$((PASS + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-DT-GHV-02: gh at exactly the minimum version does NOT trip the precheck ==="
+# ---------------------------------------------------------------------------
+write_gh_stub "2.48.0"
+output=$(run_tick)
+assert_not_contains "no version error at exactly the minimum" \
+  "ADT_CFG_GH_VERSION_TOO_OLD" "$output"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-DT-GHV-03: gh above the minimum version does NOT trip the precheck ==="
+# ---------------------------------------------------------------------------
+write_gh_stub "2.96.0"
+output=$(run_tick)
+assert_not_contains "no version error above the minimum" \
+  "ADT_CFG_GH_VERSION_TOO_OLD" "$output"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-DT-GHV-04: unparseable gh --version output surfaces a clear error, not an opaque crash ==="
+# ---------------------------------------------------------------------------
+# A `gh` present on PATH whose --version output the parser can't extract a
+# semver from (corrupt install / unexpected banner) must fail the same way as
+# "too old" — never silently pass through as "version OK". PATH is NOT reset
+# to the real system `gh` here (that would test the host's actual gh, making
+# the case non-hermetic); the stub simply reports garbage.
+cat > "$BIN/gh" <<'EOF'
+#!/bin/bash
+if [[ "$1" == "--version" ]]; then
+  echo "gh: command not properly initialized"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$BIN/gh"
+output=$(run_tick)
+rc=$(run_tick_rc)
+if [[ "$rc" -ne 0 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: tick exits non-zero when gh --version is unparseable (rc=$rc)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: tick should exit non-zero when gh --version is unparseable (got rc=0)"
+  FAIL=$((FAIL + 1))
+fi
+assert_contains "envelope code present for unparseable gh --version" "ADT_CFG_GH_VERSION_TOO_OLD" "$output"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-DT-GHV-05: precheck source line in tick script ==="
+# ---------------------------------------------------------------------------
+if grep -q 'ADT_CFG_GH_VERSION_TOO_OLD' "$TICK"; then
+  echo -e "  ${GREEN}PASS${NC}: tick references the ADT_CFG_GH_VERSION_TOO_OLD envelope"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: tick missing the gh-version precheck"
+  FAIL=$((FAIL + 1))
+fi
+
+# Precheck must come BEFORE any `dispatch ` call or label transition — same
+# positional contract as the REVIEW_BOTS / EXECUTION_BACKEND prechecks.
+PRECHECK_LINE=$(grep -n 'ADT_CFG_GH_VERSION_TOO_OLD' "$TICK" | head -1 | cut -d: -f1)
+FIRST_DISPATCH_LINE=$(grep -n '^[[:space:]]*dispatch ' "$TICK" | head -1 | cut -d: -f1)
+if [[ -n "$PRECHECK_LINE" && -n "$FIRST_DISPATCH_LINE" && "$PRECHECK_LINE" -lt "$FIRST_DISPATCH_LINE" ]]; then
+  echo -e "  ${GREEN}PASS${NC}: precheck (line $PRECHECK_LINE) runs before any dispatch (line $FIRST_DISPATCH_LINE)"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: precheck not positioned before dispatch (precheck=$PRECHECK_LINE, first dispatch=$FIRST_DISPATCH_LINE)"
+  FAIL=$((FAIL + 1))
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/tests/unit/test-dispatcher-tick-gh-version.sh
+++ b/tests/unit/test-dispatcher-tick-gh-version.sh
@@ -80,6 +80,7 @@ EOF
 }
 
 write_conf() {
+  local real_gh_line="${1:-}"
   cat > "$TMPROOT/autonomous.conf" <<EOF
 PROJECT_ID="testproj"
 REPO="owner/repo"
@@ -89,6 +90,7 @@ PROJECT_DIR="$PROJECT_DIR_FAKE"
 MAX_CONCURRENT=5
 MAX_RETRIES=3
 REVIEW_BOTS=""
+$real_gh_line
 EOF
 }
 
@@ -183,6 +185,60 @@ else
   FAIL=$((FAIL + 1))
 fi
 assert_contains "envelope code present for unparseable gh --version" "ADT_CFG_GH_VERSION_TOO_OLD" "$output"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-DT-GHV-06: REAL_GH is honored when no bare gh is on PATH ==="
+# ---------------------------------------------------------------------------
+# gh-with-token-refresh.sh's REAL_GH escape hatch (#92) lets an operator
+# point at a gh binary installed outside the minimal non-interactive PATH
+# (cron/systemd/SSM never sourced rc files). The version precheck must
+# resolve the SAME binary, not always shell out to bare `gh` — otherwise a
+# host with a perfectly good REAL_GH but no bare `gh` on PATH gets a false
+# "<not found>" FATAL.
+REALBIN="$TMPROOT/realbin"
+mkdir -p "$REALBIN"
+cat > "$REALBIN/gh" <<EOF
+#!/bin/bash
+if [[ "\$1" == "--version" ]]; then
+  echo "gh version 2.96.0 (2026-01-01)"
+  exit 0
+fi
+echo "GH_CALLED \$*" >> "$TMPROOT/gh-calls"
+exit 0
+EOF
+chmod +x "$REALBIN/gh"
+rm -f "$BIN/gh"  # no bare `gh` anywhere on PATH — only REAL_GH resolves.
+write_conf "REAL_GH=\"$REALBIN/gh\""
+output=$(run_tick)
+assert_not_contains "REAL_GH resolves — no false 'gh CLI is missing' FATAL" \
+  "ADT_CFG_GH_VERSION_TOO_OLD" "$output"
+assert_not_contains "REAL_GH resolves — GH_INSTALLED_VERSION is not '<not found>'" \
+  "<not found>" "$output"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-DT-GHV-07: REAL_GH below the minimum version still aborts ==="
+# ---------------------------------------------------------------------------
+cat > "$REALBIN/gh" <<EOF
+#!/bin/bash
+if [[ "\$1" == "--version" ]]; then
+  echo "gh version 2.40.0 (2025-01-01)"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$REALBIN/gh"
+write_conf "REAL_GH=\"$REALBIN/gh\""
+output=$(run_tick)
+assert_contains "REAL_GH below minimum still trips the precheck" \
+  "ADT_CFG_GH_VERSION_TOO_OLD" "$output"
+assert_contains "stderr names the REAL_GH-reported version" "2.40.0" "$output"
+
+# Restore the plain-PATH `gh` stub and default conf (no REAL_GH) for any
+# tests appended after this point.
+write_gh_stub "2.96.0"
+write_conf
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/unit/test-dispatcher-tick-issue-filter.sh
+++ b/tests/unit/test-dispatcher-tick-issue-filter.sh
@@ -58,6 +58,10 @@ BIN="$TMPROOT/bin"
 mkdir -p "$BIN"
 cat > "$BIN/gh" <<EOF
 #!/bin/bash
+if [[ "\$1" == "--version" ]]; then
+  echo "gh version 2.96.0 (2026-01-01)"
+  exit 0
+fi
 echo "GH_CALLED \$*" >> "$TMPROOT/gh-calls"
 exit 0
 EOF

--- a/tests/unit/test-dispatcher-tick-review-bots.sh
+++ b/tests/unit/test-dispatcher-tick-review-bots.sh
@@ -80,6 +80,10 @@ BIN="$TMPROOT/bin"
 mkdir -p "$BIN"
 cat > "$BIN/gh" <<EOF
 #!/bin/bash
+if [[ "\$1" == "--version" ]]; then
+  echo "gh version 2.96.0 (2026-01-01)"
+  exit 0
+fi
 echo "GH_CALLED \$*" >> "$TMPROOT/gh-calls"
 exit 0
 EOF

--- a/tests/unit/test-lane-gc-p6-gate.sh
+++ b/tests/unit/test-lane-gc-p6-gate.sh
@@ -907,10 +907,10 @@ _run_tick_site_harness() {
 }
 
 declare -A TICK_SITES=(
-  ["step2-dev-new"]="443"
-  ["step3-review"]="489"
-  ["step4-ptl-dev-new"]="646"
-  ["step4-dev-resume"]="686"
+  ["step2-dev-new"]="462"
+  ["step3-review"]="508"
+  ["step4-ptl-dev-new"]="665"
+  ["step4-dev-resume"]="705"
 )
 for site_label in step2-dev-new step3-review step4-ptl-dev-new step4-dev-resume; do
   start_line="${TICK_SITES[$site_label]}"

--- a/tests/unit/test-lib-github-transport.sh
+++ b/tests/unit/test-lib-github-transport.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# test-lib-github-transport.sh — direct unit test for
+# skills/autonomous-dispatcher/scripts/providers/lib-github-transport.sh.
+#
+# Companion to test-dispatcher-tick-gh-version.sh (which exercises the
+# precheck end-to-end through dispatcher-tick.sh). This file drives
+# gh_version_ok / _gh_version_ge / _gh_transport_binary directly — the
+# numeric-comparator edge cases and the REAL_GH resolution order are cheaper
+# and clearer to pin at this level than through a full tick invocation.
+#
+# Run: bash tests/unit/test-lib-github-transport.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/providers/lib-github-transport.sh"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+ok()  { echo -e "  ${GREEN}PASS${NC}: $1"; PASS=$((PASS + 1)); }
+bad() { echo -e "  ${RED}FAIL${NC}: $1"; FAIL=$((FAIL + 1)); }
+
+[[ -f "$LIB" ]] || { echo "FATAL: $LIB not found"; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ---------------------------------------------------------------------------
+echo "=== TC-GHT-001: _gh_version_ge numeric comparison (not lexical sort -V) ==="
+# ---------------------------------------------------------------------------
+# Each case run in a fresh subshell so module-scope state never leaks.
+_case_ge() {
+  local min="$1" installed="$2" want_rc="$3" desc="$4"
+  local got_rc
+  ( source "$LIB"; _gh_version_ge "$min" "$installed" )
+  got_rc=$?
+  if [[ "$got_rc" -eq "$want_rc" ]]; then
+    ok "$desc (rc=$got_rc)"
+  else
+    bad "$desc — want rc=$want_rc got rc=$got_rc"
+  fi
+}
+_case_ge "2.48.0" "2.46.0" 1 "TC-GHT-001a below minimum -> false"
+_case_ge "2.48.0" "2.48.0" 0 "TC-GHT-001b exactly minimum -> true"
+_case_ge "2.48.0" "2.96.0" 0 "TC-GHT-001c above minimum -> true"
+# The load-bearing case a naive lexical/sort -V comparator can get wrong:
+# "9" > "48" numerically per-component, but "2.9.0" < "2.48.0" as a version.
+_case_ge "2.48.0" "2.9.0" 1 "TC-GHT-001d 2.9.0 < 2.48.0 (numeric per-component, not lexical)"
+_case_ge "2.48.0" "2.100.0" 0 "TC-GHT-001e 2.100.0 > 2.48.0 (3-digit minor)"
+_case_ge "2.48.0" "10.2.0" 0 "TC-GHT-001f 10.2.0 > 2.48.0 (major version bump)"
+_case_ge "2.48.0" "2.48.1" 0 "TC-GHT-001g patch-level bump above minimum -> true"
+_case_ge "2.48.0" "2.47.99" 1 "TC-GHT-001h high patch on a lower minor still below minimum -> false"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-GHT-010: gh_version_ok resolves bare gh on PATH when REAL_GH is unset ==="
+# ---------------------------------------------------------------------------
+BIN="$WORK/bin"
+mkdir -p "$BIN"
+cat > "$BIN/gh" <<'EOF'
+#!/bin/bash
+if [[ "$1" == "--version" ]]; then
+  echo "gh version 2.96.0 (2026-01-01)"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$BIN/gh"
+
+OUT=$(env -u REAL_GH PATH="$BIN:$PATH" bash -c '
+  source "'"$LIB"'"
+  gh_version_ok "2.48.0"
+  echo "rc=$? installed=$GH_INSTALLED_VERSION"
+')
+if [[ "$OUT" == *"rc=0"* ]]; then
+  ok "TC-GHT-010a bare gh on PATH resolves and passes (no REAL_GH set)"
+else
+  bad "TC-GHT-010a expected rc=0, got: $OUT"
+fi
+if [[ "$OUT" == *"installed=gh version 2.96.0"* ]]; then
+  ok "TC-GHT-010b GH_INSTALLED_VERSION captures the bare-gh --version output"
+else
+  bad "TC-GHT-010b GH_INSTALLED_VERSION not populated as expected: $OUT"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-GHT-020: gh_version_ok honors REAL_GH when no bare gh is on PATH ==="
+# ---------------------------------------------------------------------------
+# The #92 escape hatch: REAL_GH points at an install outside the minimal
+# non-interactive PATH (cron/systemd/SSM). The precheck must resolve THIS
+# binary, not report "<not found>" just because bare `gh` isn't reachable.
+REALBIN="$WORK/realbin"
+mkdir -p "$REALBIN"
+cat > "$REALBIN/gh" <<'EOF'
+#!/bin/bash
+if [[ "$1" == "--version" ]]; then
+  echo "gh version 2.96.0 (2026-01-01)"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$REALBIN/gh"
+
+EMPTYBIN="$WORK/emptybin"
+mkdir -p "$EMPTYBIN"
+for c in bash grep head sed cat; do
+  command -v "$c" >/dev/null 2>&1 && ln -sf "$(command -v "$c")" "$EMPTYBIN/$c"
+done
+
+OUT=$(REAL_GH="$REALBIN/gh" PATH="$EMPTYBIN" bash -c '
+  source "'"$LIB"'"
+  gh_version_ok "2.48.0"
+  echo "rc=$? installed=$GH_INSTALLED_VERSION"
+')
+if [[ "$OUT" == *"rc=0"* ]]; then
+  ok "TC-GHT-020a REAL_GH resolves even with no bare gh on PATH"
+else
+  bad "TC-GHT-020a expected rc=0, got: $OUT"
+fi
+if [[ "$OUT" != *"<not found>"* ]]; then
+  ok "TC-GHT-020b GH_INSTALLED_VERSION is not the false '<not found>' sentinel"
+else
+  bad "TC-GHT-020b got the false '<not found>' regression: $OUT"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-GHT-021: REAL_GH below the minimum version still fails closed ==="
+# ---------------------------------------------------------------------------
+cat > "$REALBIN/gh" <<'EOF'
+#!/bin/bash
+if [[ "$1" == "--version" ]]; then
+  echo "gh version 2.40.0 (2025-01-01)"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$REALBIN/gh"
+
+OUT=$(REAL_GH="$REALBIN/gh" PATH="$EMPTYBIN" bash -c '
+  source "'"$LIB"'"
+  gh_version_ok "2.48.0"
+  echo "rc=$? installed=$GH_INSTALLED_VERSION"
+')
+if [[ "$OUT" == *"rc=1"* ]]; then
+  ok "TC-GHT-021a REAL_GH below minimum correctly fails"
+else
+  bad "TC-GHT-021a expected rc=1, got: $OUT"
+fi
+if [[ "$OUT" == *"2.40.0"* ]]; then
+  ok "TC-GHT-021b GH_INSTALLED_VERSION reports the REAL_GH-resolved version"
+else
+  bad "TC-GHT-021b version not captured: $OUT"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-GHT-022: a non-executable REAL_GH falls back to bare gh on PATH ==="
+# ---------------------------------------------------------------------------
+# Mirrors gh-with-token-refresh.sh's own fallback contract: REAL_GH is only
+# honored when it points at an EXECUTABLE file (-x test).
+NONEXEC="$WORK/nonexec-gh"
+: > "$NONEXEC"  # exists, not executable
+
+OUT=$(REAL_GH="$NONEXEC" PATH="$BIN:$PATH" bash -c '
+  source "'"$LIB"'"
+  gh_version_ok "2.48.0"
+  echo "rc=$? installed=$GH_INSTALLED_VERSION"
+')
+if [[ "$OUT" == *"rc=0"* && "$OUT" == *"2.96.0"* ]]; then
+  ok "TC-GHT-022 non-executable REAL_GH is ignored, bare gh on PATH resolves instead"
+else
+  bad "TC-GHT-022 expected fallback to bare gh (rc=0, 2.96.0), got: $OUT"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TC-GHT-030: neither REAL_GH nor bare gh resolves -> fails closed, not found sentinel ==="
+# ---------------------------------------------------------------------------
+OUT=$(env -u REAL_GH PATH="$EMPTYBIN" bash -c '
+  source "'"$LIB"'"
+  gh_version_ok "2.48.0"
+  echo "rc=$? installed=$GH_INSTALLED_VERSION"
+')
+if [[ "$OUT" == *"rc=1"* && "$OUT" == *"installed=<not found>"* ]]; then
+  ok "TC-GHT-030 no gh anywhere -> fails closed with the <not found> sentinel"
+else
+  bad "TC-GHT-030 expected rc=1 + '<not found>', got: $OUT"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Results ==="
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary
- `dispatcher-tick.sh` now checks the installed GitHub CLI version before any GitHub API call, since the GitHub ITP/CHP provider leaves call `gh api --paginate --slurp` (`--slurp` requires gh >= v2.48.0). An older/missing CLI previously failed that call silently, and the empty result surfaced much later as an opaque `set -euo pipefail` abort mid-tick instead of a clear, actionable error.
- The check fails fast with a documented `ADT_CFG_GH_VERSION_TOO_OLD` operator error envelope, gated on `github_seam_active` so a GitLab-only topology is never blocked by gh's version or absence.
- The `gh --version` capability probe (`gh_version_ok`) lives in a new `providers/lib-github-transport.sh`, self-sourced by `providers/itp-github.sh` and `providers/chp-github.sh` — mirroring the existing `providers/lib-gitlab-transport.sh` pattern — so the check stays inside the provider layer per the `[INV-91]` cutover guard (no new raw `gh` call in the provider-neutral caller layer).

## Docs
- `docs/pipeline/dispatcher-flow.md`: new "Pre-step: `gh` CLI minimum-version validation" section, positioned in the same pre-step chain as the `EXECUTION_BACKEND`/`REVIEW_BOTS`/`ISSUE_FILTER` prechecks.
- `docs/pipeline/errors.md`: new `ADT_CFG_GH_VERSION_TOO_OLD` registry entry (config class, dispatcher-alert surface).

## Follow-up fixes (post-review)
- **`test-lane-gc-p6-gate.sh`** hardcodes 4 absolute line numbers into `dispatcher-tick.sh` to extract dispatch-site code blocks by `awk` range; the preflight insertion shifted them. Re-pinned to the new offsets.
- **REAL_GH escape hatch**: an independent codex review found the version probe always shelled out to bare `gh`, ignoring the project's documented `REAL_GH` override (`gh-with-token-refresh.sh`'s #92 contract for installs outside the minimal non-interactive PATH used by cron/systemd/SSM). A host with a valid `REAL_GH` but no bare `gh` on PATH got a false "gh CLI is missing" FATAL. Fixed: `lib-github-transport.sh` now resolves the same binary the wrapper does.
- **Portability**: the version comparison used `sort -V`, a GNU/uutils extension absent from POSIX/BSD `sort` — on such a host every version would misreport as "too old". Replaced with a small numeric major/minor/patch comparator.

## Test plan
- [x] New `tests/unit/test-dispatcher-tick-gh-version.sh` — below-minimum, exactly-minimum, above-minimum, unparseable `--version` output, `REAL_GH` resolution (both passing and below-minimum), and precheck-runs-before-any-dispatch positional ordering.
- [x] New `tests/unit/test-lib-github-transport.sh` — direct unit coverage of the numeric comparator's edge cases and the `REAL_GH`-then-bare-`gh` resolution order.
- [x] Patched `test-dispatcher-tick-app-auth.sh`, `test-dispatcher-tick-issue-filter.sh`, `test-dispatcher-tick-review-bots.sh` so their `gh` stubs/sandboxes account for the new precheck.
- [x] Re-pinned `test-lane-gc-p6-gate.sh`'s line-number constants.
- [x] Full unit suite passes (pre-existing, unrelated environment flakiness confirmed identical against a clean `main` checkout).
- [x] `check-provider-cutover.sh` ([INV-91]) passes with zero baseline changes — the new `gh --version` call resolves entirely under `providers/`.
- [x] code-simplifier, PR-review, and an independent codex CLI review pass completed.
- [x] All CI checks green on the final commit.
