### PR TITLE
feat(agents): support Codex dev with Claude review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,9 @@ requests and bug reports.
 ## Hooks
 
 Workflow enforcement hooks are bundled in `skills/autonomous-common/hooks/`.
-Hook commands in `autonomous-dev` and `autonomous-review` SKILL.md frontmatter
-reference `$CLAUDE_PROJECT_DIR/hooks/`, so a symlink is required at the project root.
+Claude frontmatter commands reference `$CLAUDE_PROJECT_DIR/hooks/`; the Codex
+installer renders equivalent git-worktree-root commands. Both require the
+project-root `hooks` symlink.
 
 **Template users** already have `hooks -> skills/autonomous-common/hooks`.
 
@@ -55,8 +56,8 @@ ln -sf .claude/skills/autonomous-common/hooks hooks
 ln -sf .claude/skills/autonomous-dispatcher/scripts scripts
 ```
 
-Hooks are supported by Claude Code and Kiro CLI. Other IDEs follow the
-workflow steps manually. See `hooks/README.md` for the full reference.
+Hooks are supported by Claude Code, Codex CLI, and Kiro CLI. Other IDEs follow
+the workflow steps manually. See `hooks/README.md` for the full reference.
 
 ## Scripts
 

--- a/docs/agent-clis.md
+++ b/docs/agent-clis.md
@@ -20,6 +20,27 @@ adapters; the others run through the generic `<cli> -p <prompt>` fallback.
 Any CLI not listed should still work if it accepts a `-p <prompt>`
 non-interactive flag — the abstraction layer is intentionally permissive.
 
+## Canonical Codex-dev / Claude-review topology
+
+The first-class mixed setup is `AGENT_DEV_CMD=codex, AGENT_REVIEW_CMD=claude`:
+
+```bash
+AGENT_CMD="claude"
+AGENT_DEV_CMD="codex"
+AGENT_REVIEW_CMD="claude"
+AGENT_DEV_LAUNCHER=""
+AGENT_REVIEW_AGENTS="" # one wrapper-assigned Claude verdict session
+```
+
+Use `AGENT_REVIEW_LAUNCHER` only when the Claude review process needs a
+Claude-specific bridge; leave the dev launcher empty so it cannot wrap Codex.
+The wrappers rebind the selected CLI and launcher per side before dispatch.
+
+Codex/Claude internal subagents, `AGENT_REVIEW_AGENTS`, and `REVIEW_BOTS` are
+three separate mechanisms: internal subagents are advisory workers within one
+session, `AGENT_REVIEW_AGENTS` are independent verdict-reaching CLI sessions,
+and `REVIEW_BOTS` are external code-host reviewers whose comments are evidence.
+
 > **Gemini CLI is retired upstream** and no longer has an adapter row here.
 > Antigravity CLI (`agy`) is the replacement for Gemini-family models — it
 > ships its own conversation-UUID session model (grepped from `--log-file`,

--- a/docs/agent-clis.md
+++ b/docs/agent-clis.md
@@ -28,13 +28,15 @@ The first-class mixed setup is `AGENT_DEV_CMD=codex, AGENT_REVIEW_CMD=claude`:
 AGENT_CMD="claude"
 AGENT_DEV_CMD="codex"
 AGENT_REVIEW_CMD="claude"
+AGENT_LAUNCHER=""
 AGENT_DEV_LAUNCHER=""
 AGENT_REVIEW_AGENTS="" # one wrapper-assigned Claude verdict session
 ```
 
-Use `AGENT_REVIEW_LAUNCHER` only when the Claude review process needs a
-Claude-specific bridge; leave the dev launcher empty so it cannot wrap Codex.
-The wrappers rebind the selected CLI and launcher per side before dispatch.
+Clear a legacy shared `AGENT_LAUNCHER`; an explicitly empty per-side value
+otherwise inherits it for backward compatibility. Set `AGENT_REVIEW_LAUNCHER`
+only when the Claude review process needs that bridge. The wrappers rebind the
+selected CLI and launcher per side before dispatch.
 
 Codex/Claude internal subagents, `AGENT_REVIEW_AGENTS`, and `REVIEW_BOTS` are
 three separate mechanisms: internal subagents are advisory workers within one

--- a/docs/cross-agent-hooks.md
+++ b/docs/cross-agent-hooks.md
@@ -4,7 +4,11 @@ Reference for installing the autonomous-dev-team workflow hooks across coding ag
 
 ## Canonical hook intent (agent-agnostic)
 
-The hooks themselves live in `skills/autonomous-common/hooks/` and are agent-portable: they read JSON from stdin, exit `0` to allow or `2` to block, and use `$CLAUDE_PROJECT_DIR` to find scripts. This contract works on every agent in the table below.
+The hooks themselves live in `skills/autonomous-common/hooks/` and are
+agent-portable: they read JSON from stdin and exit `0` to allow or `2` to
+block. Installers render agent-specific command paths; shared scripts resolve
+the repository from the hook payload or git when an agent does not provide
+`$CLAUDE_PROJECT_DIR`.
 
 What differs between agents is **how to declare which script runs when** — i.e. the per-agent config file path, schema, event names, and tool-name matchers.
 
@@ -18,7 +22,7 @@ What differs between agents is **how to declare which script runs when** — i.e
 | **Cursor** | `.cursor/hooks.json` | Claude-style, camelCase events, `version: 1` envelope | `Shell` (or pipe regex on cmd) | `2` | `install-cursor-hooks.sh` (PR-11b) |
 | **Kiro CLI / Amazon Q** | `.kiro/agents/<name>.json` | Agent definition; camelCase events; `timeout_ms` (ms not seconds) | `execute_bash`, `fs_write` (Write+Edit unified) | `2` | `install-kiro-hooks.sh` (PR-11b) |
 | **Gemini CLI** ⚠️ retired | `.gemini/settings.json` | `BeforeTool`/`AfterTool` events; provides `$CLAUDE_PROJECT_DIR` env compat alias | `run_shell_command`, `write_file`, `replace` | `2` | `install-gemini-hooks.sh` (PR-11b) — kept for historical installs; Gemini CLI has been discontinued upstream, use Antigravity CLI (`agy`) instead |
-| **Codex CLI** | `.codex/hooks.json` + `[features]codex_hooks=true` in `config.toml` | Claude-style (modeled verbatim) | `Bash`, `Write`, `Edit` (undocumented but inferred) | `2` | `install-codex-hooks.sh` (PR-11b) |
+| **Codex CLI** | `.codex/hooks.json` + `[features] hooks = true` in `config.toml` | Official Claude-compatible event schema | `Bash`, `apply_patch` (`Write`/`Edit` aliases are also supported) | `2` | `install-codex-hooks.sh` |
 | **Windsurf** | `.windsurf/hooks.json` | snake_case events that fold matcher info; **no matcher field** on entries | event encodes the kind: `pre_run_command` (Bash) / `pre_write_code` (Write+Edit merged) / etc. | `2` | `install-windsurf-hooks.sh` (PR-11c) |
 | **Kimi CLI** | `~/.kimi/config.toml` (or `.kimi/config.toml` with `--project`) | TOML, `[[hooks]]` array of tables | exact / regex (`RunShell`, `WriteFile`, `StrReplaceFile`) | `2` | `install-kimi-hooks.sh` (PR-11c) |
 
@@ -45,7 +49,8 @@ bash .claude/skills/autonomous-common/scripts/install-kiro-hooks.sh
 # Gemini CLI (retired upstream — see the matrix note above; use Antigravity instead)
 bash .claude/skills/autonomous-common/scripts/install-gemini-hooks.sh
 
-# Codex CLI (also enables [features] codex_hooks = true in .codex/config.toml)
+# Codex CLI (also writes canonical [features] hooks = true)
+# Requires Python 3.11+ for standard-library tomllib validation.
 bash .claude/skills/autonomous-common/scripts/install-codex-hooks.sh
 
 # Windsurf (folds Bash/Write/Edit matchers into pre_run_command / pre_write_code events)
@@ -60,7 +65,15 @@ Each installer is idempotent and preserves any other top-level keys you have in 
 ## Caveats
 
 - **Antigravity**: Google has not documented hook support. Community evidence shows the Claude Code schema works in practice, but it could change without notice. Treat as best-effort.
