### PR TITLE
fix(dev-wrapper): durable PR-broker request + loud guards + single-branch recovery (INV-79/#519)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,8 @@ jobs:
             tests/unit/test-token-budget-wrapper-routing.sh \
             tests/unit/test-token-budget-e2e.sh \
             tests/e2e/run-token-budget-gates-e2e.sh \
+            tests/unit/test-pr-broker-durability.sh \
+            tests/e2e/run-pr-broker-durability-e2e.sh \
             skills/autonomous-dispatcher/scripts/metrics-report.sh \
             skills/autonomous-dispatcher/scripts/lib-run-artifacts.sh \
             skills/autonomous-dispatcher/scripts/status.sh \

--- a/docs/pipeline/dev-agent-flow.md
+++ b/docs/pipeline/dev-agent-flow.md
@@ -182,9 +182,17 @@ explicit head is load-bearing: the wrapper runs from `PROJECT_DIR` (checked out 
 the BASE branch), so a bare `gh pr create` would infer head=base and fail — the
 broker takes the agent's `branch:` line, else derives the pushed `*issue-<N>*`
 branch from origin (the [INV-45] glob), and skips with a WARN if neither yields a
-branch (#234 review). In PAT
+branch (#234 review). The request file itself is DURABLE (#519): provisioned by
+`provision_agent_pr_create_file` at `${RUN_DIR}/agent-pr-create` (mode `0600`,
+never inside the vanish-prone `GH_WRAPPER_DIR` — [INV-111]/#402), and a scoped
+run reaching the drain with a lost/empty request WARNs loudly and attempts the
+strict single-branch recovery (unique boundary-valid `issue-<N>` branch,
+strictly ahead of `${BASE_BRANCH}`, successful zero-match existence read) —
+see the [INV-79](invariants.md#inv-79-in-app-mode-the-agent-process-gets-only-a-scoped-token-the-wrapper-keeps-full-write-and-is-the-sole-approvemergepr-create-path)
+#519 amendment. The wrapper passes the issue title as the drain's 3rd argument
+for the recovery PR's synthesized title. In PAT
 mode / app-mode-mint-failure the prefix is empty (no scrub) — byte-identical to
-pre-INV-79. See [INV-79](invariants.md#inv-79-in-app-mode-the-agent-process-gets-only-a-scoped-token-the-wrapper-keeps-full-write-and-is-the-sole-approvemergepr-create-path).
+pre-INV-79.
 
 ### Structured blocked-403 marker ([INV-85], #511)
 

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -4308,6 +4308,58 @@ an agent that runs `gh pr review --approve` / `gh pr merge` gets a deterministic
   emits an EMPTY prefix (no scrub), and behavior is byte-identical to pre-INV-79.
   An app-mode scoped-mint failure degrades the same way (WARN + no scrub) —
   availability over the defense-in-depth bonus.
+
+**Broker-request durability + lost-request recovery (#519 amendment).** The
+brokered PR-create request is a LOAD-BEARING handoff: losing it converts a
+fully-verified push into a "no PR was created" retry, and three clean runs
+exhaust the retry budget to `stalled`. Three rules close that class:
+
+1. **Durable location.** `AGENT_PR_CREATE_FILE` is provisioned by
+   `lib-auth.sh::provision_agent_pr_create_file` at
+   `${RUN_DIR}/agent-pr-create` (the [INV-81](#inv-81-every-wrapper-run-gets-a-durable-per-run-artifact-dir) durable per-run dir; private `mktemp
+   /tmp/agent-pr-create-<issue>-XXXXXX` fallback when RUN_DIR is unusable),
+   pre-created empty with mode `0600` so the mode never depends on the
+   agent's umask. It must NEVER live inside `GH_WRAPPER_DIR` — that per-run
+   auth dir is documented ([INV-111](#inv-111-the-dev-wrappers-session-report-is-the-first-durable-write-in-cleanup-gh-resolution-is-re-armed-per-write-against-a-vanished-auth-shim-and-a-same-head-review-fail-with-no-resolvable-session-id-self-heals-via-a-bounded-fresh-dev-new-instead-of-parking-forever)/#402) to vanish mid-cleanup from an
+   external deleter, which is exactly how the #519 incident lost the request.
+   The drain never deletes the artifact (it survives until
+   `RUN_RETENTION_DAYS` pruning — post-hoc diagnosis of this bug class
+   depends on it).
+
+2. **Loud guards.** When the scoped token is armed, `drain_agent_pr_create`
+   runs the PR-existence check FIRST (an existing PR makes a missing request
+   harmless → silent return); only on a confirmed zero-match with the
+   request unset/absent/empty does it WARN with the pinned field grammar
+   (`path=<unset|path> exists=<yes|no> size=<0|unknown>`) — never request
+   content, never credentials. The unscoped first guard stays silent
+   (scoping off = broker never in play; a vanished auth DIR leaves the
+   `AGENT_GH_TOKEN_FILE` VARIABLE non-empty, so the diagnostic stays
+   reachable in the incident shape).
+
+3. **Strict single-branch recovery.** After the WARN,
+   `_pr_broker_recover` opens ONE minimal PR — `Closes #<N>` plus a fixed
+   note with no other numeric `#` reference (body `#N`-mention selectors
+   treat any match as PR existence) — IFF all hold: the existence read was a
+   SUCCESSFUL parseable zero-match ("never duplicate" outranks the normal
+   path's fail-soft `existing=0`, which is preserved for the request-file
+   path only); exactly ONE pushed branch passes the numeric boundary
+   `issue-<N>([^0-9]|$)`; and that branch is STRICTLY AHEAD of the resolved
+   [INV-131](#inv-131-the-pipelines-base-branch-is-a-resolved-exported-validated-conf-value--never-a-hardcoded-main-literal-in-a-prompt-hook-or-provider-argv) base branch — remote-base SHA via `ls-remote`,
+   ancestry REQUIRED (`merge-base --is-ancestor`) plus rev-list count > 0,
+   no SHA-inequality fallback (a diverged branch needs a human). Recovery
+   runs ONLY for an unset/missing/zero-byte request — malformed non-empty
+   requests and failed normal creates never trigger a second create. The
+   synthesized title is the wrapper-supplied issue title (3rd drain
+   argument, parsed from the already-fetched normalized issue object; a
+   deterministic fallback title when absent). Validation base and create
+   target are both `${BASE_BRANCH}`; the repo must keep provider-default ==
+   BASE_BRANCH for `chp_create_pr`'s implicit target. Both create paths
+   share one leaf selector (`_pr_broker_create_leaf`) so the [INV-91]
+   github-gated raw fallback and the non-GitHub fail-loud refusal cannot
+   drift between them.
+
+   Proven by `tests/unit/test-pr-broker-durability.sh` (TC-PRBROKER-001..030)
+   and `tests/e2e/run-pr-broker-durability-e2e.sh` (TC-PRBROKER-040).
 - **Containment boundary (NOT isolation)**: same OS user, so the agent could read
   the wrapper's token file off disk if it deliberately went looking — this is
   defense-in-depth, not a sandbox. OS-user / container isolation is out of scope

--- a/docs/test-cases/pr-broker-durability.md
+++ b/docs/test-cases/pr-broker-durability.md
@@ -1,0 +1,50 @@
+# Test Cases: PR-create broker durability + recovery (issue #519)
+
+Covers the INV-79 brokered PR-create path after the #519 fix: durable request
+location (D1), loud scoped-run diagnostics (D2), and the strict single-branch
+recovery fallback (D3).
+
+Unit suite: `tests/unit/test-pr-broker-durability.sh`
+E2E fixture: `tests/e2e/run-pr-broker-durability-e2e.sh`
+
+## D1 — durable request location
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| TC-PRBROKER-001 | Wrapper provisioning with `RUN_DIR` set | `AGENT_PR_CREATE_FILE=${RUN_DIR}/agent-pr-create`, pre-created empty, mode `0600` |
+| TC-PRBROKER-002 | Wrapper provisioning without `RUN_DIR` | private `mktemp /tmp/agent-pr-create-<issue>-XXXXXX` fallback, mode `0600` |
+| TC-PRBROKER-003 | Regression: `GH_WRAPPER_DIR` deleted after the agent writes the request, before the drain | request survives (it never lived in `GH_WRAPPER_DIR`); drain consumes it and records exactly one PR-create provider call |
+| TC-PRBROKER-004 | Drain succeeds | request file is NOT deleted (retained until INV-81 `RUN_RETENTION_DAYS` pruning) |
+
+## D2 — loud diagnostics (scoped runs only)
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| TC-PRBROKER-010 | Unscoped run (`AGENT_GH_TOKEN_FILE` empty), any file state | silent `return 0`, no WARN, no create |
+| TC-PRBROKER-011 | Scoped + existing PR + missing request | silent `return 0` (existing-PR check runs FIRST; missing request is harmless) |
+| TC-PRBROKER-012 | Scoped + zero-match + `AGENT_PR_CREATE_FILE` unset | WARN contains `path=<unset> exists=no size=unknown` |
+| TC-PRBROKER-013 | Scoped + zero-match + file absent | WARN contains `path=<path> exists=no size=unknown` |
+| TC-PRBROKER-014 | Scoped + zero-match + file present but empty | WARN contains `path=<path> exists=yes size=0` |
+| TC-PRBROKER-015 | Any diagnostic | never includes request body content or credential material |
+
+## D3 — single-branch recovery fallback
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| TC-PRBROKER-020 | Missing request + exactly one boundary-valid `issue-<N>` branch strictly ahead of `${BASE_BRANCH}` | exactly one `chp_create_pr` with that head; title = 3rd drain argument; body = `Closes #<N>` + fixed recovery note with no other numeric `#` reference |
+| TC-PRBROKER-021 | Missing request + two candidate branches | no create; WARN lists candidate count |
+| TC-PRBROKER-022 | Issue 12, only branch `feat/issue-123-x` pushed | boundary filter rejects it — zero candidates, no create |
+| TC-PRBROKER-023 | Candidate diverged from base (not ancestor) | no create (ancestry REQUIRED; no SHA-inequality fallback) |
+| TC-PRBROKER-024 | Candidate equal to base (zero commits ahead) | no create |
+| TC-PRBROKER-025 | `chp_pr_list` UNKNOWN (read fails) + missing request + valid candidate | no recovery create; WARN (never-duplicate outranks fail-soft) |
+| TC-PRBROKER-026 | `chp_pr_list` UNKNOWN + VALID request file (normal path) | create still fires (pre-existing fail-soft preserved) |
+| TC-PRBROKER-027 | Malformed non-empty request (empty title) | WARN, NO recovery create (recovery only for unset/missing/zero-byte) |
+| TC-PRBROKER-028 | Normal create fails | no recovery second create |
+| TC-PRBROKER-029 | Configured non-`main` `BASE_BRANCH` | recovery validates against that branch |
+| TC-PRBROKER-030 | Drain called without 3rd arg (title unavailable) | recovery uses deterministic fallback title, still exactly one create |
+
+## E2E (wrapper fixture)
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| TC-PRBROKER-040 | Clean agent exit; auth dir (`GH_WRAPPER_DIR`) deleted mid-cleanup before drain | exactly one PR created; wrapper reaches `pending-review`; no extra dev retry consumed |

--- a/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
+++ b/skills/autonomous-dispatcher/scripts/autonomous-dev.sh
@@ -744,18 +744,13 @@ _agent_progress_init
 # (AGENT_GH_TOKEN_FILE set by setup_agent_token), `gh pr create` (which needs
 # pull_requests:write) is brokered: the agent writes the PR title+body here and
 # the wrapper opens the PR in cleanup (drain_agent_pr_create). Exported so it
-# survives the agent env scrub. Lives inside the per-run GH_WRAPPER_DIR (mode
-# 700) when available, else a private mktemp file. Harmless when scoping is off
-# (drain_agent_pr_create no-ops unless AGENT_GH_TOKEN_FILE is set).
-if [[ -n "${GH_WRAPPER_DIR:-}" && -d "${GH_WRAPPER_DIR}" ]]; then
-  AGENT_PR_CREATE_FILE="${GH_WRAPPER_DIR}/agent-pr-create"
-else
-  # Split declare+assign so the mktemp exit status isn't masked by `export`
-  # (SC2155). A mktemp failure here is benign — the drain helper's `-s` guard
-  # no-ops on a missing file — but keep the file's style parity.
-  AGENT_PR_CREATE_FILE="$(mktemp "/tmp/agent-pr-create-${ISSUE_NUMBER}-XXXXXX")"
-fi
-export AGENT_PR_CREATE_FILE
+# survives the agent env scrub. #519: the file lives in the DURABLE INV-81
+# RUN_DIR (never GH_WRAPPER_DIR — that auth dir vanishes mid-cleanup per
+# INV-111/#402, and a vanished request silently burned the retry budget),
+# else a private mktemp file; pre-created 0600 by the helper. Harmless when
+# scoping is off (drain_agent_pr_create no-ops unless AGENT_GH_TOKEN_FILE is
+# set).
+provision_agent_pr_create_file "$ISSUE_NUMBER"
 
 # [INV-79] Bot-trigger broker file. GH_USER_PAT is scrubbed from the agent subtree
 # (#234 review [P1]), so the agent can no longer post the real-user bot-trigger
@@ -1359,7 +1354,16 @@ EOF
   # open the PR now with the wrapper's full-write token — BEFORE the PR_EXISTS
   # lookup below so a brokered create routes the success path to pending-review.
   # No-op when scoping is off or the agent already created the PR directly.
-  _teardown_call drain_agent_pr_create "$ISSUE_NUMBER" "$REPO" || true
+  # #519: the third argument is the issue title for the recovery fallback's
+  # synthesized PR — parsed from the already-fetched normalized ISSUE_BODY
+  # object (no cleanup-time issue read). Empty when cleanup fires before the
+  # fetch (startup failure); the recovery path then uses its deterministic
+  # fallback title.
+  _drain_issue_title=""
+  if [[ -n "${ISSUE_BODY:-}" ]]; then
+    _drain_issue_title=$(jq -r '.title // ""' <<<"$ISSUE_BODY" 2>/dev/null) || _drain_issue_title=""
+  fi
+  _teardown_call drain_agent_pr_create "$ISSUE_NUMBER" "$REPO" "$_drain_issue_title" || true
 
   # [INV-111] (#402 review round-1 [P1]) re-arm before the PR_EXISTS lookup.
   rearm_gh_resolution

--- a/skills/autonomous-dispatcher/scripts/lib-auth.sh
+++ b/skills/autonomous-dispatcher/scripts/lib-auth.sh
@@ -541,6 +541,187 @@ rearm_gh_resolution() {
   fi
 }
 
+# [INV-79]/#519 provision_agent_pr_create_file <issue> — provision the broker
+# request file at its DURABLE location and export AGENT_PR_CREATE_FILE.
+#
+# The file must NOT live inside GH_WRAPPER_DIR: that per-run auth dir is
+# documented (INV-111/#402) to vanish mid-cleanup from an external deleter,
+# and a vanished request file made the drain below silently skip a valid,
+# fully-verified PR request — three clean runs then burned the no-PR retry
+# budget to `stalled` (#519). The INV-81 RUN_DIR survives the run (pruned
+# only by RUN_RETENTION_DAYS), so the request rides there; the private
+# mktemp fallback covers a wrapper without run artifacts. Pre-created empty
+# with mode 0600 so the mode never depends on the agent's umask; the drain
+# never deletes it (post-hoc diagnosis of this bug class depends on the
+# artifact surviving the run).
+provision_agent_pr_create_file() {
+  local issue="$1"
+  if [[ -n "${RUN_DIR:-}" && -d "${RUN_DIR}" && -w "${RUN_DIR}" ]]; then
+    AGENT_PR_CREATE_FILE="${RUN_DIR}/agent-pr-create"
+  else
+    # Split declare+assign so the mktemp exit status isn't masked (SC2155). A
+    # mktemp failure is benign — the drain's guard treats a missing file as a
+    # missing request.
+    AGENT_PR_CREATE_FILE="$(mktemp "/tmp/agent-pr-create-${issue}-XXXXXX" 2>/dev/null)" \
+      || AGENT_PR_CREATE_FILE=""
+  fi
+  if [[ -n "$AGENT_PR_CREATE_FILE" ]]; then
+    # Both fail SAFE toward "no request": an unwritable path leaves the file
+    # absent/empty, which the drain's `-s` guard reads as a missing request
+    # (WARN + recovery) — never a wrapper-startup crash.
+    : > "$AGENT_PR_CREATE_FILE" 2>/dev/null || true
+    chmod 600 "$AGENT_PR_CREATE_FILE" 2>/dev/null || true
+  fi
+  export AGENT_PR_CREATE_FILE
+}
+
+# [INV-79]/#519 _pr_broker_create_leaf <issue> <repo> <branch> <title> <body> —
+# the shared create leaf used by the normal brokered path AND the #519
+# recovery fallback (so the two cannot drift). Owns the whole leaf selection:
+#
+#   [INV-87] (#282, W1e-abstracted #400) the `gh pr create` leaf sits behind
+#   chp_create_pr — the verb takes THREE POSITIONALS `<head-branch> <title>
+#   <body>` (#347/#400); the GitHub leaf owns the `--head/--title/--body` flags
+#   internally, emitting argv IDENTICAL to the pre-#400 broker-composed line.
+#   The guard is `chp_has_leaf`, NOT `declare -F chp_create_pr` — the shim is
+#   always defined once lib-code-host is sourced, so the latter would dispatch
+#   to an undefined leaf and abort under set -e on a backend without it (#282
+#   review round 4 [P1]).
+#
+#   [INV-91] (#346) fail-loud when the leaf is absent: the raw `gh pr create`
+#   fallback is retained ONLY under an explicit `CODE_HOST == github` guard
+#   (spec-sanctioned github-gated residue). A non-GitHub backend that omits the
+#   `create_pr` leaf must NOT silently open a GitHub PR — it fails LOUD (#303/B1
+#   + #327 no-silent-fallback) and creates no PR. `${CODE_HOST:-github}` (#327
+#   precedent): an unset CODE_HOST — lib-code-host.sh not sourced because
+#   chp_create_pr was already defined, or unreadable — defaults to `github`,
+#   today's exact behavior. The raw `gh pr create` line stays BYTE-IDENTICAL
+#   (cutover-baseline pinned; the baseline may only shrink) — hence the
+#   _pr_create_ok indirection shape.
+#
+# rc 0 = created; rc 1 = create attempt failed; rc 2 = no usable leaf
+# (already logged loudly).
+_pr_broker_create_leaf() {
+  local issue_number="$1" repo="$2" branch="$3" title="$4" body="$5"
+  if declare -F chp_has_leaf >/dev/null 2>&1 && chp_has_leaf create_pr; then
+    _pr_create_ok() { chp_create_pr "$branch" "$title" "$body" >/dev/null 2>&1; }
+  elif [[ "${CODE_HOST:-github}" == "github" ]]; then
+    _pr_create_ok() { gh pr create --repo "$repo" --head "$branch" --title "$title" --body "$body" >/dev/null 2>&1; }
+  else
+    echo "ERROR: [INV-79]/[INV-91] brokered PR create for issue #${issue_number} (head=${branch}): CODE_HOST='${CODE_HOST:-github}' has no chp_create_pr leaf — refusing to open a GitHub PR on a non-GitHub backend. NO PR created; the success path's no-PR retry will re-queue the issue to pending-dev." >&2
+    unset -f _pr_create_ok 2>/dev/null || true  # fails harmless: fn may be undefined on this arm; leftover defs are per-call overwritten
+    return 2
+  fi
+  local _rc=0
+  _pr_create_ok || _rc=1
+  unset -f _pr_create_ok
+  return "$_rc"
+}
+
+# [INV-79]/#519 _pr_broker_recover <issue> <repo> <title> <pr_list_ok> —
+# single-branch recovery fallback for a LOST broker request. Runs only from
+# drain_agent_pr_create's missing/empty-request branch. Deliberately STRICTER
+# than the normal path (recovery auto-opens a PR nobody reviewed the request
+# for):
+#   - pr_list_ok != 1 (the existence read was UNKNOWN) → never create;
+#     "never duplicate" outranks the normal path's fail-soft existing=0.
+#   - candidate refs must pass the numeric boundary `issue-<N>([^0-9]|$)`
+#     (the raw glob would let issue-12 claim an issue-123 branch; same
+#     boundary needs_open_pr_only applies).
+#   - EXACTLY one candidate, and it must be STRICTLY AHEAD of the resolved
+#     [INV-131] base branch: ancestry REQUIRED (merge-base --is-ancestor) +
+#     rev-list count > 0. No SHA-inequality fallback — a diverged branch
+#     needs a human.
+# The recovery body carries `Closes #<N>` and a FIXED note with no other
+# numeric `#` reference (body #N-mention selectors treat any match as PR
+# existence). Always returns 0 (fail-safe, like the drain itself).
+_pr_broker_recover() {
+  local issue_number="$1" repo="$2" issue_title="$3" pr_list_ok="$4"
+
+  if [[ "$pr_list_ok" != "1" ]]; then
+    echo "WARN: [INV-79]/#519 recovery skipped for issue #${issue_number}: the PR-existence read was UNKNOWN (chp_pr_list failed/unparseable) — never-duplicate outranks recovery. The no-PR retry re-queues to pending-dev." >&2
+    return 0
+  fi
+
+  # Resolve the [INV-131] base branch — exported by the wrapper; fall back to
+  # resolve_base_branch when sourced standalone. No branch resolvable → skip.
+  local base="${BASE_BRANCH:-}"
+  if [[ -z "$base" ]] && declare -F resolve_base_branch >/dev/null 2>&1; then
+    base="$(resolve_base_branch 2>/dev/null)" || base=""
+  fi
+  if [[ -z "$base" ]]; then
+    echo "WARN: [INV-79]/#519 recovery skipped for issue #${issue_number}: no resolvable base branch (BASE_BRANCH unset and resolve_base_branch unavailable)." >&2
+    return 0
+  fi
+
+  # Enumerate boundary-valid pushed candidates as "<sha> <branch>" pairs.
+  local -a cand_shas=() cand_branches=()
+  local _ls_line _sha _ref
+  while IFS= read -r _ls_line; do
+    [[ -n "$_ls_line" ]] || continue
+    _sha="${_ls_line%%$'\t'*}"
+    _ref="${_ls_line##*$'\t'}"
+    _ref="${_ref#refs/heads/}"
+    # Numeric boundary (see the header) — bash-native ERE, no fork per candidate.
+    [[ "$_ref" =~ issue-${issue_number}([^0-9]|$) ]] || continue
+    cand_shas+=("$_sha")
+    cand_branches+=("$_ref")
+  # `|| true`: an ls-remote failure fails SAFE to zero candidates → the
+  # count-≠-1 WARN below skips recovery (never a create from unknown state).
+  done < <(git ls-remote --heads origin "*issue-${issue_number}*" 2>/dev/null || true)
+
+  local count="${#cand_branches[@]}"
+  if [[ "$count" -ne 1 ]]; then
+    echo "WARN: [INV-79]/#519 recovery skipped for issue #${issue_number}: ${count} boundary-valid candidate branch(es) on origin — recovery requires exactly one and never selects among ambiguous branches. The no-PR retry re-queues to pending-dev." >&2
+    return 0
+  fi
+  local branch="${cand_branches[0]}" cand_sha="${cand_shas[0]}"
+
+  # Strictly-ahead check against the CURRENT remote base (a local origin/<base>
+  # ref may be stale, and fetching a head does not refresh it): resolve the
+  # remote base SHA, fetch both refs' objects, then require ancestry + a
+  # non-zero ahead count.
+  local base_sha
+  base_sha=$(git ls-remote origin "refs/heads/${base}" 2>/dev/null \
+    | head -n1 | cut -f1) || base_sha=""
+  if [[ -z "$base_sha" ]]; then
+    echo "WARN: [INV-79]/#519 recovery skipped for issue #${issue_number}: cannot resolve remote base branch '${base}' on origin." >&2
+    return 0
+  fi
+  # `|| true`: a fetch failure fails SAFE — the ancestry check below then
+  # cannot prove ahead-ness and recovery is skipped (never a blind create).
+  git fetch -q origin "refs/heads/${branch}" "refs/heads/${base}" 2>/dev/null || true
+  local ahead=0
+  if git merge-base --is-ancestor "$base_sha" "$cand_sha" 2>/dev/null; then
+    ahead=$(git rev-list --count "${base_sha}..${cand_sha}" 2>/dev/null) || ahead=0
+  fi
+  [[ "$ahead" =~ ^[0-9]+$ ]] || ahead=0
+  if [[ "$ahead" -eq 0 ]]; then
+    echo "WARN: [INV-79]/#519 recovery skipped for issue #${issue_number}: candidate '${branch}' is not strictly ahead of base '${base}' (diverged, equal, or unreadable) — a non-fast-forward candidate needs a human. The no-PR retry re-queues to pending-dev." >&2
+    return 0
+  fi
+
+  # Deterministic fallback title when the wrapper couldn't supply one. No `#`
+  # anywhere outside the body's Closes line.
+  local title="$issue_title"
+  [[ -n "$title" ]] || title="fix: recovered PR for issue ${issue_number} (broker request lost)"
+  local body="Closes #${issue_number}
+
+> Recovery PR opened by the dev wrapper's PR-create broker: the agent's
+> brokered request file was lost after a verified push, and exactly one
+> pushed issue branch is strictly ahead of the base branch. See the INV-79
+> broker-durability amendment in the pipeline invariants doc."
+
+  local _rc=0
+  _pr_broker_create_leaf "$issue_number" "$repo" "$branch" "$title" "$body" || _rc=$?
+  if [[ "$_rc" -eq 0 ]]; then
+    echo "[INV-79]/#519 recovery: wrapper opened the PR for issue #${issue_number} from the unique pushed branch '${branch}' (${ahead} commit(s) ahead of ${base}; the brokered request file was lost)." >&2
+  elif [[ "$_rc" -eq 1 ]]; then
+    echo "WARN: [INV-79]/#519 recovery PR create (head=${branch}) failed — the no-PR retry re-queues to pending-dev." >&2
+  fi
+  return 0
+}
+
 # [INV-79] drain_agent_pr_create — the narrow PR-CREATE broker. `gh pr create`
 # requires pull_requests:write, which the scoped agent token (pull_requests:read)
 # does NOT have — but the agent must still be able to open its PR. So when the
@@ -571,31 +752,64 @@ rearm_gh_resolution() {
 # app-mode-without-scoping / PAT run, or a prior tick did). Returns 0 always; a
 # `gh pr create` failure is logged (the success path's no-PR retry still applies).
 #
-# Args: $1=issue_number, $2=repo. Reads AGENT_GH_TOKEN_FILE / AGENT_PR_CREATE_FILE.
+# Args: $1=issue_number, $2=repo, $3=issue title (optional — the wrapper's
+# already-fetched normalized title, used only by the #519 recovery fallback's
+# synthesized PR; the drain never fetches it itself).
+# Reads AGENT_GH_TOKEN_FILE / AGENT_PR_CREATE_FILE.
 drain_agent_pr_create() {
-  local issue_number="$1" repo="$2"
+  local issue_number="$1" repo="$2" issue_title="${3-}"
   # Only relevant when scoping is active (app mode + scoped mint succeeded).
+  # This unscoped return stays SILENT on purpose (#519 D2): scoping off means
+  # the broker was never in play — the agent ran `gh pr create` itself. The
+  # guard is shared by the normal and SIGTERM cleanup paths, and a vanished
+  # auth DIR leaves this VARIABLE non-empty, so the loud diagnostics below
+  # stay reachable in the INV-111-style incident.
   [[ -n "$AGENT_GH_TOKEN_FILE" ]] || return 0
-  [[ -n "${AGENT_PR_CREATE_FILE:-}" && -s "${AGENT_PR_CREATE_FILE}" ]] || return 0
 
-  # Skip if a PR already exists for this issue (agent created it directly, or a
-  # prior tick did). Same body-#N selector the wrapper's PR_EXISTS uses.
+  # Existence check FIRST (#519 D2 reordering): an existing PR makes a
+  # missing request harmless, so it must return silently BEFORE the
+  # missing-request diagnostics. Same body-#N selector the wrapper's
+  # PR_EXISTS uses.
   # [INV-87]/[INV-91] (W1c1, #397) the body-mention existence read routes
   # through the ABSTRACT `chp_pr_list STATE FIELDS-CSV` contract (spec §3.2 /
   # provider-spec §3.5 COMPLETE-set); body is normalized to a string so the
   # `.body != null` guard is redundant (the #148-class fix). Fail-soft
-  # (`|| existing=0`) — a transient read error routes conservative (assume no
-  # existing PR ⇒ let the broker attempt create; a same-branch `gh pr create`
-  # against an already-open PR errors LOUDLY, still no double-open).
-  local existing _pr_list
-  _pr_list=$(chp_pr_list open "body" 2>/dev/null || true)
-  if [[ -n "$_pr_list" ]]; then
-    existing=$(jq -r "[.[] | select((.body | test(\"#${issue_number}[^0-9]\")) or (.body | test(\"#${issue_number}\$\")))] | length" <<<"$_pr_list" 2>/dev/null || echo "0")
+  # (`|| existing=0`) — a transient read error routes conservative for the
+  # NORMAL request path (assume no existing PR ⇒ let the broker attempt
+  # create; a same-branch `gh pr create` against an already-open PR errors
+  # LOUDLY, still no double-open). The #519 recovery path is the opposite:
+  # it requires a SUCCESSFUL zero-match read (`_pr_list_ok`) — recovery
+  # synthesizes a PR nobody staged a request for, so "never duplicate"
+  # outranks fail-soft there.
+  local existing _pr_list _pr_list_ok=0
+  if _pr_list=$(chp_pr_list open "body" 2>/dev/null) && [[ -n "$_pr_list" ]]; then
+    if existing=$(jq -r "[.[] | select((.body | test(\"#${issue_number}[^0-9]\")) or (.body | test(\"#${issue_number}\$\")))] | length" <<<"$_pr_list" 2>/dev/null); then
+      _pr_list_ok=1
+    else
+      existing=0
+    fi
   else
     existing=0
   fi
-  [[ "$existing" =~ ^[0-9]+$ ]] || existing=0
+  [[ "$existing" =~ ^[0-9]+$ ]] || { existing=0; _pr_list_ok=0; }
   if [[ "$existing" -gt 0 ]]; then
+    return 0
+  fi
+
+  # #519 D2: a scoped run reaching this point with NO usable request is the
+  # silent-loss incident shape — say so loudly (path/existence/size only;
+  # never request content, never credentials), then attempt the D3 recovery.
+  if [[ -z "${AGENT_PR_CREATE_FILE:-}" || ! -s "${AGENT_PR_CREATE_FILE:-}" ]]; then
+    local _diag
+    if [[ -z "${AGENT_PR_CREATE_FILE:-}" ]]; then
+      _diag="path=<unset> exists=no size=unknown"
+    elif [[ ! -e "${AGENT_PR_CREATE_FILE}" ]]; then
+      _diag="path=${AGENT_PR_CREATE_FILE} exists=no size=unknown"
+    else
+      _diag="path=${AGENT_PR_CREATE_FILE} exists=yes size=0"
+    fi
+    echo "WARN: [INV-79]/#519 scoped run reached the PR broker with no usable request (${_diag}) and no PR exists for issue #${issue_number} — the agent's brokered request was never written or was lost. Attempting single-branch recovery." >&2
+    _pr_broker_recover "$issue_number" "$repo" "$issue_title" "$_pr_list_ok"
     return 0
   fi
 
@@ -644,46 +858,21 @@ drain_agent_pr_create() {
   fi
 
   # Explicit head: the wrapper's cwd (PROJECT_DIR) is on the base branch, so a
-  # bare create would infer the wrong head (#234 [P1]).
-  #
-  # [INV-87] (#282, W1e-abstracted #400) the `gh pr create` leaf moves behind
-  # chp_create_pr — the verb now takes THREE POSITIONALS `<head-branch> <title>
-  # <body>` (W1e abstract contract, #347/#400); the GitHub leaf owns the
-  # `--head/--title/--body` flags internally. The emitted gh argv is IDENTICAL to
-  # the pre-#400 broker-composed line — the leaf still emits the same flags, but
-  # they no longer cross the seam. ALL of the INV-79 broker logic above (token
-  # scoping, file parse, head resolution, the no-PR-yet idempotency guard) is
-  # unchanged. `$REPO` is the wrapper's required env (the broker's `$repo` arg
-  # always equals it). The leaf guard is `chp_has_leaf`, NOT `declare -F
-  # chp_create_pr` — the shim is always defined once lib-code-host is sourced, so
-  # that would dispatch to an undefined leaf and abort under set -e on a backend
-  # without it (#282 review round 4 [P1]).
-  #
-  # [INV-91] (#346) fail-loud disposition for the leaf-absent case: the raw
-  # `gh pr create` fallback is retained ONLY under an explicit `CODE_HOST == github`
-  # guard (spec-sanctioned github-gated residue). A non-GitHub backend that omits
-  # the `create_pr` leaf must NOT silently open a GitHub PR — it fails LOUD (the
-  # #303/B1 + #327 no-silent-fallback pattern) and creates no PR. `${CODE_HOST:-github}`
-  # (the #327 precedent): an unset CODE_HOST — lib-code-host.sh not sourced because
-  # chp_create_pr was already defined, or the lib was unreadable — defaults to
-  # `github`, i.e. today's exact behavior; the raw path is retained BYTE-IDENTICAL
-  # (its cutover-baseline signature is unchanged — a spec-sanctioned [INV-91]
-  # residue, NOT the caller's flag-tail).
-  if declare -F chp_has_leaf >/dev/null 2>&1 && chp_has_leaf create_pr; then
-    _pr_create_ok() { chp_create_pr "$branch" "$title" "$body" >/dev/null 2>&1; }
-  elif [[ "${CODE_HOST:-github}" == "github" ]]; then
-    _pr_create_ok() { gh pr create --repo "$repo" --head "$branch" --title "$title" --body "$body" >/dev/null 2>&1; }
-  else
-    echo "ERROR: [INV-79]/[INV-91] brokered PR create for issue #${issue_number} (head=${branch}): CODE_HOST='${CODE_HOST:-github}' has no chp_create_pr leaf — refusing to open a GitHub PR on a non-GitHub backend. NO PR created; the success path's no-PR retry will re-queue the issue to pending-dev." >&2
-    unset -f _pr_create_ok 2>/dev/null || true
-    return 0
-  fi
-  if _pr_create_ok; then
+  # bare create would infer the wrong head (#234 [P1]). ALL of the INV-79 broker
+  # logic above (token scoping, file parse, head resolution, the no-PR-yet
+  # idempotency guard) is unchanged; `$REPO` is the wrapper's required env (the
+  # broker's `$repo` arg always equals it). The [INV-87]/[INV-91] leaf selection
+  # (chp_create_pr / github-gated raw-gh / fail-loud) lives in the shared
+  # _pr_broker_create_leaf so this normal path and the #519 recovery fallback
+  # cannot drift. #519 D3: a failed normal create does NOT trigger recovery (no
+  # second create after a create attempt).
+  local _create_rc=0
+  _pr_broker_create_leaf "$issue_number" "$repo" "$branch" "$title" "$body" || _create_rc=$?
+  if [[ "$_create_rc" -eq 0 ]]; then
     echo "[INV-79] wrapper brokered the PR create for issue #${issue_number} (head=${branch}, agent wrote ${AGENT_PR_CREATE_FILE})." >&2
-  else
+  elif [[ "$_create_rc" -eq 1 ]]; then
     echo "WARN: [INV-79] brokered PR create (head=${branch}) failed — the success path's no-PR retry will re-queue the issue to pending-dev." >&2
   fi
-  unset -f _pr_create_ok
   return 0
 }
 

--- a/tests/e2e/run-pr-broker-durability-e2e.sh
+++ b/tests/e2e/run-pr-broker-durability-e2e.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Hermetic wrapper E2E for issue #519 (TC-PRBROKER-040): a clean agent exit
+# whose GH_WRAPPER_DIR (auth dir) is deleted mid-cleanup — BEFORE the broker
+# drain — must still produce exactly one PR (durable request consumed) and
+# route the issue to pending-review, consuming no extra dev retry.
+#
+# Exercises the REAL drain_agent_pr_create + provision_agent_pr_create_file
+# from lib-auth.sh against a git fixture and a gh stub; the label routing is
+# asserted through the same PR_EXISTS + transition seam shape the wrapper
+# uses (a full wrapper run needs live auth; the drain-then-lookup-then-flip
+# sequence here mirrors cleanup()'s exact ordering).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPTS="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts"
+
+PASS=0
+FAIL=0
+ok()   { echo "PASS: $1"; PASS=$((PASS + 1)); }
+bad()  { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# --- sandbox: lib-auth + CHP seam + stub siblings --------------------------
+SBA="$WORK/sandbox"; mkdir -p "$SBA/providers"
+cp "$SCRIPTS/lib-auth.sh" "$SBA/"
+cp "$SCRIPTS/gh-with-token-refresh.sh" "$SBA/"; chmod +x "$SBA/gh-with-token-refresh.sh"
+cp "$SCRIPTS/lib-code-host.sh" "$SBA/"
+cp "$SCRIPTS/providers/chp-github.sh" "$SBA/providers/"
+cp "$SCRIPTS/providers/chp-github.caps" "$SBA/providers/" 2>/dev/null || true
+printf '#!/bin/bash\nload_autonomous_conf() { return 0; }\n' > "$SBA/lib-config.sh"
+printf '#!/bin/bash\nget_gh_app_token() { echo T; }\nget_gh_app_scoped_token() { echo T; }\n' > "$SBA/gh-app-token.sh"
+
+# --- gh stub: list empty until a create is recorded, then one PR -----------
+GHSB="$WORK/gh-stub"; mkdir -p "$GHSB"
+CREATE_LOG="$GHSB/create.log"
+cat > "$GHSB/gh" <<GHSTUB
+#!/bin/bash
+if [[ "\$1" == "api" && "\$2" == "graphql" ]]; then
+  if [[ -s "$CREATE_LOG" ]]; then
+    printf '%s' '{"data":{"repository":{"pullRequests":{"pageInfo":{"endCursor":null,"hasNextPage":false},"nodes":[{"body":"Closes #519"}]}}}}'
+  else
+    printf '%s' '{"data":{"repository":{"pullRequests":{"pageInfo":{"endCursor":null,"hasNextPage":false},"nodes":[]}}}}'
+  fi
+  exit 0
+fi
+if [[ "\$1" == "pr" && "\$2" == "create" ]]; then echo "CREATED \$*" >> "$CREATE_LOG"; exit 0; fi
+if [[ "\$1" == "pr" && "\$2" == "list" ]]; then
+  if [[ -s "$CREATE_LOG" ]]; then echo '[{"body":"Closes #519"}]'; else echo '[]'; fi
+  exit 0
+fi
+exit 0
+GHSTUB
+chmod +x "$GHSB/gh"
+
+# --- git fixture: origin with main + one pushed issue branch ---------------
+git init -q --bare "$WORK/origin.git"
+git init -q "$WORK/clone"
+(
+  cd "$WORK/clone"
+  git config user.email t@example.com; git config user.name t
+  git remote add origin "$WORK/origin.git"
+  echo base > f; git add f; git commit -qm c1
+  git branch -M main
+  git push -q origin main
+  git checkout -qb feat/issue-519-fix
+  echo fix >> f; git add f; git commit -qm fix
+  git push -q origin feat/issue-519-fix
+  git checkout -q main
+)
+
+# --- the run: provision durable file, agent writes request, auth dir dies,
+# --- cleanup drains, PR_EXISTS lookup, label flip --------------------------
+RUN_DIR="$WORK/run-artifacts"; mkdir -p "$RUN_DIR"
+FINAL_LABELS="$WORK/labels.out"
+
+(
+  cd "$WORK/clone"
+  PATH="$GHSB:$PATH" REPO="owner/repo" BASE_BRANCH="main" RUN_DIR="$RUN_DIR" \
+  bash -c '
+    set -uo pipefail
+    source "'"$SBA"'/lib-auth.sh"
+
+    # Wrapper startup shape: auth dir + durable request provisioning.
+    GH_WRAPPER_DIR=$(mktemp -d /tmp/agent-auth-e2e519-XXXXXX)
+    AGENT_GH_TOKEN_FILE="${GH_WRAPPER_DIR}/agent-token"
+    echo tok > "$AGENT_GH_TOKEN_FILE"
+    provision_agent_pr_create_file 519
+
+    # Agent phase: writes the brokered request (clean exit follows).
+    printf "branch: feat/issue-519-fix\nfix: broker durability\nBody.\nCloses #519\n" > "$AGENT_PR_CREATE_FILE"
+
+    # Mid-cleanup incident: the auth dir vanishes BEFORE the drain.
+    rm -rf "$GH_WRAPPER_DIR"
+
+    # cleanup() sequence: drain → PR_EXISTS lookup → label flip.
+    drain_agent_pr_create 519 owner/repo "fix: broker durability"
+
+    pr_count=$(gh pr list 2>/dev/null | jq "length" 2>/dev/null || echo 0)
+    if [[ "$pr_count" -gt 0 ]]; then
+      echo "pending-review" > "'"$FINAL_LABELS"'"
+    else
+      echo "pending-dev" > "'"$FINAL_LABELS"'"
+    fi
+  '
+)
+
+echo "=== TC-PRBROKER-040 assertions ==="
+if [[ -s "$CREATE_LOG" && $(grep -c CREATED "$CREATE_LOG") -eq 1 ]]; then
+  ok "exactly one PR created despite vanished auth dir"
+else
+  bad "create log: $(cat "$CREATE_LOG" 2>/dev/null || echo empty)"
+fi
+if grep -qF -- '--head feat/issue-519-fix' "$CREATE_LOG" 2>/dev/null; then
+  ok "created from the agent's pushed branch (durable request consumed)"
+else
+  bad "wrong head: $(cat "$CREATE_LOG" 2>/dev/null)"
+fi
+if [[ "$(cat "$FINAL_LABELS" 2>/dev/null)" == "pending-review" ]]; then
+  ok "run routes to pending-review (no extra dev retry consumed)"
+else
+  bad "routed to: $(cat "$FINAL_LABELS" 2>/dev/null || echo unknown)"
+fi
+if [[ -f "$RUN_DIR/agent-pr-create" ]]; then
+  ok "durable request artifact retained in RUN_DIR after drain"
+else
+  bad "request artifact missing from RUN_DIR"
+fi
+
+echo ""
+echo "PR-BROKER-E2E-SUMMARY pass=$PASS fail=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/unit/test-pr-broker-durability.sh
+++ b/tests/unit/test-pr-broker-durability.sh
@@ -1,0 +1,441 @@
+#!/bin/bash
+# test-pr-broker-durability.sh — Unit tests for issue #519: durable PR-broker
+# request handoff (D1), loud scoped-run diagnostics (D2), and the strict
+# single-branch recovery fallback (D3) in drain_agent_pr_create.
+#
+# Test cases: docs/test-cases/pr-broker-durability.md (TC-PRBROKER-NNN)
+# Run: bash tests/unit/test-pr-broker-durability.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPTS="$PROJECT_ROOT/skills/autonomous-dispatcher/scripts"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+assert_pass() { echo -e "  ${GREEN}PASS${NC}: $1"; PASS=$((PASS + 1)); }
+assert_fail() { echo -e "  ${RED}FAIL${NC}: $1"; FAIL=$((FAIL + 1)); }
+
+TMPROOT=$(mktemp -d)
+trap 'pkill -f "$TMPROOT" 2>/dev/null; rm -rf "$TMPROOT"' EXIT
+
+# ---------------------------------------------------------------------------
+# Sandbox: lib-auth.sh + CHP seam + stub siblings (test-token-split-234 shape)
+# ---------------------------------------------------------------------------
+copy_chp_seam() {
+  local d="$1"
+  cp "$SCRIPTS/lib-code-host.sh" "$d/lib-code-host.sh"
+  mkdir -p "$d/providers"
+  cp "$SCRIPTS/providers/chp-github.sh" "$d/providers/chp-github.sh"
+  cp "$SCRIPTS/providers/chp-github.caps" "$d/providers/chp-github.caps" 2>/dev/null || true
+}
+
+new_auth_sandbox() {
+  local d; d=$(mktemp -d "$TMPROOT/auth-XXXXXX")
+  cp "$SCRIPTS/lib-auth.sh" "$d/lib-auth.sh"
+  cp "$SCRIPTS/gh-with-token-refresh.sh" "$d/gh-with-token-refresh.sh"
+  chmod +x "$d/gh-with-token-refresh.sh"
+  copy_chp_seam "$d"
+  cat > "$d/lib-config.sh" <<'CFG'
+#!/bin/bash
+load_autonomous_conf() { return 0; }
+CFG
+  cat > "$d/gh-app-token.sh" <<'GAT'
+#!/bin/bash
+get_gh_app_token() { echo "SCOPED-TOKEN-abc123"; }
+get_gh_app_scoped_token() { echo "SCOPED-TOKEN-abc123"; }
+GAT
+  echo "$d"
+}
+
+SBA=$(new_auth_sandbox)
+
+# gh stub: pr-list via `gh api graphql` (records argv; behavior driven by env
+# GH_STUB_LIST_MODE: empty|fail|one-pr), `gh pr create` records argv.
+GHSB="$TMPROOT/gh-stub"; mkdir -p "$GHSB"
+PR_CREATE_LOG="$GHSB/pr-create.log"
+PR_LIST_LOG="$GHSB/pr-list.log"
+cat > "$GHSB/gh" <<GHSTUB
+#!/bin/bash
+if [[ "\$1" == "api" && "\$2" == "graphql" ]]; then
+  echo "LISTED \$*" >> "$PR_LIST_LOG"
+  case "\${GH_STUB_LIST_MODE:-empty}" in
+    fail) exit 1 ;;
+    one-pr)
+      printf '%s' '{"data":{"repository":{"pullRequests":{"pageInfo":{"endCursor":null,"hasNextPage":false},"nodes":[{"body":"Closes #519"}]}}}}'
+      exit 0 ;;
+    *)
+      printf '%s' '{"data":{"repository":{"pullRequests":{"pageInfo":{"endCursor":null,"hasNextPage":false},"nodes":[]}}}}'
+      exit 0 ;;
+  esac
+fi
+if [[ "\$1" == "pr" && "\$2" == "create" ]]; then
+  if [[ "\${GH_STUB_CREATE_MODE:-ok}" == "fail" ]]; then exit 1; fi
+  echo "CREATED \$*" >> "$PR_CREATE_LOG"; exit 0
+fi
+exit 0
+GHSTUB
+chmod +x "$GHSB/gh"
+
+# ---------------------------------------------------------------------------
+# Git fixture: bare origin + work clone. Branch layout is parameterized per
+# test via make_fixture <issue> <shape>[,<shape>…] where shape ∈
+#   ahead        → feat/issue-<N>-a, one commit ahead of main
+#   ahead-b      → feat/issue-<N>-b, one commit ahead of main (second candidate)
+#   equal        → feat/issue-<N>-eq, equal to main head
+#   diverged     → feat/issue-<N>-div, forked below main head + own commit
+#   decoy        → feat/issue-<N>3-decoy (boundary collision: issue 51 vs 513)
+# Echoes the work-clone path (cwd for the drain call).
+make_fixture() {
+  local issue="$1" shapes="$2"
+  local fx; fx=$(mktemp -d "$TMPROOT/git-XXXXXX")
+  local bare="$fx/origin.git" work="$fx/work"
+  git init -q --bare "$bare"
+  git init -q "$work"
+  (
+    cd "$work" || exit 1
+    git config user.email t@example.com; git config user.name t
+    git remote add origin "$bare"
+    echo base1 > f.txt; git add f.txt; git commit -qm c1
+    echo base2 >> f.txt; git add f.txt; git commit -qm c2
+    git branch -M main
+    git push -q origin main
+    local IFS=','
+    for shape in $shapes; do
+      case "$shape" in
+        ahead)
+          git checkout -qb "feat/issue-${issue}-a" main
+          echo a >> f.txt; git add f.txt; git commit -qm ahead
+          git push -q origin "feat/issue-${issue}-a" ;;
+        ahead-b)
+          git checkout -qb "feat/issue-${issue}-b" main
+          echo b >> f.txt; git add f.txt; git commit -qm aheadb
+          git push -q origin "feat/issue-${issue}-b" ;;
+        equal)
+          git checkout -qb "feat/issue-${issue}-eq" main
+          git push -q origin "feat/issue-${issue}-eq" ;;
+        diverged)
+          git checkout -qb "feat/issue-${issue}-div" main~1
+          echo d > g.txt; git add g.txt; git commit -qm div
+          git push -q origin "feat/issue-${issue}-div" ;;
+        decoy)
+          git checkout -qb "feat/issue-${issue}3-decoy" main
+          echo dec >> f.txt; git add f.txt; git commit -qm decoy
+          git push -q origin "feat/issue-${issue}3-decoy" ;;
+      esac
+      git checkout -q main
+    done
+  )
+  echo "$work"
+}
+
+# run_drain <cwd> <issue> [title] — run drain_agent_pr_create in the sandbox
+# with the gh stub; env knobs come through as-is (AGENT_PR_CREATE_FILE,
+# GH_STUB_LIST_MODE, GH_STUB_CREATE_MODE, SCOPED). Captures stderr to
+# $DRAIN_ERR.
+DRAIN_ERR="$TMPROOT/drain-stderr.log"
+run_drain() {
+  local cwd="$1" issue="$2" title="${3-}"
+  rm -f "$PR_CREATE_LOG" "$PR_LIST_LOG" "$DRAIN_ERR"
+  (
+    cd "$cwd" || exit 1
+    PATH="$GHSB:$PATH" REPO="owner/repo" BASE_BRANCH="${BASE_BRANCH_OVERRIDE:-main}" \
+    GH_STUB_LIST_MODE="${GH_STUB_LIST_MODE:-empty}" \
+    GH_STUB_CREATE_MODE="${GH_STUB_CREATE_MODE:-ok}" \
+    bash -c "
+      source '$SBA/lib-auth.sh'
+      AGENT_GH_TOKEN_FILE='${SCOPED-/some/scoped/token}'
+      AGENT_PR_CREATE_FILE='${AGENT_PR_CREATE_FILE-}'
+      drain_agent_pr_create '$issue' owner/repo ${title:+'$title'}
+    " 2>"$DRAIN_ERR"
+  )
+}
+
+# ===========================================================================
+echo ""
+echo "=== TC-PRBROKER-001/002: provisioning helper — durable location + 0600 ==="
+# ===========================================================================
+# D1 pins provisioning into a lib-auth.sh function the wrapper calls, so it is
+# unit-testable: provision_agent_pr_create_file <issue> sets+exports
+# AGENT_PR_CREATE_FILE (RUN_DIR/agent-pr-create when RUN_DIR is usable, else
+# the mktemp fallback), pre-created empty, mode 0600.
+RUND=$(mktemp -d "$TMPROOT/run-XXXXXX")
+out=$(bash -c "
+  source '$SBA/lib-auth.sh'
+  RUN_DIR='$RUND' provision_agent_pr_create_file 519
+  echo \"\$AGENT_PR_CREATE_FILE\"
+" 2>/dev/null)
+if [[ "$out" == "$RUND/agent-pr-create" ]]; then
+  assert_pass "TC-001 RUN_DIR set → AGENT_PR_CREATE_FILE=\${RUN_DIR}/agent-pr-create"
+else
+  assert_fail "TC-001 expected \$RUN_DIR/agent-pr-create, got '$out'"
+fi
+if [[ -f "$RUND/agent-pr-create" && "$(stat -c %a "$RUND/agent-pr-create" 2>/dev/null)" == "600" ]]; then
+  assert_pass "TC-001 file pre-created empty with mode 0600"
+else
+  assert_fail "TC-001 file missing or wrong mode: $(stat -c %a "$RUND/agent-pr-create" 2>/dev/null || echo absent)"
+fi
+
+out=$(bash -c "
+  source '$SBA/lib-auth.sh'
+  RUN_DIR='' provision_agent_pr_create_file 519
+  echo \"\$AGENT_PR_CREATE_FILE\"
+" 2>/dev/null)
+if [[ "$out" == /tmp/agent-pr-create-519-* && -f "$out" ]]; then
+  mode=$(stat -c %a "$out" 2>/dev/null)
+  if [[ "$mode" == "600" ]]; then
+    assert_pass "TC-002 no RUN_DIR → mktemp fallback, mode 0600 ($out)"
+  else
+    assert_fail "TC-002 fallback mode expected 600, got '$mode'"
+  fi
+  rm -f "$out"
+else
+  assert_fail "TC-002 expected /tmp/agent-pr-create-519-* fallback, got '$out'"
+fi
+
+# Wrapper actually uses the helper (content pin, test-cleanup-pr-check style).
+DEV_CONTENT=$(cat "$SCRIPTS/autonomous-dev.sh")
+if [[ "$DEV_CONTENT" == *"provision_agent_pr_create_file"* ]] \
+   && [[ "$DEV_CONTENT" != *'AGENT_PR_CREATE_FILE="${GH_WRAPPER_DIR}/agent-pr-create"'* ]]; then
+  assert_pass "TC-001 wrapper provisions via helper, not GH_WRAPPER_DIR"
+else
+  assert_fail "TC-001 wrapper still provisions AGENT_PR_CREATE_FILE inside GH_WRAPPER_DIR"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== TC-PRBROKER-003/004: request survives GH_WRAPPER_DIR deletion; drain retains it ==="
+# ===========================================================================
+WORK=$(make_fixture 519 ahead)
+RUND2=$(mktemp -d "$TMPROOT/run2-XXXXXX")
+REQ="$RUND2/agent-pr-create"
+FAKE_WRAP=$(mktemp -d "$TMPROOT/agent-auth-XXXXXX")
+printf 'branch: feat/issue-519-a\nfix: my title\nBody.\nCloses #519\n' > "$REQ"
+chmod 600 "$REQ"
+rm -rf "$FAKE_WRAP"   # the mid-cleanup vanish — must not affect the request
+AGENT_PR_CREATE_FILE="$REQ" run_drain "$WORK" 519
+if [[ -s "$PR_CREATE_LOG" ]] && grep -qF -- '--head feat/issue-519-a' "$PR_CREATE_LOG" \
+   && [[ $(grep -c CREATED "$PR_CREATE_LOG") -eq 1 ]]; then
+  assert_pass "TC-003 vanished GH_WRAPPER_DIR: durable request still consumed, exactly one create"
+else
+  assert_fail "TC-003 create log: $(cat "$PR_CREATE_LOG" 2>/dev/null || echo empty)"
+fi
+if [[ -f "$REQ" ]]; then
+  assert_pass "TC-004 drain does not delete the request artifact"
+else
+  assert_fail "TC-004 request file was deleted by the drain"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== TC-PRBROKER-010: unscoped run stays silent ==="
+# ===========================================================================
+SCOPED="" AGENT_PR_CREATE_FILE="" run_drain "$WORK" 519
+if [[ ! -s "$DRAIN_ERR" && ! -s "$PR_CREATE_LOG" ]]; then
+  assert_pass "TC-010 unscoped: no WARN, no create"
+else
+  assert_fail "TC-010 unscoped produced output: $(cat "$DRAIN_ERR" 2>/dev/null)"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== TC-PRBROKER-011: existing PR + missing request → silent ==="
+# ===========================================================================
+GH_STUB_LIST_MODE=one-pr AGENT_PR_CREATE_FILE="$TMPROOT/nonexistent-req" run_drain "$WORK" 519
+if [[ ! -s "$PR_CREATE_LOG" ]] && ! grep -qi 'WARN' "$DRAIN_ERR" 2>/dev/null; then
+  assert_pass "TC-011 existing PR: silent return, no create, no WARN"
+else
+  assert_fail "TC-011 got WARN or create: $(cat "$DRAIN_ERR" 2>/dev/null)"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== TC-PRBROKER-012/013/014/015: diagnostic field grammar ==="
+# ===========================================================================
+# Unset variable. Zero candidates fixture so recovery WARNs too but the
+# missing-request WARN grammar is what we pin.
+WORK_NOBRANCH=$(make_fixture 888 equal)   # no ahead candidate for issue 555
+AGENT_PR_CREATE_FILE="" run_drain "$WORK_NOBRANCH" 555
+if grep -qF 'path=<unset> exists=no size=unknown' "$DRAIN_ERR"; then
+  assert_pass "TC-012 unset var → path=<unset> exists=no size=unknown"
+else
+  assert_fail "TC-012 grammar missing: $(cat "$DRAIN_ERR" 2>/dev/null)"
+fi
+
+AGENT_PR_CREATE_FILE="$TMPROOT/absent-req" run_drain "$WORK_NOBRANCH" 555
+if grep -qF "path=$TMPROOT/absent-req exists=no size=unknown" "$DRAIN_ERR"; then
+  assert_pass "TC-013 absent file → path=<path> exists=no size=unknown"
+else
+  assert_fail "TC-013 grammar missing: $(cat "$DRAIN_ERR" 2>/dev/null)"
+fi
+
+EMPTYREQ="$TMPROOT/empty-req"; : > "$EMPTYREQ"
+AGENT_PR_CREATE_FILE="$EMPTYREQ" run_drain "$WORK_NOBRANCH" 555
+if grep -qF "path=$EMPTYREQ exists=yes size=0" "$DRAIN_ERR"; then
+  assert_pass "TC-014 empty file → path=<path> exists=yes size=0"
+else
+  assert_fail "TC-014 grammar missing: $(cat "$DRAIN_ERR" 2>/dev/null)"
+fi
+
+SECRETREQ="$TMPROOT/secret-req"
+printf 'branch: feat/issue-519-a\nTITLE-SECRET-MARKER\nBODY-SECRET-MARKER\n' > "$SECRETREQ"
+AGENT_PR_CREATE_FILE="$SECRETREQ" run_drain "$WORK" 519
+if ! grep -q 'TITLE-SECRET-MARKER\|BODY-SECRET-MARKER\|SCOPED-TOKEN' "$DRAIN_ERR" 2>/dev/null; then
+  assert_pass "TC-015 diagnostics never leak request content or credentials"
+else
+  assert_fail "TC-015 leaked content: $(cat "$DRAIN_ERR" 2>/dev/null)"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== TC-PRBROKER-020: unique ahead branch → one recovery create ==="
+# ===========================================================================
+WORK20=$(make_fixture 700 ahead)
+AGENT_PR_CREATE_FILE="" run_drain "$WORK20" 700 "feat: issue seven hundred"
+if [[ -s "$PR_CREATE_LOG" ]] \
+   && [[ $(grep -c CREATED "$PR_CREATE_LOG") -eq 1 ]] \
+   && grep -qF -- '--head feat/issue-700-a' "$PR_CREATE_LOG" \
+   && grep -qF 'feat: issue seven hundred' "$PR_CREATE_LOG" \
+   && grep -qF 'Closes #700' "$PR_CREATE_LOG"; then
+  assert_pass "TC-020 recovery created exactly one PR with head/title/Closes"
+else
+  assert_fail "TC-020 create log: $(cat "$PR_CREATE_LOG" 2>/dev/null || echo empty)"
+fi
+# Fixed recovery note: no numeric '#' besides Closes #700.
+created_line=$(grep CREATED "$PR_CREATE_LOG" 2>/dev/null || true)
+stripped="${created_line//Closes #700/}"
+if [[ -n "$created_line" ]] && ! grep -qE '#[0-9]' <<<"$stripped"; then
+  assert_pass "TC-020 recovery note carries no other numeric # reference"
+else
+  assert_fail "TC-020 stray #N in body: $created_line"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== TC-PRBROKER-021: two candidates → no create, WARN with count ==="
+# ===========================================================================
+WORK21=$(make_fixture 701 ahead,ahead-b)
+AGENT_PR_CREATE_FILE="" run_drain "$WORK21" 701 "t"
+if [[ ! -s "$PR_CREATE_LOG" ]] && grep -q 'candidate' "$DRAIN_ERR" && grep -q '2' "$DRAIN_ERR"; then
+  assert_pass "TC-021 ambiguous candidates: no create, WARN lists count"
+else
+  assert_fail "TC-021 log=$(cat "$PR_CREATE_LOG" 2>/dev/null) err=$(cat "$DRAIN_ERR" 2>/dev/null)"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== TC-PRBROKER-022: issue-number boundary (51 vs 513) ==="
+# ===========================================================================
+WORK22=$(make_fixture 51 decoy)   # pushes feat/issue-513-decoy only
+AGENT_PR_CREATE_FILE="" run_drain "$WORK22" 51 "t"
+if [[ ! -s "$PR_CREATE_LOG" ]]; then
+  assert_pass "TC-022 boundary filter rejects issue-513 branch for issue 51"
+else
+  assert_fail "TC-022 created from decoy branch: $(cat "$PR_CREATE_LOG")"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== TC-PRBROKER-023/024: diverged / equal candidates rejected ==="
+# ===========================================================================
+WORK23=$(make_fixture 702 diverged)
+AGENT_PR_CREATE_FILE="" run_drain "$WORK23" 702 "t"
+if [[ ! -s "$PR_CREATE_LOG" ]]; then
+  assert_pass "TC-023 diverged branch: ancestry required, no create"
+else
+  assert_fail "TC-023 created from diverged branch: $(cat "$PR_CREATE_LOG")"
+fi
+
+WORK24=$(make_fixture 703 equal)
+AGENT_PR_CREATE_FILE="" run_drain "$WORK24" 703 "t"
+if [[ ! -s "$PR_CREATE_LOG" ]]; then
+  assert_pass "TC-024 equal-to-base branch: zero ahead, no create"
+else
+  assert_fail "TC-024 created from equal branch: $(cat "$PR_CREATE_LOG")"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== TC-PRBROKER-025/026: UNKNOWN pr_list — recovery aborts, normal path fail-soft ==="
+# ===========================================================================
+GH_STUB_LIST_MODE=fail AGENT_PR_CREATE_FILE="" run_drain "$WORK20" 700 "t"
+if [[ ! -s "$PR_CREATE_LOG" ]] && grep -qi 'WARN' "$DRAIN_ERR"; then
+  assert_pass "TC-025 UNKNOWN pr_list + missing request: no recovery create, WARN"
+else
+  assert_fail "TC-025 log=$(cat "$PR_CREATE_LOG" 2>/dev/null) err=$(cat "$DRAIN_ERR" 2>/dev/null)"
+fi
+
+VALIDREQ="$TMPROOT/valid-req-700"
+printf 'branch: feat/issue-700-a\nfix: t\nCloses #700\n' > "$VALIDREQ"
+GH_STUB_LIST_MODE=fail AGENT_PR_CREATE_FILE="$VALIDREQ" run_drain "$WORK20" 700
+if [[ -s "$PR_CREATE_LOG" ]]; then
+  assert_pass "TC-026 UNKNOWN pr_list + VALID request: normal fail-soft create preserved"
+else
+  assert_fail "TC-026 normal path regressed under UNKNOWN pr_list"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== TC-PRBROKER-027/028: malformed request / failed create → no recovery ==="
+# ===========================================================================
+MALFORMED="$TMPROOT/malformed-req"
+printf 'branch: feat/issue-700-a\n' > "$MALFORMED"   # branch line, no title
+AGENT_PR_CREATE_FILE="$MALFORMED" run_drain "$WORK20" 700 "t"
+if [[ ! -s "$PR_CREATE_LOG" ]] && grep -q 'empty title' "$DRAIN_ERR"; then
+  assert_pass "TC-027 malformed non-empty request: WARN, no recovery create"
+else
+  assert_fail "TC-027 log=$(cat "$PR_CREATE_LOG" 2>/dev/null) err=$(cat "$DRAIN_ERR" 2>/dev/null)"
+fi
+
+printf 'branch: feat/issue-700-a\nfix: t\nCloses #700\n' > "$VALIDREQ"
+GH_STUB_CREATE_MODE=fail AGENT_PR_CREATE_FILE="$VALIDREQ" run_drain "$WORK20" 700 "t"
+if [[ ! -s "$PR_CREATE_LOG" ]] && grep -q 'failed' "$DRAIN_ERR"; then
+  assert_pass "TC-028 failed normal create: no recovery second create"
+else
+  assert_fail "TC-028 recovery fired after create attempt: $(cat "$PR_CREATE_LOG" 2>/dev/null)"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== TC-PRBROKER-029: non-main BASE_BRANCH honored ==="
+# ===========================================================================
+# Rebuild a fixture whose base is 'develop': candidate ahead of develop.
+FX29=$(mktemp -d "$TMPROOT/git29-XXXXXX")
+git init -q --bare "$FX29/origin.git"
+git init -q "$FX29/work"
+(
+  cd "$FX29/work" || exit 1
+  git config user.email t@example.com; git config user.name t
+  git remote add origin "$FX29/origin.git"
+  echo x > f; git add f; git commit -qm c1
+  git branch -M develop
+  git push -q origin develop
+  git checkout -qb feat/issue-704-a
+  echo y >> f; git add f; git commit -qm ahead
+  git push -q origin feat/issue-704-a
+)
+BASE_BRANCH_OVERRIDE=develop AGENT_PR_CREATE_FILE="" run_drain "$FX29/work" 704 "t"
+if [[ -s "$PR_CREATE_LOG" ]] && [[ $(grep -c CREATED "$PR_CREATE_LOG") -eq 1 ]]; then
+  assert_pass "TC-029 recovery validates against configured BASE_BRANCH=develop"
+else
+  assert_fail "TC-029 no create with non-main base: $(cat "$DRAIN_ERR" 2>/dev/null)"
+fi
+
+# ===========================================================================
+echo ""
+echo "=== TC-PRBROKER-030: missing title arg → deterministic fallback, one create ==="
+# ===========================================================================
+AGENT_PR_CREATE_FILE="" run_drain "$WORK20" 700
+if [[ -s "$PR_CREATE_LOG" ]] && [[ $(grep -c CREATED "$PR_CREATE_LOG") -eq 1 ]] \
+   && grep -qF 'Closes #700' "$PR_CREATE_LOG"; then
+  assert_pass "TC-030 no title arg: deterministic fallback title, exactly one create"
+else
+  assert_fail "TC-030 log: $(cat "$PR_CREATE_LOG" 2>/dev/null || echo empty)"
+fi
+
+# ===========================================================================
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

- Moves the INV-79 brokered PR-create request out of the vanish-prone `GH_WRAPPER_DIR` into the durable INV-81 `${RUN_DIR}/agent-pr-create` (`provision_agent_pr_create_file`, mode `0600`, mktemp fallback) — the #519 incident's silent-loss boundary.
- `drain_agent_pr_create` now checks PR existence first, then WARNs with a pinned `path=/exists=/size=` grammar when a scoped run reaches the drain with a lost/empty request (never content, never credentials), and attempts a deliberately strict single-branch recovery: successful zero-match `chp_pr_list` only, numeric-boundary candidate filter (`issue-<N>([^0-9]|$)`), exactly one candidate, ancestry REQUIRED + strictly ahead of `${BASE_BRANCH}`, fixed recovery note with no stray `#N`. Malformed requests / failed normal creates never trigger a second create.
- Both create paths share `_pr_broker_create_leaf`; the INV-91 github-gated raw `gh pr create` line stays byte-identical (cutover baseline unchanged, checker green).

## Pipeline Docs (CONTRIBUTING.md Rule 1)

- [x] INV-79 gains the #519 broker-durability amendment (durable location, loud guards, recovery semantics, provider-default==BASE_BRANCH assumption, INV-111 cross-reference); `dev-agent-flow.md` cleanup sequence updated. No new label transitions (`state-machine.md`/`transitions.json` untouched; spec-drift suite green).

## Test Plan

- [x] Local checks pass: `bash -n` + `shellcheck -x` (no new findings); new `tests/unit/test-pr-broker-durability.sh` 24/24 (TDD: 13 failed pre-fix); new hermetic `tests/e2e/run-pr-broker-durability-e2e.sh` 4/4 (mid-cleanup auth-dir deletion → exactly one PR, pending-review, artifact retained); regressions green: `test-token-split-234` 76/76, `test-w1e-chp-write-parity` 67/67, `test-cleanup-pr-check`, `test-sigterm-trap`, `test-issue-402-*`, `test-spec-drift` 66/66, `test-check-shell-idioms` 66/66; `check-provider-cutover` PASS, `check-shell-idioms` PASS
- [ ] CI checks pass

## Linked Issues

Closes #519
