### PR TITLE
feat(create-issue): flag ACs whose verification surface is agent-unwritable (#457)

### DIFF
--- a/docs/test-cases/create-issue-ac-surface.md
+++ b/docs/test-cases/create-issue-ac-surface.md
@@ -5,7 +5,7 @@ the `create-issue` skill so future doc rewrites cannot silently relax it. Mirror
 the #273 `test-create-issue-ac-verification-guidance.sh` harness
 (`extract_section` / `assert_contains`).
 
-The skill change extends the #273 advisory self-scan with a **third axis**:
+The skill change extends the #273 advisory self-scan with a **second axis**:
 pre-merge verifiable, but on a surface the dev/review agents' **scoped token**
 cannot write to (PR body/description/title, PR metadata). Such an AC is
 guaranteed to end in a `dev-actionable=false` stall regardless of how much

--- a/docs/test-cases/create-issue-ac-surface.md
+++ b/docs/test-cases/create-issue-ac-surface.md
@@ -1,0 +1,63 @@
+# Test Cases — create-issue agent-unwritable AC-surface scan (#457)
+
+Static-grep regression tests pinning the documentation/process guidance added to
+the `create-issue` skill so future doc rewrites cannot silently relax it. Mirrors
+the #273 `test-create-issue-ac-verification-guidance.sh` harness
+(`extract_section` / `assert_contains`).
+
+The skill change extends the #273 advisory self-scan with a **third axis**:
+pre-merge verifiable, but on a surface the dev/review agents' **scoped token**
+cannot write to (PR body/description/title, PR metadata). Such an AC is
+guaranteed to end in a `dev-actionable=false` stall regardless of how much
+evidence the dev agent produces, because the surface itself is unreachable —
+per the two-token split (#234), the dev agent's scoped token can post PR/issue
+comments and commit files, but cannot edit PR metadata
+(`Resource not accessible by integration`).
+
+## Files under test
+
+| File | Role |
+|------|------|
+| `skills/create-issue/references/ac-verification.md` | Documents the agent-writable-surface distinction (new §5) |
+| `skills/create-issue/SKILL.md` | Step 4 advisory self-scan extended with agent-unwritable-surface phrasing + suggested rewrite |
+| `tests/unit/test-create-issue-ac-surface-guidance.sh` (NEW) | This regression suite |
+
+## Test scenarios
+
+### Group A — `SKILL.md` Step 4 self-scan anchors (TC-AC-SURFACE-001..006)
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| TC-AC-SURFACE-001 | Step 4 lists the `in (the )?PR (body\|description\|title)` phrasing | pattern text present in Step 4 region |
+| TC-AC-SURFACE-002 | Step 4 lists `PR metadata` phrasing | phrase present in Step 4 region |
+| TC-AC-SURFACE-003 | Step 4 suggests rewording to "as a PR comment" | phrase present in Step 4 region |
+| TC-AC-SURFACE-004 | Step 4 explains WHY (scoped token cannot edit PR metadata) | `scoped token` wording present |
+| TC-AC-SURFACE-005 | Step 4 states the warning is advisory, not a hard fail, for this axis too | `advisory` present alongside the new phrasing |
+| TC-AC-SURFACE-006 | SKILL.md still links to `references/ac-verification.md` | ref link present |
+
+### Group B — `references/ac-verification.md` agent-writable-surface anchors (TC-AC-SURFACE-007..012)
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| TC-AC-SURFACE-007 | New section documents "agent-writable" surfaces | `agent-writable` present |
+| TC-AC-SURFACE-008 | PR comment / issue comment / committed file named as agent-writable | all three phrases present |
+| TC-AC-SURFACE-009 | PR body/title/labels/milestone named as maintainer-or-wrapper only | all four phrases present |
+| TC-AC-SURFACE-010 | Doc references the two-token split (#234) reasoning | `scoped token` present |
+| TC-AC-SURFACE-011 | Doc gives the canonical "in PR body" → "as a PR comment" rewrite example | both phrases present |
+| TC-AC-SURFACE-012 | SKILL.md Step 4 cross-references this new section | ref doc link present in Step 4 region |
+
+### Group C — scan-scope regression (TC-AC-SURFACE-013)
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| TC-AC-SURFACE-013 | Step 4 still scopes the scan to AC checkbox lines only (no widened scope for the new axis) | `AC checkbox lines` still present exactly where the #273 scan defines it |
+
+## Acceptance criteria for this change (pre-merge verifiable)
+
+- [ ] **Surface**: CI job `hermetic-unit` runs `tests/unit/test-*.sh`; the new
+  `test-create-issue-ac-surface-guidance.sh` passes (all TC-AC-SURFACE-* green).
+  Expected evidence: green `Hermetic / Unit + conformance` check on the PR.
+- [ ] **Surface**: the pre-existing `#273` test
+  `test-create-issue-ac-verification-guidance.sh` still passes (no harness
+  regression from editing the same Step 4 region).
+  Expected evidence: same CI check green.

--- a/skills/create-issue/SKILL.md
+++ b/skills/create-issue/SKILL.md
@@ -123,6 +123,18 @@ blocking)** and offer to split it per **`references/ac-verification.md`** §3 (c
 a non-blocking, non-`autonomous` follow-up; reference it under `## Out of Scope`,
 never under `## Dependencies`). Do not hard-fail the draft on a match.
 
+**Advisory agent-unwritable-surface self-scan** (same AC-checkbox-lines-only
+scope, a second pass over the same lines): also scan for phrasing that names a
+verification surface the dev agent's **scoped token** cannot write to — at
+minimum `in (the )?PR (body|description|title)` and `PR metadata`. Such an AC
+can be fully pre-merge verifiable and still guarantee a `dev-actionable=false`
+stall, because the scoped token can post PR/issue comments and commit files but
+cannot edit PR metadata (`Resource not accessible by integration`, by design
+per the two-token split — see **`references/ac-verification.md`** §5). On a
+match, **warn the author (advisory, not blocking)** and suggest rewording to
+name an agent-writable surface instead — e.g. "…in PR body" →
+"…as a PR comment". Do not hard-fail the draft on a match.
+
 ### Step 5: Create the Issue
 
 Use GitHub MCP tools or `gh` CLI to create the issue with:

--- a/skills/create-issue/references/ac-verification.md
+++ b/skills/create-issue/references/ac-verification.md
@@ -175,10 +175,52 @@ human resolves after deploy.
 
 ---
 
+## 5. A pre-merge-verifiable AC can still stall — if the surface is agent-unwritable
+
+Section 1's rubric asks "can the evidence be obtained before merge?" That is
+necessary but not sufficient. A second, independent question matters just as
+much: **can the dev agent's scoped token actually write to that surface?**
+
+Per the two-token split (#234), the autonomous pipeline splits write access:
+
+- **Agent-writable** (the dev agent's scoped token can write here): a **PR
+  comment**, an **issue comment**, a **committed file** (code, docs, test
+  output committed to the branch).
+- **Maintainer-or-wrapper only** (the scoped token cannot write here): the
+  **PR body**, **PR title**, **labels**, **milestone** — PR/issue *metadata*.
+  Editing these returns `Resource not accessible by integration` for the
+  scoped token; only the full-write wrapper token or a human maintainer can
+  edit them.
+
+An AC that names a maintainer-or-wrapper-only surface is **pre-merge
+verifiable in principle** — the evidence could exist before merge — but is
+**guaranteed to stall** in practice: the dev agent produces the evidence
+wherever it *can* write, the review agent (correctly) checks the literal
+surface named in the AC, finds it empty, and marks the issue
+`dev-actionable=false`. Every component behaves correctly; the defect is the
+AC's choice of surface.
+
+**The fix is almost always a one-word rewrite**, not a redesign — a PR
+comment carries the same evidentiary value as a PR-body paragraph:
+
+- ❌ "Curl transcript showing the PUT→GET round-trip **in PR body**."
+- ✅ "Curl transcript showing the PUT→GET round-trip **as a PR comment**."
+
+When drafting or reviewing an AC, check both axes:
+
+1. **Pre-merge verifiable?** (§1) — if not, split per §3.
+2. **Agent-writable surface?** (this section) — if the named surface is
+   PR body/title/labels/milestone, reword to a PR comment, issue comment, or
+   committed file instead. This is an advisory rewrite, not a hard block —
+   see `SKILL.md` Step 4's agent-unwritable-surface self-scan.
+
+---
+
 ## See also
 
 - `references/issue-templates.md` — both templates carry an always-present
   pre-merge-classification note in their `## Acceptance Criteria` section.
 - `SKILL.md` Step 1 (per-AC classification prompt), Writing Guidelines
   ("AC verification surface" bullet), and Step 4 (advisory self-scan for
-  post-merge phrasing on AC checkbox lines).
+  post-merge phrasing, and the agent-unwritable-surface self-scan, both on
+  AC checkbox lines).

--- a/tests/unit/test-create-issue-ac-surface-guidance.sh
+++ b/tests/unit/test-create-issue-ac-surface-guidance.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# test-create-issue-ac-surface-guidance.sh — Regression for issue #457.
+#
+# Pins the agent-unwritable-surface advisory scan added to the create-issue
+# skill so future doc rewrites cannot silently relax it. This extends the
+# #273 advisory self-scan with a third axis: an AC can be pre-merge
+# verifiable yet still stall forever if its verification surface (e.g. "in
+# the PR body") is writable only by a maintainer/wrapper, not by the dev
+# agent's scoped token (#234's two-token split). The scan flags that
+# phrasing and suggests a scoped-token-writable rewrite ("as a PR comment").
+#
+# Static-grep test (mirrors the #273 harness: extract_section /
+# assert_contains). Verifies anchors in two places — the SKILL.md Step 4
+# region, and the new agent-writable-surface section in
+# references/ac-verification.md.
+#
+# Run: bash tests/unit/test-create-issue-ac-surface-guidance.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SKILL_MD="$PROJECT_ROOT/skills/create-issue/SKILL.md"
+ACV_MD="$PROJECT_ROOT/skills/create-issue/references/ac-verification.md"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Extract a section delimited by an exact start line and an end-marker regex.
+# (Same contract as the #273 harness.) FIRST-match only.
+extract_section() {
+  local file="$1" start_marker="$2" end_marker_re="$3"
+  awk -v start="$start_marker" -v end_re="$end_marker_re" '
+    $0 == start { in_block=1; next }
+    in_block && $0 ~ end_re { exit }
+    in_block { print }
+  ' "$file"
+}
+
+assert_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      needle: $needle"
+    echo "      first 200 chars of haystack:"
+    echo "      $(echo "$haystack" | head -c 200)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains_ci() {
+  local desc="$1" haystack="$2" needle="$3"
+  local h n
+  h=$(printf '%s' "$haystack" | tr '[:upper:]' '[:lower:]')
+  n=$(printf '%s' "$needle"   | tr '[:upper:]' '[:lower:]')
+  if [[ "$h" == *"$n"* ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      needle (ci): $needle"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_file_exists() {
+  local desc="$1" file="$2"
+  if [[ -f "$file" ]]; then
+    echo -e "  ${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "  ${RED}FAIL${NC}: $desc"
+    echo "      missing file: $file"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ===================================================================
+# Group A — SKILL.md Step 4 self-scan anchors
+# ===================================================================
+echo "=== TC-AC-SURFACE-001..006: SKILL.md Step 4 anchors ==="
+
+assert_file_exists "TC-AC-SURFACE-000 SKILL.md exists" "$SKILL_MD"
+
+step4_block=$(extract_section "$SKILL_MD" "### Step 4: Confirm with User" "^### ")
+
+assert_contains_ci "TC-AC-SURFACE-001 Step 4 lists 'in (the )?PR (body|description|title)' phrasing" \
+  "$step4_block" "PR (body|description|title)"
+
+assert_contains "TC-AC-SURFACE-002 Step 4 lists 'PR metadata' phrasing" \
+  "$step4_block" "PR metadata"
+
+assert_contains_ci "TC-AC-SURFACE-003 Step 4 suggests rewording to 'as a PR comment'" \
+  "$step4_block" "as a PR comment"
+
+assert_contains_ci "TC-AC-SURFACE-004 Step 4 explains WHY: scoped token cannot edit PR metadata" \
+  "$step4_block" "scoped token"
+
+assert_contains_ci "TC-AC-SURFACE-005 Step 4 still frames this axis as advisory, not a hard fail" \
+  "$step4_block" "advisory"
+
+skill_all=$(cat "$SKILL_MD")
+assert_contains "TC-AC-SURFACE-006 SKILL.md links to references/ac-verification.md" \
+  "$skill_all" "references/ac-verification.md"
+
+# ===================================================================
+# Group B — references/ac-verification.md agent-writable-surface anchors
+# ===================================================================
+echo
+echo "=== TC-AC-SURFACE-007..012: references/ac-verification.md anchors ==="
+
+assert_file_exists "TC-AC-SURFACE-007a ac-verification.md exists" "$ACV_MD"
+acv_all=$(cat "$ACV_MD" 2>/dev/null)
+
+assert_contains_ci "TC-AC-SURFACE-007b doc names the 'agent-writable' surface concept" \
+  "$acv_all" "agent-writable"
+
+assert_contains_ci "TC-AC-SURFACE-008a PR comment named as agent-writable" \
+  "$acv_all" "PR comment"
+assert_contains_ci "TC-AC-SURFACE-008b issue comment named as agent-writable" \
+  "$acv_all" "issue comment"
+assert_contains_ci "TC-AC-SURFACE-008c committed file named as agent-writable" \
+  "$acv_all" "committed file"
+
+assert_contains_ci "TC-AC-SURFACE-009a PR body named as maintainer-or-wrapper only" \
+  "$acv_all" "PR body"
+assert_contains_ci "TC-AC-SURFACE-009b PR title named as maintainer-or-wrapper only" \
+  "$acv_all" "PR title"
+assert_contains_ci "TC-AC-SURFACE-009c labels named as maintainer-or-wrapper only" \
+  "$acv_all" "labels"
+assert_contains_ci "TC-AC-SURFACE-009d milestone named as maintainer-or-wrapper only" \
+  "$acv_all" "milestone"
+
+assert_contains_ci "TC-AC-SURFACE-010 doc references the scoped-token reasoning (#234 two-token split)" \
+  "$acv_all" "scoped token"
+
+assert_contains_ci "TC-AC-SURFACE-011a canonical rewrite example names 'in PR body'" \
+  "$acv_all" "in PR body"
+assert_contains_ci "TC-AC-SURFACE-011b canonical rewrite example names 'as a PR comment'" \
+  "$acv_all" "as a PR comment"
+
+assert_contains "TC-AC-SURFACE-012 Step 4 cross-references the new section" \
+  "$step4_block" "references/ac-verification.md"
+
+# ===================================================================
+# Group C — scan-scope regression (unchanged from #273)
+# ===================================================================
+echo
+echo "=== TC-AC-SURFACE-013: scan scope unchanged ==="
+
+assert_contains "TC-AC-SURFACE-013 Step 4 still scopes the scan to 'AC checkbox lines' only" \
+  "$step4_block" "AC checkbox lines"
+
+echo
+echo "=== Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/tests/unit/test-create-issue-ac-surface-guidance.sh
+++ b/tests/unit/test-create-issue-ac-surface-guidance.sh
@@ -90,20 +90,33 @@ assert_file_exists "TC-AC-SURFACE-000 SKILL.md exists" "$SKILL_MD"
 
 step4_block=$(extract_section "$SKILL_MD" "### Step 4: Confirm with User" "^### ")
 
+# TC-AC-SURFACE-001/002 anchor to strings that ONLY exist in the new paragraph,
+# so scoping to the full Step 4 block (which also contains the pre-existing
+# #273 paragraph) is safe here.
 assert_contains_ci "TC-AC-SURFACE-001 Step 4 lists 'in (the )?PR (body|description|title)' phrasing" \
   "$step4_block" "PR (body|description|title)"
 
 assert_contains "TC-AC-SURFACE-002 Step 4 lists 'PR metadata' phrasing" \
   "$step4_block" "PR metadata"
 
-assert_contains_ci "TC-AC-SURFACE-003 Step 4 suggests rewording to 'as a PR comment'" \
-  "$step4_block" "as a PR comment"
+# TC-AC-SURFACE-003/004/005/012 assert wording ('advisory', 'as a PR comment',
+# 'scoped token', the ac-verification.md cross-ref) that the pre-existing #273
+# paragraph in the SAME Step 4 block ALSO carries — a codex review finding on
+# this PR noted that scoping to step4_block alone would let these pass even if
+# the NEW "Advisory agent-unwritable-surface self-scan" paragraph regressed.
+# Scope explicitly to that paragraph (from its own heading up to the next
+# paragraph boundary) so a regression there is caught.
+new_para_block=$(printf '%s\n' "$step4_block" \
+  | awk '/^\*\*Advisory agent-unwritable-surface self-scan\*\*/{f=1} f{print; if (/Do not hard-fail the draft on a match\.$/) exit}')
 
-assert_contains_ci "TC-AC-SURFACE-004 Step 4 explains WHY: scoped token cannot edit PR metadata" \
-  "$step4_block" "scoped token"
+assert_contains_ci "TC-AC-SURFACE-003 new paragraph suggests rewording to 'as a PR comment'" \
+  "$new_para_block" "as a PR comment"
 
-assert_contains_ci "TC-AC-SURFACE-005 Step 4 still frames this axis as advisory, not a hard fail" \
-  "$step4_block" "advisory"
+assert_contains_ci "TC-AC-SURFACE-004 new paragraph explains WHY: scoped token cannot edit PR metadata" \
+  "$new_para_block" "scoped token"
+
+assert_contains_ci "TC-AC-SURFACE-005 new paragraph frames this axis as advisory, not a hard fail" \
+  "$new_para_block" "warn the author (advisory, not blocking)"
 
 skill_all=$(cat "$SKILL_MD")
 assert_contains "TC-AC-SURFACE-006 SKILL.md links to references/ac-verification.md" \
@@ -145,8 +158,8 @@ assert_contains_ci "TC-AC-SURFACE-011a canonical rewrite example names 'in PR bo
 assert_contains_ci "TC-AC-SURFACE-011b canonical rewrite example names 'as a PR comment'" \
   "$acv_all" "as a PR comment"
 
-assert_contains "TC-AC-SURFACE-012 Step 4 cross-references the new section" \
-  "$step4_block" "references/ac-verification.md"
+assert_contains "TC-AC-SURFACE-012 new paragraph cross-references the new §5 section" \
+  "$new_para_block" "references/ac-verification.md"
 
 # ===================================================================
 # Group C — scan-scope regression (unchanged from #273)


### PR DESCRIPTION
## Summary
- Extends the #273 advisory AC self-scan with a second, independent axis: an AC can be fully pre-merge verifiable and still guarantee a `dev-actionable=false` stall if its named surface (PR body/description/title, PR metadata) is writable only by the wrapper/maintainer, not by the dev agent's scoped token (per the #234 two-token split).
- `create-issue` Step 4 self-scan now also flags `in (the )?PR (body|description|title)` / `PR metadata` phrasing on AC checkbox lines and suggests rewording to an agent-writable surface (e.g. "…in PR body" → "…as a PR comment"). Advisory only, never a hard fail.
- New `references/ac-verification.md` §5 documents the agent-writable-surface distinction: PR comment / issue comment / committed file = agent-writable; PR body/title/labels/milestone = maintainer-or-wrapper only.

Closes #457.

## Design
- [x] Design canvas: not needed — additive doc/guidance change to an existing skill, no architecture decision (see acceptance criteria below, which are all pre-merge verifiable)

## Test Plan
- [x] Test cases documented (`docs/test-cases/create-issue-ac-surface.md`, TC-AC-SURFACE-001..013)
- [x] New regression test `tests/unit/test-create-issue-ac-surface-guidance.sh` (21/21 assertions green), mirrors the #273 harness style
- [x] Pre-existing `test-create-issue-ac-verification-guidance.sh` still green (no regression)
- [x] Full `tests/unit/test-*.sh` suite run — clean aside from two pre-existing environmental E2E flakes (`test-codex-rerun-orphan-containment.sh`, `test-lane-gc-p3-kill-paths-e2e.sh`) confirmed to fail identically on unmodified `main`, unrelated to this change
- [x] Code simplification review passed (no changes needed)
- [x] PR review agent review passed (one Low wording nit, fixed)

## Checklist
- [x] New unit tests written for new functionality
- [x] Documentation updated (`SKILL.md`, `references/ac-verification.md`)
- [ ] No dispatcher/wrapper code touched — `docs/pipeline/*.md` update not applicable (confirmed by PR review agent)