-- **Codex CLI** (PR-11b): hook support is behind an experimental feature flag (`codex_hooks = true` in `~/.codex/config.toml`). Tool-name matchers like `Bash`, `Write` are modeled on Claude Code but not officially documented.
+- **Codex CLI**: hooks are stable and enabled by default in current releases;
+  the installer records canonical `[features] hooks = true`.
+  `codex_hooks` remains a deprecated alias and is migrated only when doing so
+  cannot override an explicit disable. The installer requires Python 3.11+
+  (`tomllib`) and refuses noncanonical TOML forms when migration would require
+  unsafe textual rewriting. Project hook layers and each changed hook
+  definition must be trusted with `/hooks`. Vetted unattended automation can
+  pass `--dangerously-bypass-hook-trust`. See the official
+  [Codex hooks documentation](https://developers.openai.com/codex/hooks/).
 - **Windsurf**: no per-tool matcher field — `pre_run_command` fires for every shell command, `pre_write_code` for every file write/edit. Hooks must self-filter inside the script (e.g., `block-push-to-main.sh` already inspects the command). The installer folds Claude's `(event, matcher)` pairs into Windsurf's tool-specific events.
 - **Kimi CLI**: TOML config, beta feature upstream. Tool names differ (`WriteFile`/`StrReplaceFile`/`RunShell` rather than Claude's `Write`/`Edit`/`Bash`). Default install target is user-level (`~/.kimi/config.toml`); `--project` writes `.kimi/config.toml` (experimental — Kimi may only read user-level).
 
@@ -72,10 +85,14 @@ Scripts under `skills/autonomous-common/hooks/` use the canonical contract:
 stdin: {"hook_event_name": "...", "tool_name": "...", "tool_input": {...}, "cwd": "...", ...}
 exit 0: allow (stdout added to agent context)
 exit 2: block (stderr fed back to LLM as the reason)
-env:   $CLAUDE_PROJECT_DIR points at the repo root
+root:  use the agent-specific rendered command or git worktree root
 ```
 
-This works on every agent in the matrix. **Gemini CLI explicitly provides `$CLAUDE_PROJECT_DIR`** as a Claude Code compatibility alias. The other agents either provide an equivalent (e.g. `CURSOR_PROJECT_DIR`) or run hooks with `cwd = project root` so the relative path inside `tool_input.cwd` works.
+For edit-sensitive hooks, Claude `Write`/`Edit` provides
+`tool_input.file_path`. Codex provides `tool_name: "apply_patch"` and the
+structured patch in `tool_input.command`; `parse_edit_file_operations`
+normalizes both forms into `operation<TAB>path` records.
+`parse_edit_file_paths` remains the path-only compatibility projection.
 
 ## Adding a new agent
 

--- a/docs/designs/codex-dev-claude-review.md
+++ b/docs/designs/codex-dev-claude-review.md
@@ -52,9 +52,13 @@ No-op configurations such as a quoted canonical `"hooks" = true` or dotted
 `features.hooks = true` are accepted without textual rewriting. Any operation
 that must insert, rename, or remove a key is intentionally limited to one
 ordinary `[features]` table with bare keys, no multiline strings, and no
-quoted table headers. Other valid but noncanonical mutable forms are refused
-with an operator-facing diagnostic instead of risking comment or string
-corruption.
+quoted representation of the features table itself. Unrelated quoted tables
+are preserved. Other valid but noncanonical mutable forms are refused with an
+operator-facing diagnostic instead of risking comment or string corruption.
+After every textual rewrite, the parsed staging file must contain canonical
+`hooks = true` and no legacy alias; a complex form such as a multiline nested
+array therefore fails safely instead of reporting a migration that did not
+occur.
 
 | Existing `[features]` state | Result |
 |---|---|
@@ -74,13 +78,25 @@ Unrelated TOML sections, comments, quoted keys, and multiline strings are
 retained. Both generated files are rendered before installation. Existing
 changed destinations receive timestamped backups and retain their original
 file modes; fresh files are private even under a permissive umask.
-Same-directory atomic replacements are used, and a hooks replacement failure
-or termination between replacements rolls both files back. Directory and
-symbolic-link destinations, including a symlinked `.codex` parent, are
-refused. Rollback content is itself staged and atomically renamed, and pending
-files are removed on handled termination. Original content and mode snapshots
-are revalidated immediately before each replacement so an operator edit made
-during rendering is not silently overwritten.
+Same-directory atomic replacements use unpredictable `mktemp` paths, and a
+replacement failure or handled termination between replacements rolls both
+files back. Hook definitions are installed before the feature config enables
+them, so an uncatchable process death cannot newly enable stale hooks.
+Exact-target no-clobber links are used for install, capture, and rollback, so a
+concurrently created directory cannot become an implicit move target. Capture
+postconditions use inode plus content/mode snapshots to reconcile an operation
+that completed before its helper returned a failure. The transaction enters
+the physical `.codex` directory and uses relative target names, then verifies
+that the project path still names the same directory before replacement and
+commit. A concurrent parent rename/symlink swap therefore cannot redirect
+writes outside the repository. Directory and symbolic-link destinations,
+including a symlinked `.codex` parent, are refused; a newly created `.codex`
+directory is private regardless of the caller's umask. Rollback content is
+itself staged and atomically placed, rollback ignores repeated termination
+signals, and pending files are removed on handled termination. Original
+content, inode ownership, and mode snapshots are revalidated immediately
+before each replacement so an operator edit made during rendering is not
+silently overwritten.
 
 ## Hook input normalization
 
@@ -95,8 +111,9 @@ The primary API emits `operation<TAB>path` records in source order with
 duplicates removed:
 
 - Claude/Cursor `Write`: `add`; Claude/Cursor `Edit`: `edit`
-- Existing installer translations remain supported. Kiro `fs_write` uses
-  `tool_input.path` plus `command`: `create` maps to `add`, while
+- Existing installer translations remain supported. Kiro
+  `fs_write`/`write`/`fsWrite` uses `tool_input.path` plus `command`: `create`
+  maps to `add`, while
   `str_replace`/`insert`/`append` map to `edit`. Gemini
   `write_file`/`replace` and Kimi `WriteFile`/`StrReplaceFile` use
   `tool_input.file_path`; Windsurf `pre_write_code` uses
@@ -133,8 +150,9 @@ Codex patch, while updates, deletes, and pure moves cannot produce a false
 - Claude plugins/subagents remain valid equivalents.
 - Internal Codex or Claude subagents are advisory and return evidence to their
   parent session.
-- The main process launched by the review wrapper is the only session that
-  runs the Findings -> Decision Gate and invokes `post-verdict.sh`.
+- Within each wrapper-assigned verdict session, only the parent process runs
+  the Findings -> Decision Gate and invokes `post-verdict.sh`; its internal
+  subagents never do.
 - `AGENT_REVIEW_AGENTS` means independent wrapper-managed verdict agents;
   `REVIEW_BOTS` means external GitHub reviewers. Neither includes internal
   subagents.

--- a/docs/designs/codex-dev-claude-review.md
+++ b/docs/designs/codex-dev-claude-review.md
@@ -1,0 +1,150 @@
+# Design: Codex development with Claude review (#486)
+
+## Goal
+
+Make `AGENT_DEV_CMD=codex` with `AGENT_REVIEW_CMD=claude` a documented,
+tested topology without changing the existing dispatcher adapters or review
+aggregation. Codex lifecycle hooks are defense in depth; git hooks and the
+deterministic wrapper gates remain authoritative.
+
+## Scope
+
+1. Render project-scoped Codex hooks from the canonical Claude template.
+2. Use Codex's current `features.hooks` key and safely handle its deprecated
+   `codex_hooks` alias.
+3. Normalize edit-sensitive hook input across Claude `Write`/`Edit` and Codex
+   `apply_patch`.
+4. Document Codex-native simplification/review options and the ownership
+   boundary between internal review subagents and the wrapper-assigned review
+   session.
+5. Pin the existing per-side CLI/launcher behavior for the mixed topology.
+
+The Codex final-review adapter, `AGENT_REVIEW_AGENTS` aggregation, verdict
+attribution, and wrapper merge actions are unchanged.
+
+## Codex hook rendering
+
+`.codex/hooks.json` remains a hooks-only file, but it is rendered specifically
+for Codex instead of copying Claude commands verbatim:
+
+- Every command resolves the current worktree with
+  `$(git rev-parse --show-toplevel)` and does not require
+  `$CLAUDE_PROJECT_DIR`.
+- Claude's separate `Write` and `Edit` matcher groups are deduplicated into one
+  `^apply_patch$` matcher group. Codex documents `Write` and `Edit` as aliases
+  for `apply_patch`, but a direct matcher avoids running the same handler
+  twice.
+- Other event groups, timeouts, and commands stay aligned with the canonical
+  template.
+
+Project hooks execute only after the project layer and the current hook hash
+are trusted. Interactive operators review them with `/hooks`. Unattended runs
+may use `--dangerously-bypass-hook-trust` only when the hook source is vetted
+outside Codex.
+
+## Feature-key migration
+
+The installer uses Python 3.11's standard-library `tomllib` to parse the
+complete document before staging either destination. `hooks` and
+`codex_hooks`, when present under `features`, must be booleans.
+
+No-op configurations such as a quoted canonical `"hooks" = true` or dotted
+`features.hooks = true` are accepted without textual rewriting. Any operation
+that must insert, rename, or remove a key is intentionally limited to one
+ordinary `[features]` table with bare keys, no multiline strings, and no
+quoted table headers. Other valid but noncanonical mutable forms are refused
+with an operator-facing diagnostic instead of risking comment or string
+corruption.
+
+| Existing `[features]` state | Result |
+|---|---|
+| Neither key | Add `hooks = true` |
+| `hooks = true` only | No-op |
+| `hooks = false` only | Refuse; preserve explicit disable |
+| `codex_hooks = true` only | Rename to `hooks = true` |
+| `codex_hooks = false` only | Refuse; preserve explicit disable |
+| Both `true` | Keep canonical `hooks`; remove deprecated alias |
+| Both `false` | Refuse; preserve explicit disable |
+| Values differ | Refuse as a conflict; preserve file byte-for-byte |
+| Canonical true in a quoted/dotted form | Accept without rewriting |
+| Legacy/missing key in a noncanonical mutable form | Refuse; preserve file |
+| Duplicate key/table or `[[features]]` | Refuse during semantic parsing |
+
+Unrelated TOML sections, comments, quoted keys, and multiline strings are
+retained. Both generated files are rendered before installation. Existing
+changed destinations receive timestamped backups and retain their original
+file modes; fresh files are private even under a permissive umask.
+Same-directory atomic replacements are used, and a hooks replacement failure
+or termination between replacements rolls both files back. Directory and
+symbolic-link destinations, including a symlinked `.codex` parent, are
+refused. Rollback content is itself staged and atomically renamed, and pending
+files are removed on handled termination. Original content and mode snapshots
+are revalidated immediately before each replacement so an operator edit made
+during rendering is not silently overwritten.
+
+## Hook input normalization
+
+`hooks/lib.sh` exposes:
+
+```bash
+parse_edit_file_operations "$hook_json"
+parse_edit_file_paths "$hook_json"
+```
+
+The primary API emits `operation<TAB>path` records in source order with
+duplicates removed:
+
+- Claude/Cursor `Write`: `add`; Claude/Cursor `Edit`: `edit`
+- Existing installer translations remain supported. Kiro `fs_write` uses
+  `tool_input.path` plus `command`: `create` maps to `add`, while
+  `str_replace`/`insert`/`append` map to `edit`. Gemini
+  `write_file`/`replace` and Kimi `WriteFile`/`StrReplaceFile` use
+  `tool_input.file_path`; Windsurf `pre_write_code` uses
+  `tool_info.file_path`.
+- Codex `apply_patch`: every path in `tool_input.command` headers
+  `*** Add File:`, `*** Update File:`, `*** Delete File:`, and `*** Move to:`,
+  mapped to `add`, `edit`, `delete`, and `move`
+
+`parse_edit_file_paths` remains a compatibility projection that drops the
+operation column. Dispatch happens on `tool_name` first, so a non-edit tool
+cannot become an edit merely by carrying `file_path`, and an `apply_patch`
+payload always parses its complete command even if another field is present.
+The parser requires matching `*** Begin Patch` / `*** End Patch` boundaries
+and structural header lines. Recognized edit tools with malformed/missing
+data return non-zero, allowing the edit-sensitive hook to fail loudly.
+Missing/non-string tool discriminators also fail loudly. Unknown tools with a
+valid nonempty string name remain a no-op.
+
+Claude-style clients provide `tool_name` and `tool_input`; Windsurf's native
+payload uses `agent_action_name` and `tool_info`. Required path/command fields
+must be nonempty JSON strings, so malformed scalar/object values cannot be
+stringified into a policy bypass.
+
+`check-test-plan.sh` evaluates every `add` operation. A non-implementation
+first file can no longer hide a later new implementation file in the same
+Codex patch, while updates, deletes, and pure moves cannot produce a false
+"new implementation file" reminder.
+
+## Agent roles
+
+- The Codex development session may use native subagents for an independent
+  simplification pass and dev-side review. Codex's dedicated
+  `codex review --uncommitted` / `--base` workflow is also valid.
+- Claude plugins/subagents remain valid equivalents.
+- Internal Codex or Claude subagents are advisory and return evidence to their
+  parent session.
+- The main process launched by the review wrapper is the only session that
+  runs the Findings -> Decision Gate and invokes `post-verdict.sh`.
+- `AGENT_REVIEW_AGENTS` means independent wrapper-managed verdict agents;
+  `REVIEW_BOTS` means external GitHub reviewers. Neither includes internal
+  subagents.
+
+## Verification
+
+- Installer matrix and Codex-specific rendering tests.
+- Shared parser tests for Claude and Codex payloads.
+- Behavioral execution of the generated Codex command from a nested
+  directory with `$CLAUDE_PROJECT_DIR` unset.
+- Static guidance tests for Codex dev review and Claude main-session verdict
+  ownership.
+- Existing per-side CLI and launcher suites, followed by the full unit suite.

--- a/docs/designs/codex-dev-claude-review.md
+++ b/docs/designs/codex-dev-claude-review.md
@@ -34,8 +34,17 @@ for Codex instead of copying Claude commands verbatim:
   `^apply_patch$` matcher group. Codex documents `Write` and `Edit` as aliases
   for `apply_patch`, but a direct matcher avoids running the same handler
   twice.
+- Shared installer deduplication preserves the canonical hook command order
+  while removing duplicate commands that converge on one matcher or event.
 - Other event groups, timeouts, and commands stay aligned with the canonical
   template.
+
+Shared workflow state is resolved from the hook process's current Git worktree,
+not `$CLAUDE_PROJECT_DIR`. Claude Code keeps that variable fixed to the project
+where the session started even after work moves into a linked worktree, while
+manual state-manager commands do not necessarily receive it. Resolving both
+paths from `git rev-parse --show-toplevel` prevents mark/check state from
+splitting across the main checkout and linked worktree.
 
 Project hooks execute only after the project layer and the current hook hash
 are trusted. Interactive operators review them with `/hooks`. Unattended runs
@@ -128,9 +137,11 @@ cannot become an edit merely by carrying `file_path`, and an `apply_patch`
 payload always parses its complete command even if another field is present.
 The parser requires matching `*** Begin Patch` / `*** End Patch` boundaries
 and structural header lines. Recognized edit tools with malformed/missing
-data return non-zero, allowing the edit-sensitive hook to fail loudly.
-Missing/non-string tool discriminators also fail loudly. Unknown tools with a
-valid nonempty string name remain a no-op.
+data return non-zero, as do missing/non-string tool discriminators. The
+test-plan hook reports that parser failure but exits successfully because its
+TDD policy is advisory; payload-shape drift must not block every edit while an
+actual missing test plan only produces a reminder. Unknown tools with a valid
+nonempty string name remain a no-op.
 
 Claude-style clients provide `tool_name` and `tool_input`; Windsurf's native
 payload uses `agent_action_name` and `tool_info`. Required path/command fields
@@ -161,8 +172,12 @@ Codex patch, while updates, deletes, and pure moves cannot produce a false
 
 - Installer matrix and Codex-specific rendering tests.
 - Shared parser tests for Claude and Codex payloads.
+- A captured Codex 0.144.3 `PreToolUse` payload proving that `apply_patch`
+  supplies the bare patch body in `tool_input.command`.
 - Behavioral execution of the generated Codex command from a nested
   directory with `$CLAUDE_PROJECT_DIR` unset.
+- Linked-worktree state tests in both directions, including a Claude hook that
+  carries the main checkout in `$CLAUDE_PROJECT_DIR`.
 - Static guidance tests for Codex dev review and Claude main-session verdict
   ownership.
 - Existing per-side CLI and launcher suites, followed by the full unit suite.

--- a/docs/designs/cross-agent-hooks-c.md
+++ b/docs/designs/cross-agent-hooks-c.md
@@ -118,7 +118,10 @@ The function resolves each `(claude_event, claude_matcher)` pair into a Windsurf
 
 ## Why no shared TOML serializer lib
 
-The Codex installer also touches TOML (PR-11b), but only to insert a single line into a `[features]` block — different problem. The Kimi case is "generate a sequence of `[[hooks]]` blocks from JSON". A real TOML serializer would be over-engineered; a small purpose-built bash function inline in `install-kimi-hooks.sh` is enough. We document the contract clearly so a future TOML-needing installer can extract a shared lib if it makes sense.
+The current Codex installer uses a validated, transactional TOML migration for
+the canonical `[features] hooks` key, which remains a different problem from
+Kimi's generation of a sequence of `[[hooks]]` blocks from JSON. A shared TOML
+serializer is still unnecessary; each path has a deliberately narrow contract.
 
 ## Tests
 

--- a/docs/designs/cross-agent-hooks.md
+++ b/docs/designs/cross-agent-hooks.md
@@ -30,7 +30,7 @@ PR-11b and PR-11c will pick up the harder translations.
 | Cursor (PR-11b) | `.cursor/hooks.json` | Claude-style + shell-specific event | `Shell` (or pipe regex on cmd) | 2 |
 | Kiro CLI (PR-11b) | `.kiro/agents/*.json` | camelCase events, `timeout_ms` | `execute_bash`, `fs_write` | 2 |
 | Gemini CLI (PR-11b) | `.gemini/settings.json` | `BeforeTool`/`AfterTool` regex | `run_shell_command`, `write_file`, `replace` | 2 |
-| Codex CLI (PR-11b) | `.codex/hooks.json` + flag | Claude-style (modeled on it) | undocumented | 2 |
+| Codex CLI (PR-11b) | `.codex/hooks.json` + `[features] hooks = true` | Official Claude-compatible event schema | `Bash`, `apply_patch` | 2 |
 | Windsurf (PR-11c) | `.windsurf/hooks.json` | snake_case, **no matcher** | filter inside script | 2 |
 | Kimi CLI (PR-11c) | `~/.kimi/config.toml` | TOML, `[[hooks]]` array | regex (e.g. `WriteFile\|StrReplaceFile`) | 2 |
 

--- a/docs/pipeline/per-side-agent-cmd.md
+++ b/docs/pipeline/per-side-agent-cmd.md
@@ -53,6 +53,35 @@ The wrapper override exists only to make the case statements in
 `run_agent` / `resume_agent` dispatch to the right CLI; it does not
 re-trigger the guard.
 
+## Canonical Codex-dev / Claude-review topology
+
+The first-class mixed topology uses Codex for development and one
+wrapper-assigned Claude session for final review:
+
+```bash
+AGENT_CMD="claude"
+AGENT_DEV_CMD="codex"
+AGENT_REVIEW_CMD="claude"
+AGENT_LAUNCHER=""
+AGENT_DEV_LAUNCHER=""
+AGENT_REVIEW_AGENTS=""
+```
+
+`AGENT_LAUNCHER` must be empty because the per-side `:-` defaults intentionally
+treat an explicit empty value as inheritance for backward compatibility.
+`AGENT_REVIEW_LAUNCHER` may then be set when Claude needs a bridge while Codex
+runs unwrapped; the per-side
+[INV-38](invariants.md#inv-38-per-side-agent_launcher-precedence) guard evaluates
+it independently.
+
+An empty `AGENT_REVIEW_AGENTS` means the wrapper launches exactly one
+verdict-reaching session, resolved from `AGENT_REVIEW_CMD`. Internal Codex or
+Claude subagents do not belong in `AGENT_REVIEW_AGENTS`; they are advisory
+workers inside their parent session. `REVIEW_BOTS` is separate again: it names
+external code-host reviewers whose comments become review evidence. See
+[`review-agent-flow.md`](review-agent-flow.md#internal-subagents-are-advisory)
+for final-decision ownership.
+
 ## Backwards compatibility
 
 Existing deployments do not set `AGENT_DEV_CMD` or `AGENT_REVIEW_CMD`.

--- a/docs/pipeline/review-agent-flow.md
+++ b/docs/pipeline/review-agent-flow.md
@@ -248,6 +248,27 @@ By default the wrapper runs exactly ONE verdict-reaching agent (`AGENT_REVIEW_CM
 
 > **Distinct from `REVIEW_BOTS`.** `REVIEW_BOTS` (`/q review`, `/codex review`) triggers *external GitHub bots* whose review comments are read as **input** by the verdict agent(s). `AGENT_REVIEW_AGENTS` runs N *independent verdict-reaching* agents — each reaches its own approve/pushback decision, and the wrapper aggregates them.
 
+### Internal subagents are advisory
+
+Internal Claude or Codex subagents may inspect security, tests,
+maintainability, or other dimensions for one wrapper-launched review session.
+They return evidence to their parent and do not become entries in
+`AGENT_REVIEW_AGENTS`.
+
+Within each wrapper-assigned verdict session, the parent session alone executes
+the Findings -> Decision Gate and invokes `post-verdict.sh` with that session's
+assigned agent name and session id. An internal subagent must never invoke
+`post-verdict.sh` or post an independent verdict. Each parent reconciles its
+advisory findings into one PASS/FAIL result; the wrapper remains the only
+component that aggregates sessions, submits the native review action, or
+merges.
+
+The three mechanisms therefore remain disjoint:
+
+- internal subagents: advisory evidence inside one session;
+- `AGENT_REVIEW_AGENTS`: independent wrapper-managed verdict sessions;
+- `REVIEW_BOTS`: external code-host reviewers whose comments are evidence.
+
 ### Agent-list resolution
 
 `REVIEW_AGENTS_LIST` resolves once at startup:

--- a/docs/test-cases/codex-dev-claude-review.md
+++ b/docs/test-cases/codex-dev-claude-review.md
@@ -42,6 +42,7 @@
 | TC-CDCR-019M | Project `.codex` is replaced by an external symlink after final placement | Anchored rollback restores the original physical directory and writes nothing externally |
 | TC-CDCR-019N | Canonical rollback source disappears while an unrelated scratch object appears | Inode ownership check leaves both unowned objects untouched |
 | TC-CDCR-019O | Kiro/Windsurf translation deduplicates hooks that converge on one matcher/event | Duplicate commands are removed without changing canonical command order |
+| TC-CDCR-019P | An existing destination is replaced by a symlink after the shell snapshot but before atomic capture | Capture rejects the changed source type and leaves the concurrent symlink at the canonical path |
 
 ## Hook payload normalization and behavior
 

--- a/docs/test-cases/codex-dev-claude-review.md
+++ b/docs/test-cases/codex-dev-claude-review.md
@@ -41,6 +41,7 @@
 | TC-CDCR-019L | Operator creates a directory in the final placement window | Exact-target placement aborts without moving generated content inside the directory |
 | TC-CDCR-019M | Project `.codex` is replaced by an external symlink after final placement | Anchored rollback restores the original physical directory and writes nothing externally |
 | TC-CDCR-019N | Canonical rollback source disappears while an unrelated scratch object appears | Inode ownership check leaves both unowned objects untouched |
+| TC-CDCR-019O | Kiro/Windsurf translation deduplicates hooks that converge on one matcher/event | Duplicate commands are removed without changing canonical command order |
 
 ## Hook payload normalization and behavior
 
@@ -50,11 +51,13 @@
 | TC-CDCR-021 | Claude `Edit` path contains spaces | Emits `edit<TAB>path` without word splitting and does not trigger file-creation policy |
 | TC-CDCR-021A | Kiro `fs_write`/`write`/`fsWrite` uses `path` + `command`; Gemini/Kimi use `file_path`; Windsurf uses `tool_info.file_path` | Provider-native payloads retain add/edit semantics; Kiro `create` and Windsurf writes trigger policy |
 | TC-CDCR-022 | Codex patch adds, updates, moves, and deletes files | Emits all `add`/`edit`/`move`/`delete` records and compatibility paths in patch order |
+| TC-CDCR-022A | Real Codex 0.144.3 `PreToolUse` payload captured from an `apply_patch` invocation | Full runtime payload parses the bare patch body from `tool_input.command` |
 | TC-CDCR-023 | Codex multi-file patch has docs first and new `src/` file second | `check-test-plan.sh` emits the reminder; pure move does not |
-| TC-CDCR-024 | Missing boundaries, missing/non-string discriminator/path, or empty recognized edit payload | Parser fails and the direct/generated hook exits exactly `2` |
+| TC-CDCR-024 | Missing boundaries, missing/non-string discriminator/path, or empty recognized edit payload | Strict parser fails; advisory direct/generated hook warns and exits `0` without blocking the edit |
 | TC-CDCR-025 | `Read` carries a nonempty `file_path`; `apply_patch` carries a misleading one | `Read` is a no-op and `apply_patch` still parses every command header |
 | TC-CDCR-026 | Generated Codex hook command runs from a nested directory with `$CLAUDE_PROJECT_DIR` unset | Command finds the worktree hook and applies TC-CDCR-023/024 behavior |
 | TC-CDCR-027 | Main checkout has a fresh test-plan mark while Codex edits a linked worktree | Linked-worktree state stays isolated and the worktree edit still emits the reminder |
+| TC-CDCR-027A | Worktree has a fresh test-plan mark while a Claude hook carries the main checkout in `$CLAUDE_PROJECT_DIR` | Hook resolves state from its worktree `cwd`, sees the mark, and emits no reminder |
 
 ## Skills, roles, and topology
 

--- a/docs/test-cases/codex-dev-claude-review.md
+++ b/docs/test-cases/codex-dev-claude-review.md
@@ -1,0 +1,64 @@
+# Test Cases: Codex development with Claude review (#486)
+
+## Installer and feature migration
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-CDCR-001 | Fresh Codex install | `.codex/hooks.json` and `.codex/config.toml` exist; config contains `[features] hooks = true` only |
+| TC-CDCR-002 | Generated Codex hooks | Commands resolve through `git rev-parse --show-toplevel`, contain no `$CLAUDE_PROJECT_DIR`, and use one `^apply_patch$` group |
+| TC-CDCR-003 | Re-run installer | One canonical key and one apply-patch group remain |
+| TC-CDCR-004 | Existing config without `[features]` | Unrelated TOML is preserved and a single table is appended |
+| TC-CDCR-005 | Existing `[features]` without hook keys | `hooks = true` is inserted without duplicating the table |
+| TC-CDCR-006 | Existing canonical `hooks = true` | Installer is an idempotent no-op for the key |
+| TC-CDCR-007 | Existing canonical `hooks = false` | Installer fails and preserves the explicit disable without writing hooks |
+| TC-CDCR-008 | Legacy-only `codex_hooks = true` | Key migrates to canonical `hooks = true` |
+| TC-CDCR-008A | Unrelated `[[array-table]]` also contains `codex_hooks` data | Migration changes only `[features]` and preserves unrelated keys |
+| TC-CDCR-008B | Unrelated quoted table header contains `#` | Mutable migration refuses and preserves both destinations |
+| TC-CDCR-009 | Legacy-only `codex_hooks = false` | Installer fails and preserves the explicit disable |
+| TC-CDCR-010 | Both keys are `true` | Deprecated alias is removed; canonical key remains |
+| TC-CDCR-011 | Keys disagree | Installer fails loudly and preserves config byte-for-byte |
+| TC-CDCR-012 | A mutable inline `features` table has no hook key | Installer refuses instead of textually rewriting a noncanonical shape |
+| TC-CDCR-013 | Existing TOML has multiline strings and quoted keys | Appended canonical feature configuration preserves their semantic values |
+| TC-CDCR-014 | Canonical true uses a quoted or dotted key | Installer accepts it as a no-op without rewriting |
+| TC-CDCR-015 | Legacy true uses a quoted or dotted key | Installer refuses the unsafe migration and preserves the file |
+| TC-CDCR-016 | `[[features]]`, duplicate key, or duplicate table | Complete TOML parsing refuses before either destination changes |
+| TC-CDCR-017 | Hooks replacement fails after config replacement | Existing config and hooks are restored |
+| TC-CDCR-017A | Operator edits installed config before hooks failure is handled | Rollback refuses to overwrite the concurrent edit |
+| TC-CDCR-018 | Existing files have restrictive modes; fresh install runs under permissive umask | Replacements preserve existing modes and fresh files remain private |
+| TC-CDCR-019 | Destination or `.codex` parent is a directory/symbolic-link mismatch | Installer refuses before replacing either destination or writing through the link |
+| TC-CDCR-019A | Process receives SIGTERM after config replacement | Signal handler atomically restores both original destinations and removes pending files |
+| TC-CDCR-019D | Process receives SIGTERM while a pending file is staged | Signal handler leaves original destinations intact and removes pending files |
+| TC-CDCR-019B | Config changes while hooks are rendered | Installer refuses the stale snapshot and preserves the concurrent edit |
+| TC-CDCR-019C | Config mode changes while hooks are rendered | Installer refuses and preserves the restrictive mode |
+
+## Hook payload normalization and behavior
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-CDCR-020 | Claude `Write` payload | Emits `add<TAB>path`; compatibility API emits the path |
+| TC-CDCR-021 | Claude `Edit` path contains spaces | Emits `edit<TAB>path` without word splitting and does not trigger file-creation policy |
+| TC-CDCR-021A | Kiro `fs_write` uses `path` + `command`; Gemini/Kimi use `file_path`; Windsurf uses `tool_info.file_path` | Provider-native payloads retain add/edit semantics; Kiro `create` and Windsurf writes trigger policy |
+| TC-CDCR-022 | Codex patch adds, updates, moves, and deletes files | Emits all `add`/`edit`/`move`/`delete` records and compatibility paths in patch order |
+| TC-CDCR-023 | Codex multi-file patch has docs first and new `src/` file second | `check-test-plan.sh` emits the reminder; pure move does not |
+| TC-CDCR-024 | Missing boundaries, missing/non-string discriminator/path, or empty recognized edit payload | Parser fails and the direct/generated hook exits exactly `2` |
+| TC-CDCR-025 | `Read` carries a nonempty `file_path`; `apply_patch` carries a misleading one | `Read` is a no-op and `apply_patch` still parses every command header |
+| TC-CDCR-026 | Generated Codex hook command runs from a nested directory with `$CLAUDE_PROJECT_DIR` unset | Command finds the worktree hook and applies TC-CDCR-023/024 behavior |
+
+## Skills, roles, and topology
+
+| ID | Scenario | Expected |
+|---|---|---|
+| TC-CDCR-030 | `autonomous-dev` guidance and hook feedback | Names Codex native subagents and `codex review`, with Claude/manual equivalents |
+| TC-CDCR-031 | `autonomous-review` internal subagent guidance | Internal subagents are advisory; assigned main session alone runs the decision gate and calls `post-verdict.sh` |
+| TC-CDCR-032 | Operator docs compare review mechanisms | `REVIEW_BOTS`, `AGENT_REVIEW_AGENTS`, and internal subagents are distinct |
+| TC-CDCR-033 | Canonical mixed config | `AGENT_DEV_CMD=codex`, `AGENT_REVIEW_CMD=claude`, default single verdict agent, no dev launcher leakage |
+| TC-CDCR-034 | Claude-only review launcher in canonical mixed config | Review launcher is accepted while Codex dev remains unwrapped |
+
+## Regression gates
+
+- `bash tests/unit/test-install-codex-hooks.sh`
+- `bash tests/unit/test-hook-edit-paths.sh`
+- `bash tests/unit/test-codex-dev-claude-review-docs.sh`
+- `bash tests/unit/test-lib-agent-per-side-cmd.sh`
+- `bash tests/unit/test-lib-agent-per-side-launcher.sh`
+- `bash tests/run-unit-tests.sh`

--- a/docs/test-cases/codex-dev-claude-review.md
+++ b/docs/test-cases/codex-dev-claude-review.md
@@ -13,7 +13,8 @@
 | TC-CDCR-007 | Existing canonical `hooks = false` | Installer fails and preserves the explicit disable without writing hooks |
 | TC-CDCR-008 | Legacy-only `codex_hooks = true` | Key migrates to canonical `hooks = true` |
 | TC-CDCR-008A | Unrelated `[[array-table]]` also contains `codex_hooks` data | Migration changes only `[features]` and preserves unrelated keys |
-| TC-CDCR-008B | Unrelated quoted table header contains `#` | Mutable migration refuses and preserves both destinations |
+| TC-CDCR-008B | Unrelated quoted table header contains `#` | Canonical migration succeeds and preserves the unrelated table data |
+| TC-CDCR-008C | A multiline nested array precedes legacy `codex_hooks` | Semantic postcondition detects the missed rewrite and refuses before either destination changes |
 | TC-CDCR-009 | Legacy-only `codex_hooks = false` | Installer fails and preserves the explicit disable |
 | TC-CDCR-010 | Both keys are `true` | Deprecated alias is removed; canonical key remains |
 | TC-CDCR-011 | Keys disagree | Installer fails loudly and preserves config byte-for-byte |
@@ -22,14 +23,24 @@
 | TC-CDCR-014 | Canonical true uses a quoted or dotted key | Installer accepts it as a no-op without rewriting |
 | TC-CDCR-015 | Legacy true uses a quoted or dotted key | Installer refuses the unsafe migration and preserves the file |
 | TC-CDCR-016 | `[[features]]`, duplicate key, or duplicate table | Complete TOML parsing refuses before either destination changes |
-| TC-CDCR-017 | Hooks replacement fails after config replacement | Existing config and hooks are restored |
-| TC-CDCR-017A | Operator edits installed config before hooks failure is handled | Rollback refuses to overwrite the concurrent edit |
-| TC-CDCR-018 | Existing files have restrictive modes; fresh install runs under permissive umask | Replacements preserve existing modes and fresh files remain private |
+| TC-CDCR-017 | A destination replacement fails | Existing config and hooks are restored |
+| TC-CDCR-017A | Config placement fails; hooks change during rollback capture and TERM arrives | Rollback preserves the concurrent edit and cannot be re-entered by the signal |
+| TC-CDCR-017B | Both Codex files change | `hooks.json` is replaced before `config.toml` enables the canonical feature |
+| TC-CDCR-018 | Existing files have restrictive modes; fresh install runs under permissive umask | Replacements preserve existing modes and fresh files/directories remain private |
 | TC-CDCR-019 | Destination or `.codex` parent is a directory/symbolic-link mismatch | Installer refuses before replacing either destination or writing through the link |
-| TC-CDCR-019A | Process receives SIGTERM after config replacement | Signal handler atomically restores both original destinations and removes pending files |
+| TC-CDCR-019A | Process receives SIGTERM after replacement and again during rollback | Signal handler restores config before hooks, ignores the repeated signal, and removes pending files |
 | TC-CDCR-019D | Process receives SIGTERM while a pending file is staged | Signal handler leaves original destinations intact and removes pending files |
 | TC-CDCR-019B | Config changes while hooks are rendered | Installer refuses the stale snapshot and preserves the concurrent edit |
 | TC-CDCR-019C | Config mode changes while hooks are rendered | Installer refuses and preserves the restrictive mode |
+| TC-CDCR-019E | Operator creates/edits a destination in the final placement window | No-clobber installation aborts, preserves the concurrent content, and rolls back the other destination |
+| TC-CDCR-019F | Another installer wins the atomic capture race | The losing installer leaves ownership with the winner and does not synthesize an empty destination |
+| TC-CDCR-019H | Capture completes but its helper returns nonzero | Inode/content postconditions recognize the captured original and installation remains consistent |
+| TC-CDCR-019I | Operator creates a directory at the randomized backup path | Exact-target capture aborts while preserving the canonical file and directory |
+| TC-CDCR-019J | Operator creates a directory at rollback's randomized capture path | Rollback does not move the canonical file inside that directory |
+| TC-CDCR-019K | TERM arrives after capture placement but before shell bookkeeping | The signal is handled with exit 143 and both destinations are restored |
+| TC-CDCR-019L | Operator creates a directory in the final placement window | Exact-target placement aborts without moving generated content inside the directory |
+| TC-CDCR-019M | Project `.codex` is replaced by an external symlink after final placement | Anchored rollback restores the original physical directory and writes nothing externally |
+| TC-CDCR-019N | Canonical rollback source disappears while an unrelated scratch object appears | Inode ownership check leaves both unowned objects untouched |
 
 ## Hook payload normalization and behavior
 
@@ -37,21 +48,22 @@
 |---|---|---|
 | TC-CDCR-020 | Claude `Write` payload | Emits `add<TAB>path`; compatibility API emits the path |
 | TC-CDCR-021 | Claude `Edit` path contains spaces | Emits `edit<TAB>path` without word splitting and does not trigger file-creation policy |
-| TC-CDCR-021A | Kiro `fs_write` uses `path` + `command`; Gemini/Kimi use `file_path`; Windsurf uses `tool_info.file_path` | Provider-native payloads retain add/edit semantics; Kiro `create` and Windsurf writes trigger policy |
+| TC-CDCR-021A | Kiro `fs_write`/`write`/`fsWrite` uses `path` + `command`; Gemini/Kimi use `file_path`; Windsurf uses `tool_info.file_path` | Provider-native payloads retain add/edit semantics; Kiro `create` and Windsurf writes trigger policy |
 | TC-CDCR-022 | Codex patch adds, updates, moves, and deletes files | Emits all `add`/`edit`/`move`/`delete` records and compatibility paths in patch order |
 | TC-CDCR-023 | Codex multi-file patch has docs first and new `src/` file second | `check-test-plan.sh` emits the reminder; pure move does not |
 | TC-CDCR-024 | Missing boundaries, missing/non-string discriminator/path, or empty recognized edit payload | Parser fails and the direct/generated hook exits exactly `2` |
 | TC-CDCR-025 | `Read` carries a nonempty `file_path`; `apply_patch` carries a misleading one | `Read` is a no-op and `apply_patch` still parses every command header |
 | TC-CDCR-026 | Generated Codex hook command runs from a nested directory with `$CLAUDE_PROJECT_DIR` unset | Command finds the worktree hook and applies TC-CDCR-023/024 behavior |
+| TC-CDCR-027 | Main checkout has a fresh test-plan mark while Codex edits a linked worktree | Linked-worktree state stays isolated and the worktree edit still emits the reminder |
 
 ## Skills, roles, and topology
 
 | ID | Scenario | Expected |
 |---|---|---|
 | TC-CDCR-030 | `autonomous-dev` guidance and hook feedback | Names Codex native subagents and `codex review`, with Claude/manual equivalents |
-| TC-CDCR-031 | `autonomous-review` internal subagent guidance | Internal subagents are advisory; assigned main session alone runs the decision gate and calls `post-verdict.sh` |
-| TC-CDCR-032 | Operator docs compare review mechanisms | `REVIEW_BOTS`, `AGENT_REVIEW_AGENTS`, and internal subagents are distinct |
-| TC-CDCR-033 | Canonical mixed config | `AGENT_DEV_CMD=codex`, `AGENT_REVIEW_CMD=claude`, default single verdict agent, no dev launcher leakage |
+| TC-CDCR-031 | `autonomous-review` and authoritative pipeline guidance | Within each wrapper-assigned verdict session, internal subagents are advisory and only the parent runs the decision gate and calls `post-verdict.sh` |
+| TC-CDCR-032 | Operator and pipeline docs compare review mechanisms | `REVIEW_BOTS`, `AGENT_REVIEW_AGENTS`, and internal subagents are distinct |
+| TC-CDCR-033 | Canonical mixed config in operator and pipeline docs | `AGENT_DEV_CMD=codex`, `AGENT_REVIEW_CMD=claude`, default single verdict agent, no dev launcher leakage |
 | TC-CDCR-034 | Claude-only review launcher in canonical mixed config | Review launcher is accepted while Codex dev remains unwrapped |
 
 ## Regression gates

--- a/skills/autonomous-common/SKILL.md
+++ b/skills/autonomous-common/SKILL.md
@@ -28,7 +28,7 @@ After `npx skills add`, run the installer for your coding agent once from the pr
 | Cursor | `bash .claude/skills/autonomous-common/scripts/install-cursor-hooks.sh` | `.cursor/hooks.json` |
 | Kiro CLI | `bash .claude/skills/autonomous-common/scripts/install-kiro-hooks.sh [--agent <name>]` | `.kiro/agents/<name>.json` (default: `default`) |
 | Gemini CLI | `bash .claude/skills/autonomous-common/scripts/install-gemini-hooks.sh` | `.gemini/settings.json` |
-| Codex CLI | `bash .claude/skills/autonomous-common/scripts/install-codex-hooks.sh` | `.codex/hooks.json` + `.codex/config.toml` |
+| Codex CLI | `bash .claude/skills/autonomous-common/scripts/install-codex-hooks.sh` (Python 3.11+) | `.codex/hooks.json` + `.codex/config.toml` |
 | Windsurf | `bash .claude/skills/autonomous-common/scripts/install-windsurf-hooks.sh` | `.windsurf/hooks.json` |
 | Kimi CLI | `bash .claude/skills/autonomous-common/scripts/install-kimi-hooks.sh [--project]` | `~/.kimi/config.toml` (default; `--project` writes `.kimi/config.toml`) |
 
@@ -92,7 +92,7 @@ Claude Code only. The installer prompts for these; if installing manually, add t
   - `install-cursor-hooks.sh` — Cursor installer (writes `.cursor/hooks.json` — `version: 1` envelope, camelCase events, `Shell` matcher)
   - `install-kiro-hooks.sh` — Kiro CLI / Amazon Q installer (writes `.kiro/agents/<name>.json` — agent definition with camelCase events, `execute_bash`/`fs_write` matchers, `timeout_ms` in milliseconds)
   - `install-gemini-hooks.sh` — Gemini CLI installer (writes `.gemini/settings.json` — `BeforeTool`/`AfterTool` events, `run_shell_command`/`write_file`/`replace` matchers)
-  - `install-codex-hooks.sh` — Codex CLI installer (writes `.codex/hooks.json` + sets `[features] codex_hooks = true` in `.codex/config.toml`)
+  - `install-codex-hooks.sh` — Codex CLI installer (requires Python 3.11+ `tomllib`, renders worktree-root-resolvable `.codex/hooks.json`, sets canonical `[features] hooks = true`, and safely migrates the deprecated `codex_hooks` alias)
   - `install-windsurf-hooks.sh` — Windsurf installer (writes `.windsurf/hooks.json` — snake_case events that fold matcher info; no per-tool matcher field)
   - `install-kimi-hooks.sh` — Kimi CLI installer (writes `~/.kimi/config.toml` user-level by default, or `.kimi/config.toml` with `--project`; emits TOML `[[hooks]]` blocks)
   - `claude-settings.template.json` — canonical hook list applied by all per-agent installers

--- a/skills/autonomous-common/hooks/README.md
+++ b/skills/autonomous-common/hooks/README.md
@@ -1,6 +1,9 @@
 # Workflow Enforcement Hooks
 
-These hooks enforce the TDD development workflow defined in `CLAUDE.md`. They ensure that every code change follows the mandatory steps: design canvas, git worktree isolation, test-first development, code review, PR review, CI verification, and E2E testing.
+These hooks enforce the autonomous-dev TDD workflow across supported coding
+agents. They ensure that every code change follows the mandatory steps: design
+canvas, git worktree isolation, test-first development, code review, PR
+review, CI verification, and E2E testing.
 
 ## Claude Code Setup
 
@@ -27,6 +30,16 @@ Each hook entry specifies a `matcher` (the tool name it applies to), the shell c
 
 Kiro CLI supports hooks. Adapt the Claude Code hook configuration for Kiro's hook format. See Kiro CLI documentation for details.
 
+## Codex CLI Setup
+
+Run `install-codex-hooks.sh` from the project root. It writes
+`.codex/hooks.json`, uses canonical `[features] hooks = true`, and renders
+commands that resolve the active git worktree without
+`$CLAUDE_PROJECT_DIR`. The installer requires Python 3.11+ so `tomllib` can
+validate the complete existing config before migration. Codex project hooks
+and changed hook definitions must be reviewed and trusted with `/hooks`;
+vetted unattended automation may use `--dangerously-bypass-hook-trust`.
+
 ## Other IDEs
 
 IDEs without hook support (Cursor, Windsurf, etc.) rely on skill instructions for workflow enforcement. Follow each step in the autonomous-dev skill manually.
@@ -40,7 +53,7 @@ IDEs without hook support (Cursor, Windsurf, etc.) rely on skill instructions fo
 | `check-design-canvas.sh` | PreToolUse | Bash | Reminds about design canvas before coding |
 | `check-code-simplifier.sh` | PreToolUse | Bash | Blocks commits until code-simplifier review |
 | `check-pr-review.sh` | PreToolUse | Bash | Blocks pushes until PR review complete |
-| `check-test-plan.sh` | PreToolUse | Write/Edit | Reminds about test plan before code changes |
+| `check-test-plan.sh` | PreToolUse | Write/Edit or Codex apply_patch | Reminds about a test plan before creating implementation files; checks every add in a multi-file patch without treating updates/moves as creates |
 | `check-shellcheck.sh` | PreToolUse | Bash | Blocks commits if staged .sh files have shellcheck errors |
 | `check-unit-tests.sh` | PreToolUse | Bash | Warns about unrun unit tests |
 | `warn-skip-verification.sh` | PreToolUse | Bash | Warns about --no-verify usage |

--- a/skills/autonomous-common/hooks/check-code-simplifier.sh
+++ b/skills/autonomous-common/hooks/check-code-simplifier.sh
@@ -38,23 +38,25 @@ fi
 
 # Block the commit
 cat >&2 <<'EOF'
-## ⛔ BLOCKED - Run Code Simplifier First
+## BLOCKED - Run Code Simplification Review First
 
-Before committing, you must run the code-simplifier agent to review and clean up your changes.
+Before committing, run an independent simplification review of your changes.
 
 ### Required Steps:
-1. Run the code-simplifier agent (try in order):
-   a. Use Agent tool with subagent_type: code-simplifier:code-simplifier
-   b. If agent not found, fallback to: /simplify skill
+1. Use the native option for this client:
+   a. Codex: spawn a reviewer subagent focused on simplification, or run
+      `codex review --uncommitted "Focus on unnecessary complexity and duplication."`
+   b. Claude Code: use the code-simplifier agent/plugin or `/simplify`.
+   c. Other clients: use an available review agent or inspect the diff manually.
 
-2. After code-simplifier/simplify completes, mark it:
+2. After the simplification pass completes, mark it:
    ```bash
    hooks/state-manager.sh mark code-simplifier
    ```
 
 3. Retry the commit
 
-### Why This Is Required (CLAUDE.md Step 5):
+### Why This Is Required:
 - Ensures consistent code style
 - Removes redundant code
 - Validates changes follow project patterns

--- a/skills/autonomous-common/hooks/check-pr-review.sh
+++ b/skills/autonomous-common/hooks/check-pr-review.sh
@@ -29,17 +29,17 @@ fi
 
 # Block the push
 cat >&2 <<'EOF'
-## ⛔ BLOCKED - Run PR Review First
+## BLOCKED - Run PR Review First
 
-Before pushing, you must complete a code review using the PR review toolkit.
+Before pushing, you must complete an independent review of the full branch diff.
 The mark is bound to the current HEAD commit: any new commit invalidates it,
 so you must re-run the review after each commit (issue #48).
 
 ### Required Steps:
-1. Run the PR review command:
-   ```
-   /pr-review-toolkit:review-pr
-   ```
+1. Use the native option for this client:
+   - Codex: spawn a reviewer subagent or run `codex review --base <base-branch>`.
+   - Claude Code: run `/pr-review-toolkit:review-pr`.
+   - Other clients: use an available review agent or review the diff manually.
 
 2. Resolve all Critical/High/Medium severity findings:
    - 🔴 Critical/Severe: MUST fix
@@ -63,7 +63,7 @@ so you must re-run the review after each commit (issue #48).
 - Test coverage gaps
 - Security vulnerabilities
 
-### Why This Is Required (CLAUDE.md Step 6):
+### Why This Is Required:
 Per development workflow, code review must be completed before pushing.
 
 **To bypass (emergency only):** Use `--no-verify` flag and document the reason

--- a/skills/autonomous-common/hooks/check-test-plan.sh
+++ b/skills/autonomous-common/hooks/check-test-plan.sh
@@ -7,10 +7,13 @@ source "$SCRIPT_DIR/lib.sh"
 STATE_MANAGER="$SCRIPT_DIR/state-manager.sh"
 
 input=$(read_hook_stdin)
-file_path=$(parse_file_path "$input")
+if ! edit_operations=$(parse_edit_file_operations "$input"); then
+  echo "Error: could not normalize edit operations; refusing to skip the test-plan gate" >&2
+  exit 2
+fi
 
-# Skip if no file path
-if [[ -z "$file_path" ]]; then
+# Skip non-edit tools.
+if [[ -z "$edit_operations" ]]; then
   exit 0
 fi
 
@@ -18,31 +21,38 @@ fi
 # Default: TypeScript/JavaScript files in src/ directory
 IMPL_PATTERN='src/.*\.(ts|tsx|js|jsx)$'
 
-# Skip if not an implementation file
-if [[ ! "$file_path" =~ $IMPL_PATTERN ]]; then
+# Skip every path if the test plan is already marked.
+if "$STATE_MANAGER" check test-plan 2>/dev/null; then
   exit 0
 fi
 
-# Skip test files
-if [[ "$file_path" =~ (__tests__|\.test\.|\.spec\.|tests/) ]]; then
-  exit 0
-fi
+# Only creation operations can require a test plan. Updates, deletes, and move
+# destinations may name paths that do not exist yet without creating new code.
+# Patch paths are normally worktree-relative; Claude may provide an absolute
+# path.
+worktree_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+needs_test_plan=false
+while IFS=$'\t' read -r operation file_path; do
+  [[ "$operation" == "add" && -n "$file_path" ]] || continue
 
-# Skip config files
-if [[ "$file_path" =~ (\.config\.|\.d\.ts$) ]]; then
-  exit 0
-fi
+  [[ "$file_path" =~ $IMPL_PATTERN ]] || continue
+  [[ "$file_path" =~ (__tests__|\.test\.|\.spec\.|tests/) ]] && continue
+  [[ "$file_path" =~ (\.config\.|\.d\.ts$) ]] && continue
 
-# Skip if test-plan state exists or file already exists (editing existing code)
-if "$STATE_MANAGER" check test-plan 2>/dev/null || [[ -f "$file_path" ]]; then
-  exit 0
-fi
+  if [[ -f "$file_path" || -f "$worktree_root/$file_path" ]]; then
+    continue
+  fi
 
-# Warn about test plan for new file creation
+  needs_test_plan=true
+  break
+done <<< "$edit_operations"
+
+[[ "$needs_test_plan" == "true" ]] || exit 0
+
 cat >&2 <<'EOF'
 ## Reminder: Test Plan First (TDD Workflow)
 
-You're creating a new implementation file. Per CLAUDE.md Step 2, the test-driven workflow requires:
+You're creating a new implementation file. The project workflow requires:
 
 ### Before Writing Implementation:
 1. **Create test case document**: `docs/test-cases/<feature>.md`

--- a/skills/autonomous-common/hooks/check-test-plan.sh
+++ b/skills/autonomous-common/hooks/check-test-plan.sh
@@ -8,8 +8,8 @@ STATE_MANAGER="$SCRIPT_DIR/state-manager.sh"
 
 input=$(read_hook_stdin)
 if ! edit_operations=$(parse_edit_file_operations "$input"); then
-  echo "Error: could not normalize edit operations; refusing to skip the test-plan gate" >&2
-  exit 2
+  echo "Warning: could not inspect this edit payload; test-plan reminder skipped because this hook is advisory." >&2
+  exit 0
 fi
 
 # Skip non-edit tools.

--- a/skills/autonomous-common/hooks/check-test-plan.sh
+++ b/skills/autonomous-common/hooks/check-test-plan.sh
@@ -39,7 +39,9 @@ while IFS=$'\t' read -r operation file_path; do
   [[ "$file_path" =~ (__tests__|\.test\.|\.spec\.|tests/) ]] && continue
   [[ "$file_path" =~ (\.config\.|\.d\.ts$) ]] && continue
 
-  if [[ -f "$file_path" || -f "$worktree_root/$file_path" ]]; then
+  if [[ "$file_path" == /* ]]; then
+    [[ -f "$file_path" ]] && continue
+  elif [[ -f "$worktree_root/$file_path" ]]; then
     continue
   fi
 

--- a/skills/autonomous-common/hooks/lib.sh
+++ b/skills/autonomous-common/hooks/lib.sh
@@ -53,6 +53,28 @@ parse_json_field() {
   echo "$json_input" | jq -r --arg path "$field_path" 'getpath($path | split(".")) // ""'
 }
 
+# Parse a required nonempty JSON string field.
+# Usage: parse_json_string_field "field.path" "$json_input"
+parse_json_string_field() {
+  local field_path="$1"
+  local json_input="$2"
+
+  if ! command -v jq &> /dev/null; then
+    echo "Error: jq is required but not installed" >&2
+    return 1
+  fi
+  if [[ ! "$field_path" =~ ^[]a-zA-Z0-9._[\"]+$ ]]; then
+    echo "Error: Invalid field path" >&2
+    return 1
+  fi
+
+  echo "$json_input" |
+    jq -er --arg path "$field_path" '
+      getpath($path | split("."))
+      | select((type == "string") and (length > 0))
+    ' 2>/dev/null
+}
+
 # Parse tool input command from hook JSON
 # Usage: parse_command "$json_input"
 parse_command() {
@@ -77,6 +99,173 @@ parse_exit_code() {
 # Usage: parse_file_path "$json_input"
 parse_file_path() {
   parse_json_field "tool_input.file_path" "$1"
+}
+
+# Parse edit operations as tab-separated operation/path records.
+#
+# Claude Write/Edit calls provide one tool_input.file_path. Codex apply_patch
+# calls provide the patch in tool_input.command and may touch multiple paths.
+# Recognized edit tools fail when their expected path data is malformed;
+# unrelated tools remain a successful no-op.
+#
+# Operations are: add, edit, delete, move.
+parse_edit_file_operations() {
+  local json_input="$1"
+  local tool_name file_path command input_prefix
+
+  if tool_name=$(parse_json_string_field "tool_name" "$json_input"); then
+    input_prefix="tool_input"
+  elif tool_name=$(parse_json_string_field "agent_action_name" "$json_input"); then
+    input_prefix="tool_info"
+  else
+    echo "Error: hook payload is missing a string tool discriminator" >&2
+    return 1
+  fi
+
+  case "$tool_name" in
+    Write|write_file|WriteFile|pre_write_code)
+      if ! file_path=$(parse_json_string_field "${input_prefix}.file_path" "$json_input"); then
+        echo "Error: $tool_name hook payload is missing a string ${input_prefix}.file_path" >&2
+        return 1
+      fi
+      if [[ "$file_path" == *$'\t'* || "$file_path" == *$'\n'* ]]; then
+        echo "Error: $tool_name hook path contains an unsupported tab or newline" >&2
+        return 1
+      fi
+      printf 'add\t%s\n' "$file_path"
+      ;;
+    Edit|replace|StrReplaceFile)
+      if ! file_path=$(parse_json_string_field "${input_prefix}.file_path" "$json_input"); then
+        echo "Error: $tool_name hook payload is missing a string ${input_prefix}.file_path" >&2
+        return 1
+      fi
+      if [[ "$file_path" == *$'\t'* || "$file_path" == *$'\n'* ]]; then
+        echo "Error: $tool_name hook path contains an unsupported tab or newline" >&2
+        return 1
+      fi
+      printf 'edit\t%s\n' "$file_path"
+      ;;
+    fs_write)
+      if ! file_path=$(parse_json_string_field "${input_prefix}.path" "$json_input"); then
+        echo "Error: fs_write hook payload is missing a string ${input_prefix}.path" >&2
+        return 1
+      fi
+      if ! command=$(parse_json_string_field "${input_prefix}.command" "$json_input"); then
+        echo "Error: fs_write hook payload is missing a string ${input_prefix}.command" >&2
+        return 1
+      fi
+      if [[ "$file_path" == *$'\t'* || "$file_path" == *$'\n'* ]]; then
+        echo "Error: fs_write hook path contains an unsupported tab or newline" >&2
+        return 1
+      fi
+      case "$command" in
+        create) printf 'add\t%s\n' "$file_path" ;;
+        str_replace|insert|append) printf 'edit\t%s\n' "$file_path" ;;
+        *)
+          echo "Error: fs_write hook payload has unsupported command: $command" >&2
+          return 1
+          ;;
+      esac
+      ;;
+    apply_patch)
+      if ! command=$(parse_json_string_field "${input_prefix}.command" "$json_input"); then
+        echo "Error: apply_patch hook payload is missing a string ${input_prefix}.command" >&2
+        return 1
+      fi
+
+      local line operation candidate
+      local begun=0 ended=0 found=0 malformed=0
+      declare -A seen=()
+      local -a operation_records=()
+      while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%$'\r'}"
+
+        if (( begun == 0 )); then
+          if [[ "$line" == "*** Begin Patch" ]]; then
+            begun=1
+          else
+            malformed=1
+          fi
+          continue
+        fi
+
+        if (( ended == 1 )); then
+          [[ -z "$line" ]] || malformed=1
+          continue
+        fi
+
+        if [[ "$line" == "*** End Patch" ]]; then
+          ended=1
+          continue
+        fi
+        if [[ "$line" == "*** Begin Patch" ]]; then
+          malformed=1
+          continue
+        fi
+
+        operation=""
+        candidate=""
+        case "$line" in
+          '*** Add File: '*)
+            operation="add"
+            candidate="${line#'*** Add File: '}"
+            ;;
+          '*** Update File: '*)
+            operation="edit"
+            candidate="${line#'*** Update File: '}"
+            ;;
+          '*** Delete File: '*)
+            operation="delete"
+            candidate="${line#'*** Delete File: '}"
+            ;;
+          '*** Move to: '*)
+            operation="move"
+            candidate="${line#'*** Move to: '}"
+            ;;
+        esac
+
+        [[ -z "$operation" ]] && continue
+        if [[ -z "$candidate" || "$candidate" == *$'\t'* ]]; then
+          malformed=1
+          continue
+        fi
+
+        local record_key="${operation}"$'\034'"${candidate}"
+        if [[ ! ${seen["$record_key"]+present} ]]; then
+          seen["$record_key"]=1
+          operation_records+=("${operation}"$'\t'"${candidate}")
+          found=1
+        fi
+      done <<< "$command"
+
+      if (( begun == 0 || ended == 0 || found == 0 || malformed == 1 )); then
+        echo "Error: apply_patch payload is not a complete supported patch" >&2
+        return 1
+      fi
+      printf '%s\n' "${operation_records[@]}"
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+# Parse all paths affected by an edit tool, one path per output line.
+# This compatibility projection intentionally drops operation semantics.
+parse_edit_file_paths() {
+  local json_input="$1"
+  local records operation file_path
+
+  records=$(parse_edit_file_operations "$json_input") || return 1
+
+  declare -A seen=()
+  while IFS=$'\t' read -r operation file_path; do
+    [[ -z "$operation" || -z "$file_path" ]] && continue
+    if [[ ! ${seen["$file_path"]+present} ]]; then
+      seen["$file_path"]=1
+      printf '%s\n' "$file_path"
+    fi
+  done <<< "$records"
 }
 
 # Check if command invokes a given git subcommand.

--- a/skills/autonomous-common/hooks/lib.sh
+++ b/skills/autonomous-common/hooks/lib.sh
@@ -21,13 +21,13 @@ read_hook_stdin() {
 # Workflow state is per worktree; only fall back to the common checkout when
 # no worktree toplevel can be resolved.
 resolve_project_root() {
-  if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
-    echo "$CLAUDE_PROJECT_DIR"
+  local root
+  if root=$(git rev-parse --show-toplevel 2>/dev/null); then
+    printf '%s\n' "$root"
+  elif root=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null); then
+    printf '%s\n' "${root%/.git}"
   else
-    git rev-parse --show-toplevel 2>/dev/null ||
-      git rev-parse --path-format=absolute --git-common-dir 2>/dev/null |
-        sed 's|/\.git$||' ||
-      pwd
+    pwd
   fi
 }
 

--- a/skills/autonomous-common/hooks/lib.sh
+++ b/skills/autonomous-common/hooks/lib.sh
@@ -17,14 +17,17 @@ read_hook_stdin() {
   printf '%s' "$input"
 }
 
-# Resolve main project root (works from worktrees and subdirectories).
-# Git worktrees have their own .git file pointing to the main repo's .git/worktrees/<name>.
-# --git-common-dir returns the main repo's .git directory in both cases.
+# Resolve the current worktree root from worktrees and subdirectories.
+# Workflow state is per worktree; only fall back to the common checkout when
+# no worktree toplevel can be resolved.
 resolve_project_root() {
   if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
     echo "$CLAUDE_PROJECT_DIR"
   else
-    git rev-parse --path-format=absolute --git-common-dir 2>/dev/null | sed 's|/\.git$||' || git rev-parse --show-toplevel 2>/dev/null || pwd
+    git rev-parse --show-toplevel 2>/dev/null ||
+      git rev-parse --path-format=absolute --git-common-dir 2>/dev/null |
+        sed 's|/\.git$||' ||
+      pwd
   fi
 }
 
@@ -145,24 +148,24 @@ parse_edit_file_operations() {
       fi
       printf 'edit\t%s\n' "$file_path"
       ;;
-    fs_write)
+    fs_write|write|fsWrite)
       if ! file_path=$(parse_json_string_field "${input_prefix}.path" "$json_input"); then
-        echo "Error: fs_write hook payload is missing a string ${input_prefix}.path" >&2
+        echo "Error: $tool_name hook payload is missing a string ${input_prefix}.path" >&2
         return 1
       fi
       if ! command=$(parse_json_string_field "${input_prefix}.command" "$json_input"); then
-        echo "Error: fs_write hook payload is missing a string ${input_prefix}.command" >&2
+        echo "Error: $tool_name hook payload is missing a string ${input_prefix}.command" >&2
         return 1
       fi
       if [[ "$file_path" == *$'\t'* || "$file_path" == *$'\n'* ]]; then
-        echo "Error: fs_write hook path contains an unsupported tab or newline" >&2
+        echo "Error: $tool_name hook path contains an unsupported tab or newline" >&2
         return 1
       fi
       case "$command" in
         create) printf 'add\t%s\n' "$file_path" ;;
         str_replace|insert|append) printf 'edit\t%s\n' "$file_path" ;;
         *)
-          echo "Error: fs_write hook payload has unsupported command: $command" >&2
+          echo "Error: $tool_name hook payload has unsupported command: $command" >&2
           return 1
           ;;
       esac

--- a/skills/autonomous-common/scripts/install-codex-hooks.sh
+++ b/skills/autonomous-common/scripts/install-codex-hooks.sh
@@ -353,25 +353,40 @@ _CODEX_TARGET_DIR_ID=""
 _CODEX_TARGET_DIR_PATH=""
 
 _place_codex_path_no_clobber() {
-  local source="$1" destination="$2"
+  local source="$1" destination="$2" expected_identity="${3:-}"
 
   # link(2) and symlink(2) address the exact destination and fail if any path
   # already exists there. Unlike `mv -n`, they never reinterpret a concurrent
-  # directory as a container for the source.
-  CODEX_ATOMIC_PLACE=1 python3 - "$source" "$destination" <<'PY'
+  # directory as a container for the source. Capture callers also pass the
+  # inode observed before entering this helper so a raced symlink or file is
+  # rejected before it can be linked and unlinked.
+  CODEX_ATOMIC_PLACE=1 python3 - \
+    "$source" "$destination" "$expected_identity" <<'PY'
 import os
 import stat
 import sys
 
-source, destination = sys.argv[1:]
+source, destination, expected_identity = sys.argv[1:]
 try:
-    mode = os.lstat(source).st_mode
+    source_stat = os.lstat(source)
+    mode = source_stat.st_mode
+    if expected_identity:
+        actual_identity = f"{source_stat.st_dev}:{source_stat.st_ino}"
+        if actual_identity != expected_identity or not stat.S_ISREG(mode):
+            raise OSError("source changed before capture")
     if stat.S_ISREG(mode):
         os.link(source, destination, follow_symlinks=False)
     elif stat.S_ISLNK(mode):
         os.symlink(os.readlink(source), destination)
     else:
         raise OSError("unsupported source type")
+    if expected_identity:
+        linked_stat = os.lstat(destination)
+        active_stat = os.lstat(source)
+        linked_identity = f"{linked_stat.st_dev}:{linked_stat.st_ino}"
+        active_identity = f"{active_stat.st_dev}:{active_stat.st_ino}"
+        if linked_identity != expected_identity or active_identity != expected_identity:
+            raise OSError("source changed during capture")
     os.unlink(source)
 except OSError:
     raise SystemExit(1)
@@ -383,7 +398,7 @@ _capture_codex_destination() {
   local source_identity
 
   source_identity=$(_file_identity "$path") || return 1
-  if _place_codex_path_no_clobber "$path" "$backup"; then
+  if _place_codex_path_no_clobber "$path" "$backup" "$source_identity"; then
     :
   else
     # The helper status is intentionally reconciled from inode postconditions.

--- a/skills/autonomous-common/scripts/install-codex-hooks.sh
+++ b/skills/autonomous-common/scripts/install-codex-hooks.sh
@@ -2,21 +2,16 @@
 # install-codex-hooks.sh — bootstrap project-scoped OpenAI Codex CLI hooks
 # from the canonical template.
 #
-# Codex CLI's hook system is modeled directly on Claude Code's
-# (per github.com/openai/codex codex-rs/hooks/) and accepts the same
-# event names + matcher field. The differences:
+# Codex accepts the same hook event structure as Claude Code, with two
+# project-specific adaptations:
 #
 #   1. Hooks live in `.codex/hooks.json` (NOT `.claude/settings.json`).
 #      The file is hooks-only — no other top-level keys.
-#   2. The feature is gated behind `[features] codex_hooks = true` in
-#      `~/.codex/config.toml` or the project's `.codex/config.toml`.
-#      We toggle the project-level flag here.
+#   2. The canonical feature key is `[features] hooks = true`.
 #
-# Caveat: Codex hook support is experimental upstream. The exact tool-
-# name matchers ("Bash", "Write", "Edit") are modeled on Claude Code's
-# but not officially documented in the Codex docs at
-# developers.openai.com/codex/config-advanced. Verify your first hook
-# fires before relying on the install.
+# Codex project hooks and each changed hook definition must be trusted before
+# they run. Use /hooks interactively, or --dangerously-bypass-hook-trust only
+# in automation that vets the installed hook source independently.
 #
 # Usage:
 #   bash skills/autonomous-common/scripts/install-codex-hooks.sh
@@ -44,6 +39,16 @@ source "$SCRIPT_DIR/lib-installer.sh"
 
 require_jq
 
+require_tomllib() {
+  if ! command -v python3 >/dev/null 2>&1 ||
+     ! python3 -c 'import tomllib' >/dev/null 2>&1; then
+    echo "ERROR: Python 3.11+ with the standard-library tomllib module is required." >&2
+    exit 1
+  fi
+}
+
+require_tomllib
+
 TEMPLATE="$SCRIPT_DIR/claude-settings.template.json"
 if [[ ! -f "$TEMPLATE" ]]; then
   echo "ERROR: canonical template not found at: $TEMPLATE" >&2
@@ -54,88 +59,550 @@ target_dir="$(project_root)/.codex"
 target="$target_dir/hooks.json"
 config_toml="$target_dir/config.toml"
 
-# Codex's hooks.json is hooks-only (same shape as Antigravity). Use the
-# hooks-only writer.
-write_hooks_only_settings "$TEMPLATE" "$target"
-
-# Toggle the [features] codex_hooks = true flag. This is required
-# upstream; without it, the hooks.json file is ignored.
-#
-# TOML constraint (PR-11b code review C1): defining `[features]` more
-# than once is invalid TOML — the Rust `toml` crate that Codex uses
-# rejects the entire config. So we MUST NOT blindly append a second
-# `[features]` block. The strategy:
-#
-#   1. No file → create a fresh one with a single `[features]` block.
-#   2. File has `codex_hooks = true` already (anywhere) → no-op.
-#   3. File has `codex_hooks = false` → refuse + ask operator to fix.
-#      (We assume `false` is intentional; flipping it would surprise.)
-#   4. File has a `[features]` section → insert `codex_hooks = true` as
-#      the first line of that section.
-#   5. File has no `[features]` section → append a new one at EOF.
+if [[ -L "$target_dir" ]]; then
+  echo "ERROR: refusing to install through symbolic-link directory: $target_dir" >&2
+  exit 1
+fi
+if [[ -e "$target_dir" && ! -d "$target_dir" ]]; then
+  echo "ERROR: Codex config path exists but is not a directory: $target_dir" >&2
+  exit 1
+fi
 mkdir -p "$target_dir"
 
-toggle_codex_hooks_flag() {
-  local file="$1"
-
-  if [[ ! -f "$file" ]]; then
-    cat > "$file" <<'EOF'
-# Created by install-codex-hooks.sh — required for hooks.json to take effect.
-[features]
-codex_hooks = true
-EOF
-    echo "Created: $file" >&2
-    return 0
-  fi
-
-  # Already enabled? (No-op.)
-  if grep -qE '^[[:space:]]*codex_hooks[[:space:]]*=[[:space:]]*true' "$file"; then
-    echo "Note: codex_hooks already enabled in $file" >&2
-    return 0
-  fi
-
-  # Explicitly disabled? Refuse — operator likely set it on purpose.
-  if grep -qE '^[[:space:]]*codex_hooks[[:space:]]*=[[:space:]]*false' "$file"; then
-    echo "ERROR: $file contains 'codex_hooks = false'. Hooks would not fire." >&2
-    echo "       Edit that line to 'true' (or remove it) and re-run." >&2
+_require_regular_destination() {
+  local path="$1"
+  if [[ -L "$path" ]]; then
+    echo "ERROR: refusing to replace symbolic-link destination: $path" >&2
     return 1
   fi
-
-  # Insert into existing [features] section, or append a new section.
-  if grep -qE '^[[:space:]]*\[features\][[:space:]]*$' "$file"; then
-    # Use awk to insert `codex_hooks = true` as the first line after
-    # the `[features]` header. Robust against trailing whitespace and
-    # blank lines.
-    local tmp
-    tmp=$(mktemp)
-    # shellcheck disable=SC2064
-    trap "rm -f '$tmp'" RETURN
-    awk '
-      BEGIN { inserted = 0 }
-      /^[[:space:]]*\[features\][[:space:]]*$/ {
-        print
-        if (!inserted) {
-          print "codex_hooks = true  # added by install-codex-hooks.sh"
-          inserted = 1
-        }
-        next
-      }
-      { print }
-    ' "$file" > "$tmp"
-    mv "$tmp" "$file"
-    trap - RETURN
-    echo "Updated: $file (inserted codex_hooks = true into existing [features] section)" >&2
-  else
-    {
-      printf '\n# Added by install-codex-hooks.sh — required for hooks.json to take effect.\n'
-      printf '[features]\n'
-      printf 'codex_hooks = true\n'
-    } >> "$file"
-    echo "Updated: $file (appended new [features] section)" >&2
+  if [[ -e "$path" && ! -f "$path" ]]; then
+    echo "ERROR: destination exists but is not a regular file: $path" >&2
+    return 1
   fi
 }
 
-toggle_codex_hooks_flag "$config_toml" || exit 1
+# Parse the complete TOML document before making any textual change. Python's
+# standard-library parser catches quoted/dotted keys, arrays of tables,
+# multiline strings, and duplicate definitions that a line parser cannot.
+_analyze_codex_config() {
+  python3 - "$1" "${2:-$1}" <<'PY'
+import json
+import sys
+import tomllib
+
+path = sys.argv[1]
+display_path = sys.argv[2]
+try:
+    with open(path, "rb") as stream:
+        config = tomllib.load(stream)
+except (OSError, tomllib.TOMLDecodeError) as exc:
+    print(f"ERROR: cannot parse {display_path}: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+
+if "features" not in config:
+    print(json.dumps({"features_present": False, "hooks": None, "codex_hooks": None}))
+    raise SystemExit(0)
+
+features = config["features"]
+if not isinstance(features, dict):
+    print(f"ERROR: {display_path} must define features as a TOML table", file=sys.stderr)
+    raise SystemExit(1)
+
+values = {}
+for key in ("hooks", "codex_hooks"):
+    value = features.get(key)
+    if value is not None and type(value) is not bool:
+        print(f"ERROR: [features].{key} must be boolean in {display_path}", file=sys.stderr)
+        raise SystemExit(1)
+    values[key] = value
+
+print(json.dumps({"features_present": True, **values}))
+PY
+}
+
+_canonical_line_count() {
+  local file="$1" kind="$2" pattern
+  case "$kind" in
+    header) pattern='^[[:space:]]*\[[[:space:]]*features[[:space:]]*\][[:space:]]*(#.*)?$' ;;
+    legacy) pattern='^[[:space:]]*codex_hooks[[:space:]]*=[[:space:]]*(true|false)[[:space:]]*(#.*)?$' ;;
+    *) return 2 ;;
+  esac
+  # grep -c prints the desired zero count but exits 1 when no line matches.
+  grep -cE "$pattern" "$file" 2>/dev/null || true
+}
+
+# Comment-preserving edits are intentionally limited to one ordinary
+# [features] table with bare keys. tomllib still validates every other shape;
+# valid but noncanonical forms are refused rather than rewritten unsafely.
+_require_mutable_feature_table() {
+  local file="$1" require_legacy="${2:-0}" display_file="${3:-$1}"
+  local header_count legacy_count
+
+  if grep -qE "'''|\"\"\"" "$file"; then
+    echo "ERROR: $display_file uses multiline TOML strings; automatic [features] edits are disabled." >&2
+    return 1
+  fi
+  if grep -qE "^[[:space:]]*\\[\\[?[^]]*['\"]" "$file"; then
+    echo "ERROR: $display_file uses quoted TOML table headers; automatic [features] edits are disabled." >&2
+    return 1
+  fi
+
+  header_count=$(_canonical_line_count "$file" "header")
+  if (( header_count != 1 )); then
+    echo "ERROR: $display_file does not use one canonical [features] table." >&2
+    echo "       Normalize that table to a bare [features] header, then re-run." >&2
+    return 1
+  fi
+
+  if (( require_legacy == 1 )); then
+    legacy_count=$(_canonical_line_count "$file" "legacy")
+    if (( legacy_count != 1 )); then
+      echo "ERROR: $display_file uses a noncanonical codex_hooks key representation." >&2
+      echo "       Replace it with a bare boolean key in [features], then re-run." >&2
+      return 1
+    fi
+  fi
+}
+
+_rewrite_staged_config() {
+  local file="$1" action="$2"
+  local tmp
+  tmp=$(mktemp "${file}.next.XXXXXX")
+
+  if ! awk -v action="$action" '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+    {
+      raw = $0
+      comparable = raw
+      sub(/[[:space:]]*#.*/, "", comparable)
+      comparable = trim(comparable)
+
+      if (comparable ~ /^\[\[.*\]\]$/) {
+        section = "other"
+        print raw
+        next
+      }
+
+      if (comparable ~ /^\[[^]]+\]$/) {
+        section = (comparable ~ /^\[[[:space:]]*features[[:space:]]*\]$/) ? "features" : "other"
+        print raw
+        if (section == "features" && action == "insert") {
+          print "hooks = true  # added by install-codex-hooks.sh"
+        }
+        next
+      }
+
+      if (section == "features" &&
+          comparable ~ /^codex_hooks[[:space:]]*=/) {
+        if (action == "migrate") {
+          sub(/codex_hooks/, "hooks", raw)
+          print raw
+        } else if (action != "drop-legacy") {
+          print raw
+        }
+        next
+      }
+
+      print raw
+    }
+    END {
+      if (action == "append") {
+        print ""
+        print "# Added by install-codex-hooks.sh."
+        print "[features]"
+        print "hooks = true"
+      }
+    }
+  ' "$file" > "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+
+  # Keep the staged file's mode; replacing it with the umask-created temp file
+  # could widen permissions inherited from a private config.
+  if ! cat "$tmp" > "$file"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  rm -f "$tmp"
+}
+
+_stage_codex_config() {
+  local file="$1" staged="$2" display_file="${3:-$1}"
+
+  if [[ ! -f "$file" ]]; then
+    cat > "$staged" <<'EOF'
+# Created by install-codex-hooks.sh.
+[features]
+hooks = true
+EOF
+    _analyze_codex_config "$staged" >/dev/null
+    return 0
+  fi
+
+  local analysis features_present canonical legacy
+  if ! analysis=$(_analyze_codex_config "$file" "$display_file"); then
+    return 1
+  fi
+  features_present=$(jq -r '.features_present' <<<"$analysis")
+  canonical=$(jq -r 'if .hooks == null then "" else (.hooks | tostring) end' <<<"$analysis")
+  legacy=$(jq -r 'if .codex_hooks == null then "" else (.codex_hooks | tostring) end' <<<"$analysis")
+
+  if [[ -n "$canonical" && -n "$legacy" && "$canonical" != "$legacy" ]]; then
+    echo "ERROR: $display_file has conflicting hooks=$canonical and codex_hooks=$legacy." >&2
+    echo "       Resolve the conflict explicitly, then re-run." >&2
+    return 1
+  fi
+
+  if [[ "$canonical" == "false" || "$legacy" == "false" ]]; then
+    echo "ERROR: $display_file explicitly disables Codex hooks." >&2
+    echo "       Preserve that choice, or set the relevant feature key to true and re-run." >&2
+    return 1
+  fi
+
+  cp -p "$file" "$staged"
+
+  if [[ "$canonical" == "true" && "$legacy" == "true" ]]; then
+    _require_mutable_feature_table "$file" 1 "$display_file" || return 1
+    _rewrite_staged_config "$staged" "drop-legacy"
+  elif [[ "$legacy" == "true" ]]; then
+    _require_mutable_feature_table "$file" 1 "$display_file" || return 1
+    _rewrite_staged_config "$staged" "migrate"
+  elif [[ "$canonical" == "true" ]]; then
+    :
+  elif [[ "$features_present" == "true" ]]; then
+    _require_mutable_feature_table "$file" 0 "$display_file" || return 1
+    _rewrite_staged_config "$staged" "insert"
+  else
+    _rewrite_staged_config "$staged" "append"
+  fi
+
+  _analyze_codex_config "$staged" >/dev/null
+}
+
+render_codex_hooks() {
+  local template="$1" output="$2"
+  if ! jq '
+    ._managed_note = "This hooks block is maintained by skills/autonomous-common/scripts/install-codex-hooks.sh. Hand-edits inside this block are overwritten on the next install."
+    | .hooks.PreToolUse as $pre
+    | ([
+        $pre[]
+        | select(.matcher == "Write" or .matcher == "Edit")
+        | .hooks[]
+      ] | unique_by(.command)) as $edit_hooks
+    | .hooks.PreToolUse = (
+        [$pre[] | select(.matcher != "Write" and .matcher != "Edit")]
+        + (if ($edit_hooks | length) > 0
+           then [{matcher: "^apply_patch$", hooks: $edit_hooks}]
+           else []
+           end)
+      )
+    | (.hooks[][] | .hooks[] | .command) |=
+        sub("^\"\\$CLAUDE_PROJECT_DIR\"/hooks/";
+            "\"$(git rev-parse --show-toplevel)\"/hooks/")
+  ' "$template" > "$output"; then
+    echo "ERROR: failed to render Codex hook configuration" >&2
+    return 1
+  fi
+
+  if ! jq -e '
+    ([.hooks.PreToolUse[] | select(.matcher == "^apply_patch$")] | length == 1)
+    and ([.. | strings | select(contains("$CLAUDE_PROJECT_DIR"))] | length == 0)
+  ' "$output" >/dev/null; then
+    echo "ERROR: rendered Codex hooks failed validation" >&2
+    return 1
+  fi
+}
+
+_CODEX_TXN_ACTIVE=0
+_CODEX_TXN_CONFIG_CHANGED=0
+_CODEX_TXN_CONFIG_EXISTED=0
+_CODEX_TXN_CONFIG_BACKUP=""
+_CODEX_TXN_CONFIG_PATH=""
+_CODEX_TXN_HOOKS_CHANGED=0
+_CODEX_TXN_HOOKS_EXISTED=0
+_CODEX_TXN_HOOKS_BACKUP=""
+_CODEX_TXN_HOOKS_PATH=""
+_CODEX_TXN_PENDING_CONFIG=""
+_CODEX_TXN_PENDING_HOOKS=""
+_CODEX_TXN_STAGED_CONFIG=""
+_CODEX_TXN_STAGED_HOOKS=""
+_CODEX_TXN_REPLACEMENTS_STARTED=0
+
+_restore_codex_destination() {
+  local backup="$1" path="$2"
+  local restore_tmp="${path}.rollback.$$"
+
+  rm -f "$restore_tmp"
+  if ! cp -p "$backup" "$restore_tmp"; then
+    rm -f "$restore_tmp"
+    return 1
+  fi
+  if ! mv "$restore_tmp" "$path"; then
+    rm -f "$restore_tmp"
+    return 1
+  fi
+}
+
+_rollback_codex_destination() {
+  local path="$1" original="$2" existed="$3" installed="$4"
+
+  if (( existed == 1 )); then
+    if _destination_matches_snapshot "$path" "$original" 1; then
+      return 0
+    fi
+    if ! _destination_matches_snapshot "$path" "$installed" 1; then
+      echo "ERROR: refusing to overwrite a concurrent edit at $path during rollback" >&2
+      return 1
+    fi
+    _restore_codex_destination "$original" "$path"
+    return
+  fi
+
+  if [[ ! -e "$path" && ! -L "$path" ]]; then
+    return 0
+  fi
+  if ! _destination_matches_snapshot "$path" "$installed" 1; then
+    echo "ERROR: refusing to remove a concurrent file at $path during rollback" >&2
+    return 1
+  fi
+  rm -f "$path"
+}
+
+_rollback_codex_transaction() {
+  (( _CODEX_TXN_ACTIVE == 1 )) || return 0
+  local rollback_failed=0
+
+  rm -f "$_CODEX_TXN_PENDING_CONFIG" "$_CODEX_TXN_PENDING_HOOKS"
+
+  if (( _CODEX_TXN_REPLACEMENTS_STARTED == 1 )); then
+    if (( _CODEX_TXN_HOOKS_CHANGED == 1 )) &&
+       ! _rollback_codex_destination \
+         "$_CODEX_TXN_HOOKS_PATH" "$_CODEX_TXN_HOOKS_BACKUP" \
+         "$_CODEX_TXN_HOOKS_EXISTED" "$_CODEX_TXN_STAGED_HOOKS"; then
+      echo "ERROR: failed to restore $_CODEX_TXN_HOOKS_PATH" >&2
+      rollback_failed=1
+    fi
+
+    if (( _CODEX_TXN_CONFIG_CHANGED == 1 )) &&
+       ! _rollback_codex_destination \
+         "$_CODEX_TXN_CONFIG_PATH" "$_CODEX_TXN_CONFIG_BACKUP" \
+         "$_CODEX_TXN_CONFIG_EXISTED" "$_CODEX_TXN_STAGED_CONFIG"; then
+      echo "ERROR: failed to restore $_CODEX_TXN_CONFIG_PATH" >&2
+      rollback_failed=1
+    fi
+  fi
+
+  _CODEX_TXN_ACTIVE=0
+  return "$rollback_failed"
+}
+
+_cancel_codex_transaction() {
+  local rollback_failed=0
+  if ! _rollback_codex_transaction; then
+    rollback_failed=1
+  fi
+  trap - HUP INT TERM
+  return "$rollback_failed"
+}
+
+_abort_codex_transaction() {
+  local exit_code="$1"
+  trap - HUP INT TERM
+  echo "ERROR: hook installation interrupted; rolling back config and hooks" >&2
+  if ! _rollback_codex_transaction; then
+    echo "ERROR: interrupted installation could not be fully rolled back" >&2
+  fi
+  exit "$exit_code"
+}
+
+_file_mode() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null
+}
+
+_destination_matches_snapshot() {
+  local path="$1" snapshot="$2" existed="$3"
+  if (( existed == 1 )); then
+    [[ -f "$path" && ! -L "$path" ]] &&
+      cmp -s "$snapshot" "$path" &&
+      [[ "$(_file_mode "$snapshot")" == "$(_file_mode "$path")" ]]
+  else
+    [[ ! -e "$path" && ! -L "$path" ]]
+  fi
+}
+
+_commit_codex_files() {
+  local staged_config="$1" config="$2" staged_hooks="$3" hooks="$4"
+  local expected_config="$5" config_existed="$6"
+  local expected_hooks="$7" hooks_existed="$8"
+  local config_changed=1 hooks_changed=1
+  local config_backup="" hooks_backup=""
+  local pending_config="${config}.pending.$$"
+  local pending_hooks="${hooks}.pending.$$"
+
+  (( config_existed == 1 )) &&
+    cmp -s "$staged_config" "$expected_config" &&
+    config_changed=0
+  (( hooks_existed == 1 )) &&
+    cmp -s "$staged_hooks" "$expected_hooks" &&
+    hooks_changed=0
+
+  if ! _destination_matches_snapshot "$config" "$expected_config" "$config_existed" ||
+     ! _destination_matches_snapshot "$hooks" "$expected_hooks" "$hooks_existed"; then
+    echo "ERROR: Codex config changed while hooks were being rendered; refusing to overwrite it." >&2
+    return 1
+  fi
+
+  _CODEX_TXN_ACTIVE=1
+  _CODEX_TXN_CONFIG_CHANGED=$config_changed
+  _CODEX_TXN_CONFIG_EXISTED=$config_existed
+  _CODEX_TXN_CONFIG_PATH=$config
+  _CODEX_TXN_HOOKS_CHANGED=$hooks_changed
+  _CODEX_TXN_HOOKS_EXISTED=$hooks_existed
+  _CODEX_TXN_HOOKS_PATH=$hooks
+  _CODEX_TXN_PENDING_CONFIG=$pending_config
+  _CODEX_TXN_PENDING_HOOKS=$pending_hooks
+  _CODEX_TXN_STAGED_CONFIG=$staged_config
+  _CODEX_TXN_STAGED_HOOKS=$staged_hooks
+  _CODEX_TXN_REPLACEMENTS_STARTED=0
+  trap '_abort_codex_transaction 129' HUP
+  trap '_abort_codex_transaction 130' INT
+  trap '_abort_codex_transaction 143' TERM
+
+  # Copy across filesystem boundaries before touching either destination.
+  # The final moves stay within target_dir, so each individual replacement is
+  # atomic and the config can be rolled back if the hooks replacement fails.
+  if (( config_changed == 1 )) && ! cp -p "$staged_config" "$pending_config"; then
+    echo "ERROR: failed to stage $config" >&2
+    _cancel_codex_transaction
+    return 1
+  fi
+  if (( hooks_changed == 1 )) && ! cp -p "$staged_hooks" "$pending_hooks"; then
+    echo "ERROR: failed to stage $hooks" >&2
+    _cancel_codex_transaction
+    return 1
+  fi
+
+  if (( config_changed == 1 )) && [[ -f "$config" ]]; then
+    config_backup=$(backup_path "$config")
+    if ! cp -p "$config" "$config_backup" ||
+       ! cmp -s "$expected_config" "$config_backup"; then
+      echo "ERROR: $config changed before backup; refusing to overwrite it." >&2
+      _cancel_codex_transaction
+      return 1
+    fi
+  fi
+  if (( hooks_changed == 1 )) && [[ -f "$hooks" ]]; then
+    hooks_backup=$(backup_path "$hooks")
+    if ! cp -p "$hooks" "$hooks_backup" ||
+       ! cmp -s "$expected_hooks" "$hooks_backup"; then
+      echo "ERROR: $hooks changed before backup; refusing to overwrite it." >&2
+      _cancel_codex_transaction
+      return 1
+    fi
+  fi
+
+  if ! _destination_matches_snapshot "$config" "$expected_config" "$config_existed" ||
+     ! _destination_matches_snapshot "$hooks" "$expected_hooks" "$hooks_existed"; then
+    echo "ERROR: Codex config changed before replacement; refusing to overwrite it." >&2
+    _cancel_codex_transaction
+    return 1
+  fi
+
+  _CODEX_TXN_CONFIG_BACKUP=$config_backup
+  _CODEX_TXN_HOOKS_BACKUP=$hooks_backup
+  _CODEX_TXN_REPLACEMENTS_STARTED=1
+
+  if ! _destination_matches_snapshot "$config" "$expected_config" "$config_existed"; then
+    echo "ERROR: $config changed immediately before replacement; refusing to overwrite it." >&2
+    _cancel_codex_transaction
+    return 1
+  fi
+  if (( config_changed == 1 )) && ! mv "$pending_config" "$config"; then
+    echo "ERROR: failed to install $config" >&2
+    if ! _rollback_codex_transaction; then
+      echo "ERROR: failed config installation could not be fully rolled back" >&2
+    fi
+    trap - HUP INT TERM
+    rm -f "$pending_config" "$pending_hooks"
+    return 1
+  fi
+
+  if ! _destination_matches_snapshot "$hooks" "$expected_hooks" "$hooks_existed"; then
+    echo "ERROR: $hooks changed immediately before replacement; rolling back config." >&2
+    _cancel_codex_transaction
+    return 1
+  fi
+  if (( hooks_changed == 1 )) && ! mv "$pending_hooks" "$hooks"; then
+    echo "ERROR: failed to install $hooks; rolling back config and hooks" >&2
+    if ! _rollback_codex_transaction; then
+      echo "ERROR: failed hooks installation could not be fully rolled back" >&2
+    fi
+    trap - HUP INT TERM
+    rm -f "$pending_config" "$pending_hooks"
+    return 1
+  fi
+
+  _CODEX_TXN_ACTIVE=0
+  trap - HUP INT TERM
+  rm -f "$pending_config" "$pending_hooks"
+
+  if (( config_changed == 1 )); then
+    if [[ -n "$config_backup" ]]; then
+      echo "Updated: $config (backup at $config_backup)" >&2
+    else
+      echo "Created: $config" >&2
+    fi
+  else
+    echo "Note: Codex feature config already current in $config" >&2
+  fi
+
+  if (( hooks_changed == 1 )); then
+    if [[ -n "$hooks_backup" ]]; then
+      echo "Updated: $hooks (backup at $hooks_backup)" >&2
+    else
+      echo "Created: $hooks" >&2
+    fi
+  else
+    echo "Note: Codex hooks already current in $hooks" >&2
+  fi
+}
+
+_require_regular_destination "$config_toml" || exit 1
+_require_regular_destination "$target" || exit 1
+
+staged_config=$(mktemp)
+staged_hooks=$(mktemp)
+original_config=$(mktemp)
+original_hooks=$(mktemp)
+rm -f "$original_config" "$original_hooks"
+trap 'rm -f "$staged_config" "$staged_hooks" "$original_config" "$original_hooks"' EXIT
+
+config_existed=0
+hooks_existed=0
+if [[ -f "$config_toml" ]]; then
+  cp -p "$config_toml" "$original_config"
+  config_existed=1
+fi
+if [[ -f "$target" ]]; then
+  cp -p "$target" "$original_hooks"
+  cp -p "$original_hooks" "$staged_hooks"
+  hooks_existed=1
+fi
+
+_stage_codex_config "$original_config" "$staged_config" "$config_toml" || exit 1
+render_codex_hooks "$TEMPLATE" "$staged_hooks" || exit 1
+_commit_codex_files \
+  "$staged_config" "$config_toml" "$staged_hooks" "$target" \
+  "$original_config" "$config_existed" "$original_hooks" "$hooks_existed" ||
+  exit 1
+
+rm -f "$staged_config" "$staged_hooks" "$original_config" "$original_hooks"
+trap - EXIT
 
 if (( INSTALL_GIT_HOOK == 1 )); then
   install_per_worktree_pre_push
@@ -145,11 +612,9 @@ ensure_dispatcher_scripts_executable
 
 cat <<'EOF' >&2
 
-NOTE: Codex CLI hook support is experimental upstream. Tool-name
-matchers (Bash, Write, Edit) are modeled on Claude Code but not
-officially documented. Run a no-op test (e.g., a benign shell command
-that triggers the push-to-main hook by mistake) to verify hooks fire
-before relying on them.
+NOTE: Codex project hooks run only after the project and current hook
+definitions are trusted. Review them with /hooks. For vetted unattended
+automation, Codex also provides --dangerously-bypass-hook-trust.
 
 EOF
 echo "Done. Project-scoped Codex hooks installed at $target." >&2

--- a/skills/autonomous-common/scripts/install-codex-hooks.sh
+++ b/skills/autonomous-common/scripts/install-codex-hooks.sh
@@ -55,9 +55,12 @@ if [[ ! -f "$TEMPLATE" ]]; then
   exit 1
 fi
 
-target_dir="$(project_root)/.codex"
+project_dir="$(project_root)"
+target_dir="$project_dir/.codex"
 target="$target_dir/hooks.json"
 config_toml="$target_dir/config.toml"
+target_display="$target"
+config_display="$config_toml"
 
 if [[ -L "$target_dir" ]]; then
   echo "ERROR: refusing to install through symbolic-link directory: $target_dir" >&2
@@ -67,7 +70,10 @@ if [[ -e "$target_dir" && ! -d "$target_dir" ]]; then
   echo "ERROR: Codex config path exists but is not a directory: $target_dir" >&2
   exit 1
 fi
-mkdir -p "$target_dir"
+if [[ ! -d "$target_dir" ]] && ! (umask 077; mkdir -p "$target_dir"); then
+  echo "ERROR: could not create private Codex config directory: $target_dir" >&2
+  exit 1
+fi
 
 _require_regular_destination() {
   local path="$1"
@@ -142,11 +148,6 @@ _require_mutable_feature_table() {
     echo "ERROR: $display_file uses multiline TOML strings; automatic [features] edits are disabled." >&2
     return 1
   fi
-  if grep -qE "^[[:space:]]*\\[\\[?[^]]*['\"]" "$file"; then
-    echo "ERROR: $display_file uses quoted TOML table headers; automatic [features] edits are disabled." >&2
-    return 1
-  fi
-
   header_count=$(_canonical_line_count "$file" "header")
   if (( header_count != 1 )); then
     echo "ERROR: $display_file does not use one canonical [features] table." >&2
@@ -177,24 +178,27 @@ _rewrite_staged_config() {
     }
     {
       raw = $0
-      comparable = raw
-      sub(/[[:space:]]*#.*/, "", comparable)
-      comparable = trim(comparable)
 
-      if (comparable ~ /^\[\[.*\]\]$/) {
+      # Recognize table headers before removing comments: a quoted table
+      # component may itself contain "#".
+      header = trim(raw)
+      if (header ~ /^\[\[.*\]\][[:space:]]*(#.*)?$/) {
         section = "other"
         print raw
         next
       }
-
-      if (comparable ~ /^\[[^]]+\]$/) {
-        section = (comparable ~ /^\[[[:space:]]*features[[:space:]]*\]$/) ? "features" : "other"
+      if (header ~ /^\[.*\][[:space:]]*(#.*)?$/) {
+        section = (header ~ /^\[[[:space:]]*features[[:space:]]*\][[:space:]]*(#.*)?$/) ? "features" : "other"
         print raw
         if (section == "features" && action == "insert") {
           print "hooks = true  # added by install-codex-hooks.sh"
         }
         next
       }
+
+      comparable = raw
+      sub(/[[:space:]]*#.*/, "", comparable)
+      comparable = trim(comparable)
 
       if (section == "features" &&
           comparable ~ /^codex_hooks[[:space:]]*=/) {
@@ -281,7 +285,16 @@ EOF
     _rewrite_staged_config "$staged" "append"
   fi
 
-  _analyze_codex_config "$staged" >/dev/null
+  local staged_analysis
+  if ! staged_analysis=$(_analyze_codex_config "$staged" "$display_file") ||
+     ! jq -e '
+       .features_present == true
+       and .hooks == true
+       and .codex_hooks == null
+     ' <<<"$staged_analysis" >/dev/null; then
+    echo "ERROR: could not safely canonicalize [features].hooks in $display_file" >&2
+    return 1
+  fi
 }
 
 render_codex_hooks() {
@@ -322,77 +335,197 @@ _CODEX_TXN_ACTIVE=0
 _CODEX_TXN_CONFIG_CHANGED=0
 _CODEX_TXN_CONFIG_EXISTED=0
 _CODEX_TXN_CONFIG_BACKUP=""
+_CODEX_TXN_CONFIG_CAPTURED=0
+_CODEX_TXN_CONFIG_ORIGINAL=""
 _CODEX_TXN_CONFIG_PATH=""
 _CODEX_TXN_HOOKS_CHANGED=0
 _CODEX_TXN_HOOKS_EXISTED=0
 _CODEX_TXN_HOOKS_BACKUP=""
+_CODEX_TXN_HOOKS_CAPTURED=0
+_CODEX_TXN_HOOKS_ORIGINAL=""
 _CODEX_TXN_HOOKS_PATH=""
 _CODEX_TXN_PENDING_CONFIG=""
 _CODEX_TXN_PENDING_HOOKS=""
 _CODEX_TXN_STAGED_CONFIG=""
 _CODEX_TXN_STAGED_HOOKS=""
 _CODEX_TXN_REPLACEMENTS_STARTED=0
+_CODEX_TARGET_DIR_ID=""
+_CODEX_TARGET_DIR_PATH=""
+
+_place_codex_path_no_clobber() {
+  local source="$1" destination="$2"
+
+  # link(2) and symlink(2) address the exact destination and fail if any path
+  # already exists there. Unlike `mv -n`, they never reinterpret a concurrent
+  # directory as a container for the source.
+  CODEX_ATOMIC_PLACE=1 python3 - "$source" "$destination" <<'PY'
+import os
+import stat
+import sys
+
+source, destination = sys.argv[1:]
+try:
+    mode = os.lstat(source).st_mode
+    if stat.S_ISREG(mode):
+        os.link(source, destination, follow_symlinks=False)
+    elif stat.S_ISLNK(mode):
+        os.symlink(os.readlink(source), destination)
+    else:
+        raise OSError("unsupported source type")
+    os.unlink(source)
+except OSError:
+    raise SystemExit(1)
+PY
+}
+
+_capture_codex_destination() {
+  local path="$1" backup="$2" expected="$3" captured_var="$4"
+  local source_identity
+
+  source_identity=$(_file_identity "$path") || return 1
+  if _place_codex_path_no_clobber "$path" "$backup"; then
+    :
+  else
+    # The helper status is intentionally reconciled from inode postconditions.
+    :
+  fi
+
+  # Reconcile ambiguous helper failures from signals after link/unlink. The
+  # backup is ours only when it has the inode observed at the source path.
+  if ! _path_has_identity "$backup" "$source_identity"; then
+    return 1
+  fi
+  printf -v "$captured_var" '%s' 1
+
+  if ! _destination_matches_snapshot "$backup" "$expected" 1; then
+    return 1
+  fi
+  if _path_has_identity "$path" "$source_identity"; then
+    # link(2) completed but unlink(2) did not. Keep both names and abort; the
+    # rollback path sees the original still active and leaves it untouched.
+    return 1
+  fi
+
+  # A nonzero helper status is safe to accept once the complete postcondition
+  # proves that the original inode is captured and no longer active.
+  return 0
+}
 
 _restore_codex_destination() {
   local backup="$1" path="$2"
-  local restore_tmp="${path}.rollback.$$"
+  local restore_tmp
 
-  rm -f "$restore_tmp"
+  if ! restore_tmp=$(mktemp "${path}.rollback.XXXXXX"); then
+    return 1
+  fi
+
   if ! cp -p "$backup" "$restore_tmp"; then
     rm -f "$restore_tmp"
     return 1
   fi
-  if ! mv "$restore_tmp" "$path"; then
+  if ! _place_codex_path_no_clobber "$restore_tmp" "$path"; then
     rm -f "$restore_tmp"
     return 1
   fi
 }
 
+_remove_codex_destination_if_installed() {
+  local path="$1" installed="$2"
+  local captured path_identity place_rc=0 captured_by_us=0
+
+  if ! captured=$(mktemp "${path}.rollback-current.XXXXXX"); then
+    return 1
+  fi
+  rm -f "$captured"
+
+  if ! _destination_matches_snapshot "$path" "$installed" 1; then
+    return 1
+  fi
+  path_identity=$(_file_identity "$path") || return 1
+  _place_codex_path_no_clobber "$path" "$captured" || place_rc=$?
+
+  if (( place_rc == 0 )) ||
+     _path_has_identity "$captured" "$path_identity"; then
+    captured_by_us=1
+  fi
+  (( captured_by_us == 1 )) || return 1
+
+  if _path_has_identity "$path" "$path_identity"; then
+    return 1
+  fi
+  if _destination_matches_snapshot "$captured" "$installed" 1; then
+    rm -f "$captured"
+    return 0
+  fi
+
+  if ! _place_codex_path_no_clobber "$captured" "$path"; then
+    echo "ERROR: could not restore concurrent content at $path" >&2
+  fi
+  return 1
+}
+
 _rollback_codex_destination() {
   local path="$1" original="$2" existed="$3" installed="$4"
+  local backup="$5" captured="$6"
 
   if (( existed == 1 )); then
     if _destination_matches_snapshot "$path" "$original" 1; then
       return 0
     fi
-    if ! _destination_matches_snapshot "$path" "$installed" 1; then
+    # A signal can run the trap after atomic capture completes but before the
+    # shell records its flag. Reconcile that ambiguous state from the backup.
+    if (( captured == 0 )) && [[ -n "$backup" ]] &&
+       _destination_matches_snapshot "$backup" "$original" 1; then
+      captured=1
+    fi
+    if (( captured == 0 )); then
       echo "ERROR: refusing to overwrite a concurrent edit at $path during rollback" >&2
       return 1
     fi
-    _restore_codex_destination "$original" "$path"
+
+    if [[ -e "$path" || -L "$path" ]] &&
+       ! _remove_codex_destination_if_installed "$path" "$installed"; then
+      echo "ERROR: refusing to overwrite a concurrent edit at $path during rollback" >&2
+      return 1
+    fi
+    _restore_codex_destination "$backup" "$path"
     return
   fi
 
   if [[ ! -e "$path" && ! -L "$path" ]]; then
     return 0
   fi
-  if ! _destination_matches_snapshot "$path" "$installed" 1; then
+  if ! _remove_codex_destination_if_installed "$path" "$installed"; then
     echo "ERROR: refusing to remove a concurrent file at $path during rollback" >&2
     return 1
   fi
-  rm -f "$path"
 }
 
 _rollback_codex_transaction() {
   (( _CODEX_TXN_ACTIVE == 1 )) || return 0
   local rollback_failed=0
+  trap '' HUP INT TERM
 
   rm -f "$_CODEX_TXN_PENDING_CONFIG" "$_CODEX_TXN_PENDING_HOOKS"
 
   if (( _CODEX_TXN_REPLACEMENTS_STARTED == 1 )); then
-    if (( _CODEX_TXN_HOOKS_CHANGED == 1 )) &&
+    # Reverse installation order: disable/restore config before replacing the
+    # hook definitions it selects.
+    if (( _CODEX_TXN_CONFIG_CHANGED == 1 )) &&
        ! _rollback_codex_destination \
-         "$_CODEX_TXN_HOOKS_PATH" "$_CODEX_TXN_HOOKS_BACKUP" \
-         "$_CODEX_TXN_HOOKS_EXISTED" "$_CODEX_TXN_STAGED_HOOKS"; then
-      echo "ERROR: failed to restore $_CODEX_TXN_HOOKS_PATH" >&2
+         "$_CODEX_TXN_CONFIG_PATH" "$_CODEX_TXN_CONFIG_ORIGINAL" \
+         "$_CODEX_TXN_CONFIG_EXISTED" "$_CODEX_TXN_STAGED_CONFIG" \
+         "$_CODEX_TXN_CONFIG_BACKUP" "$_CODEX_TXN_CONFIG_CAPTURED"; then
+      echo "ERROR: failed to restore $_CODEX_TXN_CONFIG_PATH" >&2
       rollback_failed=1
     fi
 
-    if (( _CODEX_TXN_CONFIG_CHANGED == 1 )) &&
+    if (( _CODEX_TXN_HOOKS_CHANGED == 1 )) &&
        ! _rollback_codex_destination \
-         "$_CODEX_TXN_CONFIG_PATH" "$_CODEX_TXN_CONFIG_BACKUP" \
-         "$_CODEX_TXN_CONFIG_EXISTED" "$_CODEX_TXN_STAGED_CONFIG"; then
-      echo "ERROR: failed to restore $_CODEX_TXN_CONFIG_PATH" >&2
+         "$_CODEX_TXN_HOOKS_PATH" "$_CODEX_TXN_HOOKS_ORIGINAL" \
+         "$_CODEX_TXN_HOOKS_EXISTED" "$_CODEX_TXN_STAGED_HOOKS" \
+         "$_CODEX_TXN_HOOKS_BACKUP" "$_CODEX_TXN_HOOKS_CAPTURED"; then
+      echo "ERROR: failed to restore $_CODEX_TXN_HOOKS_PATH" >&2
       rollback_failed=1
     fi
   fi
@@ -403,6 +536,7 @@ _rollback_codex_transaction() {
 
 _cancel_codex_transaction() {
   local rollback_failed=0
+  trap '' HUP INT TERM
   if ! _rollback_codex_transaction; then
     rollback_failed=1
   fi
@@ -412,7 +546,7 @@ _cancel_codex_transaction() {
 
 _abort_codex_transaction() {
   local exit_code="$1"
-  trap - HUP INT TERM
+  trap '' HUP INT TERM
   echo "ERROR: hook installation interrupted; rolling back config and hooks" >&2
   if ! _rollback_codex_transaction; then
     echo "ERROR: interrupted installation could not be fully rolled back" >&2
@@ -422,6 +556,23 @@ _abort_codex_transaction() {
 
 _file_mode() {
   stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null
+}
+
+_file_identity() {
+  stat -c '%d:%i' "$1" 2>/dev/null || stat -f '%d:%i' "$1" 2>/dev/null
+}
+
+_path_has_identity() {
+  local path="$1" identity="$2" actual
+  [[ -e "$path" || -L "$path" ]] || return 1
+  actual=$(_file_identity "$path") || return 1
+  [[ "$actual" == "$identity" ]]
+}
+
+_codex_target_dir_is_current() {
+  [[ -n "$_CODEX_TARGET_DIR_PATH" && -n "$_CODEX_TARGET_DIR_ID" ]] &&
+    [[ ! -L "$_CODEX_TARGET_DIR_PATH" ]] &&
+    _path_has_identity "$_CODEX_TARGET_DIR_PATH" "$_CODEX_TARGET_DIR_ID"
 }
 
 _destination_matches_snapshot() {
@@ -441,8 +592,7 @@ _commit_codex_files() {
   local expected_hooks="$7" hooks_existed="$8"
   local config_changed=1 hooks_changed=1
   local config_backup="" hooks_backup=""
-  local pending_config="${config}.pending.$$"
-  local pending_hooks="${hooks}.pending.$$"
+  local pending_config="" pending_hooks=""
 
   (( config_existed == 1 )) &&
     cmp -s "$staged_config" "$expected_config" &&
@@ -451,7 +601,8 @@ _commit_codex_files() {
     cmp -s "$staged_hooks" "$expected_hooks" &&
     hooks_changed=0
 
-  if ! _destination_matches_snapshot "$config" "$expected_config" "$config_existed" ||
+  if ! _codex_target_dir_is_current ||
+     ! _destination_matches_snapshot "$config" "$expected_config" "$config_existed" ||
      ! _destination_matches_snapshot "$hooks" "$expected_hooks" "$hooks_existed"; then
     echo "ERROR: Codex config changed while hooks were being rendered; refusing to overwrite it." >&2
     return 1
@@ -460,9 +611,13 @@ _commit_codex_files() {
   _CODEX_TXN_ACTIVE=1
   _CODEX_TXN_CONFIG_CHANGED=$config_changed
   _CODEX_TXN_CONFIG_EXISTED=$config_existed
+  _CODEX_TXN_CONFIG_CAPTURED=0
+  _CODEX_TXN_CONFIG_ORIGINAL=$expected_config
   _CODEX_TXN_CONFIG_PATH=$config
   _CODEX_TXN_HOOKS_CHANGED=$hooks_changed
   _CODEX_TXN_HOOKS_EXISTED=$hooks_existed
+  _CODEX_TXN_HOOKS_CAPTURED=0
+  _CODEX_TXN_HOOKS_ORIGINAL=$expected_hooks
   _CODEX_TXN_HOOKS_PATH=$hooks
   _CODEX_TXN_PENDING_CONFIG=$pending_config
   _CODEX_TXN_PENDING_HOOKS=$pending_hooks
@@ -474,81 +629,132 @@ _commit_codex_files() {
   trap '_abort_codex_transaction 143' TERM
 
   # Copy across filesystem boundaries before touching either destination.
-  # The final moves stay within target_dir, so each individual replacement is
-  # atomic and the config can be rolled back if the hooks replacement fails.
-  if (( config_changed == 1 )) && ! cp -p "$staged_config" "$pending_config"; then
-    echo "ERROR: failed to stage $config" >&2
-    _cancel_codex_transaction
-    return 1
-  fi
-  if (( hooks_changed == 1 )) && ! cp -p "$staged_hooks" "$pending_hooks"; then
-    echo "ERROR: failed to stage $hooks" >&2
-    _cancel_codex_transaction
-    return 1
-  fi
-
-  if (( config_changed == 1 )) && [[ -f "$config" ]]; then
-    config_backup=$(backup_path "$config")
-    if ! cp -p "$config" "$config_backup" ||
-       ! cmp -s "$expected_config" "$config_backup"; then
-      echo "ERROR: $config changed before backup; refusing to overwrite it." >&2
+  # The final hard-link placements stay within target_dir, so each individual
+  # replacement is atomic. mktemp prevents pre-planted scratch symlinks.
+  if (( config_changed == 1 )); then
+    if ! pending_config=$(mktemp "${config}.pending.XXXXXX"); then
+      echo "ERROR: failed to stage $config" >&2
       _cancel_codex_transaction
       return 1
     fi
+    _CODEX_TXN_PENDING_CONFIG=$pending_config
+    if ! cp -p "$staged_config" "$pending_config"; then
+      echo "ERROR: failed to stage $config" >&2
+      _cancel_codex_transaction
+      return 1
+    fi
+  fi
+  if (( hooks_changed == 1 )); then
+    if ! pending_hooks=$(mktemp "${hooks}.pending.XXXXXX"); then
+      echo "ERROR: failed to stage $hooks" >&2
+      _cancel_codex_transaction
+      return 1
+    fi
+    _CODEX_TXN_PENDING_HOOKS=$pending_hooks
+    if ! cp -p "$staged_hooks" "$pending_hooks"; then
+      echo "ERROR: failed to stage $hooks" >&2
+      _cancel_codex_transaction
+      return 1
+    fi
+  fi
+
+  if (( config_changed == 1 )) && [[ -f "$config" ]]; then
+    if ! config_backup=$(mktemp "${config}.bak.$(date +%s).XXXXXX"); then
+      echo "ERROR: failed to allocate backup for $config" >&2
+      _cancel_codex_transaction
+      return 1
+    fi
+    rm -f "$config_backup"
+    _CODEX_TXN_CONFIG_BACKUP=$config_backup
   fi
   if (( hooks_changed == 1 )) && [[ -f "$hooks" ]]; then
-    hooks_backup=$(backup_path "$hooks")
-    if ! cp -p "$hooks" "$hooks_backup" ||
-       ! cmp -s "$expected_hooks" "$hooks_backup"; then
-      echo "ERROR: $hooks changed before backup; refusing to overwrite it." >&2
+    if ! hooks_backup=$(mktemp "${hooks}.bak.$(date +%s).XXXXXX"); then
+      echo "ERROR: failed to allocate backup for $hooks" >&2
       _cancel_codex_transaction
       return 1
     fi
+    rm -f "$hooks_backup"
+    _CODEX_TXN_HOOKS_BACKUP=$hooks_backup
   fi
 
-  if ! _destination_matches_snapshot "$config" "$expected_config" "$config_existed" ||
+  if ! _codex_target_dir_is_current ||
+     ! _destination_matches_snapshot "$config" "$expected_config" "$config_existed" ||
      ! _destination_matches_snapshot "$hooks" "$expected_hooks" "$hooks_existed"; then
     echo "ERROR: Codex config changed before replacement; refusing to overwrite it." >&2
     _cancel_codex_transaction
     return 1
   fi
 
-  _CODEX_TXN_CONFIG_BACKUP=$config_backup
-  _CODEX_TXN_HOOKS_BACKUP=$hooks_backup
   _CODEX_TXN_REPLACEMENTS_STARTED=1
 
-  if ! _destination_matches_snapshot "$config" "$expected_config" "$config_existed"; then
-    echo "ERROR: $config changed immediately before replacement; refusing to overwrite it." >&2
-    _cancel_codex_transaction
-    return 1
-  fi
-  if (( config_changed == 1 )) && ! mv "$pending_config" "$config"; then
-    echo "ERROR: failed to install $config" >&2
-    if ! _rollback_codex_transaction; then
-      echo "ERROR: failed config installation could not be fully rolled back" >&2
-    fi
-    trap - HUP INT TERM
-    rm -f "$pending_config" "$pending_hooks"
-    return 1
-  fi
-
+  # Install definitions before enabling them. An uncatchable process death
+  # between the two placements can leave new hooks disabled, never stale hooks
+  # newly enabled.
   if ! _destination_matches_snapshot "$hooks" "$expected_hooks" "$hooks_existed"; then
-    echo "ERROR: $hooks changed immediately before replacement; rolling back config." >&2
+    echo "ERROR: $hooks changed immediately before replacement; refusing to overwrite it." >&2
     _cancel_codex_transaction
     return 1
   fi
-  if (( hooks_changed == 1 )) && ! mv "$pending_hooks" "$hooks"; then
-    echo "ERROR: failed to install $hooks; rolling back config and hooks" >&2
-    if ! _rollback_codex_transaction; then
-      echo "ERROR: failed hooks installation could not be fully rolled back" >&2
+  if (( hooks_changed == 1 )); then
+    if (( hooks_existed == 1 )); then
+      if ! _capture_codex_destination \
+        "$hooks" "$hooks_backup" "$expected_hooks" \
+        _CODEX_TXN_HOOKS_CAPTURED; then
+        echo "ERROR: $hooks changed during atomic capture; refusing to overwrite it." >&2
+        if ! _rollback_codex_transaction; then
+          echo "ERROR: failed hooks capture could not be fully rolled back" >&2
+        fi
+        trap - HUP INT TERM
+        return 1
+      fi
     fi
-    trap - HUP INT TERM
-    rm -f "$pending_config" "$pending_hooks"
-    return 1
+    if ! _place_codex_path_no_clobber "$pending_hooks" "$hooks"; then
+      echo "ERROR: failed to install $hooks without overwriting concurrent content" >&2
+      if ! _rollback_codex_transaction; then
+        echo "ERROR: failed hooks installation could not be fully rolled back" >&2
+      fi
+      trap - HUP INT TERM
+      rm -f "$pending_config" "$pending_hooks"
+      return 1
+    fi
   fi
 
-  _CODEX_TXN_ACTIVE=0
+  if ! _destination_matches_snapshot "$config" "$expected_config" "$config_existed"; then
+    echo "ERROR: $config changed immediately before replacement; rolling back hooks." >&2
+    _cancel_codex_transaction
+    return 1
+  fi
+  if (( config_changed == 1 )); then
+    if (( config_existed == 1 )); then
+      if ! _capture_codex_destination \
+        "$config" "$config_backup" "$expected_config" \
+        _CODEX_TXN_CONFIG_CAPTURED; then
+        echo "ERROR: $config changed during atomic capture; rolling back hooks." >&2
+        if ! _rollback_codex_transaction; then
+          echo "ERROR: failed config capture could not be fully rolled back" >&2
+        fi
+        trap - HUP INT TERM
+        return 1
+      fi
+    fi
+    if ! _place_codex_path_no_clobber "$pending_config" "$config"; then
+      echo "ERROR: failed to install $config without overwriting concurrent content" >&2
+      if ! _rollback_codex_transaction; then
+        echo "ERROR: failed config installation could not be fully rolled back" >&2
+      fi
+      trap - HUP INT TERM
+      rm -f "$pending_config" "$pending_hooks"
+      return 1
+    fi
+  fi
+
+  if ! _codex_target_dir_is_current; then
+    echo "ERROR: Codex config directory changed during installation; rolling back." >&2
+    _cancel_codex_transaction
+    return 1
+  fi
   trap - HUP INT TERM
+  _CODEX_TXN_ACTIVE=0
   rm -f "$pending_config" "$pending_hooks"
 
   if (( config_changed == 1 )); then
@@ -572,6 +778,22 @@ _commit_codex_files() {
   fi
 }
 
+if ! cd -P "$target_dir"; then
+  echo "ERROR: could not enter Codex config directory: $target_dir" >&2
+  exit 1
+fi
+_CODEX_TARGET_DIR_PATH=$target_dir
+_CODEX_TARGET_DIR_ID=$(_file_identity .) || {
+  echo "ERROR: could not identify Codex config directory: $target_dir" >&2
+  exit 1
+}
+target="hooks.json"
+config_toml="config.toml"
+
+_codex_target_dir_is_current || {
+  echo "ERROR: Codex config directory changed before installation: $target_dir" >&2
+  exit 1
+}
 _require_regular_destination "$config_toml" || exit 1
 _require_regular_destination "$target" || exit 1
 
@@ -594,7 +816,7 @@ if [[ -f "$target" ]]; then
   hooks_existed=1
 fi
 
-_stage_codex_config "$original_config" "$staged_config" "$config_toml" || exit 1
+_stage_codex_config "$original_config" "$staged_config" "$config_display" || exit 1
 render_codex_hooks "$TEMPLATE" "$staged_hooks" || exit 1
 _commit_codex_files \
   "$staged_config" "$config_toml" "$staged_hooks" "$target" \
@@ -603,6 +825,8 @@ _commit_codex_files \
 
 rm -f "$staged_config" "$staged_hooks" "$original_config" "$original_hooks"
 trap - EXIT
+
+cd "$project_dir"
 
 if (( INSTALL_GIT_HOOK == 1 )); then
   install_per_worktree_pre_push
@@ -617,4 +841,4 @@ definitions are trusted. Review them with /hooks. For vetted unattended
 automation, Codex also provides --dangerously-bypass-hook-trust.
 
 EOF
-echo "Done. Project-scoped Codex hooks installed at $target." >&2
+echo "Done. Project-scoped Codex hooks installed at $target_display." >&2

--- a/skills/autonomous-common/scripts/lib-installer-translate.sh
+++ b/skills/autonomous-common/scripts/lib-installer-translate.sh
@@ -121,6 +121,17 @@ translate_template_hooks() {
   #      otherwise produce duplicate matcher entries that fire the same
   #      check twice (PR-11b code review C2).
   jq --argjson event_map "$event_remap" --argjson tool_map "$tool_remap" '
+    def stable_unique_by(f):
+      reduce .[] as $item (
+        {seen: {}, items: []};
+        ($item | f | tojson) as $key
+        | if (.seen | has($key))
+          then .
+          else .seen[$key] = true | .items += [$item]
+          end
+      )
+      | .items;
+
     .hooks
     | with_entries(
         .key |= ($event_map[.] // .)
@@ -147,7 +158,7 @@ translate_template_hooks() {
                     (if $entry | has("matcher") then .matcher = $entry.matcher else . end)
                     | .hooks += $entry.hooks
                   )
-                  | .hooks |= unique_by(
+                  | .hooks |= stable_unique_by(
                       [.type, .command, .timeout, .timeout_ms, .max_output_size]
                     )
                 )
@@ -222,6 +233,17 @@ fold_matcher_into_event() {
   local fold_array="[${fold_array_items%, }]"
 
   jq --argjson fold_map "$fold_array" '
+    def stable_unique_by(f):
+      reduce .[] as $item (
+        {seen: {}, items: []};
+        ($item | f | tojson) as $key
+        | if (.seen | has($key))
+          then .
+          else .seen[$key] = true | .items += [$item]
+          end
+      )
+      | .items;
+
     .hooks
     | to_entries
     | map(
@@ -252,7 +274,7 @@ fold_matcher_into_event() {
         key: .[0].__target,
         value: (
           map(del(.__target))
-          | unique_by(
+          | stable_unique_by(
               [.type, .command, .timeout, .timeout_ms, .max_output_size]
             )
         )

--- a/skills/autonomous-common/scripts/lib-installer-translate.sh
+++ b/skills/autonomous-common/scripts/lib-installer-translate.sh
@@ -147,6 +147,9 @@ translate_template_hooks() {
                     (if $entry | has("matcher") then .matcher = $entry.matcher else . end)
                     | .hooks += $entry.hooks
                   )
+                  | .hooks |= unique_by(
+                      [.type, .command, .timeout, .timeout_ms, .max_output_size]
+                    )
                 )
             )
       )
@@ -245,7 +248,15 @@ fold_matcher_into_event() {
     | flatten
     | map(select(.__target != null))
     | group_by(.__target)
-    | map({key: .[0].__target, value: map(del(.__target))})
+    | map({
+        key: .[0].__target,
+        value: (
+          map(del(.__target))
+          | unique_by(
+              [.type, .command, .timeout, .timeout_ms, .max_output_size]
+            )
+        )
+      })
     | from_entries
   ' "$template"
 }

--- a/skills/autonomous-dev/SKILL.md
+++ b/skills/autonomous-dev/SKILL.md
@@ -102,7 +102,7 @@ Triggered when running inside the `scripts/autonomous-dev.sh` wrapper. The workf
 
 ## Cross-Platform Notes
 
-This skill works across IDEs that support skills.sh. Map generic verbs in this doc to your IDE's tools (Claude Code's Bash → terminal in Cursor, etc.). Hook-based enforcement is available on Claude Code and Kiro CLI; on Cursor / Windsurf, follow each step manually — the discipline is the same.
+This skill works across IDEs that support skills.sh. Map generic verbs in this doc to your IDE's tools (Claude Code's Bash → terminal in Cursor, etc.). Hook-based enforcement is available on Claude Code, Codex CLI, and Kiro CLI; on clients without installed hooks, follow each step manually — the discipline is the same.
 
 For the full IDE table + verb-to-tool map, see [`references/cross-platform.md`](references/cross-platform.md).
 
@@ -250,7 +250,10 @@ Run your project's build/test suite as **one synchronous command with a generous
 
 ## Step 6: Code Simplification
 
-1. Use a subagent if your IDE supports them (e.g., `code-simplifier:code-simplifier`), otherwise review the code manually for unnecessary complexity.
+1. Run an independent simplification pass using the strongest native option:
+   - **Codex CLI**: ask Codex to spawn a native reviewer subagent focused on unnecessary complexity, duplication, and repository conventions. Keep the subagent advisory; the main session applies any changes.
+   - **Claude Code**: use `code-simplifier:code-simplifier` when the plugin is installed.
+   - **Other clients**: use an available review subagent or perform the same review manually.
 2. Address simplification suggestions.
 3. Mark complete (if hooks are installed):
    ```bash
@@ -322,7 +325,10 @@ glab mr update {mr_number} --description "$(cat /tmp/pr_body.md)"
 
 ## Step 8: PR Review Agent (MANDATORY)
 
-1. Use a subagent if your IDE supports them (e.g., `/pr-review-toolkit:review-pr`), otherwise perform a self-review against the PR diff.
+1. Run an independent dev-side review:
+   - **Codex CLI**: use a native reviewer subagent, or run `codex review --uncommitted` before the first commit and `codex review --base <base-branch>` for the committed branch diff.
+   - **Claude Code**: use `/pr-review-toolkit:review-pr` when the plugin is installed.
+   - **Other clients**: use an available review agent or review the complete diff manually.
 2. Address findings by severity:
    - Critical/Severe: Must fix
    - High: Must fix

--- a/skills/autonomous-dev/references/cross-platform.md
+++ b/skills/autonomous-dev/references/cross-platform.md
@@ -7,6 +7,7 @@ This skill is portable across coding agents that follow the skills.sh model. The
 | IDE/CLI | Hooks support | Setup |
 |---------|--------------|-------|
 | Claude Code | Full | `hooks/README.md` (in `autonomous-common`) |
+| Codex CLI | Full | Run `install-codex-hooks.sh`; review project hooks with `/hooks` |
 | Kiro CLI | Full | `hooks/README.md` (in `autonomous-common`) |
 | Cursor | None | Follow workflow steps manually |
 | Windsurf | None | Follow workflow steps manually |
@@ -18,12 +19,12 @@ If your IDE supports hooks, install them from `autonomous-common/hooks/` for har
 
 The SKILL.md uses generic verbs. Map them to your IDE's tools:
 
-| SKILL.md says | Claude Code | Cursor | Gemini CLI |
-|---|---|---|---|
-| "Execute in your terminal" | Bash tool | terminal | shell |
-| "Read the file" | Read tool | file viewer / open | `cat` |
-| "Create or edit the file" | Write / Edit tool | editor | manual edit |
-| "Use a subagent" | Task / Agent tool | (no equivalent — do it inline) | (no equivalent) |
-| "Load the skill" | Skill tool | read the referenced SKILL.md | read the referenced SKILL.md |
+| SKILL.md says | Claude Code | Codex CLI | Cursor | Gemini CLI |
+|---|---|---|---|---|
+| "Execute in your terminal" | Bash tool | shell tool | terminal | shell |
+| "Read the file" | Read tool | shell/read tool | file viewer / open | `cat` |
+| "Create or edit the file" | Write / Edit tool | `apply_patch` | editor | manual edit |
+| "Use a subagent" | Task / Agent tool | Native subagent | (no equivalent — do it inline) | (no equivalent) |
+| "Load the skill" | Skill tool | read the referenced SKILL.md | read the referenced SKILL.md | read the referenced SKILL.md |
 
 When the SKILL.md says "use a subagent" and your IDE doesn't have one, follow the listed steps manually instead.

--- a/skills/autonomous-dispatcher/scripts/autonomous.conf.example
+++ b/skills/autonomous-dispatcher/scripts/autonomous.conf.example
@@ -331,6 +331,14 @@ AGENT_REVIEW_EXTRA_ARGS=""
 #   AGENT_DEV_MODEL="opus[1m]"
 #   AGENT_REVIEW_MODEL="Gemini 3.5 Flash (High)"  # an agy-namespace model — see agy block
 #
+# Canonical Codex-dev/Claude-review: AGENT_DEV_CMD=codex, AGENT_REVIEW_CMD=claude
+#
+#   AGENT_CMD="claude"
+#   AGENT_DEV_CMD="codex"
+#   AGENT_REVIEW_CMD="claude"
+#   AGENT_DEV_LAUNCHER=""       # do not leak a Claude bridge into Codex
+#   AGENT_REVIEW_AGENTS=""      # one wrapper-assigned Claude verdict agent
+#
 # AGENT_LAUNCHER (claude-only) is gated per-side by INV-38: each side's
 # launcher requires THAT side's CLI to be claude. The natural mixed-
 # CLI deployment (claude dev with cc + non-claude review without

--- a/skills/autonomous-dispatcher/scripts/autonomous.conf.example
+++ b/skills/autonomous-dispatcher/scripts/autonomous.conf.example
@@ -336,6 +336,7 @@ AGENT_REVIEW_EXTRA_ARGS=""
 #   AGENT_CMD="claude"
 #   AGENT_DEV_CMD="codex"
 #   AGENT_REVIEW_CMD="claude"
+#   AGENT_LAUNCHER=""           # clear a legacy shared Claude-only bridge
 #   AGENT_DEV_LAUNCHER=""       # do not leak a Claude bridge into Codex
 #   AGENT_REVIEW_AGENTS=""      # one wrapper-assigned Claude verdict agent
 #

--- a/skills/autonomous-review/SKILL.md
+++ b/skills/autonomous-review/SKILL.md
@@ -44,7 +44,7 @@ steps use Chrome DevTools MCP — ensure your IDE has this MCP server configured
 for E2E verification.
 
 ### Hooks (Optional)
-If your IDE supports hooks (Claude Code, Kiro CLI), workflow enforcement
+If your IDE supports hooks (Claude Code, Codex CLI, Kiro CLI), workflow enforcement
 hooks in `hooks/` provide automatic gate checks. Without hooks, follow
 each step manually.
 
@@ -275,6 +275,23 @@ When the project sets `AGENT_REVIEW_AGENTS` to more than one CLI, several review
 - Run the Findings -> Decision Gate **independently** — reach your own PASS/FAIL based on your own findings. Do NOT try to coordinate with or defer to the other agents; you cannot see their verdicts.
 - Post your own verdict via `bash scripts/post-verdict.sh` with your assigned agent name + session id (both are in your prompt) — never a bare `gh issue comment` ([INV-56](../../docs/pipeline/invariants.md)). The helper writes your `Review Agent: <name>` discriminator line from the argument you pass, so it is always correct; that line is how the wrapper attributes your verdict among the parallel reviewers ([INV-40](../../docs/pipeline/invariants.md)).
 - The wrapper aggregates all agents' verdicts under a **unanimous-PASS** rule: the wrapper approves+merges only if **every** available agent passed; any single FAIL makes the wrapper submit `--request-changes` and send the PR back to dev. This mirrors the gate's own "any blocking finding → FAIL" philosophy, applied across agents. As above, **no agent submits the GitHub-native action** — the wrapper does, once, after aggregating.
+
+### Internal review subagents are advisory
+
+Claude or Codex internal subagents may inspect security, tests, maintainability,
+or other review dimensions in parallel. They return evidence and findings to
+their parent; they are advisory and are not entries in
+`AGENT_REVIEW_AGENTS`.
+
+The assigned main review session alone executes the Findings -> Decision Gate
+and calls `post-verdict.sh` with the wrapper-provided agent name and session
+id. Do not delegate `post-verdict.sh` to an internal subagent. The main session
+must reconcile the advisory findings into its own single PASS/FAIL decision.
+
+Keep these three mechanisms distinct: `REVIEW_BOTS` are external code-host
+reviewers, `AGENT_REVIEW_AGENTS` are independent wrapper-managed
+verdict-reaching sessions, and internal subagents are advisory workers inside
+one such session.
 
 ---
 

--- a/skills/autonomous-review/SKILL.md
+++ b/skills/autonomous-review/SKILL.md
@@ -283,10 +283,11 @@ or other review dimensions in parallel. They return evidence and findings to
 their parent; they are advisory and are not entries in
 `AGENT_REVIEW_AGENTS`.
 
-The assigned main review session alone executes the Findings -> Decision Gate
-and calls `post-verdict.sh` with the wrapper-provided agent name and session
-id. Do not delegate `post-verdict.sh` to an internal subagent. The main session
-must reconcile the advisory findings into its own single PASS/FAIL decision.
+Within each wrapper-assigned verdict session, the parent review session alone
+executes the Findings -> Decision Gate and calls `post-verdict.sh` with the
+wrapper-provided agent name and session id. Do not delegate `post-verdict.sh`
+to an internal subagent. Each parent must reconcile the advisory findings into
+its own single PASS/FAIL decision.
 
 Keep these three mechanisms distinct: `REVIEW_BOTS` are external code-host
 reviewers, `AGENT_REVIEW_AGENTS` are independent wrapper-managed

--- a/tests/unit/fixtures/codex-pre-tool-use-apply-patch.json
+++ b/tests/unit/fixtures/codex-pre-tool-use-apply-patch.json
@@ -1,0 +1,14 @@
+{
+  "session_id": "019f644b-0931-72d0-b829-95c9bdadb19d",
+  "turn_id": "019f644b-1160-7df2-91ac-61557120ec56",
+  "transcript_path": null,
+  "cwd": "/tmp/codex-hook-capture",
+  "hook_event_name": "PreToolUse",
+  "model": "openai.gpt-5.6-sol",
+  "permission_mode": "bypassPermissions",
+  "tool_name": "apply_patch",
+  "tool_input": {
+    "command": "*** Begin Patch\n*** Add File: src/probe.ts\n+export const probe = true;\n*** End Patch\n"
+  },
+  "tool_use_id": "call_2"
+}

--- a/tests/unit/test-codex-dev-claude-review-docs.sh
+++ b/tests/unit/test-codex-dev-claude-review-docs.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Static workflow guidance regressions for issue #486.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+ok() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+require_text() {
+  local desc="$1" file="$2" pattern="$3"
+  if tr '\n' ' ' < "$file" | grep -qiE "$pattern"; then
+    ok "$desc"
+  else
+    bad "$desc"
+  fi
+}
+
+DEV_SKILL="$PROJECT_ROOT/skills/autonomous-dev/SKILL.md"
+DEV_CROSS="$PROJECT_ROOT/skills/autonomous-dev/references/cross-platform.md"
+REVIEW_SKILL="$PROJECT_ROOT/skills/autonomous-review/SKILL.md"
+AGENT_DOC="$PROJECT_ROOT/docs/agent-clis.md"
+HOOK_DOC="$PROJECT_ROOT/docs/cross-agent-hooks.md"
+SIMPLIFIER_HOOK="$PROJECT_ROOT/skills/autonomous-common/hooks/check-code-simplifier.sh"
+PR_REVIEW_HOOK="$PROJECT_ROOT/skills/autonomous-common/hooks/check-pr-review.sh"
+CONF="$PROJECT_ROOT/scripts/autonomous.conf.example"
+VENDORED_CONF="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous.conf.example"
+
+echo "=== TC-CDCR-030: Codex-native dev quality passes ==="
+require_text "dev skill names Codex native subagents" "$DEV_SKILL" \
+  'Codex.*(native )?subagent|subagent.*Codex'
+require_text "dev skill names dedicated codex review" "$DEV_SKILL" \
+  'codex review --(uncommitted|base)'
+require_text "cross-platform map lists Codex hooks as full" "$DEV_CROSS" \
+  'Codex CLI[[:space:]]*\|[[:space:]]*Full'
+require_text "simplification hook feedback offers Codex-native review" "$SIMPLIFIER_HOOK" \
+  'Codex.*(subagent|codex review --uncommitted)'
+require_text "pre-push hook feedback offers Codex-native review" "$PR_REVIEW_HOOK" \
+  'Codex.*(subagent|codex review --base)'
+
+echo "=== TC-CDCR-031/032: final-review ownership and mechanism separation ==="
+require_text "internal subagents are advisory" "$REVIEW_SKILL" \
+  'internal.*subagents?.*advisory|subagents?.*advisory'
+require_text "main review session owns decision gate" "$REVIEW_SKILL" \
+  'main review session.*Findings.*Decision Gate|assigned main.*Decision Gate'
+require_text "main review session alone calls post-verdict" "$REVIEW_SKILL" \
+  'main review session.*post-verdict\.sh|only.*main.*post-verdict\.sh'
+require_text "operator docs distinguish all three review mechanisms" "$AGENT_DOC" \
+  'REVIEW_BOTS.*AGENT_REVIEW_AGENTS.*internal subagents|internal subagents.*AGENT_REVIEW_AGENTS.*REVIEW_BOTS'
+
+echo "=== TC-CDCR-033: canonical mixed topology guidance ==="
+require_text "agent docs name Codex-dev Claude-review topology" "$AGENT_DOC" \
+  'AGENT_DEV_CMD="?codex"?.*AGENT_REVIEW_CMD="?claude"?'
+require_text "config example names Codex-dev Claude-review topology" "$CONF" \
+  'AGENT_DEV_CMD="?codex"?.*AGENT_REVIEW_CMD="?claude"?'
+require_text "hook docs use canonical features.hooks" "$HOOK_DOC" \
+  'features\][[:space:]]*hooks[[:space:]]*=[[:space:]]*true'
+require_text "hook docs describe project trust" "$HOOK_DOC" \
+  'project.*trust|trust.*project'
+require_text "hook docs state the tomllib prerequisite" "$HOOK_DOC" \
+  'Python 3\.11.*tomllib|tomllib.*Python 3\.11'
+require_text "hook docs name operation-aware normalization" "$HOOK_DOC" \
+  'parse_edit_file_operations.*operation.*path'
+if cmp -s "$CONF" "$VENDORED_CONF"; then
+  ok "root and vendored config examples remain identical"
+else
+  bad "root and vendored config examples remain identical"
+fi
+
+echo "=== Summary ==="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/unit/test-codex-dev-claude-review-docs.sh
+++ b/tests/unit/test-codex-dev-claude-review-docs.sh
@@ -25,10 +25,14 @@ DEV_CROSS="$PROJECT_ROOT/skills/autonomous-dev/references/cross-platform.md"
 REVIEW_SKILL="$PROJECT_ROOT/skills/autonomous-review/SKILL.md"
 AGENT_DOC="$PROJECT_ROOT/docs/agent-clis.md"
 HOOK_DOC="$PROJECT_ROOT/docs/cross-agent-hooks.md"
+PIPELINE_AGENT_DOC="$PROJECT_ROOT/docs/pipeline/per-side-agent-cmd.md"
+PIPELINE_REVIEW_DOC="$PROJECT_ROOT/docs/pipeline/review-agent-flow.md"
 SIMPLIFIER_HOOK="$PROJECT_ROOT/skills/autonomous-common/hooks/check-code-simplifier.sh"
 PR_REVIEW_HOOK="$PROJECT_ROOT/skills/autonomous-common/hooks/check-pr-review.sh"
 CONF="$PROJECT_ROOT/scripts/autonomous.conf.example"
 VENDORED_CONF="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts/autonomous.conf.example"
+HISTORICAL_HOOK_DESIGN="$PROJECT_ROOT/docs/designs/cross-agent-hooks.md"
+HISTORICAL_HOOK_DESIGN_C="$PROJECT_ROOT/docs/designs/cross-agent-hooks-c.md"
 
 echo "=== TC-CDCR-030: Codex-native dev quality passes ==="
 require_text "dev skill names Codex native subagents" "$DEV_SKILL" \
@@ -46,17 +50,25 @@ echo "=== TC-CDCR-031/032: final-review ownership and mechanism separation ==="
 require_text "internal subagents are advisory" "$REVIEW_SKILL" \
   'internal.*subagents?.*advisory|subagents?.*advisory'
 require_text "main review session owns decision gate" "$REVIEW_SKILL" \
-  'main review session.*Findings.*Decision Gate|assigned main.*Decision Gate'
+  'parent review session.*Findings.*Decision Gate|assigned main.*Decision Gate'
 require_text "main review session alone calls post-verdict" "$REVIEW_SKILL" \
   'main review session.*post-verdict\.sh|only.*main.*post-verdict\.sh'
 require_text "operator docs distinguish all three review mechanisms" "$AGENT_DOC" \
   'REVIEW_BOTS.*AGENT_REVIEW_AGENTS.*internal subagents|internal subagents.*AGENT_REVIEW_AGENTS.*REVIEW_BOTS'
+require_text "pipeline spec makes internal subagents advisory" "$PIPELINE_REVIEW_DOC" \
+  'internal.*subagents?.*advisory|subagents?.*advisory'
+require_text "pipeline spec reserves post-verdict for the main session" "$PIPELINE_REVIEW_DOC" \
+  'within each.*session.*parent.*post-verdict\.sh|each.*session.*parent.*post-verdict\.sh'
 
 echo "=== TC-CDCR-033: canonical mixed topology guidance ==="
 require_text "agent docs name Codex-dev Claude-review topology" "$AGENT_DOC" \
   'AGENT_DEV_CMD="?codex"?.*AGENT_REVIEW_CMD="?claude"?'
+require_text "pipeline spec names Codex-dev Claude-review topology" "$PIPELINE_AGENT_DOC" \
+  'AGENT_DEV_CMD="?codex"?.*AGENT_REVIEW_CMD="?claude"?'
 require_text "config example names Codex-dev Claude-review topology" "$CONF" \
   'AGENT_DEV_CMD="?codex"?.*AGENT_REVIEW_CMD="?claude"?'
+require_text "canonical mixed config clears the legacy shared launcher" "$CONF" \
+  'Canonical Codex-dev/Claude-review.*AGENT_LAUNCHER=""'
 require_text "hook docs use canonical features.hooks" "$HOOK_DOC" \
   'features\][[:space:]]*hooks[[:space:]]*=[[:space:]]*true'
 require_text "hook docs describe project trust" "$HOOK_DOC" \
@@ -65,6 +77,15 @@ require_text "hook docs state the tomllib prerequisite" "$HOOK_DOC" \
   'Python 3\.11.*tomllib|tomllib.*Python 3\.11'
 require_text "hook docs name operation-aware normalization" "$HOOK_DOC" \
   'parse_edit_file_operations.*operation.*path'
+if grep -qiE 'Codex CLI.*(undocumented|modeled on it)' \
+    "$HISTORICAL_HOOK_DESIGN"; then
+  bad "historical hook design no longer states stale Codex assumptions"
+else
+  ok "historical hook design no longer states stale Codex assumptions"
+fi
+require_text "historical TOML design points to the current transactional installer" \
+  "$HISTORICAL_HOOK_DESIGN_C" \
+  'Codex installer.*transactional|transactional.*Codex installer'
 if cmp -s "$CONF" "$VENDORED_CONF"; then
   ok "root and vendored config examples remain identical"
 else

--- a/tests/unit/test-hook-edit-paths.sh
+++ b/tests/unit/test-hook-edit-paths.sh
@@ -11,6 +11,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 HOOK_LIB="$PROJECT_ROOT/skills/autonomous-common/hooks/lib.sh"
 CHECK_TEST_PLAN="$PROJECT_ROOT/skills/autonomous-common/hooks/check-test-plan.sh"
 INSTALLER="$PROJECT_ROOT/skills/autonomous-common/scripts/install-codex-hooks.sh"
+CODEX_PAYLOAD_FIXTURE="$PROJECT_ROOT/tests/unit/fixtures/codex-pre-tool-use-apply-patch.json"
 source "$HOOK_LIB"
 
 TMPDIR=$(mktemp -d)
@@ -109,6 +110,13 @@ out=$(parse_edit_file_operations "$codex_payload" 2>/dev/null); rc=$?
 [[ "$rc" -eq 0 ]] && assert_eq "patch operations retain their semantics" \
   "$expected_operations" "$out" \
   || bad "patch operations retain their semantics (rc=$rc)"
+
+echo "=== TC-CDCR-022A: captured Codex PreToolUse payload ==="
+captured_codex_payload=$(cat "$CODEX_PAYLOAD_FIXTURE")
+out=$(parse_edit_file_operations "$captured_codex_payload" 2>/dev/null); rc=$?
+[[ "$rc" -eq 0 ]] && assert_eq "captured Codex payload emits its added file" \
+  $'add\tsrc/probe.ts' "$out" \
+  || bad "captured Codex payload emits its added file (rc=$rc)"
 
 echo "=== TC-CDCR-024/025: malformed recognized edits and unknown tools ==="
 malformed='{"tool_name":"apply_patch","tool_input":{"command":"*** Begin Patch\n*** End Patch"}}'
@@ -220,13 +228,12 @@ else
 fi
 
 malformed_file_payload='{"tool_name":"Write","tool_input":{"file_path":42}}'
-(cd "$repo" && CLAUDE_PROJECT_DIR="$repo" bash "$CHECK_TEST_PLAN" \
-  <<<"$malformed_file_payload" >/dev/null 2>&1)
-rc=$?
-if [[ "$rc" -eq 2 ]]; then
-  ok "malformed file path makes the hook exit exactly 2"
+policy_out=$(cd "$repo" && CLAUDE_PROJECT_DIR="$repo" bash "$CHECK_TEST_PLAN" \
+  <<<"$malformed_file_payload" 2>&1); rc=$?
+if [[ "$rc" -eq 0 && "$policy_out" == *"could not inspect this edit payload"* ]]; then
+  ok "malformed file path warns without blocking the edit"
 else
-  bad "malformed file path makes the hook exit exactly 2 (rc=$rc)"
+  bad "malformed file path warns without blocking the edit (rc=$rc)"
 fi
 
 pure_move_payload=$(jq -n --arg command '*** Begin Patch
@@ -245,13 +252,12 @@ else
   bad "pure move does not trigger a new-file reminder (rc=$rc)"
 fi
 
-(cd "$repo" && CLAUDE_PROJECT_DIR="$repo" bash "$CHECK_TEST_PLAN" \
-  <<<"$missing_boundary" >/dev/null 2>&1)
-rc=$?
-if [[ "$rc" -eq 2 ]]; then
-  ok "malformed direct hook invocation exits exactly 2"
+policy_out=$(cd "$repo" && CLAUDE_PROJECT_DIR="$repo" bash "$CHECK_TEST_PLAN" \
+  <<<"$missing_boundary" 2>&1); rc=$?
+if [[ "$rc" -eq 0 && "$policy_out" == *"could not inspect this edit payload"* ]]; then
+  ok "malformed direct hook invocation warns without blocking"
 else
-  bad "malformed direct hook invocation exits exactly 2 (rc=$rc)"
+  bad "malformed direct hook invocation warns without blocking (rc=$rc)"
 fi
 
 echo "=== TC-CDCR-026: generated command executes without CLAUDE_PROJECT_DIR ==="
@@ -274,13 +280,12 @@ if [[ "$rc" -eq 0 && "$generated_out" == *"Reminder: Test Plan First"* ]]; then
 else
   bad "generated hook resolves worktree root and applies policy (rc=$rc, command=$hook_command)"
 fi
-(cd "$repo/nested/dir" && unset CLAUDE_PROJECT_DIR && \
-  eval "$hook_command" <<<"$missing_boundary" >/dev/null 2>&1)
-rc=$?
-if [[ "$rc" -eq 2 ]]; then
-  ok "malformed generated hook invocation exits exactly 2"
+generated_out=$(cd "$repo/nested/dir" && unset CLAUDE_PROJECT_DIR && \
+  eval "$hook_command" <<<"$missing_boundary" 2>&1); rc=$?
+if [[ "$rc" -eq 0 && "$generated_out" == *"could not inspect this edit payload"* ]]; then
+  ok "malformed generated hook invocation warns without blocking"
 else
-  bad "malformed generated hook invocation exits exactly 2 (rc=$rc)"
+  bad "malformed generated hook invocation warns without blocking (rc=$rc)"
 fi
 
 echo "=== TC-CDCR-027: generated command isolates linked-worktree state ==="
@@ -309,6 +314,21 @@ if [[ "$rc" -eq 0 && "$linked_out" == *"Reminder: Test Plan First"* ]]; then
   ok "linked worktree does not consume the main checkout test-plan mark"
 else
   bad "linked worktree does not consume the main checkout test-plan mark (rc=$rc)"
+fi
+
+echo "=== TC-CDCR-027A: Claude hook sees mark written in linked worktree ==="
+CLAUDE_PROJECT_DIR="$main_repo" \
+  "$PROJECT_ROOT/skills/autonomous-common/hooks/state-manager.sh" \
+  clear test-plan >/dev/null
+(cd "$worktree" && unset CLAUDE_PROJECT_DIR && \
+  "$PROJECT_ROOT/skills/autonomous-common/hooks/state-manager.sh" \
+    mark test-plan >/dev/null)
+linked_out=$(cd "$worktree" && CLAUDE_PROJECT_DIR="$main_repo" \
+  bash "$CHECK_TEST_PLAN" <<<"$linked_payload" 2>&1); rc=$?
+if [[ "$rc" -eq 0 && "$linked_out" != *"Reminder: Test Plan First"* ]]; then
+  ok "Claude hook consumes the linked-worktree test-plan mark"
+else
+  bad "Claude hook consumes the linked-worktree test-plan mark (rc=$rc)"
 fi
 
 echo "=== Summary ==="

--- a/tests/unit/test-hook-edit-paths.sh
+++ b/tests/unit/test-hook-edit-paths.sh
@@ -1,0 +1,271 @@
+#!/bin/bash
+# Shared Claude/Codex edit payload normalization tests for issue #486.
+# shellcheck disable=SC1090,SC2015
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK_LIB="$PROJECT_ROOT/skills/autonomous-common/hooks/lib.sh"
+CHECK_TEST_PLAN="$PROJECT_ROOT/skills/autonomous-common/hooks/check-test-plan.sh"
+INSTALLER="$PROJECT_ROOT/skills/autonomous-common/scripts/install-codex-hooks.sh"
+source "$HOOK_LIB"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+ok() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+bad() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    ok "$desc"
+  else
+    bad "$desc (expected=$(printf %q "$expected"), actual=$(printf %q "$actual"))"
+  fi
+}
+
+echo "=== TC-CDCR-020/021: Claude Write/Edit ==="
+write_payload='{"tool_name":"Write","tool_input":{"file_path":"src/new.ts"}}'
+out=$(parse_edit_file_operations "$write_payload" 2>/dev/null); rc=$?
+[[ "$rc" -eq 0 ]] && assert_eq "Write emits an add operation" \
+  $'add\tsrc/new.ts' "$out" \
+  || bad "Write emits an add operation (rc=$rc)"
+out=$(parse_edit_file_paths "$write_payload" 2>/dev/null); rc=$?
+[[ "$rc" -eq 0 ]] && assert_eq "Write emits file_path" "src/new.ts" "$out" \
+  || bad "Write emits file_path (rc=$rc)"
+
+edit_payload='{"tool_name":"Edit","tool_input":{"file_path":"src/path with spaces.ts"}}'
+out=$(parse_edit_file_operations "$edit_payload" 2>/dev/null); rc=$?
+[[ "$rc" -eq 0 ]] && assert_eq "Edit emits an edit operation" \
+  $'edit\tsrc/path with spaces.ts' "$out" \
+  || bad "Edit emits an edit operation (rc=$rc)"
+out=$(parse_edit_file_paths "$edit_payload" 2>/dev/null); rc=$?
+[[ "$rc" -eq 0 ]] && assert_eq "Edit preserves spaces" "src/path with spaces.ts" "$out" \
+  || bad "Edit preserves spaces (rc=$rc)"
+
+echo "=== TC-CDCR-021A: translated write/edit tool names remain supported ==="
+for tool_name in write_file WriteFile; do
+  translated_payload=$(jq -nc --arg tool "$tool_name" \
+    '{tool_name:$tool,tool_input:{file_path:"src/translated.ts"}}')
+  out=$(parse_edit_file_operations "$translated_payload" 2>/dev/null); rc=$?
+  [[ "$rc" -eq 0 ]] && assert_eq "$tool_name emits an add candidate" \
+    $'add\tsrc/translated.ts' "$out" \
+    || bad "$tool_name emits an add candidate (rc=$rc)"
+done
+for tool_name in replace StrReplaceFile; do
+  translated_payload=$(jq -nc --arg tool "$tool_name" \
+    '{tool_name:$tool,tool_input:{file_path:"src/translated.ts"}}')
+  out=$(parse_edit_file_operations "$translated_payload" 2>/dev/null); rc=$?
+  [[ "$rc" -eq 0 ]] && assert_eq "$tool_name emits an edit operation" \
+    $'edit\tsrc/translated.ts' "$out" \
+    || bad "$tool_name emits an edit operation (rc=$rc)"
+done
+kiro_create_payload='{"tool_name":"fs_write","tool_input":{"command":"create","path":"src/kiro-new.ts"}}'
+out=$(parse_edit_file_operations "$kiro_create_payload" 2>/dev/null); rc=$?
+[[ "$rc" -eq 0 ]] && assert_eq "Kiro create uses path and emits an add candidate" \
+  $'add\tsrc/kiro-new.ts' "$out" \
+  || bad "Kiro create uses path and emits an add candidate (rc=$rc)"
+for kiro_command in str_replace insert append; do
+  kiro_edit_payload=$(jq -nc --arg command "$kiro_command" \
+    '{tool_name:"fs_write",tool_input:{command:$command,path:"src/kiro-old.ts"}}')
+  out=$(parse_edit_file_operations "$kiro_edit_payload" 2>/dev/null); rc=$?
+  [[ "$rc" -eq 0 ]] && assert_eq "Kiro $kiro_command emits an edit operation" \
+    $'edit\tsrc/kiro-old.ts' "$out" \
+    || bad "Kiro $kiro_command emits an edit operation (rc=$rc)"
+done
+windsurf_payload='{"agent_action_name":"pre_write_code","tool_info":{"file_path":"src/windsurf.ts"}}'
+out=$(parse_edit_file_operations "$windsurf_payload" 2>/dev/null); rc=$?
+[[ "$rc" -eq 0 ]] && assert_eq "native Windsurf payload emits an add candidate" \
+  $'add\tsrc/windsurf.ts' "$out" \
+  || bad "native Windsurf payload emits an add candidate (rc=$rc)"
+
+echo "=== TC-CDCR-022: Codex structured multi-file apply_patch ==="
+codex_payload=$(jq -n --arg command '*** Begin Patch
+*** Add File: docs/first.md
++documentation
+*** Add File: src/new file.ts
++export const value = 1;
+*** Update File: src/old name.ts
+*** Move to: src/new name.ts
+@@
+-old
++new
+*** Delete File: src/delete me.ts
+*** End Patch' \
+  '{tool_name:"apply_patch",tool_input:{command:$command}}')
+expected=$'docs/first.md\nsrc/new file.ts\nsrc/old name.ts\nsrc/new name.ts\nsrc/delete me.ts'
+out=$(parse_edit_file_paths "$codex_payload" 2>/dev/null); rc=$?
+[[ "$rc" -eq 0 ]] && assert_eq "all patch paths are emitted in order" "$expected" "$out" \
+  || bad "all patch paths are emitted in order (rc=$rc)"
+expected_operations=$'add\tdocs/first.md\nadd\tsrc/new file.ts\nedit\tsrc/old name.ts\nmove\tsrc/new name.ts\ndelete\tsrc/delete me.ts'
+out=$(parse_edit_file_operations "$codex_payload" 2>/dev/null); rc=$?
+[[ "$rc" -eq 0 ]] && assert_eq "patch operations retain their semantics" \
+  "$expected_operations" "$out" \
+  || bad "patch operations retain their semantics (rc=$rc)"
+
+echo "=== TC-CDCR-024/025: malformed recognized edits and unknown tools ==="
+malformed='{"tool_name":"apply_patch","tool_input":{"command":"*** Begin Patch\n*** End Patch"}}'
+if parse_edit_file_paths "$malformed" >/dev/null 2>&1; then
+  bad "malformed apply_patch fails loudly"
+else
+  ok "malformed apply_patch fails loudly"
+fi
+missing_boundary='{"tool_name":"apply_patch","tool_input":{"command":"*** Add File: src/new.ts\n+value"}}'
+if parse_edit_file_operations "$missing_boundary" >/dev/null 2>&1; then
+  bad "apply_patch without begin/end markers fails loudly"
+else
+  ok "apply_patch without begin/end markers fails loudly"
+fi
+for malformed_tool_name in \
+  '{"tool_input":{"command":"*** Begin Patch\n*** Add File: src/new.ts\n+value\n*** End Patch"}}' \
+  '{"tool_name":null,"tool_input":{"command":"*** Begin Patch\n*** Add File: src/new.ts\n+value\n*** End Patch"}}' \
+  '{"tool_name":42,"tool_input":{"command":"*** Begin Patch\n*** Add File: src/new.ts\n+value\n*** End Patch"}}'; do
+  if parse_edit_file_operations "$malformed_tool_name" >/dev/null 2>&1; then
+    bad "missing/non-string tool_name must fail"
+  else
+    ok "missing/non-string tool_name fails"
+  fi
+done
+for malformed_path in '42' 'true' '[]' '{}'; do
+  malformed_file_payload=$(jq -nc --argjson path "$malformed_path" \
+    '{tool_name:"Write",tool_input:{file_path:$path}}')
+  if parse_edit_file_operations "$malformed_file_payload" >/dev/null 2>&1; then
+    bad "non-string file_path must fail ($malformed_path)"
+  else
+    ok "non-string file_path fails ($malformed_path)"
+  fi
+done
+for malformed_kiro_payload in \
+  '{"tool_name":"fs_write","tool_input":{"command":"create","path":42}}' \
+  '{"tool_name":"fs_write","tool_input":{"command":42,"path":"src/new.ts"}}' \
+  '{"tool_name":"fs_write","tool_input":{"command":"unknown","path":"src/new.ts"}}'; do
+  if parse_edit_file_operations "$malformed_kiro_payload" >/dev/null 2>&1; then
+    bad "malformed Kiro fs_write payload must fail"
+  else
+    ok "malformed Kiro fs_write payload fails"
+  fi
+done
+unknown='{"tool_name":"Read","tool_input":{"file_path":"src/not-an-edit.ts"}}'
+out=$(parse_edit_file_paths "$unknown" 2>/dev/null); rc=$?
+[[ "$rc" -eq 0 ]] && assert_eq "Read with file_path is still a no-op" "" "$out" \
+  || bad "unknown tool is a no-op (rc=$rc)"
+
+misleading_payload=$(jq -c '.tool_input.file_path = "src/wrong.ts"' <<<"$codex_payload")
+out=$(parse_edit_file_paths "$misleading_payload" 2>/dev/null); rc=$?
+[[ "$rc" -eq 0 ]] && assert_eq "apply_patch ignores misleading file_path" \
+  "$expected" "$out" \
+  || bad "apply_patch ignores misleading file_path (rc=$rc)"
+
+echo "=== TC-CDCR-023: check-test-plan evaluates creation operations ==="
+repo="$TMPDIR/policy-repo"
+mkdir -p "$repo/docs" "$repo/src"
+git -C "$repo" init --quiet --initial-branch=main
+policy_out=$(cd "$repo" && CLAUDE_PROJECT_DIR="$repo" bash "$CHECK_TEST_PLAN" \
+  <<<"$codex_payload" 2>&1); rc=$?
+if [[ "$rc" -eq 0 && "$policy_out" == *"Reminder: Test Plan First"* ]]; then
+  ok "later new src file triggers policy after a docs path"
+else
+  bad "later new src file triggers policy after a docs path (rc=$rc)"
+fi
+policy_out=$(cd "$repo" && CLAUDE_PROJECT_DIR="$repo" bash "$CHECK_TEST_PLAN" \
+  <<<"$write_payload" 2>&1); rc=$?
+if [[ "$rc" -eq 0 && "$policy_out" == *"Reminder: Test Plan First"* ]]; then
+  ok "equivalent Claude Write triggers the same policy"
+else
+  bad "equivalent Claude Write triggers the same policy (rc=$rc)"
+fi
+policy_out=$(cd "$repo" && CLAUDE_PROJECT_DIR="$repo" bash "$CHECK_TEST_PLAN" \
+  <<<"$edit_payload" 2>&1); rc=$?
+if [[ "$rc" -eq 0 && "$policy_out" != *"Reminder: Test Plan First"* ]]; then
+  ok "Claude Edit does not masquerade as file creation"
+else
+  bad "Claude Edit does not masquerade as file creation (rc=$rc)"
+fi
+
+policy_out=$(cd "$repo" && CLAUDE_PROJECT_DIR="$repo" bash "$CHECK_TEST_PLAN" \
+  <<<"$kiro_create_payload" 2>&1); rc=$?
+if [[ "$rc" -eq 0 && "$policy_out" == *"Reminder: Test Plan First"* ]]; then
+  ok "native Kiro create still triggers file-creation policy"
+else
+  bad "native Kiro create still triggers file-creation policy (rc=$rc)"
+fi
+policy_out=$(cd "$repo" && CLAUDE_PROJECT_DIR="$repo" bash "$CHECK_TEST_PLAN" \
+  <<<"$windsurf_payload" 2>&1); rc=$?
+if [[ "$rc" -eq 0 && "$policy_out" == *"Reminder: Test Plan First"* ]]; then
+  ok "native Windsurf write still triggers file-creation policy"
+else
+  bad "native Windsurf write still triggers file-creation policy (rc=$rc)"
+fi
+
+malformed_file_payload='{"tool_name":"Write","tool_input":{"file_path":42}}'
+(cd "$repo" && CLAUDE_PROJECT_DIR="$repo" bash "$CHECK_TEST_PLAN" \
+  <<<"$malformed_file_payload" >/dev/null 2>&1)
+rc=$?
+if [[ "$rc" -eq 2 ]]; then
+  ok "malformed file path makes the hook exit exactly 2"
+else
+  bad "malformed file path makes the hook exit exactly 2 (rc=$rc)"
+fi
+
+pure_move_payload=$(jq -n --arg command '*** Begin Patch
+*** Update File: src/original.ts
+*** Move to: src/renamed.ts
+@@
+-old
++new
+*** End Patch' \
+  '{tool_name:"apply_patch",tool_input:{command:$command}}')
+policy_out=$(cd "$repo" && CLAUDE_PROJECT_DIR="$repo" bash "$CHECK_TEST_PLAN" \
+  <<<"$pure_move_payload" 2>&1); rc=$?
+if [[ "$rc" -eq 0 && "$policy_out" != *"Reminder: Test Plan First"* ]]; then
+  ok "pure move does not trigger a new-file reminder"
+else
+  bad "pure move does not trigger a new-file reminder (rc=$rc)"
+fi
+
+(cd "$repo" && CLAUDE_PROJECT_DIR="$repo" bash "$CHECK_TEST_PLAN" \
+  <<<"$missing_boundary" >/dev/null 2>&1)
+rc=$?
+if [[ "$rc" -eq 2 ]]; then
+  ok "malformed direct hook invocation exits exactly 2"
+else
+  bad "malformed direct hook invocation exits exactly 2 (rc=$rc)"
+fi
+
+echo "=== TC-CDCR-026: generated command executes without CLAUDE_PROJECT_DIR ==="
+repo="$TMPDIR/generated repo"
+mkdir -p "$repo/nested/dir"
+git -C "$repo" init --quiet --initial-branch=main
+ln -s "$PROJECT_ROOT/skills/autonomous-common/hooks" "$repo/hooks"
+(cd "$repo" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+hook_command=$(jq -r '
+  .hooks.PreToolUse[]
+  | select(.matcher == "^apply_patch$")
+  | .hooks[]
+  | select(.command | contains("check-test-plan.sh"))
+  | .command
+' "$repo/.codex/hooks.json")
+generated_out=$(cd "$repo/nested/dir" && unset CLAUDE_PROJECT_DIR && \
+  eval "$hook_command" <<<"$codex_payload" 2>&1); rc=$?
+if [[ "$rc" -eq 0 && "$generated_out" == *"Reminder: Test Plan First"* ]]; then
+  ok "generated hook resolves worktree root and applies policy"
+else
+  bad "generated hook resolves worktree root and applies policy (rc=$rc, command=$hook_command)"
+fi
+(cd "$repo/nested/dir" && unset CLAUDE_PROJECT_DIR && \
+  eval "$hook_command" <<<"$missing_boundary" >/dev/null 2>&1)
+rc=$?
+if [[ "$rc" -eq 2 ]]; then
+  ok "malformed generated hook invocation exits exactly 2"
+else
+  bad "malformed generated hook invocation exits exactly 2 (rc=$rc)"
+fi
+
+echo "=== Summary ==="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/unit/test-hook-edit-paths.sh
+++ b/tests/unit/test-hook-edit-paths.sh
@@ -64,11 +64,14 @@ for tool_name in replace StrReplaceFile; do
     $'edit\tsrc/translated.ts' "$out" \
     || bad "$tool_name emits an edit operation (rc=$rc)"
 done
-kiro_create_payload='{"tool_name":"fs_write","tool_input":{"command":"create","path":"src/kiro-new.ts"}}'
-out=$(parse_edit_file_operations "$kiro_create_payload" 2>/dev/null); rc=$?
-[[ "$rc" -eq 0 ]] && assert_eq "Kiro create uses path and emits an add candidate" \
-  $'add\tsrc/kiro-new.ts' "$out" \
-  || bad "Kiro create uses path and emits an add candidate (rc=$rc)"
+for tool_name in fs_write write fsWrite; do
+  kiro_create_payload=$(jq -nc --arg tool "$tool_name" \
+    '{tool_name:$tool,tool_input:{command:"create",path:"src/kiro-new.ts"}}')
+  out=$(parse_edit_file_operations "$kiro_create_payload" 2>/dev/null); rc=$?
+  [[ "$rc" -eq 0 ]] && assert_eq "Kiro $tool_name create emits an add candidate" \
+    $'add\tsrc/kiro-new.ts' "$out" \
+    || bad "Kiro $tool_name create emits an add candidate (rc=$rc)"
+done
 for kiro_command in str_replace insert append; do
   kiro_edit_payload=$(jq -nc --arg command "$kiro_command" \
     '{tool_name:"fs_write",tool_input:{command:$command,path:"src/kiro-old.ts"}}')
@@ -201,6 +204,21 @@ else
   bad "native Windsurf write still triggers file-creation policy (rc=$rc)"
 fi
 
+mkdir -p "$repo/nested/src"
+printf 'existing only below cwd\n' > "$repo/nested/src/root-relative.ts"
+root_relative_payload=$(jq -n --arg command '*** Begin Patch
+*** Add File: src/root-relative.ts
++export const rootRelative = true;
+*** End Patch' \
+  '{tool_name:"apply_patch",tool_input:{command:$command}}')
+policy_out=$(cd "$repo/nested" && CLAUDE_PROJECT_DIR="$repo" \
+  bash "$CHECK_TEST_PLAN" <<<"$root_relative_payload" 2>&1); rc=$?
+if [[ "$rc" -eq 0 && "$policy_out" == *"Reminder: Test Plan First"* ]]; then
+  ok "Codex relative paths are checked only against the worktree root"
+else
+  bad "Codex relative paths are checked only against the worktree root (rc=$rc)"
+fi
+
 malformed_file_payload='{"tool_name":"Write","tool_input":{"file_path":42}}'
 (cd "$repo" && CLAUDE_PROJECT_DIR="$repo" bash "$CHECK_TEST_PLAN" \
   <<<"$malformed_file_payload" >/dev/null 2>&1)
@@ -263,6 +281,34 @@ if [[ "$rc" -eq 2 ]]; then
   ok "malformed generated hook invocation exits exactly 2"
 else
   bad "malformed generated hook invocation exits exactly 2 (rc=$rc)"
+fi
+
+echo "=== TC-CDCR-027: generated command isolates linked-worktree state ==="
+main_repo="$TMPDIR/state-main"
+worktree="$TMPDIR/state-worktree"
+mkdir -p "$main_repo"
+git -C "$main_repo" init --quiet --initial-branch=main
+git -C "$main_repo" config user.name test
+git -C "$main_repo" config user.email test@example.com
+printf 'seed\n' > "$main_repo/README.md"
+git -C "$main_repo" add README.md
+git -C "$main_repo" commit --quiet -m seed
+git -C "$main_repo" worktree add --quiet -b feature "$worktree"
+CLAUDE_PROJECT_DIR="$main_repo" \
+  "$PROJECT_ROOT/skills/autonomous-common/hooks/state-manager.sh" \
+  mark test-plan >/dev/null
+mkdir -p "$worktree/src"
+linked_payload=$(jq -n --arg command '*** Begin Patch
+*** Add File: src/worktree-only.ts
++export const isolated = true;
+*** End Patch' \
+  '{tool_name:"apply_patch",tool_input:{command:$command}}')
+linked_out=$(cd "$worktree" && unset CLAUDE_PROJECT_DIR && \
+  bash "$CHECK_TEST_PLAN" <<<"$linked_payload" 2>&1); rc=$?
+if [[ "$rc" -eq 0 && "$linked_out" == *"Reminder: Test Plan First"* ]]; then
+  ok "linked worktree does not consume the main checkout test-plan mark"
+else
+  bad "linked worktree does not consume the main checkout test-plan mark (rc=$rc)"
 fi
 
 echo "=== Summary ==="

--- a/tests/unit/test-install-codex-hooks.sh
+++ b/tests/unit/test-install-codex-hooks.sh
@@ -902,6 +902,49 @@ else
   bad "losing capture leaves ownership with the concurrent installer"
 fi
 
+echo "=== TC-CDCR-019P: capture rejects a concurrent symlink replacement ==="
+repo=$(new_repo capture_symlink_replacement)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
+printf 'operator target\n' > "$repo/operator-target.json"
+cp "$repo/.codex/config.toml" "$repo/config.before"
+cat > "$repo/fakebin/python3" <<'EOF'
+#!/bin/bash
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${2:-}" == "$CAPTURE_SOURCE" &&
+      "${3:-}" == "$CAPTURE_SOURCE".bak.* &&
+      ! -e "$CAPTURE_STATE" ]]; then
+  : > "$CAPTURE_STATE"
+  "$REAL_MV" "$2" "$OPERATOR_HELD"
+  ln -s "$OPERATOR_TARGET" "$2"
+fi
+exec "$REAL_PYTHON" "$@"
+EOF
+chmod +x "$repo/fakebin/python3"
+if (
+  cd "$repo" &&
+    REAL_MV="$real_mv" REAL_PYTHON="$real_python" \
+      CAPTURE_SOURCE="hooks.json" CAPTURE_STATE="$repo/capture-fired" \
+      OPERATOR_HELD="$repo/operator-held-hooks.json" \
+      OPERATOR_TARGET="$repo/operator-target.json" \
+      PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+); then
+  bad "concurrent symlink replacement must abort installation"
+elif [[ -L "$repo/.codex/hooks.json" ]] &&
+     [[ "$(readlink "$repo/.codex/hooks.json")" == "$repo/operator-target.json" ]] &&
+     grep -q 'operator target' "$repo/operator-target.json" &&
+     grep -q '"sentinel":true' "$repo/operator-held-hooks.json" &&
+     cmp -s "$repo/.codex/config.toml" "$repo/config.before"; then
+  ok "capture rejects and preserves the concurrent symlink replacement"
+else
+  bad "capture rejects and preserves the concurrent symlink replacement"
+fi
+
 echo "=== TC-CDCR-019H: ambiguous capture failure reconciles its postcondition ==="
 repo=$(new_repo ambiguous_capture)
 mkdir -p "$repo/.codex" "$repo/fakebin"

--- a/tests/unit/test-install-codex-hooks.sh
+++ b/tests/unit/test-install-codex-hooks.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
-# test-install-codex-hooks.sh — Tests for the Codex installer (PR-11b).
-#
-# Verifies: file paths .codex/hooks.json + .codex/config.toml, the
-# `[features] codex_hooks = true` flag toggle (required upstream), and
-# Claude-verbatim hooks block (Codex models its schema on Claude).
-#
-# Run: bash tests/unit/test-install-codex-hooks.sh
+# Codex hook installer regression tests for issue #486.
+# shellcheck disable=SC2015
 
 set -uo pipefail
 
@@ -14,191 +9,706 @@ FAIL=0
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 INSTALLER="$PROJECT_ROOT/skills/autonomous-common/scripts/install-codex-hooks.sh"
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-NC='\033[0m'
-
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-# ---------------------------------------------------------------------------
-echo "=== TC-CDX-01: first-time install creates both files ==="
-# ---------------------------------------------------------------------------
-mkdir -p "$TMPDIR/repo1"
-git -C "$TMPDIR/repo1" init --quiet --initial-branch=main
-(cd "$TMPDIR/repo1" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
-
-hooks_file="$TMPDIR/repo1/.codex/hooks.json"
-config_file="$TMPDIR/repo1/.codex/config.toml"
-
-if [[ -f "$hooks_file" ]]; then
-  echo -e "  ${GREEN}PASS${NC}: hooks.json created"
+ok() {
+  echo "  PASS: $1"
   PASS=$((PASS + 1))
-else
-  echo -e "  ${RED}FAIL${NC}: hooks.json NOT created"
+}
+
+bad() {
+  echo "  FAIL: $1"
   FAIL=$((FAIL + 1))
+}
+
+assert_file_contains() {
+  local desc="$1" file="$2" pattern="$3"
+  if [[ -r "$file" ]] && grep -qE "$pattern" "$file"; then
+    ok "$desc"
+  else
+    bad "$desc"
+  fi
+}
+
+assert_file_not_contains() {
+  local desc="$1" file="$2" pattern="$3"
+  if [[ -r "$file" ]] && ! grep -qE "$pattern" "$file"; then
+    ok "$desc"
+  else
+    bad "$desc"
+  fi
+}
+
+assert_backup_exists() {
+  local desc="$1" file="$2"
+  if compgen -G "${file}.bak.*" >/dev/null; then
+    ok "$desc"
+  else
+    bad "$desc"
+  fi
+}
+
+file_mode() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
+new_repo() {
+  local name="$1"
+  mkdir -p "$TMPDIR/$name"
+  git -C "$TMPDIR/$name" init --quiet --initial-branch=main
+  printf '%s' "$TMPDIR/$name"
+}
+
+install() {
+  (
+    cd "$1" &&
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$1/install.err" &&
+      python3 -c 'import sys, tomllib; tomllib.load(open(sys.argv[1], "rb"))' \
+        "$1/.codex/config.toml"
+  )
+}
+
+echo "=== TC-CDCR-001: fresh install uses canonical features.hooks ==="
+repo=$(new_repo fresh)
+if install "$repo"; then
+  ok "fresh install succeeds"
+else
+  bad "fresh install succeeds"
+fi
+hooks_file="$repo/.codex/hooks.json"
+config_file="$repo/.codex/config.toml"
+[[ -f "$hooks_file" && -f "$config_file" ]] \
+  && ok "fresh install creates hooks.json and config.toml" \
+  || bad "fresh install creates hooks.json and config.toml"
+assert_file_contains "canonical hooks=true is present" "$config_file" \
+  '^[[:space:]]*hooks[[:space:]]*=[[:space:]]*true'
+assert_file_not_contains "deprecated codex_hooks is absent" "$config_file" \
+  '^[[:space:]]*codex_hooks[[:space:]]*='
+
+echo "=== TC-CDCR-002: Codex-specific hook rendering ==="
+if jq -e '[.hooks.PreToolUse[] | select(.matcher == "^apply_patch$")] | length == 1' \
+    "$hooks_file" >/dev/null; then
+  ok "one direct apply_patch matcher is generated"
+else
+  bad "one direct apply_patch matcher is generated"
+fi
+if jq -e '[.hooks.PreToolUse[] | select(.matcher == "Write" or .matcher == "Edit")] | length == 0' \
+    "$hooks_file" >/dev/null; then
+  ok "Claude Write/Edit matcher groups are removed"
+else
+  bad "Claude Write/Edit matcher groups are removed"
+fi
+assert_file_not_contains "generated commands do not use CLAUDE_PROJECT_DIR" \
+  "$hooks_file" 'CLAUDE_PROJECT_DIR'
+assert_file_contains "generated commands resolve from git worktree root" \
+  "$hooks_file" 'git rev-parse --show-toplevel'
+if jq -e '.hooks.PreToolUse | any(.matcher == "Bash")' "$hooks_file" >/dev/null; then
+  ok "Bash matcher remains present"
+else
+  bad "Bash matcher remains present"
 fi
 
-if [[ -f "$config_file" ]]; then
-  echo -e "  ${GREEN}PASS${NC}: config.toml created"
-  PASS=$((PASS + 1))
-else
-  echo -e "  ${RED}FAIL${NC}: config.toml NOT created"
-  FAIL=$((FAIL + 1))
-fi
+echo "=== TC-CDCR-003: re-run remains idempotent ==="
+install "$repo" || bad "second install succeeds"
+canonical_count=$(grep -cE '^[[:space:]]*hooks[[:space:]]*=[[:space:]]*true' "$config_file")
+apply_patch_count=$(jq '[.hooks.PreToolUse[] | select(.matcher == "^apply_patch$")] | length' "$hooks_file")
+[[ "$canonical_count" -eq 1 && "$apply_patch_count" -eq 1 ]] \
+  && ok "canonical key and apply_patch group appear once" \
+  || bad "canonical key and apply_patch group appear once"
 
-# ---------------------------------------------------------------------------
-echo ""
-echo "=== TC-CDX-02: codex_hooks feature flag is enabled ==="
-# ---------------------------------------------------------------------------
-if grep -qE '^\s*codex_hooks\s*=\s*true\s*$' "$config_file"; then
-  echo -e "  ${GREEN}PASS${NC}: [features] codex_hooks = true present in config.toml"
-  PASS=$((PASS + 1))
-else
-  echo -e "  ${RED}FAIL${NC}: codex_hooks = true missing — hooks.json will be ignored upstream"
-  FAIL=$((FAIL + 1))
-fi
-
-# ---------------------------------------------------------------------------
-echo ""
-echo "=== TC-CDX-03: hooks block uses Claude-verbatim event names ==="
-# ---------------------------------------------------------------------------
-# Codex modeled schema on Claude — should keep PreToolUse/PostToolUse/Stop.
-if jq -e '.hooks.PreToolUse | length > 0' "$hooks_file" >/dev/null 2>&1; then
-  echo -e "  ${GREEN}PASS${NC}: hooks.PreToolUse populated (Claude-verbatim)"
-  PASS=$((PASS + 1))
-else
-  echo -e "  ${RED}FAIL${NC}: hooks.PreToolUse missing"
-  FAIL=$((FAIL + 1))
-fi
-
-# Bash matcher should be preserved verbatim
-matchers=$(jq -r '.hooks.PreToolUse[].matcher' "$hooks_file" | sort -u)
-if grep -q '^Bash$' <<<"$matchers"; then
-  echo -e "  ${GREEN}PASS${NC}: Bash matcher preserved (Claude-verbatim)"
-  PASS=$((PASS + 1))
-else
-  echo -e "  ${RED}FAIL${NC}: Bash matcher missing"
-  FAIL=$((FAIL + 1))
-fi
-
-# ---------------------------------------------------------------------------
-echo ""
-echo "=== TC-CDX-04: re-running installer doesn't duplicate config.toml flag ==="
-# ---------------------------------------------------------------------------
-(cd "$TMPDIR/repo1" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
-flag_count=$(grep -cE '^\s*codex_hooks\s*=\s*true\s*$' "$config_file")
-if [[ "$flag_count" -eq 1 ]]; then
-  echo -e "  ${GREEN}PASS${NC}: codex_hooks flag appears exactly once after re-run (got $flag_count)"
-  PASS=$((PASS + 1))
-else
-  echo -e "  ${RED}FAIL${NC}: re-run duplicated the flag (got $flag_count occurrences)"
-  FAIL=$((FAIL + 1))
-fi
-
-# ---------------------------------------------------------------------------
-echo ""
-echo "=== TC-CDX-05: existing config.toml without flag → flag appended (no overwrite) ==="
-# ---------------------------------------------------------------------------
-mkdir -p "$TMPDIR/repo2/.codex"
-git -C "$TMPDIR/repo2" init --quiet --initial-branch=main
-cat > "$TMPDIR/repo2/.codex/config.toml" <<'EOF'
-# Existing user config
+echo "=== TC-CDCR-004: unrelated TOML is preserved ==="
+repo=$(new_repo no_features)
+mkdir -p "$repo/.codex"
+cat > "$repo/.codex/config.toml" <<'EOF'
+# operator setting
 [some_other_section]
 foo = "bar"
 EOF
-(cd "$TMPDIR/repo2" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
+install "$repo" || bad "install with unrelated TOML succeeds"
+assert_file_contains "unrelated section survives" "$repo/.codex/config.toml" \
+  '^\[some_other_section\]$'
+assert_file_contains "canonical key is appended" "$repo/.codex/config.toml" \
+  '^[[:space:]]*hooks[[:space:]]*=[[:space:]]*true'
+[[ $(grep -cE '^[[:space:]]*\[features\][[:space:]]*$' "$repo/.codex/config.toml") -eq 1 ]] \
+  && ok "one features table is present" || bad "one features table is present"
 
-if grep -q '\[some_other_section\]' "$TMPDIR/repo2/.codex/config.toml"; then
-  echo -e "  ${GREEN}PASS${NC}: existing user TOML preserved"
-  PASS=$((PASS + 1))
-else
-  echo -e "  ${RED}FAIL${NC}: existing user TOML lost"
-  FAIL=$((FAIL + 1))
-fi
-
-if grep -qE '^\s*codex_hooks\s*=\s*true' "$TMPDIR/repo2/.codex/config.toml"; then
-  echo -e "  ${GREEN}PASS${NC}: codex_hooks flag appended"
-  PASS=$((PASS + 1))
-else
-  echo -e "  ${RED}FAIL${NC}: codex_hooks flag NOT appended"
-  FAIL=$((FAIL + 1))
-fi
-
-# ---------------------------------------------------------------------------
-echo ""
-echo "=== TC-CDX-06: existing [features] section → insert into it (don't duplicate the table) ==="
-# ---------------------------------------------------------------------------
-# C1 from PR-11b code review: TOML rejects duplicate table headers.
-mkdir -p "$TMPDIR/repo3/.codex"
-git -C "$TMPDIR/repo3" init --quiet --initial-branch=main
-cat > "$TMPDIR/repo3/.codex/config.toml" <<'EOF'
-# user config
-[features]
+echo "=== TC-CDCR-005/006: existing features table and canonical true ==="
+repo=$(new_repo empty_features)
+mkdir -p "$repo/.codex"
+cat > "$repo/.codex/config.toml" <<'EOF'
+# operator comment
+[features] # feature flags
 some_other_flag = true
 EOF
-(cd "$TMPDIR/repo3" && bash "$INSTALLER" --no-git-hook >/dev/null 2>&1)
-target3="$TMPDIR/repo3/.codex/config.toml"
+install "$repo" || bad "empty features install succeeds"
+assert_file_contains "canonical key is inserted into existing features table" \
+  "$repo/.codex/config.toml" '^[[:space:]]*hooks[[:space:]]*=[[:space:]]*true'
+assert_file_contains "existing feature and comments survive insertion" \
+  "$repo/.codex/config.toml" 'some_other_flag[[:space:]]*=[[:space:]]*true'
+[[ $(grep -cE '^[[:space:]]*\[[[:space:]]*features[[:space:]]*\]' \
+    "$repo/.codex/config.toml") -eq 1 ]] \
+  && ok "insertion does not duplicate the features table" \
+  || bad "insertion does not duplicate the features table"
+assert_backup_exists "features-table insertion creates a backup" \
+  "$repo/.codex/config.toml"
 
-# Should have exactly ONE [features] header (not duplicated)
-header_count=$(grep -cE '^\[features\][[:space:]]*$' "$target3")
-if [[ "$header_count" -eq 1 ]]; then
-  echo -e "  ${GREEN}PASS${NC}: only one [features] header (TOML stays valid)"
-  PASS=$((PASS + 1))
+repo=$(new_repo canonical_true)
+mkdir -p "$repo/.codex"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+some_other_flag = true
+hooks = true # operator enabled
+EOF
+install "$repo" || bad "canonical true install succeeds"
+assert_file_contains "other feature survives" "$repo/.codex/config.toml" \
+  '^[[:space:]]*some_other_flag[[:space:]]*='
+[[ $(grep -cE '^[[:space:]]*\[features\][[:space:]]*$' "$repo/.codex/config.toml") -eq 1 ]] \
+  && ok "existing features table is not duplicated" \
+  || bad "existing features table is not duplicated"
+[[ $(grep -cE '^[[:space:]]*hooks[[:space:]]*=' "$repo/.codex/config.toml") -eq 1 ]] \
+  && ok "existing canonical key is not duplicated" \
+  || bad "existing canonical key is not duplicated"
+if compgen -G "$repo/.codex/config.toml.bak.*" >/dev/null; then
+  bad "canonical no-op should not create a config backup"
 else
-  echo -e "  ${RED}FAIL${NC}: [features] appears $header_count times — TOML invalid"
-  FAIL=$((FAIL + 1))
+  ok "canonical no-op does not create a config backup"
 fi
 
-# Both flags should still be present
-if grep -qE '^\s*some_other_flag\s*=' "$target3" && \
-   grep -qE '^\s*codex_hooks\s*=\s*true' "$target3"; then
-  echo -e "  ${GREEN}PASS${NC}: both old and new flags inside same [features] block"
-  PASS=$((PASS + 1))
+echo "=== TC-CDCR-007: canonical false is preserved and refuses partial install ==="
+repo=$(new_repo canonical_false)
+mkdir -p "$repo/.codex"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+hooks = false
+EOF
+before=$(cat "$repo/.codex/config.toml")
+if install "$repo"; then
+  bad "canonical false must refuse"
 else
-  echo -e "  ${RED}FAIL${NC}: missing flag — old: $(grep -c some_other_flag "$target3"), new: $(grep -c codex_hooks "$target3")"
-  FAIL=$((FAIL + 1))
+  ok "canonical false refuses"
+fi
+[[ "$(cat "$repo/.codex/config.toml")" == "$before" ]] \
+  && ok "canonical false config is unchanged" \
+  || bad "canonical false config is unchanged"
+[[ ! -f "$repo/.codex/hooks.json" ]] \
+  && ok "refusal happens before hooks.json is written" \
+  || bad "refusal happens before hooks.json is written"
+
+echo "=== TC-CDCR-008: legacy true migrates to canonical key ==="
+repo=$(new_repo legacy_true)
+mkdir -p "$repo/.codex"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true # legacy operator config
+EOF
+install "$repo" || bad "legacy true migration succeeds"
+assert_file_contains "legacy true becomes canonical true" "$repo/.codex/config.toml" \
+  '^[[:space:]]*hooks[[:space:]]*=[[:space:]]*true'
+assert_file_not_contains "legacy key is removed after migration" "$repo/.codex/config.toml" \
+  '^[[:space:]]*codex_hooks[[:space:]]*='
+assert_backup_exists "legacy migration creates a config backup" \
+  "$repo/.codex/config.toml"
+
+echo "=== TC-CDCR-008A: unrelated array tables survive migration ==="
+repo=$(new_repo legacy_with_array)
+mkdir -p "$repo/.codex"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+
+[[other]]
+codex_hooks = "operator-data"
+EOF
+install "$repo" || bad "legacy migration with unrelated array table succeeds"
+if python3 - "$repo/.codex/config.toml" <<'PY'
+import sys
+import tomllib
+
+config = tomllib.load(open(sys.argv[1], "rb"))
+assert config["features"]["hooks"] is True
+assert "codex_hooks" not in config["features"]
+assert config["other"][0]["codex_hooks"] == "operator-data"
+PY
+then
+  ok "migration does not rewrite keys in unrelated array tables"
+else
+  bad "migration does not rewrite keys in unrelated array tables"
 fi
 
-# ---------------------------------------------------------------------------
-echo ""
-echo "=== TC-CDX-07: codex_hooks = false → installer refuses (operator set on purpose) ==="
-# ---------------------------------------------------------------------------
-mkdir -p "$TMPDIR/repo4/.codex"
-git -C "$TMPDIR/repo4" init --quiet --initial-branch=main
-cat > "$TMPDIR/repo4/.codex/config.toml" <<'EOF'
+echo "=== TC-CDCR-008B: quoted table headers refuse mutable migration ==="
+repo=$(new_repo legacy_with_quoted_table)
+mkdir -p "$repo/.codex"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+
+["operator#table"]
+codex_hooks = "operator-data"
+EOF
+cp "$repo/.codex/config.toml" "$repo/before.toml"
+if install "$repo"; then
+  bad "quoted table header must refuse mutable migration"
+elif cmp -s "$repo/.codex/config.toml" "$repo/before.toml" &&
+     [[ ! -e "$repo/.codex/hooks.json" ]]; then
+  ok "quoted table header refuses without changing either destination"
+else
+  bad "quoted table header refuses without changing either destination"
+fi
+
+echo "=== TC-CDCR-009: legacy false is preserved ==="
+repo=$(new_repo legacy_false)
+mkdir -p "$repo/.codex"
+cat > "$repo/.codex/config.toml" <<'EOF'
 [features]
 codex_hooks = false
 EOF
-err=$(cd "$TMPDIR/repo4" && bash "$INSTALLER" --no-git-hook 2>&1 >/dev/null) || rc=$?
-if [[ "${rc:-0}" -ne 0 ]]; then
-  echo -e "  ${GREEN}PASS${NC}: installer refused (rc=${rc:-0})"
-  PASS=$((PASS + 1))
+before=$(cat "$repo/.codex/config.toml")
+if install "$repo"; then bad "legacy false must refuse"; else ok "legacy false refuses"; fi
+[[ "$(cat "$repo/.codex/config.toml")" == "$before" ]] \
+  && ok "legacy false config is unchanged" \
+  || bad "legacy false config is unchanged"
+
+echo "=== TC-CDCR-010: same-value dual keys converge ==="
+repo=$(new_repo dual_true)
+mkdir -p "$repo/.codex"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+hooks = true
+codex_hooks = true
+EOF
+install "$repo" || bad "same-value dual-key migration succeeds"
+assert_file_contains "canonical true remains" "$repo/.codex/config.toml" \
+  '^[[:space:]]*hooks[[:space:]]*=[[:space:]]*true'
+assert_file_not_contains "same-value legacy alias is removed" "$repo/.codex/config.toml" \
+  '^[[:space:]]*codex_hooks[[:space:]]*='
+
+echo "=== TC-CDCR-011: conflicting dual keys fail loudly ==="
+repo=$(new_repo conflict)
+mkdir -p "$repo/.codex"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+hooks = true
+codex_hooks = false
+EOF
+cp "$repo/.codex/config.toml" "$repo/before.toml"
+if install "$repo"; then bad "conflicting keys must refuse"; else ok "conflicting keys refuse"; fi
+cmp -s "$repo/.codex/config.toml" "$repo/before.toml" \
+  && ok "conflicting config is byte-for-byte unchanged" \
+  || bad "conflicting config is byte-for-byte unchanged"
+assert_file_contains "conflict diagnostic names both keys" "$repo/install.err" \
+  'hooks.*codex_hooks|codex_hooks.*hooks'
+assert_file_contains "conflict diagnostic names the operator config path" \
+  "$repo/install.err" "$repo/.codex/config.toml"
+
+echo "=== TC-CDCR-012: unsupported mutable feature shape refuses ==="
+repo=$(new_repo inline_features)
+mkdir -p "$repo/.codex"
+cat > "$repo/.codex/config.toml" <<'EOF'
+features = { another_feature = true }
+EOF
+cp "$repo/.codex/config.toml" "$repo/before.toml"
+if install "$repo"; then bad "mutable inline features table must refuse"; else ok "mutable inline features table refuses"; fi
+cmp -s "$repo/.codex/config.toml" "$repo/before.toml" \
+  && ok "unsupported TOML is unchanged" \
+  || bad "unsupported TOML is unchanged"
+[[ ! -f "$repo/.codex/hooks.json" ]] \
+  && ok "unsupported TOML refuses before hooks are written" \
+  || bad "unsupported TOML refuses before hooks are written"
+
+echo "=== TC-CDCR-013: complex valid TOML is preserved ==="
+repo=$(new_repo multiline)
+mkdir -p "$repo/.codex"
+cat > "$repo/.codex/config.toml" <<'EOF'
+instructions = """
+This literal-looking content is data:
+[features]
+codex_hooks = false
+"""
+[other]
+"quoted.key" = "preserved"
+EOF
+cp "$repo/.codex/config.toml" "$repo/before.toml"
+install "$repo" || bad "config with multiline string installs"
+python3 - "$repo/before.toml" "$repo/.codex/config.toml" <<'PY'
+import sys
+import tomllib
+
+before = tomllib.load(open(sys.argv[1], "rb"))
+after = tomllib.load(open(sys.argv[2], "rb"))
+after.pop("features")
+raise SystemExit(0 if after == before else 1)
+PY
+if [[ $? -eq 0 ]]; then
+  ok "multiline strings and quoted keys retain their semantic value"
 else
-  echo -e "  ${RED}FAIL${NC}: installer should refuse when codex_hooks = false"
-  FAIL=$((FAIL + 1))
-fi
-case "$err" in
-  *"codex_hooks = false"*)
-    echo -e "  ${GREEN}PASS${NC}: stderr explains the conflict"
-    PASS=$((PASS + 1)) ;;
-  *)
-    echo -e "  ${RED}FAIL${NC}: stderr should mention 'codex_hooks = false'; got: $err"
-    FAIL=$((FAIL + 1)) ;;
-esac
-# Operator's `false` setting must NOT have been overwritten
-if grep -qE '^\s*codex_hooks\s*=\s*false' "$TMPDIR/repo4/.codex/config.toml"; then
-  echo -e "  ${GREEN}PASS${NC}: operator's codex_hooks = false preserved"
-  PASS=$((PASS + 1))
-else
-  echo -e "  ${RED}FAIL${NC}: operator's codex_hooks = false was modified"
-  FAIL=$((FAIL + 1))
+  bad "multiline strings and quoted keys retain their semantic value"
 fi
 
-# ---------------------------------------------------------------------------
-echo ""
+echo "=== TC-CDCR-014: noncanonical no-op forms are accepted ==="
+for form in quoted dotted; do
+  repo=$(new_repo "canonical_$form")
+  mkdir -p "$repo/.codex"
+  if [[ "$form" == "quoted" ]]; then
+    printf '[features]\n"hooks" = true\n' > "$repo/.codex/config.toml"
+  else
+    printf 'features.hooks = true\n' > "$repo/.codex/config.toml"
+  fi
+  cp "$repo/.codex/config.toml" "$repo/before.toml"
+  if install "$repo" && cmp -s "$repo/.codex/config.toml" "$repo/before.toml"; then
+    ok "$form canonical true is accepted without rewriting"
+  else
+    bad "$form canonical true is accepted without rewriting"
+  fi
+done
+
+echo "=== TC-CDCR-015: noncanonical legacy migration refuses ==="
+for form in quoted dotted; do
+  repo=$(new_repo "legacy_$form")
+  mkdir -p "$repo/.codex"
+  if [[ "$form" == "quoted" ]]; then
+    printf '[features]\n"codex_hooks" = true\n' > "$repo/.codex/config.toml"
+  else
+    printf 'features.codex_hooks = true\n' > "$repo/.codex/config.toml"
+  fi
+  cp "$repo/.codex/config.toml" "$repo/before.toml"
+  if install "$repo"; then
+    bad "$form legacy key must refuse unsafe migration"
+  elif cmp -s "$repo/.codex/config.toml" "$repo/before.toml"; then
+    ok "$form legacy key refuses and remains unchanged"
+  else
+    bad "$form legacy key refuses and remains unchanged"
+  fi
+done
+
+echo "=== TC-CDCR-016: invalid or array feature tables refuse ==="
+for form in array duplicate_key duplicate_table; do
+  repo=$(new_repo "$form")
+  mkdir -p "$repo/.codex"
+  case "$form" in
+    array)
+      printf '[[features]]\nhooks = true\n' > "$repo/.codex/config.toml"
+      ;;
+    duplicate_key)
+      printf '[features]\nhooks = true\nhooks = true\n' > "$repo/.codex/config.toml"
+      ;;
+    duplicate_table)
+      printf '[features]\nhooks = true\n[features]\nother = true\n' > "$repo/.codex/config.toml"
+      ;;
+  esac
+  cp "$repo/.codex/config.toml" "$repo/before.toml"
+  if install "$repo"; then
+    bad "$form must refuse"
+  elif cmp -s "$repo/.codex/config.toml" "$repo/before.toml" &&
+       [[ ! -f "$repo/.codex/hooks.json" ]]; then
+    ok "$form refuses before changing either destination"
+  else
+    bad "$form refuses before changing either destination"
+  fi
+done
+
+echo "=== TC-CDCR-017: second-file failure rolls back config ==="
+repo=$(new_repo rollback)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
+cp "$repo/.codex/config.toml" "$repo/config.before"
+cp "$repo/.codex/hooks.json" "$repo/hooks.before"
+real_mv=$(command -v mv)
+cat > "$repo/fakebin/mv" <<'EOF'
+#!/bin/bash
+if [[ "${FAIL_MOVE_DEST:-}" == "${@: -1}" ]]; then
+  exit 73
+fi
+exec "$REAL_MV" "$@"
+EOF
+chmod +x "$repo/fakebin/mv"
+if (
+  cd "$repo" &&
+    REAL_MV="$real_mv" FAIL_MOVE_DEST="$repo/.codex/hooks.json" \
+      PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+); then
+  bad "simulated hooks replacement failure must fail"
+else
+  ok "simulated hooks replacement failure fails"
+fi
+if cmp -s "$repo/.codex/config.toml" "$repo/config.before" &&
+   cmp -s "$repo/.codex/hooks.json" "$repo/hooks.before"; then
+  ok "config and hooks are restored after second-file failure"
+else
+  bad "config and hooks are restored after second-file failure"
+fi
+
+echo "=== TC-CDCR-017A: rollback preserves a concurrent operator edit ==="
+repo=$(new_repo rollback_concurrent_edit)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
+cat > "$repo/fakebin/mv" <<'EOF'
+#!/bin/bash
+if [[ "${FAIL_MOVE_DEST:-}" == "${@: -1}" ]]; then
+  printf '\n# operator edit during rollback window\n' >> "$ROLLBACK_RACE_CONFIG"
+  exit 73
+fi
+exec "$REAL_MV" "$@"
+EOF
+chmod +x "$repo/fakebin/mv"
+if (
+  cd "$repo" &&
+    REAL_MV="$real_mv" FAIL_MOVE_DEST="$repo/.codex/hooks.json" \
+      ROLLBACK_RACE_CONFIG="$repo/.codex/config.toml" \
+      PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+); then
+  bad "hooks failure with concurrent config edit must fail"
+elif grep -q 'operator edit during rollback window' "$repo/.codex/config.toml" &&
+     grep -q '^hooks = true' "$repo/.codex/config.toml" &&
+     grep -q 'refusing to overwrite a concurrent edit' "$repo/install.err" &&
+     grep -q '"sentinel":true' "$repo/.codex/hooks.json"; then
+  ok "rollback refuses to overwrite the concurrent operator edit"
+else
+  bad "rollback refuses to overwrite the concurrent operator edit"
+fi
+
+echo "=== TC-CDCR-018: successful replacement preserves file modes ==="
+repo=$(new_repo preserve_modes)
+mkdir -p "$repo/.codex"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
+chmod 0640 "$repo/.codex/config.toml"
+chmod 0604 "$repo/.codex/hooks.json"
+if (umask 000; install "$repo"); then
+  ok "install under permissive umask succeeds"
+else
+  bad "install under permissive umask succeeds"
+fi
+[[ "$(file_mode "$repo/.codex/config.toml")" == "640" ]] \
+  && ok "config mode is preserved" \
+  || bad "config mode is preserved"
+[[ "$(file_mode "$repo/.codex/hooks.json")" == "604" ]] \
+  && ok "hooks mode is preserved" \
+  || bad "hooks mode is preserved"
+
+repo=$(new_repo secure_fresh_modes)
+if (umask 000; install "$repo"); then
+  ok "fresh install under permissive umask succeeds"
+else
+  bad "fresh install under permissive umask succeeds"
+fi
+[[ "$(file_mode "$repo/.codex/config.toml")" == "600" &&
+   "$(file_mode "$repo/.codex/hooks.json")" == "600" ]] \
+  && ok "fresh generated files remain private under permissive umask" \
+  || bad "fresh generated files remain private under permissive umask"
+
+echo "=== TC-CDCR-019: non-regular destinations refuse ==="
+repo=$(new_repo config_directory)
+mkdir -p "$repo/.codex/config.toml"
+if install "$repo"; then
+  bad "config directory must refuse"
+elif [[ -d "$repo/.codex/config.toml" && ! -e "$repo/.codex/hooks.json" ]]; then
+  ok "config directory refuses before writing hooks"
+else
+  bad "config directory refuses before writing hooks"
+fi
+
+repo=$(new_repo symlinked_codex_directory)
+mkdir -p "$repo/external-codex"
+ln -s "$repo/external-codex" "$repo/.codex"
+if install "$repo"; then
+  bad "symlinked .codex directory must refuse"
+elif [[ -L "$repo/.codex" ]] &&
+     [[ -z "$(find "$repo/external-codex" -mindepth 1 -print -quit)" ]]; then
+  ok "symlinked .codex directory refuses without writing outside the repo path"
+else
+  bad "symlinked .codex directory refuses without writing outside the repo path"
+fi
+
+repo=$(new_repo hooks_symlink)
+mkdir -p "$repo/.codex"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/hooks-target.json"
+ln -s "$repo/hooks-target.json" "$repo/.codex/hooks.json"
+cp "$repo/.codex/config.toml" "$repo/config.before"
+if install "$repo"; then
+  bad "hooks symlink must refuse"
+elif [[ -L "$repo/.codex/hooks.json" ]] &&
+     cmp -s "$repo/.codex/config.toml" "$repo/config.before" &&
+     grep -q '"sentinel":true' "$repo/hooks-target.json"; then
+  ok "hooks symlink refuses without replacing the link or changing config"
+else
+  bad "hooks symlink refuses without replacing the link or changing config"
+fi
+
+echo "=== TC-CDCR-019A: interruption between replacements rolls back ==="
+repo=$(new_repo signal_rollback)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
+cp "$repo/.codex/config.toml" "$repo/config.before"
+cp "$repo/.codex/hooks.json" "$repo/hooks.before"
+cat > "$repo/fakebin/mv" <<'EOF'
+#!/bin/bash
+if [[ "${FAIL_SIGNAL_DEST:-}" == "${@: -1}" &&
+      ! -e "${FAIL_SIGNAL_STATE:-}" ]]; then
+  : > "$FAIL_SIGNAL_STATE"
+  "$REAL_MV" "$@"
+  rc=$?
+  kill -TERM "$PPID"
+  sleep 1
+  exit "$rc"
+fi
+exec "$REAL_MV" "$@"
+EOF
+chmod +x "$repo/fakebin/mv"
+(
+  cd "$repo" &&
+    REAL_MV="$real_mv" FAIL_SIGNAL_DEST="$repo/.codex/config.toml" \
+      FAIL_SIGNAL_STATE="$repo/signal-fired" \
+      PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+)
+rc=$?
+if [[ "$rc" -eq 143 ]]; then
+  ok "SIGTERM during the transaction exits 143"
+else
+  bad "SIGTERM during the transaction exits 143 (rc=$rc)"
+fi
+if cmp -s "$repo/.codex/config.toml" "$repo/config.before" &&
+   cmp -s "$repo/.codex/hooks.json" "$repo/hooks.before"; then
+  ok "signal handler restores both destinations"
+else
+  bad "signal handler restores both destinations"
+fi
+if compgen -G "$repo/.codex/*.pending.*" >/dev/null; then
+  bad "signal handler removes pending files"
+else
+  ok "signal handler removes pending files"
+fi
+
+echo "=== TC-CDCR-019D: signal during pending staging cleans up ==="
+repo=$(new_repo signal_during_staging)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+cp "$repo/.codex/config.toml" "$repo/config.before"
+real_cp=$(command -v cp)
+cat > "$repo/fakebin/cp" <<'EOF'
+#!/bin/bash
+"$REAL_CP" "$@"
+rc=$?
+destination="${@: -1}"
+if [[ "$destination" == *".pending."* &&
+      ! -e "${FAIL_SIGNAL_STATE:-}" ]]; then
+  : > "$FAIL_SIGNAL_STATE"
+  kill -TERM "$PPID"
+  sleep 1
+fi
+exit "$rc"
+EOF
+chmod +x "$repo/fakebin/cp"
+(
+  cd "$repo" &&
+    REAL_CP="$real_cp" FAIL_SIGNAL_STATE="$repo/signal-fired" \
+      PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+)
+rc=$?
+if [[ "$rc" -eq 143 ]] &&
+   cmp -s "$repo/.codex/config.toml" "$repo/config.before" &&
+   [[ ! -e "$repo/.codex/hooks.json" ]] &&
+   ! compgen -G "$repo/.codex/*.pending.*" >/dev/null; then
+  ok "early signal preserves destinations and removes pending files"
+else
+  bad "early signal preserves destinations and removes pending files (rc=$rc)"
+fi
+
+echo "=== TC-CDCR-019B: concurrent config edit is not overwritten ==="
+repo=$(new_repo concurrent_edit)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+cat > "$repo/fakebin/jq" <<'EOF'
+#!/bin/bash
+"$REAL_JQ" "$@"
+rc=$?
+if (( rc == 0 )) &&
+   [[ "${@: -1}" == *claude-settings.template.json ]]; then
+  printf '\n# concurrent operator edit\n' >> "$RACE_CONFIG"
+fi
+exit "$rc"
+EOF
+chmod +x "$repo/fakebin/jq"
+real_jq=$(command -v jq)
+if (
+  cd "$repo" &&
+    REAL_JQ="$real_jq" RACE_CONFIG="$repo/.codex/config.toml" \
+      PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+); then
+  bad "concurrent edit must refuse installation"
+elif grep -q 'concurrent operator edit' "$repo/.codex/config.toml" &&
+     grep -q '^codex_hooks = true' "$repo/.codex/config.toml" &&
+     [[ ! -e "$repo/.codex/hooks.json" ]]; then
+  ok "concurrent edit survives and neither destination is replaced"
+else
+  bad "concurrent edit survives and neither destination is replaced"
+fi
+
+echo "=== TC-CDCR-019C: concurrent mode change is not overwritten ==="
+repo=$(new_repo concurrent_mode)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+chmod 0644 "$repo/.codex/config.toml"
+cat > "$repo/fakebin/jq" <<'EOF'
+#!/bin/bash
+"$REAL_JQ" "$@"
+rc=$?
+if (( rc == 0 )) &&
+   [[ "${@: -1}" == *claude-settings.template.json ]]; then
+  chmod 0600 "$RACE_CONFIG"
+fi
+exit "$rc"
+EOF
+chmod +x "$repo/fakebin/jq"
+if (
+  cd "$repo" &&
+    REAL_JQ="$real_jq" RACE_CONFIG="$repo/.codex/config.toml" \
+      PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+); then
+  bad "concurrent mode change must refuse installation"
+elif [[ "$(file_mode "$repo/.codex/config.toml")" == "600" ]] &&
+     grep -q '^codex_hooks = true' "$repo/.codex/config.toml" &&
+     [[ ! -e "$repo/.codex/hooks.json" ]]; then
+  ok "concurrent mode change survives and neither destination is replaced"
+else
+  bad "concurrent mode change survives and neither destination is replaced"
+fi
+
 echo "=== Summary ==="
-echo "  PASS: $PASS"
-echo "  FAIL: $FAIL"
-[[ $FAIL -eq 0 ]] || exit 1
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+[[ $FAIL -eq 0 ]]

--- a/tests/unit/test-install-codex-hooks.sh
+++ b/tests/unit/test-install-codex-hooks.sh
@@ -236,7 +236,7 @@ else
   bad "migration does not rewrite keys in unrelated array tables"
 fi
 
-echo "=== TC-CDCR-008B: quoted table headers refuse mutable migration ==="
+echo "=== TC-CDCR-008B: unrelated quoted table headers survive migration ==="
 repo=$(new_repo legacy_with_quoted_table)
 mkdir -p "$repo/.codex"
 cat > "$repo/.codex/config.toml" <<'EOF'
@@ -246,14 +246,41 @@ codex_hooks = true
 ["operator#table"]
 codex_hooks = "operator-data"
 EOF
+if install "$repo" &&
+   python3 - "$repo/.codex/config.toml" <<'PY'
+import sys
+import tomllib
+
+config = tomllib.load(open(sys.argv[1], "rb"))
+assert config["features"]["hooks"] is True
+assert "codex_hooks" not in config["features"]
+assert config["operator#table"]["codex_hooks"] == "operator-data"
+PY
+then
+  ok "unrelated quoted table survives canonical migration"
+else
+  bad "unrelated quoted table survives canonical migration"
+fi
+
+echo "=== TC-CDCR-008C: multiline arrays cannot hide a failed migration ==="
+repo=$(new_repo legacy_with_multiline_array)
+mkdir -p "$repo/.codex"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+matrix = [
+  [1, 2]
+]
+codex_hooks = true
+EOF
 cp "$repo/.codex/config.toml" "$repo/before.toml"
 if install "$repo"; then
-  bad "quoted table header must refuse mutable migration"
+  bad "unsafe multiline-array migration must refuse"
 elif cmp -s "$repo/.codex/config.toml" "$repo/before.toml" &&
-     [[ ! -e "$repo/.codex/hooks.json" ]]; then
-  ok "quoted table header refuses without changing either destination"
+     [[ ! -e "$repo/.codex/hooks.json" ]] &&
+     grep -q 'could not safely canonicalize' "$repo/install.err"; then
+  ok "semantic postcondition refuses a missed multiline-array migration"
 else
-  bad "quoted table header refuses without changing either destination"
+  bad "semantic postcondition refuses a missed multiline-array migration"
 fi
 
 echo "=== TC-CDCR-009: legacy false is preserved ==="
@@ -407,7 +434,7 @@ for form in array duplicate_key duplicate_table; do
   fi
 done
 
-echo "=== TC-CDCR-017: second-file failure rolls back config ==="
+echo "=== TC-CDCR-017: config failure rolls back the earlier hooks install ==="
 repo=$(new_repo rollback)
 mkdir -p "$repo/.codex" "$repo/fakebin"
 cat > "$repo/.codex/config.toml" <<'EOF'
@@ -418,29 +445,72 @@ printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
 cp "$repo/.codex/config.toml" "$repo/config.before"
 cp "$repo/.codex/hooks.json" "$repo/hooks.before"
 real_mv=$(command -v mv)
-cat > "$repo/fakebin/mv" <<'EOF'
+real_python=$(command -v python3)
+cat > "$repo/fakebin/python3" <<'EOF'
 #!/bin/bash
-if [[ "${FAIL_MOVE_DEST:-}" == "${@: -1}" ]]; then
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${FAIL_PLACE_DEST:-}" == "${3:-}" &&
+      "${2:-}" == *".pending."* ]]; then
   exit 73
 fi
-exec "$REAL_MV" "$@"
+exec "$REAL_PYTHON" "$@"
 EOF
-chmod +x "$repo/fakebin/mv"
+chmod +x "$repo/fakebin/python3"
 if (
   cd "$repo" &&
-    REAL_MV="$real_mv" FAIL_MOVE_DEST="$repo/.codex/hooks.json" \
+    REAL_PYTHON="$real_python" FAIL_PLACE_DEST="config.toml" \
       PATH="$repo/fakebin:$PATH" \
       bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
 ); then
-  bad "simulated hooks replacement failure must fail"
+  bad "simulated config replacement failure must fail"
 else
-  ok "simulated hooks replacement failure fails"
+  ok "simulated config replacement failure fails"
 fi
 if cmp -s "$repo/.codex/config.toml" "$repo/config.before" &&
    cmp -s "$repo/.codex/hooks.json" "$repo/hooks.before"; then
   ok "config and hooks are restored after second-file failure"
 else
   bad "config and hooks are restored after second-file failure"
+fi
+
+echo "=== TC-CDCR-017B: hooks install before the enabling feature flag ==="
+repo=$(new_repo replacement_order)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
+cat > "$repo/fakebin/python3" <<'EOF'
+#!/bin/bash
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${2:-}" == *".pending."* &&
+      ( "${3:-}" == "$ORDER_HOOKS" || "${3:-}" == "$ORDER_CONFIG" ) ]]; then
+  printf '%s\n' "$3" >> "$ORDER_LOG"
+fi
+exec "$REAL_PYTHON" "$@"
+EOF
+chmod +x "$repo/fakebin/python3"
+if (
+  cd "$repo" &&
+    REAL_PYTHON="$real_python" ORDER_LOG="$repo/move-order" \
+      ORDER_HOOKS="hooks.json" \
+      ORDER_CONFIG="config.toml" \
+      PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+); then
+  move_order=()
+  while IFS= read -r item; do
+    move_order[${#move_order[@]}]="$item"
+  done < "$repo/move-order"
+  if [[ "${move_order[0]:-}" == "hooks.json" &&
+        "${move_order[1]:-}" == "config.toml" ]]; then
+    ok "hooks are replaced before config enables them"
+  else
+    bad "hooks are replaced before config enables them"
+  fi
+else
+  bad "replacement-order fixture installs"
 fi
 
 echo "=== TC-CDCR-017A: rollback preserves a concurrent operator edit ==="
@@ -451,27 +521,42 @@ cat > "$repo/.codex/config.toml" <<'EOF'
 codex_hooks = true
 EOF
 printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
-cat > "$repo/fakebin/mv" <<'EOF'
+cat > "$repo/fakebin/python3" <<'EOF'
 #!/bin/bash
-if [[ "${FAIL_MOVE_DEST:-}" == "${@: -1}" ]]; then
-  printf '\n# operator edit during rollback window\n' >> "$ROLLBACK_RACE_CONFIG"
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${FAIL_PLACE_DEST:-}" == "${3:-}" &&
+      "${2:-}" == *".pending."* ]]; then
   exit 73
 fi
-exec "$REAL_MV" "$@"
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${2:-}" == "$ROLLBACK_RACE_HOOKS" &&
+      "${3:-}" == *".rollback-current."* &&
+      ! -e "$ROLLBACK_SIGNAL_STATE" ]]; then
+  : > "$ROLLBACK_SIGNAL_STATE"
+  "$REAL_PYTHON" "$@"
+  rc=$?
+  printf '\n// operator edit during rollback window\n' >> "$3"
+  kill -TERM "$PPID"
+  sleep 1
+  exit "$rc"
+fi
+exec "$REAL_PYTHON" "$@"
 EOF
-chmod +x "$repo/fakebin/mv"
+chmod +x "$repo/fakebin/python3"
 if (
   cd "$repo" &&
-    REAL_MV="$real_mv" FAIL_MOVE_DEST="$repo/.codex/hooks.json" \
-      ROLLBACK_RACE_CONFIG="$repo/.codex/config.toml" \
+    REAL_PYTHON="$real_python" FAIL_PLACE_DEST="config.toml" \
+      ROLLBACK_RACE_HOOKS="hooks.json" \
+      ROLLBACK_SIGNAL_STATE="$repo/rollback-signal-fired" \
       PATH="$repo/fakebin:$PATH" \
       bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
 ); then
-  bad "hooks failure with concurrent config edit must fail"
-elif grep -q 'operator edit during rollback window' "$repo/.codex/config.toml" &&
-     grep -q '^hooks = true' "$repo/.codex/config.toml" &&
+  bad "config failure with concurrent hooks edit must fail"
+elif grep -q 'operator edit during rollback window' "$repo/.codex/hooks.json" &&
+     grep -q '^codex_hooks = true' "$repo/.codex/config.toml" &&
+     [[ -e "$repo/rollback-signal-fired" ]] &&
      grep -q 'refusing to overwrite a concurrent edit' "$repo/install.err" &&
-     grep -q '"sentinel":true' "$repo/.codex/hooks.json"; then
+     ! grep -q '"sentinel":true' "$repo/.codex/hooks.json"; then
   ok "rollback refuses to overwrite the concurrent operator edit"
 else
   bad "rollback refuses to overwrite the concurrent operator edit"
@@ -509,6 +594,11 @@ fi
    "$(file_mode "$repo/.codex/hooks.json")" == "600" ]] \
   && ok "fresh generated files remain private under permissive umask" \
   || bad "fresh generated files remain private under permissive umask"
+[[ "$(file_mode "$repo/.codex")" == "700" ]] \
+  && ok "fresh Codex directory remains private under permissive umask" \
+  || bad "fresh Codex directory remains private under permissive umask"
+assert_file_not_contains "transaction scratch names are not PID-predictable" \
+  "$INSTALLER" 'pending\.\$\$|rollback\.\$\$'
 
 echo "=== TC-CDCR-019: non-regular destinations refuse ==="
 repo=$(new_repo config_directory)
@@ -562,24 +652,42 @@ EOF
 printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
 cp "$repo/.codex/config.toml" "$repo/config.before"
 cp "$repo/.codex/hooks.json" "$repo/hooks.before"
-cat > "$repo/fakebin/mv" <<'EOF'
+cat > "$repo/fakebin/python3" <<'EOF'
 #!/bin/bash
-if [[ "${FAIL_SIGNAL_DEST:-}" == "${@: -1}" &&
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" ]]; then
+  printf '%s\n' "${3:-}" >> "$SIGNAL_ORDER"
+fi
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${FAIL_SIGNAL_DEST:-}" == "${3:-}" &&
+      "${2:-}" == *".pending."* &&
       ! -e "${FAIL_SIGNAL_STATE:-}" ]]; then
   : > "$FAIL_SIGNAL_STATE"
-  "$REAL_MV" "$@"
+  "$REAL_PYTHON" "$@"
   rc=$?
   kill -TERM "$PPID"
   sleep 1
   exit "$rc"
 fi
-exec "$REAL_MV" "$@"
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${FAIL_SIGNAL_DEST:-}" == "${3:-}" &&
+      "${2:-}" == *".rollback."* &&
+      ! -e "${FAIL_SIGNAL_SECOND_STATE:-}" ]]; then
+  : > "$FAIL_SIGNAL_SECOND_STATE"
+  "$REAL_PYTHON" "$@"
+  rc=$?
+  kill -TERM "$PPID"
+  sleep 1
+  exit "$rc"
+fi
+exec "$REAL_PYTHON" "$@"
 EOF
-chmod +x "$repo/fakebin/mv"
+chmod +x "$repo/fakebin/python3"
 (
   cd "$repo" &&
-    REAL_MV="$real_mv" FAIL_SIGNAL_DEST="$repo/.codex/config.toml" \
+    REAL_PYTHON="$real_python" FAIL_SIGNAL_DEST="config.toml" \
       FAIL_SIGNAL_STATE="$repo/signal-fired" \
+      FAIL_SIGNAL_SECOND_STATE="$repo/second-signal-fired" \
+      SIGNAL_ORDER="$repo/signal-order" \
       PATH="$repo/fakebin:$PATH" \
       bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
 )
@@ -594,6 +702,19 @@ if cmp -s "$repo/.codex/config.toml" "$repo/config.before" &&
   ok "signal handler restores both destinations"
 else
   bad "signal handler restores both destinations"
+fi
+signal_order=()
+while IFS= read -r item; do
+  signal_order[${#signal_order[@]}]="$item"
+done < <(grep -Fx -e "config.toml" -e "hooks.json" "$repo/signal-order")
+signal_count=${#signal_order[@]}
+if [[ -e "$repo/second-signal-fired" &&
+      "$signal_count" -ge 4 &&
+      "${signal_order[signal_count - 2]}" == "config.toml" &&
+      "${signal_order[signal_count - 1]}" == "hooks.json" ]]; then
+  ok "rollback ignores a repeated signal and restores config before hooks"
+else
+  bad "rollback ignores a repeated signal and restores config before hooks"
 fi
 if compgen -G "$repo/.codex/*.pending.*" >/dev/null; then
   bad "signal handler removes pending files"
@@ -706,6 +827,373 @@ elif [[ "$(file_mode "$repo/.codex/config.toml")" == "600" ]] &&
   ok "concurrent mode change survives and neither destination is replaced"
 else
   bad "concurrent mode change survives and neither destination is replaced"
+fi
+
+echo "=== TC-CDCR-019E: edit in the final placement window is preserved ==="
+repo=$(new_repo final_placement_race)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
+cp "$repo/.codex/hooks.json" "$repo/hooks.before"
+cat > "$repo/fakebin/python3" <<'EOF'
+#!/bin/bash
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${3:-}" == "$RACE_CONFIG" &&
+      "${2:-}" == *".pending."* &&
+      ! -e "$RACE_STATE" ]]; then
+  : > "$RACE_STATE"
+  printf '[features]\ncodex_hooks = true\n# final-window operator edit\n' \
+    > "$RACE_CONFIG"
+fi
+exec "$REAL_PYTHON" "$@"
+EOF
+chmod +x "$repo/fakebin/python3"
+if (
+  cd "$repo" &&
+    REAL_PYTHON="$real_python" RACE_CONFIG="config.toml" \
+      RACE_STATE="$repo/race-fired" PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+); then
+  bad "final-window edit must abort installation"
+elif grep -q 'final-window operator edit' "$repo/.codex/config.toml" &&
+     cmp -s "$repo/.codex/hooks.json" "$repo/hooks.before"; then
+  ok "final-window edit survives and the earlier hooks replacement rolls back"
+else
+  bad "final-window edit survives and the earlier hooks replacement rolls back"
+fi
+
+echo "=== TC-CDCR-019F: a losing capture leaves ownership with its winner ==="
+repo=$(new_repo capture_loser)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
+cp "$repo/.codex/config.toml" "$repo/config.before"
+cat > "$repo/fakebin/python3" <<'EOF'
+#!/bin/bash
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${2:-}" == "$CAPTURE_SOURCE" &&
+      "${3:-}" == "$CAPTURE_SOURCE".bak.* ]]; then
+  "$REAL_MV" "$2" "$CAPTURE_HELD"
+fi
+exec "$REAL_PYTHON" "$@"
+EOF
+chmod +x "$repo/fakebin/python3"
+if (
+  cd "$repo" &&
+    REAL_MV="$real_mv" REAL_PYTHON="$real_python" \
+      CAPTURE_SOURCE="hooks.json" \
+      CAPTURE_HELD="$repo/concurrent-capture.json" \
+      PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+); then
+  bad "losing capture must abort installation"
+elif [[ ! -e "$repo/.codex/hooks.json" ]] &&
+     grep -q '"sentinel":true' "$repo/concurrent-capture.json" &&
+     cmp -s "$repo/.codex/config.toml" "$repo/config.before" &&
+     ! compgen -G "$repo/.codex/*.bak.*" >/dev/null; then
+  ok "losing capture leaves ownership with the concurrent installer"
+else
+  bad "losing capture leaves ownership with the concurrent installer"
+fi
+
+echo "=== TC-CDCR-019H: ambiguous capture failure reconciles its postcondition ==="
+repo=$(new_repo ambiguous_capture)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
+cat > "$repo/fakebin/python3" <<'EOF'
+#!/bin/bash
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${2:-}" == "$CAPTURE_SOURCE" &&
+      "${3:-}" == "$CAPTURE_SOURCE".bak.* &&
+      ! -e "$CAPTURE_STATE" ]]; then
+  : > "$CAPTURE_STATE"
+  "$REAL_PYTHON" "$@"
+  exit 73
+fi
+exec "$REAL_PYTHON" "$@"
+EOF
+chmod +x "$repo/fakebin/python3"
+if (
+  cd "$repo" &&
+    REAL_PYTHON="$real_python" CAPTURE_SOURCE="hooks.json" \
+      CAPTURE_STATE="$repo/capture-fired" PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+) &&
+   grep -q '^hooks = true' "$repo/.codex/config.toml" &&
+   ! grep -q '"sentinel":true' "$repo/.codex/hooks.json" &&
+   grep -q '"sentinel":true' "$repo"/.codex/hooks.json.bak.*; then
+  ok "completed capture is accepted despite an ambiguous helper status"
+else
+  bad "completed capture is accepted despite an ambiguous helper status"
+fi
+
+echo "=== TC-CDCR-019I: capture never treats its backup path as a directory ==="
+repo=$(new_repo capture_backup_directory)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
+cp "$repo/.codex/config.toml" "$repo/config.before"
+cat > "$repo/fakebin/python3" <<'EOF'
+#!/bin/bash
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${2:-}" == "$CAPTURE_SOURCE" &&
+      "${3:-}" == "$CAPTURE_SOURCE".bak.* &&
+      ! -e "$CAPTURE_STATE" ]]; then
+  : > "$CAPTURE_STATE"
+  mkdir "$3"
+fi
+exec "$REAL_PYTHON" "$@"
+EOF
+chmod +x "$repo/fakebin/python3"
+if (
+  cd "$repo" &&
+    REAL_PYTHON="$real_python" CAPTURE_SOURCE="hooks.json" \
+      CAPTURE_STATE="$repo/capture-fired" PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+); then
+  bad "capture backup directory must abort installation"
+else
+  backup_dir=$(find "$repo/.codex" -maxdepth 1 -type d \
+    -name 'hooks.json.bak.*' -print -quit)
+  if [[ -n "$backup_dir" ]] &&
+     [[ -z "$(find "$backup_dir" -mindepth 1 -print -quit)" ]] &&
+     grep -q '"sentinel":true' "$repo/.codex/hooks.json" &&
+     cmp -s "$repo/.codex/config.toml" "$repo/config.before"; then
+    ok "capture preserves both the canonical file and concurrent directory"
+  else
+    bad "capture preserves both the canonical file and concurrent directory"
+  fi
+fi
+
+echo "=== TC-CDCR-019J: rollback capture never targets a concurrent directory ==="
+repo=$(new_repo rollback_capture_directory)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
+cp "$repo/.codex/config.toml" "$repo/config.before"
+cat > "$repo/fakebin/python3" <<'EOF'
+#!/bin/bash
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${2:-}" == *".pending."* &&
+      "${3:-}" == "$FAIL_PLACE_DEST" ]]; then
+  exit 73
+fi
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${2:-}" == "$ROLLBACK_SOURCE" &&
+      "${3:-}" == *".rollback-current."* &&
+      ! -e "$ROLLBACK_STATE" ]]; then
+  : > "$ROLLBACK_STATE"
+  mkdir "$3"
+fi
+exec "$REAL_PYTHON" "$@"
+EOF
+chmod +x "$repo/fakebin/python3"
+if (
+  cd "$repo" &&
+    REAL_PYTHON="$real_python" FAIL_PLACE_DEST="config.toml" \
+      ROLLBACK_SOURCE="hooks.json" \
+      ROLLBACK_STATE="$repo/rollback-fired" PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+); then
+  bad "rollback capture directory race must fail installation"
+else
+  rollback_dir=$(find "$repo/.codex" -maxdepth 1 -type d \
+    -name 'hooks.json.rollback-current.*' -print -quit)
+  if [[ -n "$rollback_dir" ]] &&
+     [[ -z "$(find "$rollback_dir" -mindepth 1 -print -quit)" ]] &&
+     [[ -f "$repo/.codex/hooks.json" ]] &&
+     cmp -s "$repo/.codex/config.toml" "$repo/config.before"; then
+    ok "rollback preserves the canonical file and concurrent directory"
+  else
+    bad "rollback preserves the canonical file and concurrent directory"
+  fi
+fi
+
+echo "=== TC-CDCR-019K: capture-time SIGTERM is handled, not discarded ==="
+repo=$(new_repo signal_during_capture)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
+cp "$repo/.codex/config.toml" "$repo/config.before"
+cp "$repo/.codex/hooks.json" "$repo/hooks.before"
+cat > "$repo/fakebin/python3" <<'EOF'
+#!/bin/bash
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${2:-}" == "$CAPTURE_SOURCE" &&
+      "${3:-}" == "$CAPTURE_SOURCE".bak.* &&
+      ! -e "$CAPTURE_STATE" ]]; then
+  : > "$CAPTURE_STATE"
+  "$REAL_PYTHON" "$@"
+  rc=$?
+  kill -TERM "$PPID"
+  sleep 1
+  exit "$rc"
+fi
+exec "$REAL_PYTHON" "$@"
+EOF
+chmod +x "$repo/fakebin/python3"
+(
+  cd "$repo" &&
+    REAL_PYTHON="$real_python" CAPTURE_SOURCE="hooks.json" \
+      CAPTURE_STATE="$repo/capture-fired" PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+)
+rc=$?
+if [[ "$rc" -eq 143 ]] &&
+   cmp -s "$repo/.codex/config.toml" "$repo/config.before" &&
+   cmp -s "$repo/.codex/hooks.json" "$repo/hooks.before"; then
+  ok "capture-time SIGTERM exits 143 and restores both destinations"
+else
+  bad "capture-time SIGTERM exits 143 and restores both destinations (rc=$rc)"
+fi
+
+echo "=== TC-CDCR-019L: a concurrent directory is never used as a move target ==="
+repo=$(new_repo final_directory_race)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
+cp "$repo/.codex/config.toml" "$repo/config.before"
+cat > "$repo/fakebin/python3" <<'EOF'
+#!/bin/bash
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${3:-}" == "$RACE_HOOKS" &&
+      "${2:-}" == *".pending."* &&
+      ! -e "$RACE_STATE" ]]; then
+  : > "$RACE_STATE"
+  mkdir "$RACE_HOOKS"
+fi
+exec "$REAL_PYTHON" "$@"
+EOF
+chmod +x "$repo/fakebin/python3"
+if (
+  cd "$repo" &&
+    REAL_PYTHON="$real_python" RACE_HOOKS="hooks.json" \
+      RACE_STATE="$repo/race-fired" PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+); then
+  bad "concurrent directory must abort installation"
+elif [[ -d "$repo/.codex/hooks.json" ]] &&
+     [[ -z "$(find "$repo/.codex/hooks.json" -mindepth 1 -print -quit)" ]] &&
+     cmp -s "$repo/.codex/config.toml" "$repo/config.before"; then
+  ok "concurrent directory stays empty and config remains unchanged"
+else
+  bad "concurrent directory stays empty and config remains unchanged"
+fi
+
+echo "=== TC-CDCR-019M: parent-directory swap cannot redirect writes ==="
+repo=$(new_repo parent_directory_swap)
+mkdir -p "$repo/.codex" "$repo/external-codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
+cp "$repo/.codex/config.toml" "$repo/config.before"
+cp "$repo/.codex/hooks.json" "$repo/hooks.before"
+cat > "$repo/fakebin/python3" <<'EOF'
+#!/bin/bash
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${2:-}" == *".pending."* &&
+      "${3:-}" == "config.toml" &&
+      ! -e "$SWAP_STATE" ]]; then
+  : > "$SWAP_STATE"
+  "$REAL_PYTHON" "$@"
+  rc=$?
+  "$REAL_MV" "$PROJECT_CODEX" "$HELD_CODEX"
+  ln -s "$EXTERNAL_CODEX" "$PROJECT_CODEX"
+  exit "$rc"
+fi
+exec "$REAL_PYTHON" "$@"
+EOF
+chmod +x "$repo/fakebin/python3"
+if (
+  cd "$repo" &&
+    REAL_PYTHON="$real_python" REAL_MV="$real_mv" \
+      PROJECT_CODEX="$repo/.codex" HELD_CODEX="$repo/held-codex" \
+      EXTERNAL_CODEX="$repo/external-codex" SWAP_STATE="$repo/swap-fired" \
+      PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+); then
+  bad "parent-directory swap must abort installation"
+elif [[ -L "$repo/.codex" ]] &&
+     cmp -s "$repo/held-codex/config.toml" "$repo/config.before" &&
+     cmp -s "$repo/held-codex/hooks.json" "$repo/hooks.before" &&
+     [[ -z "$(find "$repo/external-codex" -mindepth 1 -print -quit)" ]]; then
+  ok "anchored rollback restores the original directory without external writes"
+else
+  bad "anchored rollback restores the original directory without external writes"
+fi
+
+echo "=== TC-CDCR-019N: rollback never claims an unowned scratch object ==="
+repo=$(new_repo rollback_scratch_ownership)
+mkdir -p "$repo/.codex" "$repo/fakebin"
+cat > "$repo/.codex/config.toml" <<'EOF'
+[features]
+codex_hooks = true
+EOF
+printf '{"sentinel":true}\n' > "$repo/.codex/hooks.json"
+cp "$repo/.codex/config.toml" "$repo/config.before"
+cat > "$repo/fakebin/python3" <<'EOF'
+#!/bin/bash
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${2:-}" == *".pending."* &&
+      "${3:-}" == "config.toml" ]]; then
+  exit 73
+fi
+if [[ "${CODEX_ATOMIC_PLACE:-}" == "1" &&
+      "${2:-}" == "hooks.json" &&
+      "${3:-}" == *".rollback-current."* &&
+      ! -e "$OWNERSHIP_STATE" ]]; then
+  : > "$OWNERSHIP_STATE"
+  "$REAL_MV" "$2" "$OPERATOR_HELD"
+  printf 'operator-owned scratch\n' > "$3"
+  exit 73
+fi
+exec "$REAL_PYTHON" "$@"
+EOF
+chmod +x "$repo/fakebin/python3"
+if (
+  cd "$repo" &&
+    REAL_PYTHON="$real_python" REAL_MV="$real_mv" \
+      OPERATOR_HELD="$repo/operator-held-hooks.json" \
+      OWNERSHIP_STATE="$repo/ownership-fired" PATH="$repo/fakebin:$PATH" \
+      bash "$INSTALLER" --no-git-hook >/dev/null 2>"$repo/install.err"
+); then
+  bad "unowned rollback scratch race must fail installation"
+else
+  scratch_file=$(find "$repo/.codex" -maxdepth 1 -type f \
+    -name 'hooks.json.rollback-current.*' -print -quit)
+  if [[ ! -e "$repo/.codex/hooks.json" ]] &&
+     [[ -n "$scratch_file" ]] &&
+     grep -q 'operator-owned scratch' "$scratch_file" &&
+     [[ -f "$repo/operator-held-hooks.json" ]] &&
+     cmp -s "$repo/.codex/config.toml" "$repo/config.before"; then
+    ok "rollback preserves both unowned objects without moving either one"
+  else
+    bad "rollback preserves both unowned objects without moving either one"
+  fi
 fi
 
 echo "=== Summary ==="

--- a/tests/unit/test-install-kiro-hooks.sh
+++ b/tests/unit/test-install-kiro-hooks.sh
@@ -145,6 +145,19 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# Deduplication must retain the canonical execution order within each matcher.
+mapfile -t execute_bash_hooks < <(
+  jq -r '.hooks.preToolUse[] | select(.matcher == "execute_bash") | .hooks[].command' "$target"
+)
+if [[ "${execute_bash_hooks[0]:-}" == *"block-push-to-main.sh"* &&
+      "${execute_bash_hooks[1]:-}" == *"block-commit-outside-worktree.sh"* ]]; then
+  echo -e "  ${GREEN}PASS${NC}: dedup preserves canonical Bash hook order"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: dedup reordered canonical Bash hooks"
+  FAIL=$((FAIL + 1))
+fi
+
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== TC-KIRO-05: --agent <name> overrides default agent name ==="

--- a/tests/unit/test-install-kiro-hooks.sh
+++ b/tests/unit/test-install-kiro-hooks.sh
@@ -134,16 +134,14 @@ else
   FAIL=$((FAIL + 1))
 fi
 
-# The merged fs_write entry should contain hooks from BOTH Write and Edit.
-# In the canonical template, Write has 1 hook (check-test-plan.sh) and
-# Edit has 1 hook (also check-test-plan.sh). After dedup, fs_write should
-# have 2 hooks total (the concat).
+# Write and Edit currently name the same hook command, so the merged matcher
+# must execute it once.
 fs_write_hooks=$(jq '.hooks.preToolUse[] | select(.matcher == "fs_write") | .hooks | length' "$target")
-if [[ "$fs_write_hooks" -ge 2 ]]; then
-  echo -e "  ${GREEN}PASS${NC}: fs_write entry has $fs_write_hooks merged hooks (Write+Edit both preserved)"
+if [[ "$fs_write_hooks" -eq 1 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: duplicate Write/Edit hook command executes once"
   PASS=$((PASS + 1))
 else
-  echo -e "  ${RED}FAIL${NC}: fs_write entry has only $fs_write_hooks hook(s) — Write+Edit not merged"
+  echo -e "  ${RED}FAIL${NC}: fs_write entry has $fs_write_hooks duplicate hook commands"
   FAIL=$((FAIL + 1))
 fi
 

--- a/tests/unit/test-install-windsurf-hooks.sh
+++ b/tests/unit/test-install-windsurf-hooks.sh
@@ -87,14 +87,14 @@ fi
 echo ""
 echo "=== TC-WS-04: pre_write_code dedups Write+Edit hooks ==="
 # ---------------------------------------------------------------------------
-# Canonical template: PreToolUse + Write has 1 hook, PreToolUse + Edit has
-# 1 hook. After folding both into pre_write_code, expect 2 hooks total.
+# Canonical Write and Edit currently name the same command. Folding them into
+# one event must execute that command once.
 pre_write_count=$(jq '.hooks.pre_write_code | length' "$target")
-if [[ "$pre_write_count" -eq 2 ]]; then
-  echo -e "  ${GREEN}PASS${NC}: pre_write_code has 2 merged hooks (Write + Edit)"
+if [[ "$pre_write_count" -eq 1 ]]; then
+  echo -e "  ${GREEN}PASS${NC}: pre_write_code deduplicates the shared hook command"
   PASS=$((PASS + 1))
 else
-  echo -e "  ${RED}FAIL${NC}: pre_write_code expected 2, got $pre_write_count"
+  echo -e "  ${RED}FAIL${NC}: pre_write_code expected 1 command, got $pre_write_count"
   FAIL=$((FAIL + 1))
 fi
 

--- a/tests/unit/test-install-windsurf-hooks.sh
+++ b/tests/unit/test-install-windsurf-hooks.sh
@@ -98,6 +98,17 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# Deduplication must retain the canonical execution order within each event.
+mapfile -t pre_run_hooks < <(jq -r '.hooks.pre_run_command[].command' "$target")
+if [[ "${pre_run_hooks[0]:-}" == *"block-push-to-main.sh"* &&
+      "${pre_run_hooks[1]:-}" == *"block-commit-outside-worktree.sh"* ]]; then
+  echo -e "  ${GREEN}PASS${NC}: dedup preserves canonical command order"
+  PASS=$((PASS + 1))
+else
+  echo -e "  ${RED}FAIL${NC}: dedup reordered canonical commands"
+  FAIL=$((FAIL + 1))
+fi
+
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== TC-WS-05: re-install creates a backup ==="

--- a/tests/unit/test-lib-agent-per-side-launcher.sh
+++ b/tests/unit/test-lib-agent-per-side-launcher.sh
@@ -164,6 +164,15 @@ assert_contains "guard returns rc=1 (source aborted)" "RC=1" "$out"
 
 # ---------------------------------------------------------------------------
 echo ""
+echo "=== PSL-S8b: canonical Codex-dev / Claude-review launcher isolation ==="
+# ---------------------------------------------------------------------------
+# A Claude-only launcher is valid on the review side while Codex dev runs
+# naked. This is the first-class mixed topology from issue #486.
+out=$(launcher_guard "" "" "cc" "codex" "claude")
+assert_contains "review-only Claude launcher is accepted with Codex dev" "RC=0" "$out"
+
+# ---------------------------------------------------------------------------
+echo ""
 echo "=== PSL-S9: autonomous-dev.sh — launcher rebind AFTER source lib-auth.sh ==="
 # ---------------------------------------------------------------------------
 # Same invariant as INV-37 PSC-S9: the per-side rebind MUST come AFTER


### PR DESCRIPTION
## Summary
- make `AGENT_DEV_CMD=codex` with `AGENT_REVIEW_CMD=claude` a documented and tested first-class topology
- migrate Codex hook installation to canonical `features.hooks`, transaction-safe exact-target operations, git-root-resolvable commands, and project trust guidance
- normalize Claude, Codex, Kiro, Gemini, Kimi, and Windsurf edit payloads while keeping final verdict ownership with each wrapper-assigned parent review session

Closes #486

## Design
- [x] Design canvas created (`docs/designs/codex-dev-claude-review.md`)
- [x] LLM Team design review completed and posted to #486

## Test Plan
- [x] Test cases documented (`docs/test-cases/codex-dev-claude-review.md`)
- [x] Codex installer matrix passes (79/79)
- [x] Cross-agent hook payload behavior passes (43/43)
- [x] Kiro and Windsurf installer suites pass (13/13 and 11/11)
- [x] Mixed per-side command/launcher suites pass (17/17 each)
- [x] Documentation gate suite passes (22/22)
- [x] Shell idiom suite passes (66/66)
- [x] Provider cutover suite passes (80/80)
- [x] Code simplification and independent review completed with no blocking findings
- [x] Generated Codex hook command E2E fixture passes
- [x] CI checks pass
- [x] Reviewer bot findings addressed

## Local Full-Suite Note

`bash tests/run-unit-tests.sh` reports 216/219 in this environment. The same three failing test files reproduce on unchanged `main` and are unrelated to this diff:

- `test-codex-rerun-orphan-containment.sh`
- `test-lane-gc-p3-kill-paths-e2e.sh`
- `test-pgid-has-agent-process.sh`

All changed and newly added test surfaces pass locally. GitHub CI remains the merge gate.

## Checklist
- [x] New regression tests added
- [x] Documentation updated
- [x] Hook and installer failure paths covered
- [x] No change to Codex final-review adapter or verdict aggregation
