### PR TITLE
fix(hooks): ignore non-executable git mentions

### DIFF
--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -9394,6 +9394,15 @@ flow, substitutions/expansions, malformed quotes, multiple matching
 invocations, attached or repeated `-C`, and special/option-like `cd` operands
 are unsupported and take the rc `2` fail-closed path.
 
+Before detection and cwd resolution, shell comments and bounded file-generation
+heredocs are removed from consideration so documentation text is not mistaken
+for an invocation (#547). Heredoc masking applies only to simple external
+`cat` commands that are the first executable command, use identifier
+delimiters, and have no control operators or physical-line continuations.
+Unquoted heredoc substitutions, preceding setup commands, shell consumers,
+pipelines, ambiguous syntax, and unsupported quote contexts retain the original
+command text and fail closed. The preprocessor never evaluates command text.
+
 **Producer**: `lib.sh::resolve_git_command_cwd`.
 
 **Consumer**: `block-commit-outside-worktree.sh`.
@@ -9405,7 +9414,9 @@ are unsupported and take the rc `2` fail-closed path.
 worktrees, all supported path forms, helper return codes, the fail-closed
 syntax matrix, and non-execution sentinels. The exact unrelated-repository
 reproduction is red on the parent implementation and green with this
-invariant.
+invariant. `tests/unit/test-is-git-command-non-executable-regions.sh`
+(`TC-IGC-547-001..126`) covers comment/heredoc false positives and the
+fail-closed substitution, interpreter, pipeline, and shadowing controls.
 
 **Cross-reference**:
 [`docs/designs/block-commit-command-context.md`](../designs/block-commit-command-context.md)

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -9397,11 +9397,14 @@ are unsupported and take the rc `2` fail-closed path.
 Before detection and cwd resolution, shell comments and bounded file-generation
 heredocs are removed from consideration so documentation text is not mistaken
 for an invocation (#547). Heredoc masking applies only to simple external
-`cat` commands that are the first executable command, use identifier
-delimiters, and have no control operators or physical-line continuations.
+`cat` commands or external `gh pr create|comment|edit --body-file -` commands
+that are the first executable command, use identifier delimiters, and have no
+control operators or physical-line continuations.
 Unquoted heredoc substitutions, preceding setup commands, shell consumers,
 pipelines, ambiguous syntax, and unsupported quote contexts retain the original
-command text and fail closed. The preprocessor never evaluates command text.
+command text and fail closed. Once an ambiguous expansion is reached, later
+heredocs are intentionally not reclassified. The preprocessor never evaluates
+command text.
 
 **Producer**: `lib.sh::resolve_git_command_cwd`.
 
@@ -9410,27 +9413,31 @@ command text and fail closed. The preprocessor never evaluates command text.
 **Status**: **ENFORCED**.
 
 **Test**: `tests/unit/test-block-commit-outside-worktree.sh`
-(`TC-BCOW-001..013`) covers both repository identities and main/linked
+(`TC-BCOW-001..015`) covers both repository identities and main/linked
 worktrees, all supported path forms, helper return codes, the fail-closed
 syntax matrix, and non-execution sentinels. The exact unrelated-repository
 reproduction is red on the parent implementation and green with this
 invariant. `tests/unit/test-is-git-command-non-executable-regions.sh`
-(`TC-IGC-547-001..145`) covers comment/heredoc false positives, dynamic
+(`TC-IGC-547-001..175`) covers comment/heredoc false positives, dynamic
 git-free shell consumers, generic/quoted/dynamic operation forms, the
 five-second hook budget, and the fail-closed substitution, interpreter,
 pipeline, and shadowing controls. Ambiguous inputs at least 4 KiB take one
-linear static candidate pass before any bounded tokenization fallback instead
-of the older repeated character scans; approximately 20 KiB
-operation-bearing and git-free cases pin the five-second hook budget.
-`tests/unit/test-block-push-regex.sh` (`TC-BP-35..60`) covers the same budget,
+linear static candidate pass plus a bounded substitution-span pass instead of
+the older repeated character scans. Substitution bodies are masked
+independently before the 64-body/8 KiB semantic-analysis budget is charged, so
+generated PR bodies remain data while executable siblings remain visible.
+Approximately 20 KiB unmasked inputs, 35 KiB masked heredocs, 53 KiB
+comment-masked inputs, and sub-4 KiB deeply nested substitutions pin the
+five-second hook budget.
+`tests/unit/test-block-push-regex.sh` (`TC-BP-35..61`) covers the same budget,
 chained, multiline, and prefixed feature pushes, git-free expansions,
 non-executable and shell-consumed push text, shell redirections, brace groups,
 line continuations, mixed quote fragments, dynamic refspecs, arithmetic
 expansions, ordinary data pipelines, benign versus executable substitutions,
 multi-stage and compound stdin evaluators, compact `env -S` forms, alternate
 shell applets, substitution-bearing large inputs, linear long-pipeline and
-grouped-segment handling, and fail-closed handling for an unreadable operation
-or refspec.
+indexed grouped-segment and command-list handling, and fail-closed handling for
+an unreadable operation or refspec.
 
 **Cross-reference**:
 [`docs/designs/block-commit-command-context.md`](../designs/block-commit-command-context.md)
@@ -9740,7 +9747,7 @@ they read only what the wrapper exported and never parse conf.
 
 **Status**: **ENFORCED**.
 
-**Test**: `tests/unit/test-block-push-regex.sh` (`TC-BP-01..53`, 206 assertions) —
+**Test**: `tests/unit/test-block-push-regex.sh` (`TC-BP-01..61`, 410 assertions) —
 the 11 pre-existing #64 cases unchanged, plus TC-BP-13b (bare push from inside
 the wiki), TC-BP-13c (no anchor → fail closed), TC-BP-16 (second clone of this
 project's remote, all three command shapes), TC-BP-17 (five URL spellings),
@@ -9780,58 +9787,105 @@ fail-closed. A quoted dynamic remote remains one shell word, so a following
 literal feature refspec stays readable; an unquoted dynamic remote remains
 fail-closed because word splitting could change the positional grammar.
 Expansion-bearing commands without a literal Git operation are not treated as
-pushes, while a dynamic command name followed by the literal `push` operation
-remains fail-closed. Builtin `echo`/`printf` arguments and bounded heredoc data
-are non-executable when consumed only as data. Variable data piped to ordinary
-consumers such as `jq`, `tee`, `sort`, `gh`, `cut`, remote `cat`, or wrapped
-`jq` remains data. Consumers that execute stdin are recognized structurally:
-shell/interpreter commands, evaluated `awk` programs, dynamic commands,
-executing output process substitutions, and `xargs` commands whose appended
-arguments complete a wrapper. A command-position scan descends through
+pushes, while a single dynamic command-word token such as `$GIT` followed by the
+literal `push` operation remains fail-closed. Builtin `echo`/`printf` arguments
+and bounded heredoc data are non-executable when consumed only as data. Variable
+data piped to ordinary consumers such as `jq`, `tee`, `sort`, `gh`, `cut`,
+remote `cat`, or wrapped `jq` remains data. Consumers that execute stdin are
+recognized structurally:
+shell/interpreter commands, awk programs containing `system()` or command
+pipes, and awk source-loading options or directives. Awk classification permits
+only the statically safe `-F`/`--field-separator`, `-v`/`--assign`, and `--`
+option forms; every other option fails closed, covering gawk `-E`/`--exec`,
+source-loading forms, accepted long-option abbreviations, and future extension
+options. Sed programs that may contain the lowercase `e` execution command/flag,
+dynamic or unknown commands, executing output process substitutions, and
+`xargs` commands whose appended arguments complete a wrapper are likewise
+executable. Only explicit data commands and statically safe awk/sed programs
+remain data-only. A command-position scan descends through
 `if`/loop/`case`/group bodies and inspects static arguments of otherwise unknown
-launchers, while explicit data commands remain data-only. `env -S` and
+wrappers, while unclassified consumers fail closed. `env -S` and
 `--split-string` command text, including attached and clustered short-option
 forms, is reconstructed with its trailing arguments and classified by the same
 scanner. Alternate shell names and BusyBox shell applets execute stdin.
 Classification follows each pipeline once until a command-list boundary, so
 data-only filters cannot hide a later executable consumer. Enclosing compound
-stages are located once per token snapshot and cached, so grouped producers and
-long benign pipelines do not cause repeated downstream walks.
+stages are indexed once per token snapshot, and each stage's downstream result
+is memoized. Each pipe token also memoizes its bounded transitive consumer
+result, and every token index memoizes whether it opens an executing process
+substitution. Flat and nested multi-producer pipelines therefore remain linear;
+deep output-process-substitution chains do not recursively rescan each enclosing
+stage. Inner data-only pipelines cannot hide an outer shell or executing process
+substitution, while grouped producers, long benign pipelines, and many distinct
+command-list stages avoid repeated downstream walks.
 Literal, ANSI-quoted, quote-concatenated, and dynamic shell input therefore
 fails closed without classifying arithmetic expansion as executable. Command
 and process substitution bodies are analyzed independently by the shared shell
 code scanner: benign `$(date)`-style data remains allowed, while a body that
-executes a possible push keeps the trunk check armed. Redirections,
-brace-group delimiters, and backslash-newline continuations are shell syntax
-rather than refspecs. A dynamic global argument followed by more global flags
-and then a definite non-push operation remains allowed, while a dynamic refspec
-remains unknown because its runtime value could be trunk. Mixed quote fragments
-cannot hide either the push operation or a trunk refspec.
-Approximately 20–21 KiB PR-body and single-word push-option inputs stay inside
-the five-second budget. Ambiguous substitution-bearing inputs at least 4 KiB
-use a linear static command-position scan before the bounded tokenizer. The
-scan preserves quote concatenation, ignores data-command arguments, and can
-prove an explicit trunk destination without paying for full refspec parsing.
-When the resolver proves no push and the command has no pipeline, expansion-only
-data and large heredoc prose reuse that negative result; data that reaches an
-executable pipeline consumer still enters the fail-closed refspec parser.
+executes a possible push keeps the trunk check armed. Identical bodies reuse a
+per-scan result keyed by body text and trusted-data context. At most 64 distinct
+bodies and 8 KiB of cumulative uncached body text receive recursive parsing per
+top-level command. Exceeding either budget is unknown and fails closed,
+including deeply nested benign substitutions whose cumulative work crosses the
+byte cap. This keeps repeated command, backtick, and process substitutions
+bounded without allowing nested or unique-body input to exhaust the hook
+timeout. Within each body, the conservative whole-body verdict is computed once
+and reused by every dynamic command-position candidate rather than rescanning
+the same text per token. Redirections, brace-group delimiters, and
+backslash-newline continuations are shell syntax rather than refspecs. A dynamic
+global argument followed by more global flags and then a definite non-push
+operation remains allowed, while a dynamic refspec remains unknown because its
+runtime value could be trunk. Mixed quote fragments cannot hide either the push
+operation or a trunk refspec.
+Approximately 20–21 KiB unmasked PR-body and single-word push-option inputs stay
+inside the five-second budget. Ambiguous substitution-bearing inputs at least
+4 KiB use the preprocessor's bounded partial projection for the linear static
+command-position scan and refspec parser instead of rescanning masked heredoc or
+comment text. The scan preserves quote concatenation, ignores data-command
+arguments, and can prove an explicit trunk destination without paying for full
+refspec parsing. When the resolver proves no push and the command has no
+pipeline, expansion-only data and large heredoc prose reuse that negative
+result; data that reaches an executable pipeline consumer still enters the
+fail-closed refspec parser.
 Two hundred data-only pipeline stages complete in approximately 0.21–0.34
 seconds. Two hundred grouped data segments complete in approximately 0.71
 seconds through `cat` and 1.01 seconds through `bash`. Approximately 41 KiB
 benign substitution input allows in 0.51 seconds, while literal and
 quote-concatenated trunk controls block in 0.21–0.31 seconds in the pinned
-regression environment. All remain below the five-second hook budget without
-relying on an early executable-consumer short circuit.
+regression environment. Four hundred and eight hundred distinct command-list
+stages complete in approximately 0.91 and 2.01 seconds respectively. Flat
+50/100/200-stage producer pipelines complete in approximately 0.21/0.51/1.01
+seconds as data and 0.41/0.71/1.51 seconds with a trailing shell; the grouped
+200-stage forms have the same 1.01/1.51-second profile. Repeated command,
+backtick, and process-substitution controls complete in approximately
+0.45–0.68 seconds, a 300-unique-body trunk control in 1.12 seconds, the
+64-body benign boundary in 1.22 seconds, and its fail-closed 65th body in
+2.28 seconds. A 1.5 KiB body containing 500 dynamic command-position tokens
+completes in 0.34–0.43 seconds, and 40 nested output process substitutions
+complete in 1.47–1.50 seconds. All pinned forms remain below the five-second
+hook budget without relying on an early executable-consumer short circuit.
 
 Destination parsing consumes the same non-executable-region projection as
 operation detection. The direct-command parser returns `0` when every matched
 push is readable, `1` when its token stream contains no executable push, and `2`
 when a possible push is unreadable. The cwd resolver's substitution-aware result
 is reused before the parser's rc `1` early exit: resolver rc `1` already proves
-its bounded scanner found no push, while resolved or ambiguous commands receive
-an independent substitution-body scan for a nested invocation. Thus only a
-parser rc `1` with no substitution-push evidence is a positive data-only result;
-combined rc `2` keeps the trunk check armed.
+its bounded scanner found no push, while resolved or ambiguous commands without
+an already-readable trunk ref receive an independent substitution-body scan for
+a nested invocation. An already-readable trunk ref skips that potentially
+expensive scan because it has already proved the block. Thus only a parser rc
+`1` with no substitution-push evidence is a positive data-only result; combined
+rc `2` keeps the trunk check armed.
+Substitution spans are measured and sliced under `LC_ALL=C`, so byte offsets
+remain aligned even when UTF-8 text precedes the body. The top-level projection
+replaces each substitution with an adjacent dynamic marker rather than spaces,
+preserving split words such as `p$(echo ush)` as one unsafe operation token.
+Each body is masked independently before the 64-body/8 KiB semantic budget is
+charged. A static builtin `echo`/`printf` body may bypass the byte budget only
+when both the body and its outer `echo` or `gh pr ... --body` argument are
+proven data-only. The 4090-byte alternating `$()`/backtick stress case remains
+within its three-second serial test budget and concurrent verification remains
+below the five-second hook budget.
 
 Measured red/green: **20 of 56 red on PR #539's parent** (`216a906` — the wiki
 and allowlist allows, the second-clone forms, the URL spellings, the

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -9415,11 +9415,15 @@ worktrees, all supported path forms, helper return codes, the fail-closed
 syntax matrix, and non-execution sentinels. The exact unrelated-repository
 reproduction is red on the parent implementation and green with this
 invariant. `tests/unit/test-is-git-command-non-executable-regions.sh`
-(`TC-IGC-547-001..141`) covers comment/heredoc false positives, dynamic
-git-free shell consumers, the five-second hook budget, and the fail-closed
-substitution, interpreter, pipeline, and shadowing controls.
-`tests/unit/test-block-push-regex.sh` (`TC-BP-35`) covers the same budget and
-fail-closed requirement for an ambiguous push whose refspec is unparseable.
+(`TC-IGC-547-001..145`) covers comment/heredoc false positives, dynamic
+git-free shell consumers, generic/quoted/dynamic operation forms, the
+five-second hook budget, and the fail-closed substitution, interpreter,
+pipeline, and shadowing controls. Ambiguous inputs at least 4 KiB take one
+bounded tokenization pass plus conservative literal scanning; they do not enter
+the quadratic fallback paths. `tests/unit/test-block-push-regex.sh`
+(`TC-BP-35..39`) covers the same budget, chained and multiline feature pushes,
+git-free expansions, and non-executable push text while preserving fail-closed
+handling for an unreadable refspec.
 
 **Cross-reference**:
 [`docs/designs/block-commit-command-context.md`](../designs/block-commit-command-context.md)
@@ -9729,7 +9733,7 @@ they read only what the wrapper exported and never parse conf.
 
 **Status**: **ENFORCED**.
 
-**Test**: `tests/unit/test-block-push-regex.sh` (`TC-BP-01..35`, 75 assertions) —
+**Test**: `tests/unit/test-block-push-regex.sh` (`TC-BP-01..39`, 93 assertions) —
 the 11 pre-existing #64 cases unchanged, plus TC-BP-13b (bare push from inside
 the wiki), TC-BP-13c (no anchor → fail closed), TC-BP-16 (second clone of this
 project's remote, all three command shapes), TC-BP-17 (five URL spellings),
@@ -9758,6 +9762,21 @@ trunk (26), and an unreadable anchor read as "not mine" (27).
 TC-BP-35 pins the five-second hook budget and fail-closed fallback when an
 approximately 8 KiB ambiguous command contains a real trunk push but the
 bounded refspec parser cannot produce a destination token.
+
+TC-BP-36..39 pin the review regressions: every literal push in chained or
+multiline command text is classified independently; feature-only workflows are
+allowed while any trunk destination blocks. A quoted dynamic remote remains one
+shell word, so a following literal feature refspec stays readable; an unquoted
+dynamic remote remains fail-closed because word splitting could change the
+positional grammar. Expansion-bearing commands without a literal Git operation
+are not treated as pushes, while a dynamic command name followed by the literal
+`push` operation remains fail-closed. Large git-free inputs stay inside the
+five-second budget, and `echo` arguments or heredoc data cannot override the
+destination of a real push. Destination parsing consumes the same
+non-executable-region projection as operation detection. Its tri-state contract
+is `0` when all literal pushes are readable, `1` when no literal push is found,
+and `2` when any matched push is unreadable; both non-zero results fail closed
+after the resolver has established that a push exists.
 
 Measured red/green: **20 of 56 red on PR #539's parent** (`216a906` — the wiki
 and allowlist allows, the second-clone forms, the URL spellings, the

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -9422,10 +9422,11 @@ pipeline, and shadowing controls. Ambiguous inputs at least 4 KiB take one
 bounded tokenization pass plus conservative literal scanning instead of the
 older repeated fallback passes; approximately 20 KiB operation-bearing and
 git-free cases pin the five-second hook budget.
-`tests/unit/test-block-push-regex.sh` (`TC-BP-35..44`) covers the same budget,
+`tests/unit/test-block-push-regex.sh` (`TC-BP-35..47`) covers the same budget,
 chained, multiline, and prefixed feature pushes, git-free expansions,
-non-executable push text, mixed quote fragments, and fail-closed handling for
-an unreadable refspec.
+non-executable and shell-consumed push text, shell redirections, brace groups,
+line continuations, mixed quote fragments, dynamic refspecs, and fail-closed
+handling for an unreadable refspec.
 
 **Cross-reference**:
 [`docs/designs/block-commit-command-context.md`](../designs/block-commit-command-context.md)
@@ -9735,7 +9736,7 @@ they read only what the wrapper exported and never parse conf.
 
 **Status**: **ENFORCED**.
 
-**Test**: `tests/unit/test-block-push-regex.sh` (`TC-BP-01..44`, 118 assertions) —
+**Test**: `tests/unit/test-block-push-regex.sh` (`TC-BP-01..47`, 155 assertions) —
 the 11 pre-existing #64 cases unchanged, plus TC-BP-13b (bare push from inside
 the wiki), TC-BP-13c (no anchor → fail closed), TC-BP-16 (second clone of this
 project's remote, all three command shapes), TC-BP-17 (five URL spellings),
@@ -9765,7 +9766,7 @@ TC-BP-35 pins the five-second hook budget and fail-closed fallback when an
 approximately 8 KiB ambiguous command contains a real trunk push but the
 bounded refspec parser cannot produce a destination token.
 
-TC-BP-36..44 pin the review regressions. A single structured token snapshot is
+TC-BP-36..47 pin the review regressions. A single structured token snapshot is
 shared by destination and refspec parsing, with newlines and shell control
 operators preserving command boundaries. Each executable push in chained,
 multiline, subshell, assignment-prefixed, or supported wrapper-prefixed command
@@ -9776,10 +9777,18 @@ literal feature refspec stays readable; an unquoted dynamic remote remains
 fail-closed because word splitting could change the positional grammar.
 Expansion-bearing commands without a literal Git operation are not treated as
 pushes, while a dynamic command name followed by the literal `push` operation
-remains fail-closed. Builtin `echo` arguments and bounded heredoc data are
-non-executable even when no real push follows. Mixed quote fragments cannot
-hide a trunk refspec. Approximately 20–21 KiB git-free, PR-body, and
-single-word push-option inputs stay inside the five-second budget.
+remains fail-closed. Builtin `echo`/`printf` arguments and bounded heredoc data
+are non-executable when consumed only as data, but literal push text piped to a
+shell, embedded in command substitution, or sent to process substitution is
+executable and fails closed. The executable-data prefilter recognizes ordinary,
+ANSI-quoted, quote-concatenated, and dynamic shell input without forcing
+git-free literal pipelines through the full parser. Redirections, brace-group
+delimiters, and backslash-newline continuations are shell syntax rather than
+refspecs. A dynamic global argument followed by a definite non-push operation
+remains allowed, while a dynamic refspec remains unknown because its runtime
+value could be trunk. Mixed quote fragments cannot hide a trunk refspec.
+Approximately 20–21 KiB git-free, PR-body, and single-word push-option inputs
+stay inside the five-second budget.
 
 Destination parsing consumes the same non-executable-region projection as
 operation detection. Its tri-state contract is `0` when every executable push

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -9419,11 +9419,13 @@ invariant. `tests/unit/test-is-git-command-non-executable-regions.sh`
 git-free shell consumers, generic/quoted/dynamic operation forms, the
 five-second hook budget, and the fail-closed substitution, interpreter,
 pipeline, and shadowing controls. Ambiguous inputs at least 4 KiB take one
-bounded tokenization pass plus conservative literal scanning; they do not enter
-the quadratic fallback paths. `tests/unit/test-block-push-regex.sh`
-(`TC-BP-35..39`) covers the same budget, chained and multiline feature pushes,
-git-free expansions, and non-executable push text while preserving fail-closed
-handling for an unreadable refspec.
+bounded tokenization pass plus conservative literal scanning instead of the
+older repeated fallback passes; approximately 20 KiB operation-bearing and
+git-free cases pin the five-second hook budget.
+`tests/unit/test-block-push-regex.sh` (`TC-BP-35..44`) covers the same budget,
+chained, multiline, and prefixed feature pushes, git-free expansions,
+non-executable push text, mixed quote fragments, and fail-closed handling for
+an unreadable refspec.
 
 **Cross-reference**:
 [`docs/designs/block-commit-command-context.md`](../designs/block-commit-command-context.md)
@@ -9733,7 +9735,7 @@ they read only what the wrapper exported and never parse conf.
 
 **Status**: **ENFORCED**.
 
-**Test**: `tests/unit/test-block-push-regex.sh` (`TC-BP-01..39`, 93 assertions) —
+**Test**: `tests/unit/test-block-push-regex.sh` (`TC-BP-01..44`, 118 assertions) —
 the 11 pre-existing #64 cases unchanged, plus TC-BP-13b (bare push from inside
 the wiki), TC-BP-13c (no anchor → fail closed), TC-BP-16 (second clone of this
 project's remote, all three command shapes), TC-BP-17 (five URL spellings),
@@ -9763,20 +9765,27 @@ TC-BP-35 pins the five-second hook budget and fail-closed fallback when an
 approximately 8 KiB ambiguous command contains a real trunk push but the
 bounded refspec parser cannot produce a destination token.
 
-TC-BP-36..39 pin the review regressions: every literal push in chained or
-multiline command text is classified independently; feature-only workflows are
-allowed while any trunk destination blocks. A quoted dynamic remote remains one
-shell word, so a following literal feature refspec stays readable; an unquoted
-dynamic remote remains fail-closed because word splitting could change the
-positional grammar. Expansion-bearing commands without a literal Git operation
-are not treated as pushes, while a dynamic command name followed by the literal
-`push` operation remains fail-closed. Large git-free inputs stay inside the
-five-second budget, and `echo` arguments or heredoc data cannot override the
-destination of a real push. Destination parsing consumes the same
-non-executable-region projection as operation detection. Its tri-state contract
-is `0` when all literal pushes are readable, `1` when no literal push is found,
-and `2` when any matched push is unreadable; both non-zero results fail closed
-after the resolver has established that a push exists.
+TC-BP-36..44 pin the review regressions. A single structured token snapshot is
+shared by destination and refspec parsing, with newlines and shell control
+operators preserving command boundaries. Each executable push in chained,
+multiline, subshell, assignment-prefixed, or supported wrapper-prefixed command
+text is classified independently; feature-only workflows are allowed while any
+trunk destination blocks. An unknown wrapper containing a possible push remains
+fail-closed. A quoted dynamic remote remains one shell word, so a following
+literal feature refspec stays readable; an unquoted dynamic remote remains
+fail-closed because word splitting could change the positional grammar.
+Expansion-bearing commands without a literal Git operation are not treated as
+pushes, while a dynamic command name followed by the literal `push` operation
+remains fail-closed. Builtin `echo` arguments and bounded heredoc data are
+non-executable even when no real push follows. Mixed quote fragments cannot
+hide a trunk refspec. Approximately 20–21 KiB git-free, PR-body, and
+single-word push-option inputs stay inside the five-second budget.
+
+Destination parsing consumes the same non-executable-region projection as
+operation detection. Its tri-state contract is `0` when every executable push
+is readable, `1` only when no executable push exists, and `2` when any possible
+executable push is unreadable. After the resolver reports a match, rc `1` is a
+positive data-only result and may exit early; rc `2` keeps the trunk check armed.
 
 Measured red/green: **20 of 56 red on PR #539's parent** (`216a906` — the wiki
 and allowlist allows, the second-clone forms, the URL spellings, the

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -9422,13 +9422,14 @@ pipeline, and shadowing controls. Ambiguous inputs at least 4 KiB take one
 bounded tokenization pass plus conservative literal scanning instead of the
 older repeated fallback passes; approximately 20 KiB operation-bearing and
 git-free cases pin the five-second hook budget.
-`tests/unit/test-block-push-regex.sh` (`TC-BP-35..55`) covers the same budget,
+`tests/unit/test-block-push-regex.sh` (`TC-BP-35..57`) covers the same budget,
 chained, multiline, and prefixed feature pushes, git-free expansions,
 non-executable and shell-consumed push text, shell redirections, brace groups,
 line continuations, mixed quote fragments, dynamic refspecs, arithmetic
 expansions, ordinary data pipelines, benign versus executable substitutions,
-multi-stage stdin evaluators, substitution-bearing large inputs, and fail-closed
-handling for an unreadable operation or refspec.
+multi-stage and compound stdin evaluators, substitution-bearing large inputs,
+linear long-pipeline handling, and fail-closed handling for an unreadable
+operation or refspec.
 
 **Cross-reference**:
 [`docs/designs/block-commit-command-context.md`](../designs/block-commit-command-context.md)
@@ -9768,7 +9769,7 @@ TC-BP-35 pins the five-second hook budget and fail-closed fallback when an
 approximately 8 KiB ambiguous command contains a real trunk push but the
 bounded refspec parser cannot produce a destination token.
 
-TC-BP-36..55 pin the review regressions. A single structured token snapshot is
+TC-BP-36..57 pin the review regressions. A single structured token snapshot is
 shared by destination and refspec parsing, with newlines and shell control
 operators preserving command boundaries. Each executable push in chained,
 multiline, subshell, assignment-prefixed, or supported wrapper-prefixed command
@@ -9783,11 +9784,15 @@ remains fail-closed. Builtin `echo`/`printf` arguments and bounded heredoc data
 are non-executable when consumed only as data. Variable data piped to ordinary
 consumers such as `jq`, `tee`, `sort`, `gh`, `cut`, remote `cat`, or wrapped
 `jq` remains data. Consumers that execute stdin are recognized structurally:
-shell/interpreter commands and supported wrappers, `awk` programs containing
-`system(...)`, dynamic loop-body commands, executing output process
-substitutions, and `xargs` commands whose appended arguments complete a wrapper.
-Classification follows the whole pipeline until a command-list boundary, so
-data-only filters cannot hide a later executable consumer.
+shell/interpreter commands, evaluated `awk` programs, dynamic commands,
+executing output process substitutions, and `xargs` commands whose appended
+arguments complete a wrapper. A command-position scan descends through
+`if`/loop/`case`/group bodies and inspects static arguments of otherwise unknown
+launchers, while explicit data commands remain data-only. `env -S` and
+`--split-string` command text is reconstructed with its trailing arguments and
+classified by the same scanner. Classification follows each pipeline once until
+a command-list boundary, so data-only filters cannot hide a later executable
+consumer and a long benign pipeline does not cause repeated downstream walks.
 Literal, ANSI-quoted, quote-concatenated, and dynamic shell input therefore
 fails closed without classifying arithmetic expansion as executable. Command
 and process substitution bodies are analyzed independently by the shared shell
@@ -9805,6 +9810,10 @@ conservative scan as the shared detector instead of the character-wise
 substitution scanner. When that resolver scan proves no push, expansion-only
 data reuses the negative result; data that reaches an executable pipeline
 consumer still enters the fail-closed refspec parser.
+Two hundred data-only pipeline stages complete in approximately 0.21 seconds,
+and a roughly 3 KiB mixed filter pipeline completes in approximately 0.31
+seconds in the pinned regression environment; both remain below the five-second
+hook budget without relying on an early executable-consumer short circuit.
 
 Destination parsing consumes the same non-executable-region projection as
 operation detection. The direct-command parser returns `0` when every matched

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -9422,11 +9422,12 @@ pipeline, and shadowing controls. Ambiguous inputs at least 4 KiB take one
 bounded tokenization pass plus conservative literal scanning instead of the
 older repeated fallback passes; approximately 20 KiB operation-bearing and
 git-free cases pin the five-second hook budget.
-`tests/unit/test-block-push-regex.sh` (`TC-BP-35..47`) covers the same budget,
+`tests/unit/test-block-push-regex.sh` (`TC-BP-35..51`) covers the same budget,
 chained, multiline, and prefixed feature pushes, git-free expansions,
 non-executable and shell-consumed push text, shell redirections, brace groups,
-line continuations, mixed quote fragments, dynamic refspecs, and fail-closed
-handling for an unreadable refspec.
+line continuations, mixed quote fragments, dynamic refspecs, arithmetic
+expansions, ordinary data pipelines, and fail-closed handling for an unreadable
+operation or refspec.
 
 **Cross-reference**:
 [`docs/designs/block-commit-command-context.md`](../designs/block-commit-command-context.md)
@@ -9736,7 +9737,7 @@ they read only what the wrapper exported and never parse conf.
 
 **Status**: **ENFORCED**.
 
-**Test**: `tests/unit/test-block-push-regex.sh` (`TC-BP-01..47`, 155 assertions) —
+**Test**: `tests/unit/test-block-push-regex.sh` (`TC-BP-01..51`, 181 assertions) —
 the 11 pre-existing #64 cases unchanged, plus TC-BP-13b (bare push from inside
 the wiki), TC-BP-13c (no anchor → fail closed), TC-BP-16 (second clone of this
 project's remote, all three command shapes), TC-BP-17 (five URL spellings),
@@ -9766,7 +9767,7 @@ TC-BP-35 pins the five-second hook budget and fail-closed fallback when an
 approximately 8 KiB ambiguous command contains a real trunk push but the
 bounded refspec parser cannot produce a destination token.
 
-TC-BP-36..47 pin the review regressions. A single structured token snapshot is
+TC-BP-36..51 pin the review regressions. A single structured token snapshot is
 shared by destination and refspec parsing, with newlines and shell control
 operators preserving command boundaries. Each executable push in chained,
 multiline, subshell, assignment-prefixed, or supported wrapper-prefixed command
@@ -9778,15 +9779,18 @@ fail-closed because word splitting could change the positional grammar.
 Expansion-bearing commands without a literal Git operation are not treated as
 pushes, while a dynamic command name followed by the literal `push` operation
 remains fail-closed. Builtin `echo`/`printf` arguments and bounded heredoc data
-are non-executable when consumed only as data, but literal push text piped to a
-shell, embedded in command substitution, or sent to process substitution is
-executable and fails closed. The executable-data prefilter recognizes ordinary,
-ANSI-quoted, quote-concatenated, and dynamic shell input without forcing
-git-free literal pipelines through the full parser. Redirections, brace-group
-delimiters, and backslash-newline continuations are shell syntax rather than
-refspecs. A dynamic global argument followed by a definite non-push operation
-remains allowed, while a dynamic refspec remains unknown because its runtime
-value could be trunk. Mixed quote fragments cannot hide a trunk refspec.
+are non-executable when consumed only as data. Variable data piped to ordinary
+consumers such as `jq`, `tee`, `sort`, `gh`, `cut`, remote `cat`, or wrapped
+`jq` remains data; only a shell/interpreter consumer (including supported
+`env`, `command`, `timeout`, remote-shell, and `xargs` wrappers) makes its stdin
+possible executable text. Literal, ANSI-quoted, quote-concatenated, and dynamic
+shell input therefore fails closed, as do command and process substitutions,
+without classifying arithmetic expansion as executable. Redirections,
+brace-group delimiters, and backslash-newline continuations are shell syntax
+rather than refspecs. A dynamic global argument followed by more global flags
+and then a definite non-push operation remains allowed, while a dynamic refspec
+remains unknown because its runtime value could be trunk. Mixed quote fragments
+cannot hide either the push operation or a trunk refspec.
 Approximately 20–21 KiB git-free, PR-body, and single-word push-option inputs
 stay inside the five-second budget.
 

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -9415,8 +9415,11 @@ worktrees, all supported path forms, helper return codes, the fail-closed
 syntax matrix, and non-execution sentinels. The exact unrelated-repository
 reproduction is red on the parent implementation and green with this
 invariant. `tests/unit/test-is-git-command-non-executable-regions.sh`
-(`TC-IGC-547-001..126`) covers comment/heredoc false positives and the
-fail-closed substitution, interpreter, pipeline, and shadowing controls.
+(`TC-IGC-547-001..141`) covers comment/heredoc false positives, dynamic
+git-free shell consumers, the five-second hook budget, and the fail-closed
+substitution, interpreter, pipeline, and shadowing controls.
+`tests/unit/test-block-push-regex.sh` (`TC-BP-35`) covers the same budget and
+fail-closed requirement for an ambiguous push whose refspec is unparseable.
 
 **Cross-reference**:
 [`docs/designs/block-commit-command-context.md`](../designs/block-commit-command-context.md)
@@ -9726,7 +9729,7 @@ they read only what the wrapper exported and never parse conf.
 
 **Status**: **ENFORCED**.
 
-**Test**: `tests/unit/test-block-push-regex.sh` (`TC-BP-01..34`, 74 assertions) —
+**Test**: `tests/unit/test-block-push-regex.sh` (`TC-BP-01..35`, 75 assertions) —
 the 11 pre-existing #64 cases unchanged, plus TC-BP-13b (bare push from inside
 the wiki), TC-BP-13c (no anchor → fail closed), TC-BP-16 (second clone of this
 project's remote, all three command shapes), TC-BP-17 (five URL spellings),
@@ -9751,6 +9754,10 @@ chained pushes (20), quoted/expansion operands (21), rc=2 grammars evaluated
 against the wrong repository (22), local push-config redirect (23), path-embedded
 `@` collapsing distinct hosts (24/24b), DNS/path-equivalent spellings of own
 trunk (26), and an unreadable anchor read as "not mine" (27).
+
+TC-BP-35 pins the five-second hook budget and fail-closed fallback when an
+approximately 8 KiB ambiguous command contains a real trunk push but the
+bounded refspec parser cannot produce a destination token.
 
 Measured red/green: **20 of 56 red on PR #539's parent** (`216a906` — the wiki
 and allowlist allows, the second-clone forms, the URL spellings, the

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -9422,12 +9422,13 @@ pipeline, and shadowing controls. Ambiguous inputs at least 4 KiB take one
 bounded tokenization pass plus conservative literal scanning instead of the
 older repeated fallback passes; approximately 20 KiB operation-bearing and
 git-free cases pin the five-second hook budget.
-`tests/unit/test-block-push-regex.sh` (`TC-BP-35..51`) covers the same budget,
+`tests/unit/test-block-push-regex.sh` (`TC-BP-35..53`) covers the same budget,
 chained, multiline, and prefixed feature pushes, git-free expansions,
 non-executable and shell-consumed push text, shell redirections, brace groups,
 line continuations, mixed quote fragments, dynamic refspecs, arithmetic
-expansions, ordinary data pipelines, and fail-closed handling for an unreadable
-operation or refspec.
+expansions, ordinary data pipelines, benign versus executable substitutions,
+stdin evaluators, and fail-closed handling for an unreadable operation or
+refspec.
 
 **Cross-reference**:
 [`docs/designs/block-commit-command-context.md`](../designs/block-commit-command-context.md)
@@ -9737,7 +9738,7 @@ they read only what the wrapper exported and never parse conf.
 
 **Status**: **ENFORCED**.
 
-**Test**: `tests/unit/test-block-push-regex.sh` (`TC-BP-01..51`, 181 assertions) —
+**Test**: `tests/unit/test-block-push-regex.sh` (`TC-BP-01..53`, 206 assertions) —
 the 11 pre-existing #64 cases unchanged, plus TC-BP-13b (bare push from inside
 the wiki), TC-BP-13c (no anchor → fail closed), TC-BP-16 (second clone of this
 project's remote, all three command shapes), TC-BP-17 (five URL spellings),
@@ -9767,7 +9768,7 @@ TC-BP-35 pins the five-second hook budget and fail-closed fallback when an
 approximately 8 KiB ambiguous command contains a real trunk push but the
 bounded refspec parser cannot produce a destination token.
 
-TC-BP-36..51 pin the review regressions. A single structured token snapshot is
+TC-BP-36..53 pin the review regressions. A single structured token snapshot is
 shared by destination and refspec parsing, with newlines and shell control
 operators preserving command boundaries. Each executable push in chained,
 multiline, subshell, assignment-prefixed, or supported wrapper-prefixed command
@@ -9781,11 +9782,15 @@ pushes, while a dynamic command name followed by the literal `push` operation
 remains fail-closed. Builtin `echo`/`printf` arguments and bounded heredoc data
 are non-executable when consumed only as data. Variable data piped to ordinary
 consumers such as `jq`, `tee`, `sort`, `gh`, `cut`, remote `cat`, or wrapped
-`jq` remains data; only a shell/interpreter consumer (including supported
-`env`, `command`, `timeout`, remote-shell, and `xargs` wrappers) makes its stdin
-possible executable text. Literal, ANSI-quoted, quote-concatenated, and dynamic
-shell input therefore fails closed, as do command and process substitutions,
-without classifying arithmetic expansion as executable. Redirections,
+`jq` remains data. Consumers that execute stdin are recognized structurally:
+shell/interpreter commands and supported wrappers, `awk` programs containing
+`system(...)`, dynamic loop-body commands, executing output process
+substitutions, and `xargs` commands whose appended arguments complete a wrapper.
+Literal, ANSI-quoted, quote-concatenated, and dynamic shell input therefore
+fails closed without classifying arithmetic expansion as executable. Command
+and process substitution bodies are analyzed independently by the shared shell
+code scanner: benign `$(date)`-style data remains allowed, while a body that
+executes a possible push keeps the trunk check armed. Redirections,
 brace-group delimiters, and backslash-newline continuations are shell syntax
 rather than refspecs. A dynamic global argument followed by more global flags
 and then a definite non-push operation remains allowed, while a dynamic refspec
@@ -9795,10 +9800,13 @@ Approximately 20–21 KiB git-free, PR-body, and single-word push-option inputs
 stay inside the five-second budget.
 
 Destination parsing consumes the same non-executable-region projection as
-operation detection. Its tri-state contract is `0` when every executable push
-is readable, `1` only when no executable push exists, and `2` when any possible
-executable push is unreadable. After the resolver reports a match, rc `1` is a
-positive data-only result and may exit early; rc `2` keeps the trunk check armed.
+operation detection. The direct-command parser returns `0` when every matched
+push is readable, `1` when its token stream contains no executable push, and `2`
+when a possible push is unreadable. Independent substitution-body analysis runs
+before the rc `1` early exit and upgrades the hook's combined decision to `2`
+whenever executable substitution code may push. Thus only a parser rc `1` with
+no substitution-push evidence is a positive data-only result; combined rc `2`
+keeps the trunk check armed.
 
 Measured red/green: **20 of 56 red on PR #539's parent** (`216a906` — the wiki
 and allowlist allows, the second-clone forms, the URL spellings, the

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -9419,17 +9419,18 @@ invariant. `tests/unit/test-is-git-command-non-executable-regions.sh`
 git-free shell consumers, generic/quoted/dynamic operation forms, the
 five-second hook budget, and the fail-closed substitution, interpreter,
 pipeline, and shadowing controls. Ambiguous inputs at least 4 KiB take one
-bounded tokenization pass plus conservative literal scanning instead of the
-older repeated fallback passes; approximately 20 KiB operation-bearing and
-git-free cases pin the five-second hook budget.
-`tests/unit/test-block-push-regex.sh` (`TC-BP-35..57`) covers the same budget,
+linear static candidate pass before any bounded tokenization fallback instead
+of the older repeated character scans; approximately 20 KiB
+operation-bearing and git-free cases pin the five-second hook budget.
+`tests/unit/test-block-push-regex.sh` (`TC-BP-35..60`) covers the same budget,
 chained, multiline, and prefixed feature pushes, git-free expansions,
 non-executable and shell-consumed push text, shell redirections, brace groups,
 line continuations, mixed quote fragments, dynamic refspecs, arithmetic
 expansions, ordinary data pipelines, benign versus executable substitutions,
-multi-stage and compound stdin evaluators, substitution-bearing large inputs,
-linear long-pipeline handling, and fail-closed handling for an unreadable
-operation or refspec.
+multi-stage and compound stdin evaluators, compact `env -S` forms, alternate
+shell applets, substitution-bearing large inputs, linear long-pipeline and
+grouped-segment handling, and fail-closed handling for an unreadable operation
+or refspec.
 
 **Cross-reference**:
 [`docs/designs/block-commit-command-context.md`](../designs/block-commit-command-context.md)
@@ -9769,7 +9770,7 @@ TC-BP-35 pins the five-second hook budget and fail-closed fallback when an
 approximately 8 KiB ambiguous command contains a real trunk push but the
 bounded refspec parser cannot produce a destination token.
 
-TC-BP-36..57 pin the review regressions. A single structured token snapshot is
+TC-BP-36..60 pin the review regressions. A single structured token snapshot is
 shared by destination and refspec parsing, with newlines and shell control
 operators preserving command boundaries. Each executable push in chained,
 multiline, subshell, assignment-prefixed, or supported wrapper-prefixed command
@@ -9789,10 +9790,13 @@ executing output process substitutions, and `xargs` commands whose appended
 arguments complete a wrapper. A command-position scan descends through
 `if`/loop/`case`/group bodies and inspects static arguments of otherwise unknown
 launchers, while explicit data commands remain data-only. `env -S` and
-`--split-string` command text is reconstructed with its trailing arguments and
-classified by the same scanner. Classification follows each pipeline once until
-a command-list boundary, so data-only filters cannot hide a later executable
-consumer and a long benign pipeline does not cause repeated downstream walks.
+`--split-string` command text, including attached and clustered short-option
+forms, is reconstructed with its trailing arguments and classified by the same
+scanner. Alternate shell names and BusyBox shell applets execute stdin.
+Classification follows each pipeline once until a command-list boundary, so
+data-only filters cannot hide a later executable consumer. Enclosing compound
+stages are located once per token snapshot and cached, so grouped producers and
+long benign pipelines do not cause repeated downstream walks.
 Literal, ANSI-quoted, quote-concatenated, and dynamic shell input therefore
 fails closed without classifying arithmetic expansion as executable. Command
 and process substitution bodies are analyzed independently by the shared shell
@@ -9803,17 +9807,21 @@ rather than refspecs. A dynamic global argument followed by more global flags
 and then a definite non-push operation remains allowed, while a dynamic refspec
 remains unknown because its runtime value could be trunk. Mixed quote fragments
 cannot hide either the push operation or a trunk refspec.
-Approximately 20–21 KiB git-free, substitution-bearing, PR-body, and
-single-word push-option inputs stay inside the five-second budget. Ambiguous
-substitution-bearing inputs at least 4 KiB use the same bounded tokenization and
-conservative scan as the shared detector instead of the character-wise
-substitution scanner. When that resolver scan proves no push, expansion-only
-data reuses the negative result; data that reaches an executable pipeline
-consumer still enters the fail-closed refspec parser.
-Two hundred data-only pipeline stages complete in approximately 0.21 seconds,
-and a roughly 3 KiB mixed filter pipeline completes in approximately 0.31
-seconds in the pinned regression environment; both remain below the five-second
-hook budget without relying on an early executable-consumer short circuit.
+Approximately 20–21 KiB PR-body and single-word push-option inputs stay inside
+the five-second budget. Ambiguous substitution-bearing inputs at least 4 KiB
+use a linear static command-position scan before the bounded tokenizer. The
+scan preserves quote concatenation, ignores data-command arguments, and can
+prove an explicit trunk destination without paying for full refspec parsing.
+When the resolver proves no push and the command has no pipeline, expansion-only
+data and large heredoc prose reuse that negative result; data that reaches an
+executable pipeline consumer still enters the fail-closed refspec parser.
+Two hundred data-only pipeline stages complete in approximately 0.21–0.34
+seconds. Two hundred grouped data segments complete in approximately 0.71
+seconds through `cat` and 1.01 seconds through `bash`. Approximately 41 KiB
+benign substitution input allows in 0.51 seconds, while literal and
+quote-concatenated trunk controls block in 0.21–0.31 seconds in the pinned
+regression environment. All remain below the five-second hook budget without
+relying on an early executable-consumer short circuit.
 
 Destination parsing consumes the same non-executable-region projection as
 operation detection. The direct-command parser returns `0` when every matched

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -9422,13 +9422,13 @@ pipeline, and shadowing controls. Ambiguous inputs at least 4 KiB take one
 bounded tokenization pass plus conservative literal scanning instead of the
 older repeated fallback passes; approximately 20 KiB operation-bearing and
 git-free cases pin the five-second hook budget.
-`tests/unit/test-block-push-regex.sh` (`TC-BP-35..53`) covers the same budget,
+`tests/unit/test-block-push-regex.sh` (`TC-BP-35..55`) covers the same budget,
 chained, multiline, and prefixed feature pushes, git-free expansions,
 non-executable and shell-consumed push text, shell redirections, brace groups,
 line continuations, mixed quote fragments, dynamic refspecs, arithmetic
 expansions, ordinary data pipelines, benign versus executable substitutions,
-stdin evaluators, and fail-closed handling for an unreadable operation or
-refspec.
+multi-stage stdin evaluators, substitution-bearing large inputs, and fail-closed
+handling for an unreadable operation or refspec.
 
 **Cross-reference**:
 [`docs/designs/block-commit-command-context.md`](../designs/block-commit-command-context.md)
@@ -9768,7 +9768,7 @@ TC-BP-35 pins the five-second hook budget and fail-closed fallback when an
 approximately 8 KiB ambiguous command contains a real trunk push but the
 bounded refspec parser cannot produce a destination token.
 
-TC-BP-36..53 pin the review regressions. A single structured token snapshot is
+TC-BP-36..55 pin the review regressions. A single structured token snapshot is
 shared by destination and refspec parsing, with newlines and shell control
 operators preserving command boundaries. Each executable push in chained,
 multiline, subshell, assignment-prefixed, or supported wrapper-prefixed command
@@ -9786,6 +9786,8 @@ consumers such as `jq`, `tee`, `sort`, `gh`, `cut`, remote `cat`, or wrapped
 shell/interpreter commands and supported wrappers, `awk` programs containing
 `system(...)`, dynamic loop-body commands, executing output process
 substitutions, and `xargs` commands whose appended arguments complete a wrapper.
+Classification follows the whole pipeline until a command-list boundary, so
+data-only filters cannot hide a later executable consumer.
 Literal, ANSI-quoted, quote-concatenated, and dynamic shell input therefore
 fails closed without classifying arithmetic expansion as executable. Command
 and process substitution bodies are analyzed independently by the shared shell
@@ -9796,17 +9798,23 @@ rather than refspecs. A dynamic global argument followed by more global flags
 and then a definite non-push operation remains allowed, while a dynamic refspec
 remains unknown because its runtime value could be trunk. Mixed quote fragments
 cannot hide either the push operation or a trunk refspec.
-Approximately 20–21 KiB git-free, PR-body, and single-word push-option inputs
-stay inside the five-second budget.
+Approximately 20–21 KiB git-free, substitution-bearing, PR-body, and
+single-word push-option inputs stay inside the five-second budget. Ambiguous
+substitution-bearing inputs at least 4 KiB use the same bounded tokenization and
+conservative scan as the shared detector instead of the character-wise
+substitution scanner. When that resolver scan proves no push, expansion-only
+data reuses the negative result; data that reaches an executable pipeline
+consumer still enters the fail-closed refspec parser.
 
 Destination parsing consumes the same non-executable-region projection as
 operation detection. The direct-command parser returns `0` when every matched
 push is readable, `1` when its token stream contains no executable push, and `2`
-when a possible push is unreadable. Independent substitution-body analysis runs
-before the rc `1` early exit and upgrades the hook's combined decision to `2`
-whenever executable substitution code may push. Thus only a parser rc `1` with
-no substitution-push evidence is a positive data-only result; combined rc `2`
-keeps the trunk check armed.
+when a possible push is unreadable. The cwd resolver's substitution-aware result
+is reused before the parser's rc `1` early exit: resolver rc `1` already proves
+its bounded scanner found no push, while resolved or ambiguous commands receive
+an independent substitution-body scan for a nested invocation. Thus only a
+parser rc `1` with no substitution-push evidence is a positive data-only result;
+combined rc `2` keeps the trunk check armed.
 
 Measured red/green: **20 of 56 red on PR #539's parent** (`216a906` — the wiki
 and allowlist allows, the second-clone forms, the URL spellings, the

--- a/docs/test-cases/issue-547-non-executable-git-mentions.md
+++ b/docs/test-cases/issue-547-non-executable-git-mentions.md
@@ -146,6 +146,22 @@ Those shapes retain the original command text and fail closed.
 | `TC-IGC-547-124` | Main-workspace hook receives the prefix redirect consumer | Hook exits `2` |
 | `TC-IGC-547-125` | An array subscript consumes generated text containing `$(git commit ...)` | Detector rejects the parameter-expansion context |
 | `TC-IGC-547-126` | Main-workspace hook receives the array subscript consumer | Hook exits `2` |
+| `TC-IGC-547-127` | `bash "$f"` runs a dynamic script path without literal git text | Detector returns no match |
+| `TC-IGC-547-128` | Main-workspace hook receives that dynamic script path | Hook exits `0` |
+| `TC-IGC-547-129` | `sh -c "ls $dir"` contains dynamic shell code without literal git text | Detector returns no match |
+| `TC-IGC-547-130` | Main-workspace hook receives that dynamic shell code | Hook exits `0` |
+| `TC-IGC-547-131` | `env FOO="$BAR" bash -c ls` contains a dynamic environment value without git text | Detector returns no match |
+| `TC-IGC-547-132` | Main-workspace hook receives that dynamic environment value | Hook exits `0` |
+| `TC-IGC-547-133` | `exec bash "$f"` uses a dynamic script path without git text | Detector returns no match |
+| `TC-IGC-547-134` | Main-workspace hook receives the exec-wrapped dynamic script | Hook exits `0` |
+| `TC-IGC-547-135` | `command bash "$f"` uses a dynamic script path without git text | Detector returns no match |
+| `TC-IGC-547-136` | Main-workspace hook receives the command-wrapped dynamic script | Hook exits `0` |
+| `TC-IGC-547-137` | `eval "$generated"` contains no literal git text | Detector returns no match |
+| `TC-IGC-547-138` | Main-workspace hook receives that dynamic eval | Hook exits `0` |
+| `TC-IGC-547-139` | An approximately 8 KiB ambiguous command ends with a genuine `git commit` | Main-workspace hook exits `2` within its configured five-second timeout |
+| `TC-IGC-547-140` | A masked heredoc terminator is followed by a genuine commit | Resolver returns `2` for a visible but unsupported matching invocation instead of reprocessing and hiding it |
+| `TC-IGC-547-141` | An approximately 20 KiB ambiguous command ends with a genuine `git commit` | Main-workspace hook still exits `2` within five seconds, proving the operation-bearing path does not retain quadratic scaling |
+| `TC-BP-35` | An approximately 8 KiB ambiguous command ends with `git push origin main` | Trunk-protection hook exits `2` within five seconds; unresolved refspec parsing cannot grant the push |
 
 ## Evidence contract
 
@@ -156,6 +172,6 @@ false-positive detector behavior and its user-visible hook impact without
 changing production code. The controls also prevent a future comment/heredoc
 stripper from hiding a real commit after quoted text or a heredoc terminator.
 
-The eventual fix is complete only when all one hundred twenty-six cases pass together with the
+The eventual fix is complete only when all one hundred forty-one cases pass together with the
 existing `test-is-git-command.sh` and
 `test-block-commit-outside-worktree.sh` suites.

--- a/docs/test-cases/issue-547-non-executable-git-mentions.md
+++ b/docs/test-cases/issue-547-non-executable-git-mentions.md
@@ -161,7 +161,15 @@ Those shapes retain the original command text and fail closed.
 | `TC-IGC-547-139` | An approximately 8 KiB ambiguous command ends with a genuine `git commit` | Main-workspace hook exits `2` within its configured five-second timeout |
 | `TC-IGC-547-140` | A masked heredoc terminator is followed by a genuine commit | Resolver returns `2` for a visible but unsupported matching invocation instead of reprocessing and hiding it |
 | `TC-IGC-547-141` | An approximately 20 KiB ambiguous command ends with a genuine `git commit` | Main-workspace hook still exits `2` within five seconds, proving the operation-bearing path does not retain quadratic scaling |
+| `TC-IGC-547-142` | An approximately 20 KiB ambiguous command ends with `git -p commit` | Main-workspace hook exits `2` within five seconds |
+| `TC-IGC-547-143` | An approximately 20 KiB ambiguous command ends with `git 'commit'` | Main-workspace hook exits `2` within five seconds |
+| `TC-IGC-547-144` | An approximately 20 KiB ambiguous command ends with `git ${G} commit` | Main-workspace hook exits `2` within five seconds |
+| `TC-IGC-547-145` | An approximately 20 KiB ambiguous command contains no literal `git` word | Main-workspace hook exits `0` within five seconds |
 | `TC-BP-35` | An approximately 8 KiB ambiguous command ends with `git push origin main` | Trunk-protection hook exits `2` within five seconds; unresolved refspec parsing cannot grant the push |
+| `TC-BP-36` | Chained/multiline workflows and a quoted dynamic remote end with a literal feature refspec | Trunk-protection hook exits `0`; the equivalent trunk push and an unquoted dynamic remote exit `2` |
+| `TC-BP-37` | Expansion-bearing commands contain no literal `git push`; control uses `$GIT push origin main` | Git-free commands exit `0`; the explicit dynamic Git operation remains fail-closed |
+| `TC-BP-38` | An approximately 20 KiB ambiguous command contains no literal `git` word | Trunk-protection hook exits `0` within five seconds |
+| `TC-BP-39` | `echo` arguments or heredoc data mention a trunk push before a real feature push | Non-executable push text is ignored; a real trunk push remains blocked |
 
 ## Evidence contract
 
@@ -172,6 +180,13 @@ false-positive detector behavior and its user-visible hook impact without
 changing production code. The controls also prevent a future comment/heredoc
 stripper from hiding a real commit after quoted text or a heredoc terminator.
 
-The eventual fix is complete only when all one hundred forty-one cases pass together with the
+The review-regression cases `142` through `145` and `TC-BP-36` through
+`TC-BP-39` must fail on the first reviewed fix: operation-bearing large
+commands time out, git-free expansion commands are misclassified, chained
+feature pushes are blocked, or non-executable push text overrides the real
+refspec.
+
+The eventual fix is complete only when all one hundred forty-five detector
+cases and all ninety-three trunk-protection assertions pass together with the
 existing `test-is-git-command.sh` and
 `test-block-commit-outside-worktree.sh` suites.

--- a/docs/test-cases/issue-547-non-executable-git-mentions.md
+++ b/docs/test-cases/issue-547-non-executable-git-mentions.md
@@ -182,6 +182,8 @@ Those shapes retain the original command text and fail closed.
 | `TC-BP-49` | Builtin data commands contain `$((...))` arithmetic expansion and write to a regular file | Hook exits `0`; arithmetic expansion is not command substitution |
 | `TC-BP-50` | Dynamic `git -C` is followed by one or more static global options and then `commit` or `log` | Hook exits `0`; the definite non-push operation remains readable after intervening flags |
 | `TC-BP-51` | The `push` operation word itself is assembled from mixed quote fragments and targets trunk | Hook exits `2`; resolver uncertainty cannot be discarded as a parser no-match |
+| `TC-BP-52` | Benign command substitutions (`$(date)`, `$(cat ...)`, backticks, or a nested `echo` that only generates push text) appear in builtin data commands; controls execute a trunk push from top-level command/process substitution, assignment, `eval`, an arithmetic expression, or an `if` command | Benign substitutions exit `0`; substitution bodies that execute a possible push exit `2` |
+| `TC-BP-53` | Trunk-push text is piped to `awk system($0)`, a dynamic `while` body, `tee >(bash)`, or `xargs env`; controls use print/echo/cat-only equivalents | Stdin evaluators exit `2`; data-only consumers exit `0` |
 
 ## Evidence contract
 
@@ -193,7 +195,7 @@ changing production code. The controls also prevent a future comment/heredoc
 stripper from hiding a real commit after quoted text or a heredoc terminator.
 
 The review-regression cases `142` through `145` and `TC-BP-36` through
-`TC-BP-51` must fail across the reviewed intermediate fixes: operation-bearing
+`TC-BP-53` must fail across the reviewed intermediate fixes: operation-bearing
 large commands time out, git-free expansion commands are misclassified,
 chained or prefixed feature pushes are blocked, prefixed trunk pushes disappear,
 non-executable push text is treated as executable, executable data is treated
@@ -201,8 +203,10 @@ as inert, redirection/continuation syntax is treated as a refspec, or mixed
 quotes hide the operation or trunk refspec. In particular, `TC-BP-48..51`
 reproduce the fourth Opus review's ordinary-pipeline, arithmetic-expansion,
 intervening-global-option, and mixed-operation findings before the fix.
+`TC-BP-52..53` reproduce the fifth review's benign-substitution false positive,
+executable-substitution fail-open, and stdin-evaluator regressions.
 
 The eventual fix is complete only when all one hundred forty-five detector
-cases and all one hundred eighty-one trunk-protection assertions pass together with the
+cases and all two hundred six trunk-protection assertions pass together with the
 existing `test-is-git-command.sh` and
 `test-block-commit-outside-worktree.sh` suites.

--- a/docs/test-cases/issue-547-non-executable-git-mentions.md
+++ b/docs/test-cases/issue-547-non-executable-git-mentions.md
@@ -165,6 +165,36 @@ Those shapes retain the original command text and fail closed.
 | `TC-IGC-547-143` | An approximately 20 KiB ambiguous command ends with `git 'commit'` | Main-workspace hook exits `2` within five seconds |
 | `TC-IGC-547-144` | An approximately 20 KiB ambiguous command ends with `git ${G} commit` | Main-workspace hook exits `2` within five seconds |
 | `TC-IGC-547-145` | An approximately 20 KiB ambiguous command contains no literal `git` word | Main-workspace hook exits `0` within five seconds |
+| `TC-IGC-547-146` | A real commit command contains one substitution body with 500 dynamic command-position tokens | Detector still matches within five seconds |
+| `TC-IGC-547-147` | A git-free command contains the same dense substitution body | Detector returns no match within five seconds |
+| `TC-IGC-547-148` | An approximately 35 KiB masked heredoc is followed by a benign substitution | Detector returns no match within five seconds |
+| `TC-IGC-547-149` | The same masked heredoc is followed by a substitution-hidden commit | Detector matches within five seconds |
+| `TC-IGC-547-150` | Main-workspace hook receives the benign masked-heredoc command | Hook exits `0` within five seconds |
+| `TC-IGC-547-151` | Main-workspace hook receives the hidden-commit masked-heredoc command | Hook exits `2` within five seconds |
+| `TC-IGC-547-152` | A sub-4 KiB git-free substitution has 62 padded nesting levels | Detector terminates within five seconds and fails closed when cumulative analysis exceeds 8 KiB |
+| `TC-IGC-547-153` | The same deep substitution hides a commit in its outer body | Detector matches within five seconds |
+| `TC-IGC-547-154` | Main-workspace hook receives the deeply nested git-free command | Hook terminates fail-closed with exit `2` within five seconds |
+| `TC-IGC-547-155` | Main-workspace hook receives the deeply nested hidden commit | Hook exits `2` within five seconds |
+| `TC-IGC-547-156` | A greater-than-4 KiB command contains a benign backtick substitution | Detector returns no match within five seconds |
+| `TC-IGC-547-157` | The same large command contains a backtick-hidden commit | Detector matches within five seconds |
+| `TC-IGC-547-158` | Main-workspace hook receives the large benign backtick command | Hook exits `0` within five seconds |
+| `TC-IGC-547-159` | Main-workspace hook receives the large backtick-hidden commit | Hook exits `2` within five seconds |
+| `TC-IGC-547-160` | A 4090-byte command alternates deeply nested `$()` and backtick substitutions | Detector terminates fail-closed within three seconds |
+| `TC-IGC-547-161` | Main-workspace hook receives that worst-case mixed nesting | Hook exits `2` within three seconds |
+| `TC-IGC-547-162` | A greater-than-4 KiB backtick body assembles `git commit` with ANSI-C quoted words | Detector still matches the executable commit |
+| `TC-IGC-547-163` | Main-workspace hook receives that ANSI-C quoted backtick commit | Hook exits `2` |
+| `TC-IGC-547-164` | A sub-4 KiB masked heredoc contains commit prose and is followed by `$(date)` | Detector keeps the heredoc prose hidden |
+| `TC-IGC-547-165` | Main-workspace hook receives that masked heredoc plus benign substitution | Hook exits `0` |
+| `TC-IGC-547-166` | A generated PR body contains backtick-formatted `git commit` prose inside a quoted heredoc | Detector keeps the body prose hidden |
+| `TC-IGC-547-167` | Main-workspace hook receives that generated PR body | Hook exits `0` |
+| `TC-IGC-547-168` | A real substitution-hidden commit follows the generated PR body | Detector still matches the executable sibling |
+| `TC-IGC-547-169` | Main-workspace hook receives the generated body plus real hidden commit | Hook exits `2` |
+| `TC-IGC-547-170` | UTF-8 text precedes a substitution-hidden commit | Byte offsets remain aligned and the detector matches |
+| `TC-IGC-547-171` | Main-workspace hook receives that UTF-8-prefixed hidden commit | Hook exits `2` |
+| `TC-IGC-547-172` | `git com$(echo mit)` dynamically completes the operation word | Detector remains fail-closed and matches |
+| `TC-IGC-547-173` | Main-workspace hook receives that split commit operation | Hook exits `2` |
+| `TC-IGC-547-174` | `git "com"$(echo mit)` combines a quoted prefix and dynamic suffix | Detector remains fail-closed and matches |
+| `TC-IGC-547-175` | Main-workspace hook receives that quoted split operation | Hook exits `2` |
 | `TC-BP-35` | An approximately 8 KiB ambiguous command ends with `git push origin main` | Trunk-protection hook exits `2` within five seconds; unresolved refspec parsing cannot grant the push |
 | `TC-BP-36` | Chained/multiline workflows and a quoted dynamic remote end with a literal feature refspec | Trunk-protection hook exits `0`; the equivalent trunk push and an unquoted dynamic remote exit `2` |
 | `TC-BP-37` | Expansion-bearing commands contain no literal `git push`; control uses `$GIT push origin main` | Git-free commands exit `0`; the explicit dynamic Git operation remains fail-closed |
@@ -183,14 +213,15 @@ Those shapes retain the original command text and fail closed.
 | `TC-BP-50` | Dynamic `git -C` is followed by one or more static global options and then `commit` or `log` | Hook exits `0`; the definite non-push operation remains readable after intervening flags |
 | `TC-BP-51` | The `push` operation word itself is assembled from mixed quote fragments and targets trunk | Hook exits `2`; resolver uncertainty cannot be discarded as a parser no-match |
 | `TC-BP-52` | Benign command substitutions (`$(date)`, `$(cat ...)`, backticks, or a nested `echo` that only generates push text) appear in builtin data commands; controls execute a trunk push from top-level command/process substitution, assignment, `eval`, an arithmetic expression, or an `if` command | Benign substitutions exit `0`; substitution bodies that execute a possible push exit `2` |
-| `TC-BP-53` | Trunk-push text is piped to `awk system($0)`, a dynamic `while` body, `tee >(bash)`, or `xargs env`; controls use print/echo/cat-only equivalents | Stdin evaluators exit `2`; data-only consumers exit `0` |
+| `TC-BP-53` | Trunk-push text is piped to awk `system()` or command-pipe forms, external awk source forms including gawk `-E`/`--exec`, `-i`/`--include`, `@load`, and accepted long-option abbreviations, sed `e` forms, dynamic/unknown executors such as `parallel`, `at`, or `crontab`, a dynamic `while` body, `tee >(bash)`, or `xargs env`; controls use safe awk `-F`/`-v`/`--` forms, statically safe sed programs, and explicitly classified text filters | Stdin evaluators and unknown consumers exit `2`; explicit data-only consumers exit `0` |
 | `TC-BP-54` | Trunk-push text passes through one or more data-only filters before reaching a shell, interpreter, source command, compound command, nested process substitution, or `|&` consumer; controls remain data-only through every stage or place an unrelated shell pipeline after a command-list boundary | Any downstream executable consumer exits `2`; multi-stage data-only and boundary-separated pipelines exit `0` |
-| `TC-BP-55` | An approximately 20 KiB git-free ambiguous command contains a benign `$(date)` substitution | Trunk-protection hook exits `0` within five seconds; substitution evidence uses the bounded large-input scanner |
+| `TC-BP-55` | An approximately 20 KiB unmasked git-free ambiguous command contains a benign `$(date)` substitution | Trunk-protection hook exits `0` within five seconds; substitution evidence uses the bounded large-input scanner |
 | `TC-BP-56` | Trunk-push text reaches a shell inside `if`, `for`, `select`, single- or multi-arm nested `case`, or an output process substitution, or through an unlisted launcher or `env -S`/`--split-string`; every form has a `cat`-only twin | Executable bodies exit `2`; data-only twins, including `{ cat; }` and `(cat)`, exit `0` |
-| `TC-BP-57` | A benign pipeline has 200 `cat` stages; a dynamic-input control has the same stages followed by `bash` | Both finish within five seconds; benign data exits `0` and the executable control exits `2` |
-| `TC-BP-58` | Trunk-push data is consumed inside nested brace groups, or produced inside subshell, brace, `if`, `for`, or `case` stages whose outer pipeline reaches `bash`; every form has a `cat` twin | Every executable flow exits `2`; grouped data-only flows and boundary-separated unrelated pipelines exit `0` |
+| `TC-BP-57` | A benign pipeline has 200 `cat` stages; additional data/executable controls use 200 distinct `echo` producer stages, including inside an outer group, plus 40 nested output process substitutions | Every form finishes within three to five seconds as pinned; benign data exits `0` and executable controls exit `2` |
+| `TC-BP-58` | Trunk-push data is consumed inside nested brace groups, or produced inside subshell, brace, `if`, `for`, `while`, or `case` stages whose outer pipeline or output process substitution reaches a shell, including an inner data-only pipeline before that outer consumer; every form has a data-only twin | Every executable flow exits `2`; grouped data-only flows and boundary-separated unrelated pipelines exit `0` |
 | `TC-BP-59` | Trunk-push data reaches compact or clustered `env -Sbash` forms, including forms after attached `-C`/`-u` operands, alternate shell names, or a BusyBox shell applet; controls use compact `-Scat` forms or `busybox cat` | Shell consumers exit `2`; data-only consumers exit `0` |
-| `TC-BP-60` | Approximately 41 KiB benign, large-heredoc, literal-trunk, and quote-concatenated-trunk inputs are paired with 200 grouped data segments ending in `cat` or `bash` | Every case finishes within three seconds; benign/heredoc/data-only cases exit `0` and trunk/executable cases exit `2` |
+| `TC-BP-60` | Approximately 41 KiB unmasked inputs, a 35 KiB masked heredoc, 53 KiB of comment-masked text, greater-than-4 KiB backtick substitutions, 200 grouped data segments ending in `cat` or `bash`, 400 distinct data-only command-list stages, hundreds of repeated command/backtick/process substitutions, the 64/65 unique-body boundary, one body containing 500 dynamic command-position tokens, 62-level padded nesting, and a 4090-byte alternating `$()`/backtick nest | Every case finishes within three to five seconds; masked and large-backtick benign substitutions remain allowed, hidden trunk pushes exit `2`, repeated/dense benign bodies and exactly 64 small unique bodies remain allowed, and count- or cumulative-byte-budget overflow fails closed |
+| `TC-BP-61` | Large ANSI-C quoted backtick pushes, UTF-8-prefixed hidden pushes, dynamically split operation words, feature pushes beside benign command/process substitutions, 3 KiB data-only process substitutions, sub-4 KiB masked heredocs, compact/large generated PR bodies, an 8.3 KiB inline `printf` body, and `gh pr comment --body-file -` heredoc input | Hidden trunk pushes exit `2`; feature pushes and push prose that remain data exit `0`, including both generated-body and stdin-body PR workflows |
 
 ## Evidence contract
 
@@ -201,8 +232,8 @@ false-positive detector behavior and its user-visible hook impact without
 changing production code. The controls also prevent a future comment/heredoc
 stripper from hiding a real commit after quoted text or a heredoc terminator.
 
-The review-regression cases `142` through `145` and `TC-BP-36` through
-`TC-BP-60` must fail across the reviewed intermediate fixes: operation-bearing
+The review-regression cases `142` through `175` and `TC-BP-36` through
+`TC-BP-61` must fail across the reviewed intermediate fixes: operation-bearing
 large commands time out, git-free expansion commands are misclassified,
 chained or prefixed feature pushes are blocked, prefixed trunk pushes disappear,
 non-executable push text is treated as executable, executable data is treated
@@ -218,9 +249,25 @@ substitution-bearing large-input timeout.
 quadratic downstream pipeline scan.
 `TC-BP-58..60` reproduce the eighth review's brace-stage truncation,
 compound-producer bypass, compact `env -S` and alternate-shell bypasses, and
-large-input or repeated-group timeout paths.
+large-input or repeated-group timeout paths. The expanded `TC-BP-58` and
+`TC-BP-60` cases reproduce the ninth review's grouped inner-pipeline bypass,
+output-process-substitution variant, and quadratic scan across distinct
+command-list stages. The expanded `TC-BP-53` and `TC-BP-57` cases reproduce the
+tenth review's flat-pipeline quadratic scan and the sed, awk, and unknown
+stdin-executor fail-open paths. The expanded `TC-BP-53` and `TC-BP-60` cases
+reproduce the eleventh review's omitted gawk include/load executors and
+substitution-count timeout paths. The expanded `TC-BP-53`, `TC-BP-57`, and
+`TC-BP-60` cases reproduce the twelfth review's gawk `-E`/abbreviation bypass,
+deep process-substitution timeout, and repeated whole-body executor scan.
+`TC-IGC-547-162..169` and `TC-BP-61` reproduce the thirteenth review's
+large ANSI-C backtick bypass, whole-command feature-push false positive,
+resolver-uncertainty false positive, discarded top-level heredoc mask, and
+generated-PR-body heredoc false positive.
+`TC-IGC-547-170..175` and the expanded `TC-BP-61` reproduce the fourteenth
+review's UTF-8 byte/character offset bypass, split-operation-word bypass,
+8 KiB inline-body false positive, and stdin PR-body heredoc false positive.
 
-The eventual fix is complete only when all one hundred forty-five detector
-cases and all three hundred thirteen trunk-protection assertions pass together with the
-existing `test-is-git-command.sh` and
+The eventual fix is complete only when all one hundred seventy-five detector
+cases and all four hundred ten trunk-protection assertions pass
+together with the existing `test-is-git-command.sh` and
 `test-block-commit-outside-worktree.sh` suites.

--- a/docs/test-cases/issue-547-non-executable-git-mentions.md
+++ b/docs/test-cases/issue-547-non-executable-git-mentions.md
@@ -186,6 +186,8 @@ Those shapes retain the original command text and fail closed.
 | `TC-BP-53` | Trunk-push text is piped to `awk system($0)`, a dynamic `while` body, `tee >(bash)`, or `xargs env`; controls use print/echo/cat-only equivalents | Stdin evaluators exit `2`; data-only consumers exit `0` |
 | `TC-BP-54` | Trunk-push text passes through one or more data-only filters before reaching a shell, interpreter, source command, compound command, nested process substitution, or `|&` consumer; controls remain data-only through every stage or place an unrelated shell pipeline after a command-list boundary | Any downstream executable consumer exits `2`; multi-stage data-only and boundary-separated pipelines exit `0` |
 | `TC-BP-55` | An approximately 20 KiB git-free ambiguous command contains a benign `$(date)` substitution | Trunk-protection hook exits `0` within five seconds; substitution evidence uses the bounded large-input scanner |
+| `TC-BP-56` | Trunk-push text reaches a shell inside `if`, `for`, `select`, single- or multi-arm nested `case`, or an output process substitution, or through an unlisted launcher or `env -S`/`--split-string`; every form has a `cat`-only twin | Executable bodies exit `2`; data-only twins, including `{ cat; }` and `(cat)`, exit `0` |
+| `TC-BP-57` | A benign pipeline has 200 `cat` stages; a dynamic-input control has the same stages followed by `bash` | Both finish within five seconds; benign data exits `0` and the executable control exits `2` |
 
 ## Evidence contract
 
@@ -197,7 +199,7 @@ changing production code. The controls also prevent a future comment/heredoc
 stripper from hiding a real commit after quoted text or a heredoc terminator.
 
 The review-regression cases `142` through `145` and `TC-BP-36` through
-`TC-BP-55` must fail across the reviewed intermediate fixes: operation-bearing
+`TC-BP-57` must fail across the reviewed intermediate fixes: operation-bearing
 large commands time out, git-free expansion commands are misclassified,
 chained or prefixed feature pushes are blocked, prefixed trunk pushes disappear,
 non-executable push text is treated as executable, executable data is treated
@@ -209,8 +211,10 @@ intervening-global-option, and mixed-operation findings before the fix.
 executable-substitution fail-open, and stdin-evaluator regressions.
 `TC-BP-54..55` reproduce the sixth review's downstream-consumer fail-open and
 substitution-bearing large-input timeout.
+`TC-BP-56..57` reproduce the seventh review's compound/wrapper fail-open and
+quadratic downstream pipeline scan.
 
 The eventual fix is complete only when all one hundred forty-five detector
-cases and all two hundred twenty-seven trunk-protection assertions pass together with the
+cases and all two hundred fifty-seven trunk-protection assertions pass together with the
 existing `test-is-git-command.sh` and
 `test-block-commit-outside-worktree.sh` suites.

--- a/docs/test-cases/issue-547-non-executable-git-mentions.md
+++ b/docs/test-cases/issue-547-non-executable-git-mentions.md
@@ -175,6 +175,9 @@ Those shapes retain the original command text and fail closed.
 | `TC-BP-42` | A builtin `echo` is the only command and its arguments mention a feature or trunk push | Hook exits `0`; parser rc `1` proves no executable push exists |
 | `TC-BP-43` | A trunk refspec is assembled with empty or interior quote fragments | Hook exits `2`; mixed quoting is unknown rather than decoded as a safe feature ref |
 | `TC-BP-44` | A feature push is chained to an approximately 21 KiB PR body or carries an approximately 21 KiB single-word push option | Hook exits `0` within five seconds |
+| `TC-BP-45` | Builtin `echo`/`printf` push text, including ANSI-quoted or quote-concatenated forms, is piped to a local/remote shell, sent through `|&`, used in command substitution, or redirected to process substitution | Literal or dynamic executable shell input exits `2`; git-free literal input, dynamic data without a consumer, and regular-file output exit `0` |
+| `TC-BP-46` | Feature/trunk pushes use regular redirections, brace groups, or backslash-newline continuations; controls contain a continued non-push command or dynamic global args before definite `status` | Shell syntax is not parsed as a refspec; feature/control commands exit `0` and trunk commands exit `2` |
+| `TC-BP-47` | A feature push uses a quoted variable or command substitution as its refspec | Hook exits `2`; the runtime value could target trunk, so dynamic refspecs are intentionally fail-closed |
 
 ## Evidence contract
 
@@ -186,13 +189,14 @@ changing production code. The controls also prevent a future comment/heredoc
 stripper from hiding a real commit after quoted text or a heredoc terminator.
 
 The review-regression cases `142` through `145` and `TC-BP-36` through
-`TC-BP-44` must fail across the reviewed intermediate fixes: operation-bearing
+`TC-BP-47` must fail across the reviewed intermediate fixes: operation-bearing
 large commands time out, git-free expansion commands are misclassified,
 chained or prefixed feature pushes are blocked, prefixed trunk pushes disappear,
-non-executable push text is treated as executable, or mixed quotes hide the
-trunk refspec.
+non-executable push text is treated as executable, executable data is treated
+as inert, redirection/continuation syntax is treated as a refspec, or mixed
+quotes hide the trunk refspec.
 
 The eventual fix is complete only when all one hundred forty-five detector
-cases and all one hundred eighteen trunk-protection assertions pass together with the
+cases and all one hundred fifty-five trunk-protection assertions pass together with the
 existing `test-is-git-command.sh` and
 `test-block-commit-outside-worktree.sh` suites.

--- a/docs/test-cases/issue-547-non-executable-git-mentions.md
+++ b/docs/test-cases/issue-547-non-executable-git-mentions.md
@@ -170,6 +170,11 @@ Those shapes retain the original command text and fail closed.
 | `TC-BP-37` | Expansion-bearing commands contain no literal `git push`; control uses `$GIT push origin main` | Git-free commands exit `0`; the explicit dynamic Git operation remains fail-closed |
 | `TC-BP-38` | An approximately 20 KiB ambiguous command contains no literal `git` word | Trunk-protection hook exits `0` within five seconds |
 | `TC-BP-39` | `echo` arguments or heredoc data mention a trunk push before a real feature push | Non-executable push text is ignored; a real trunk push remains blocked |
+| `TC-BP-40` | A trunk push appears in a subshell, after a supported or unknown wrapper, after a quoted assignment, or beside a readable feature push | Every trunk destination exits `2`; an unreadable second push cannot inherit the first push's remote scope |
+| `TC-BP-41` | A feature-only push is wrapped by `timeout`, shell control flow, `sudo`, `nohup`, `command`, `time`, `stdbuf`, or a quoted environment assignment | Supported prefixed feature pushes exit `0` |
+| `TC-BP-42` | A builtin `echo` is the only command and its arguments mention a feature or trunk push | Hook exits `0`; parser rc `1` proves no executable push exists |
+| `TC-BP-43` | A trunk refspec is assembled with empty or interior quote fragments | Hook exits `2`; mixed quoting is unknown rather than decoded as a safe feature ref |
+| `TC-BP-44` | A feature push is chained to an approximately 21 KiB PR body or carries an approximately 21 KiB single-word push option | Hook exits `0` within five seconds |
 
 ## Evidence contract
 
@@ -181,12 +186,13 @@ changing production code. The controls also prevent a future comment/heredoc
 stripper from hiding a real commit after quoted text or a heredoc terminator.
 
 The review-regression cases `142` through `145` and `TC-BP-36` through
-`TC-BP-39` must fail on the first reviewed fix: operation-bearing large
-commands time out, git-free expansion commands are misclassified, chained
-feature pushes are blocked, or non-executable push text overrides the real
-refspec.
+`TC-BP-44` must fail across the reviewed intermediate fixes: operation-bearing
+large commands time out, git-free expansion commands are misclassified,
+chained or prefixed feature pushes are blocked, prefixed trunk pushes disappear,
+non-executable push text is treated as executable, or mixed quotes hide the
+trunk refspec.
 
 The eventual fix is complete only when all one hundred forty-five detector
-cases and all ninety-three trunk-protection assertions pass together with the
+cases and all one hundred eighteen trunk-protection assertions pass together with the
 existing `test-is-git-command.sh` and
 `test-block-commit-outside-worktree.sh` suites.

--- a/docs/test-cases/issue-547-non-executable-git-mentions.md
+++ b/docs/test-cases/issue-547-non-executable-git-mentions.md
@@ -184,6 +184,8 @@ Those shapes retain the original command text and fail closed.
 | `TC-BP-51` | The `push` operation word itself is assembled from mixed quote fragments and targets trunk | Hook exits `2`; resolver uncertainty cannot be discarded as a parser no-match |
 | `TC-BP-52` | Benign command substitutions (`$(date)`, `$(cat ...)`, backticks, or a nested `echo` that only generates push text) appear in builtin data commands; controls execute a trunk push from top-level command/process substitution, assignment, `eval`, an arithmetic expression, or an `if` command | Benign substitutions exit `0`; substitution bodies that execute a possible push exit `2` |
 | `TC-BP-53` | Trunk-push text is piped to `awk system($0)`, a dynamic `while` body, `tee >(bash)`, or `xargs env`; controls use print/echo/cat-only equivalents | Stdin evaluators exit `2`; data-only consumers exit `0` |
+| `TC-BP-54` | Trunk-push text passes through one or more data-only filters before reaching a shell, interpreter, source command, compound command, nested process substitution, or `|&` consumer; controls remain data-only through every stage or place an unrelated shell pipeline after a command-list boundary | Any downstream executable consumer exits `2`; multi-stage data-only and boundary-separated pipelines exit `0` |
+| `TC-BP-55` | An approximately 20 KiB git-free ambiguous command contains a benign `$(date)` substitution | Trunk-protection hook exits `0` within five seconds; substitution evidence uses the bounded large-input scanner |
 
 ## Evidence contract
 
@@ -195,7 +197,7 @@ changing production code. The controls also prevent a future comment/heredoc
 stripper from hiding a real commit after quoted text or a heredoc terminator.
 
 The review-regression cases `142` through `145` and `TC-BP-36` through
-`TC-BP-53` must fail across the reviewed intermediate fixes: operation-bearing
+`TC-BP-55` must fail across the reviewed intermediate fixes: operation-bearing
 large commands time out, git-free expansion commands are misclassified,
 chained or prefixed feature pushes are blocked, prefixed trunk pushes disappear,
 non-executable push text is treated as executable, executable data is treated
@@ -205,8 +207,10 @@ reproduce the fourth Opus review's ordinary-pipeline, arithmetic-expansion,
 intervening-global-option, and mixed-operation findings before the fix.
 `TC-BP-52..53` reproduce the fifth review's benign-substitution false positive,
 executable-substitution fail-open, and stdin-evaluator regressions.
+`TC-BP-54..55` reproduce the sixth review's downstream-consumer fail-open and
+substitution-bearing large-input timeout.
 
 The eventual fix is complete only when all one hundred forty-five detector
-cases and all two hundred six trunk-protection assertions pass together with the
+cases and all two hundred twenty-seven trunk-protection assertions pass together with the
 existing `test-is-git-command.sh` and
 `test-block-commit-outside-worktree.sh` suites.

--- a/docs/test-cases/issue-547-non-executable-git-mentions.md
+++ b/docs/test-cases/issue-547-non-executable-git-mentions.md
@@ -175,9 +175,13 @@ Those shapes retain the original command text and fail closed.
 | `TC-BP-42` | A builtin `echo` is the only command and its arguments mention a feature or trunk push | Hook exits `0`; parser rc `1` proves no executable push exists |
 | `TC-BP-43` | A trunk refspec is assembled with empty or interior quote fragments | Hook exits `2`; mixed quoting is unknown rather than decoded as a safe feature ref |
 | `TC-BP-44` | A feature push is chained to an approximately 21 KiB PR body or carries an approximately 21 KiB single-word push option | Hook exits `0` within five seconds |
-| `TC-BP-45` | Builtin `echo`/`printf` push text, including ANSI-quoted or quote-concatenated forms, is piped to a local/remote shell, sent through `|&`, used in command substitution, or redirected to process substitution | Literal or dynamic executable shell input exits `2`; git-free literal input, dynamic data without a consumer, and regular-file output exit `0` |
+| `TC-BP-45` | Builtin `echo`/`printf` push text, including ANSI-quoted or quote-concatenated forms, is piped to a local/remote shell (including absolute paths, quoted remote commands, `source`, `.`, and supported wrappers), sent through `|&`, used in command substitution, or redirected to process substitution | Literal or dynamic executable shell input exits `2`; git-free literal input, dynamic data without a consumer, and regular-file output exit `0` |
 | `TC-BP-46` | Feature/trunk pushes use regular redirections, brace groups, or backslash-newline continuations; controls contain a continued non-push command or dynamic global args before definite `status` | Shell syntax is not parsed as a refspec; feature/control commands exit `0` and trunk commands exit `2` |
 | `TC-BP-47` | A feature push uses a quoted variable or command substitution as its refspec | Hook exits `2`; the runtime value could target trunk, so dynamic refspecs are intentionally fail-closed |
+| `TC-BP-48` | Variable data is piped to `jq`, `tee`, `sort`, `gh`, `cut`, wrapped `jq`, remote `cat`, or `xargs jq` | Hook exits `0`; a pipe is not executable merely because its producer contains `$` |
+| `TC-BP-49` | Builtin data commands contain `$((...))` arithmetic expansion and write to a regular file | Hook exits `0`; arithmetic expansion is not command substitution |
+| `TC-BP-50` | Dynamic `git -C` is followed by one or more static global options and then `commit` or `log` | Hook exits `0`; the definite non-push operation remains readable after intervening flags |
+| `TC-BP-51` | The `push` operation word itself is assembled from mixed quote fragments and targets trunk | Hook exits `2`; resolver uncertainty cannot be discarded as a parser no-match |
 
 ## Evidence contract
 
@@ -189,14 +193,16 @@ changing production code. The controls also prevent a future comment/heredoc
 stripper from hiding a real commit after quoted text or a heredoc terminator.
 
 The review-regression cases `142` through `145` and `TC-BP-36` through
-`TC-BP-47` must fail across the reviewed intermediate fixes: operation-bearing
+`TC-BP-51` must fail across the reviewed intermediate fixes: operation-bearing
 large commands time out, git-free expansion commands are misclassified,
 chained or prefixed feature pushes are blocked, prefixed trunk pushes disappear,
 non-executable push text is treated as executable, executable data is treated
 as inert, redirection/continuation syntax is treated as a refspec, or mixed
-quotes hide the trunk refspec.
+quotes hide the operation or trunk refspec. In particular, `TC-BP-48..51`
+reproduce the fourth Opus review's ordinary-pipeline, arithmetic-expansion,
+intervening-global-option, and mixed-operation findings before the fix.
 
 The eventual fix is complete only when all one hundred forty-five detector
-cases and all one hundred fifty-five trunk-protection assertions pass together with the
+cases and all one hundred eighty-one trunk-protection assertions pass together with the
 existing `test-is-git-command.sh` and
 `test-block-commit-outside-worktree.sh` suites.

--- a/docs/test-cases/issue-547-non-executable-git-mentions.md
+++ b/docs/test-cases/issue-547-non-executable-git-mentions.md
@@ -1,0 +1,161 @@
+# Test cases: non-executable git mentions (issue #547)
+
+## Context
+
+`is_git_command()` claims to match an actual `git <operation>` invocation and
+already removes quoted strings before scanning. It does not remove heredoc
+bodies or shell comments, so text written to a file or ignored by the shell can
+be mistaken for an executable `git commit`.
+
+The same distinction must be preserved by `resolve_git_command_cwd()`. Otherwise
+the commit hook still fails closed through resolver return code `2`, even if the
+boolean detector is corrected.
+
+Heredoc masking is intentionally bounded to simple external `cat` commands
+without shell control operators or physical-line continuations. Other consumers
+may interpret stdin as code, and unquoted heredocs can execute substitutions.
+Those shapes retain the original command text and fail closed.
+
+## Test matrix
+
+| ID | Scenario | Expected result |
+|---|---|---|
+| `TC-IGC-547-001` | Quoted-delimiter heredoc body contains `git commit` | `is_git_command commit` returns no match |
+| `TC-IGC-547-002` | `<<-EOF` indented heredoc body contains `git add && git commit` | `is_git_command commit` returns no match |
+| `TC-IGC-547-003` | Command ends with `# git commit ...` | `is_git_command commit` returns no match |
+| `TC-IGC-547-004` | Quoted string contains `git commit` | Existing no-match behavior remains |
+| `TC-IGC-547-005` | Resolver receives the quoted-delimiter heredoc case | Returns empty output and status `1` (no commit) |
+| `TC-IGC-547-006` | Resolver receives the comment-only case | Returns empty output and status `1` (no commit) |
+| `TC-IGC-547-007` | Main-workspace hook receives the heredoc file-generation command | Hook exits `0` |
+| `TC-IGC-547-008` | Main-workspace hook receives the indented heredoc file-generation command | Hook exits `0` |
+| `TC-IGC-547-009` | Main-workspace hook receives the comment-only command | Hook exits `0` |
+| `TC-IGC-547-010` | Genuine `git commit` | Detector still matches |
+| `TC-IGC-547-011` | Comment line followed by a genuine `git commit` | Detector still matches the executable line |
+| `TC-IGC-547-012` | Genuine `git commit` from a main workspace | Hook still exits `2` |
+| `TC-IGC-547-013` | Quoted string contains `#`, followed by a genuine `git commit` | Quoted hash does not begin a comment; detector still matches |
+| `TC-IGC-547-014` | Heredoc terminator is followed by a genuine `git commit` | Detector still matches the executable line after the heredoc |
+| `TC-IGC-547-015` | Quoted hash is followed by a genuine commit from a main workspace | Hook still exits `2` |
+| `TC-IGC-547-016` | Heredoc is followed by a genuine commit from a main workspace | Hook still exits `2` |
+| `TC-IGC-547-017` | Double-quoted heredoc delimiter with `git commit` in its body | Detector returns no match |
+| `TC-IGC-547-018` | Main-workspace hook receives the double-quoted heredoc case | Hook exits `0` |
+| `TC-IGC-547-019` | Here-string is followed by a genuine `git commit` | Here-string is not mistaken for a heredoc; detector matches |
+| `TC-IGC-547-020` | Main-workspace hook receives the here-string plus genuine commit | Hook exits `2` |
+| `TC-IGC-547-021` | Escaped `#` is followed by a genuine commit | Escaped hash does not begin a comment; detector matches |
+| `TC-IGC-547-022` | Mid-word `#` is followed by a genuine commit | Mid-word hash does not begin a comment; detector matches |
+| `TC-IGC-547-023` | Quoted text looks like a heredoc opener, followed by a genuine commit | Quoted opener does not start heredoc masking; detector matches |
+| `TC-IGC-547-024` | Multiline quoted string contains a line-leading `#`, followed by a genuine commit | Quote state survives newlines; detector matches |
+| `TC-IGC-547-025` | One-megabyte heredoc body | No match and completion within two seconds, below the five-second hook timeout |
+| `TC-IGC-547-026` | Preprocessor command fails while detector receives a genuine commit | Detector retains the original command and still matches |
+| `TC-IGC-547-027` | Preprocessor command fails while resolver receives a genuine commit | Resolver retains the original command and resolves it normally |
+| `TC-IGC-547-028` | Heredoc delimiter is followed by an output redirect | Detector returns no match for body prose |
+| `TC-IGC-547-029` | Main-workspace hook receives the trailing-redirect heredoc | Hook exits `0` |
+| `TC-IGC-547-030` | Backslash-quoted identifier delimiter | Detector returns no match for body prose |
+| `TC-IGC-547-031` | One command declares two heredocs containing commit prose | Detector returns no match |
+| `TC-IGC-547-032` | Main-workspace hook receives the two-heredoc command | Hook exits `0` |
+| `TC-IGC-547-033` | Command substitution is immediately followed by `#suffix`, then a real commit | Detector still matches the executable commit |
+| `TC-IGC-547-034` | Main-workspace hook receives that command-substitution case | Hook exits `2` |
+| `TC-IGC-547-035` | Multiline arithmetic expression contains `<<IDENT`, followed by a real commit | Arithmetic shift is not treated as heredoc; detector matches |
+| `TC-IGC-547-036` | Main-workspace hook receives the arithmetic-shift case | Hook exits `2` |
+| `TC-IGC-547-037` | Heredoc declaration line also contains a genuine `git commit` after `;` | Detector still matches executable text on the opener line |
+| `TC-IGC-547-038` | `cat` heredoc is piped to a shell interpreter | Detector matches the potentially executable body |
+| `TC-IGC-547-039` | Main-workspace hook receives the pipeline-to-shell heredoc | Hook exits `2` |
+| `TC-IGC-547-040` | Unquoted heredoc body contains `$(git commit ...)` | Detector matches because command substitution executes |
+| `TC-IGC-547-041` | Main-workspace hook receives that unquoted substitution | Hook exits `2` |
+| `TC-IGC-547-042` | Unquoted heredoc body contains escaped `\$(git commit ...)` | Detector returns no match because the text is literal |
+| `TC-IGC-547-043` | Main-workspace hook receives the escaped substitution prose | Hook exits `0` |
+| `TC-IGC-547-044` | Double-quoted argument contains `$(git commit ...)` | Detector matches the executable substitution |
+| `TC-IGC-547-045` | Main-workspace hook receives the double-quoted substitution | Hook exits `2` |
+| `TC-IGC-547-046` | Double-quoted argument contains a backtick `git commit` substitution | Detector matches the executable substitution |
+| `TC-IGC-547-047` | Main-workspace hook receives the backtick substitution | Hook exits `2` |
+| `TC-IGC-547-048` | A shell interpreter consumes a quoted heredoc containing `git commit` | Detector keeps the body visible |
+| `TC-IGC-547-049` | Main-workspace hook receives the shell-consumer heredoc | Hook exits `2` |
+| `TC-IGC-547-050` | Command text defines a `cat` function that sends stdin to Bash | Detector keeps the later heredoc body visible |
+| `TC-IGC-547-051` | Main-workspace hook receives the in-command `cat` override | Hook exits `2` |
+| `TC-IGC-547-052` | The detector environment already defines `cat` as a function | Heredoc masking is disabled and the commit remains visible |
+| `TC-IGC-547-053` | A backslash continuation forms a `cat` function definition across physical lines | Detector keeps the later heredoc body visible |
+| `TC-IGC-547-054` | Main-workspace hook receives the continued function-definition case | Hook exits `2` |
+| `TC-IGC-547-055` | A double-quoted string runs `$(date)` and separately contains `git commit` prose | Detector returns no match because the git text is not inside the substitution |
+| `TC-IGC-547-056` | Main-workspace hook receives that benign quoted substitution | Hook exits `0` |
+| `TC-IGC-547-057` | `eval` dynamically defines `cat` before a heredoc containing `git commit` | Detector keeps the heredoc body visible |
+| `TC-IGC-547-058` | Main-workspace hook receives the dynamic `cat` replacement | Hook exits `2` |
+| `TC-IGC-547-059` | A command substitution runs `bash -c 'git commit ...'` | Detector matches the executable shell code |
+| `TC-IGC-547-060` | Main-workspace hook receives the `bash -c` substitution | Hook exits `2` |
+| `TC-IGC-547-061` | A command substitution runs `eval 'git commit ...'` | Detector matches the executable evaluated code |
+| `TC-IGC-547-062` | Main-workspace hook receives the `eval` substitution | Hook exits `2` |
+| `TC-IGC-547-063` | A command substitution runs `echo 'git commit ...'` | Detector returns no match because the text remains data |
+| `TC-IGC-547-064` | Main-workspace hook receives the benign `echo` substitution | Hook exits `0` |
+| `TC-IGC-547-065` | A substitution contains quoted parentheses before a real commit | Detector matches the later executable commit |
+| `TC-IGC-547-066` | Main-workspace hook receives that parenthesized substitution | Hook exits `2` |
+| `TC-IGC-547-067` | `bash -c` receives grouped code containing `git commit` | Detector matches the grouped executable commit |
+| `TC-IGC-547-068` | Main-workspace hook receives the grouped `bash -c` code | Hook exits `2` |
+| `TC-IGC-547-069` | `bash -O extglob -c` receives code containing `git commit` | Detector skips the option argument and matches the code |
+| `TC-IGC-547-070` | Main-workspace hook receives the option-bearing shell command | Hook exits `2` |
+| `TC-IGC-547-071` | A substitution comment contains `)` before a real commit | Comment text does not truncate the executable substitution body |
+| `TC-IGC-547-072` | Main-workspace hook receives that commented substitution | Hook exits `2` |
+| `TC-IGC-547-073` | A substitution directly groups `git commit` in a subshell | Detector matches the grouped executable commit |
+| `TC-IGC-547-074` | Main-workspace hook receives the grouped substitution | Hook exits `2` |
+| `TC-IGC-547-075` | `bash +O extglob -c` receives code containing `git commit` | Detector skips the `+O` argument and matches the code |
+| `TC-IGC-547-076` | Main-workspace hook receives the `+O` shell command | Hook exits `2` |
+| `TC-IGC-547-077` | `env -u X` wraps `bash -c 'git commit ...'` | Detector skips the env option argument and matches the code |
+| `TC-IGC-547-078` | Main-workspace hook receives the env-wrapped shell command | Hook exits `2` |
+| `TC-IGC-547-079` | `command -p` wraps `bash -c 'git commit ...'` | Detector skips the command option and matches the code |
+| `TC-IGC-547-080` | Main-workspace hook receives the command-wrapped shell command | Hook exits `2` |
+| `TC-IGC-547-081` | A completed substitution is followed by `# git commit` prose | Detector removes the top-level EOF comment |
+| `TC-IGC-547-082` | Main-workspace hook receives the substitution plus EOF comment | Hook exits `0` |
+| `TC-IGC-547-083` | `$SHELL -c` dynamically selects the shell for `git commit` | Detector fails closed on the dynamic executor |
+| `TC-IGC-547-084` | Main-workspace hook receives the dynamic shell command | Hook exits `2` |
+| `TC-IGC-547-085` | `exec bash -c` runs code containing `git commit` | Detector recognizes the exec wrapper |
+| `TC-IGC-547-086` | Main-workspace hook receives the exec-wrapped shell command | Hook exits `2` |
+| `TC-IGC-547-087` | An `if` branch runs `bash -c 'git commit ...'` | Detector recognizes the control-flow command boundary |
+| `TC-IGC-547-088` | Main-workspace hook receives the conditional shell command | Hook exits `2` |
+| `TC-IGC-547-089` | An escaped `\bash` runs code containing `git commit` | Detector resolves the static escaped command name |
+| `TC-IGC-547-090` | Main-workspace hook receives the escaped shell command | Hook exits `2` |
+| `TC-IGC-547-091` | `! bash -c` runs code containing `git commit` | Detector recognizes the negation prefix |
+| `TC-IGC-547-092` | Main-workspace hook receives the negated shell command | Hook exits `2` |
+| `TC-IGC-547-093` | An `if` condition runs `bash -c 'git commit ...'` | Detector conservatively matches the executable code |
+| `TC-IGC-547-094` | Main-workspace hook receives the condition command | Hook exits `2` |
+| `TC-IGC-547-095` | `time` prefixes `bash -c 'git commit ...'` | Detector conservatively matches the executable code |
+| `TC-IGC-547-096` | Main-workspace hook receives the timed shell command | Hook exits `2` |
+| `TC-IGC-547-097` | A redirection precedes `bash -c 'git commit ...'` | Detector conservatively matches the executable code |
+| `TC-IGC-547-098` | Main-workspace hook receives the redirected shell command | Hook exits `2` |
+| `TC-IGC-547-099` | Bash reads `git commit` code from a here-string | Detector conservatively matches the stdin code |
+| `TC-IGC-547-100` | Main-workspace hook receives the Bash stdin command | Hook exits `2` |
+| `TC-IGC-547-101` | `bash -s` reads `git commit` code from a here-string | Detector conservatively matches the stdin code |
+| `TC-IGC-547-102` | Main-workspace hook receives the `bash -s` stdin command | Hook exits `2` |
+| `TC-IGC-547-103` | A simple `printf` outputs `git commit` prose | Detector treats the quoted text as data |
+| `TC-IGC-547-104` | Main-workspace hook receives the benign `printf` substitution | Hook exits `0` |
+| `TC-IGC-547-105` | Earlier command text replaces `echo` with an evaluator function | Detector does not apply the builtin data exception |
+| `TC-IGC-547-106` | Main-workspace hook receives the shadowed `echo` command | Hook exits `2` |
+| `TC-IGC-547-107` | Earlier command text replaces `printf` with an evaluator function | Detector does not apply the builtin data exception |
+| `TC-IGC-547-108` | Main-workspace hook receives the shadowed `printf` command | Hook exits `2` |
+| `TC-IGC-547-109` | `/tmp/echo` receives `git commit` text | Detector does not trust an explicit path as the `echo` builtin |
+| `TC-IGC-547-110` | Main-workspace hook receives the path-qualified echo command | Hook exits `2` |
+| `TC-IGC-547-111` | `/tmp/printf` receives `git commit` text | Detector does not trust an explicit path as the `printf` builtin |
+| `TC-IGC-547-112` | Main-workspace hook receives the path-qualified printf command | Hook exits `2` |
+| `TC-IGC-547-113` | `printf -v` uses an array subscript containing `$(git commit ...)` | Detector excludes assignment mode from the data exception |
+| `TC-IGC-547-114` | Main-workspace hook receives the `printf -v` command | Hook exits `2` |
+| `TC-IGC-547-115` | `eval` consumes output from `echo 'git commit ...'` | Detector treats the generated code as executable |
+| `TC-IGC-547-116` | Main-workspace hook receives the eval consumer | Hook exits `2` |
+| `TC-IGC-547-117` | `bash -c` consumes output from `echo 'git commit ...'` | Detector treats the generated code as executable |
+| `TC-IGC-547-118` | Main-workspace hook receives the shell code consumer | Hook exits `2` |
+| `TC-IGC-547-119` | Bash consumes a process substitution that outputs `git commit` | Detector does not apply the data exception |
+| `TC-IGC-547-120` | Main-workspace hook receives the process-substitution consumer | Hook exits `2` |
+| `TC-IGC-547-121` | Builtin echo output containing `git commit` is piped to Bash | Detector does not apply the data exception |
+| `TC-IGC-547-122` | Main-workspace hook receives the pipeline consumer | Hook exits `2` |
+| `TC-IGC-547-123` | Echo redirects generated `git commit` text to a Bash process substitution | Detector rejects the prefix redirection |
+| `TC-IGC-547-124` | Main-workspace hook receives the prefix redirect consumer | Hook exits `2` |
+| `TC-IGC-547-125` | An array subscript consumes generated text containing `$(git commit ...)` | Detector rejects the parameter-expansion context |
+| `TC-IGC-547-126` | Main-workspace hook receives the array subscript consumer | Hook exits `2` |
+
+## Evidence contract
+
+On the issue's reported parent revision (`86dd067`), cases `001`, `002`, `003`,
+`005`, `006`, `007`, `008`, and `009` must fail while the eight safety controls
+`004` and `010` through `016` pass. That RED result demonstrates both the
+false-positive detector behavior and its user-visible hook impact without
+changing production code. The controls also prevent a future comment/heredoc
+stripper from hiding a real commit after quoted text or a heredoc terminator.
+
+The eventual fix is complete only when all one hundred twenty-six cases pass together with the
+existing `test-is-git-command.sh` and
+`test-block-commit-outside-worktree.sh` suites.

--- a/docs/test-cases/issue-547-non-executable-git-mentions.md
+++ b/docs/test-cases/issue-547-non-executable-git-mentions.md
@@ -188,6 +188,9 @@ Those shapes retain the original command text and fail closed.
 | `TC-BP-55` | An approximately 20 KiB git-free ambiguous command contains a benign `$(date)` substitution | Trunk-protection hook exits `0` within five seconds; substitution evidence uses the bounded large-input scanner |
 | `TC-BP-56` | Trunk-push text reaches a shell inside `if`, `for`, `select`, single- or multi-arm nested `case`, or an output process substitution, or through an unlisted launcher or `env -S`/`--split-string`; every form has a `cat`-only twin | Executable bodies exit `2`; data-only twins, including `{ cat; }` and `(cat)`, exit `0` |
 | `TC-BP-57` | A benign pipeline has 200 `cat` stages; a dynamic-input control has the same stages followed by `bash` | Both finish within five seconds; benign data exits `0` and the executable control exits `2` |
+| `TC-BP-58` | Trunk-push data is consumed inside nested brace groups, or produced inside subshell, brace, `if`, `for`, or `case` stages whose outer pipeline reaches `bash`; every form has a `cat` twin | Every executable flow exits `2`; grouped data-only flows and boundary-separated unrelated pipelines exit `0` |
+| `TC-BP-59` | Trunk-push data reaches compact or clustered `env -Sbash` forms, including forms after attached `-C`/`-u` operands, alternate shell names, or a BusyBox shell applet; controls use compact `-Scat` forms or `busybox cat` | Shell consumers exit `2`; data-only consumers exit `0` |
+| `TC-BP-60` | Approximately 41 KiB benign, large-heredoc, literal-trunk, and quote-concatenated-trunk inputs are paired with 200 grouped data segments ending in `cat` or `bash` | Every case finishes within three seconds; benign/heredoc/data-only cases exit `0` and trunk/executable cases exit `2` |
 
 ## Evidence contract
 
@@ -199,7 +202,7 @@ changing production code. The controls also prevent a future comment/heredoc
 stripper from hiding a real commit after quoted text or a heredoc terminator.
 
 The review-regression cases `142` through `145` and `TC-BP-36` through
-`TC-BP-57` must fail across the reviewed intermediate fixes: operation-bearing
+`TC-BP-60` must fail across the reviewed intermediate fixes: operation-bearing
 large commands time out, git-free expansion commands are misclassified,
 chained or prefixed feature pushes are blocked, prefixed trunk pushes disappear,
 non-executable push text is treated as executable, executable data is treated
@@ -213,8 +216,11 @@ executable-substitution fail-open, and stdin-evaluator regressions.
 substitution-bearing large-input timeout.
 `TC-BP-56..57` reproduce the seventh review's compound/wrapper fail-open and
 quadratic downstream pipeline scan.
+`TC-BP-58..60` reproduce the eighth review's brace-stage truncation,
+compound-producer bypass, compact `env -S` and alternate-shell bypasses, and
+large-input or repeated-group timeout paths.
 
 The eventual fix is complete only when all one hundred forty-five detector
-cases and all two hundred fifty-seven trunk-protection assertions pass together with the
+cases and all three hundred thirteen trunk-protection assertions pass together with the
 existing `test-is-git-command.sh` and
 `test-block-commit-outside-worktree.sh` suites.

--- a/skills/autonomous-common/hooks/block-commit-outside-worktree.sh
+++ b/skills/autonomous-common/hooks/block-commit-outside-worktree.sh
@@ -17,13 +17,10 @@ if hook_common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/de
   hook_common_dir=$(_canonical_existing_directory "$hook_common_dir") || hook_common_dir=""
 fi
 
-# Resolve command context independently from the boolean detector. The resolver
-# also recognizes supported quoted `git -C` paths that the detector strips.
-detected_commit=0
-if is_git_command "commit" "$command"; then
-  detected_commit=1
-fi
-
+# The resolver is the single source of truth: rc=0 is a supported commit,
+# rc=1 is a proven no-match, and rc=2 is a matching but uncertain command that
+# must fail closed. Avoid running the same shell scanner twice inside the
+# hook's five-second budget.
 resolved_dir=""
 if resolved_dir=$(resolve_git_command_cwd "commit" "$command" "$base_dir"); then
   resolve_rc=0
@@ -31,7 +28,7 @@ else
   resolve_rc=$?
 fi
 
-if [[ "$resolve_rc" -eq 1 && "$detected_commit" -eq 0 ]]; then
+if [[ "$resolve_rc" -eq 1 ]]; then
   exit 0
 fi
 

--- a/skills/autonomous-common/hooks/block-push-to-main.sh
+++ b/skills/autonomous-common/hooks/block-push-to-main.sh
@@ -71,6 +71,23 @@ if stripped_push_command=$(_strip_shell_non_executable_regions "$command"); then
   push_command="$stripped_push_command"
 fi
 
+# Tokenize once in the parent shell. Both parser command substitutions inherit
+# this immutable snapshot, avoiding repeated character scans on large commands.
+_push_prepare_command_tokens "$push_command"
+
+# Parse destination refs before repository scoping. rc=1 positively means the
+# resolver matched only non-executable data (for example `echo git push ...`);
+# rc=2 remains unknown and therefore fail-closed after scope evaluation.
+parsed_refs=""
+if parsed_refs=$(parse_push_target_refspec "$push_command"); then
+  parse_rc=0
+else
+  parse_rc=$?
+fi
+if (( parse_rc == 1 )); then
+  exit 0
+fi
+
 # Both destinations must be PROVEN before the push may be waved through. Each
 # of these can report "unknown", and any unknown leaves the trunk check armed.
 target_url=""
@@ -121,12 +138,6 @@ trunk="${BASE_BRANCH:-${TRUNK_BRANCH:-main}}"
 # Parse the destination ref(s) the push would write to. Block if any of
 # them target the trunk (covers --all/--mirror via __ALL__/__MIRROR__).
 should_block=0
-parsed_refs=""
-if parsed_refs=$(parse_push_target_refspec "$push_command"); then
-  parse_rc=0
-else
-  parse_rc=$?
-fi
 while IFS= read -r ref; do
   [[ -z "$ref" ]] && continue
   if is_trunk_ref "$ref" "$trunk"; then
@@ -135,10 +146,9 @@ while IFS= read -r ref; do
   fi
 done <<<"$parsed_refs"
 
-# Parser rc=1 means no literal push was found, while rc=2 means one was found
-# but its destination was unreadable. The resolver already proved this command
-# contains a push, so either non-zero parser result remains fail-closed.
-if (( parse_rc != 0 )); then
+# Parser rc=2 means an executable push was found but its destination was
+# unreadable. rc=1 was handled above as a proven data-only resolver match.
+if (( parse_rc == 2 )); then
   should_block=1
 fi
 

--- a/skills/autonomous-common/hooks/block-push-to-main.sh
+++ b/skills/autonomous-common/hooks/block-push-to-main.sh
@@ -64,10 +64,17 @@ if [[ "$resolve_rc" -eq 1 ]]; then
   exit 0
 fi
 
+# Apply the resolver's non-executable-region policy to destination parsing too.
+# On uncertain syntax, retain the original text so parsing stays fail-closed.
+push_command="$command"
+if stripped_push_command=$(_strip_shell_non_executable_regions "$command"); then
+  push_command="$stripped_push_command"
+fi
+
 # Both destinations must be PROVEN before the push may be waved through. Each
 # of these can report "unknown", and any unknown leaves the trunk check armed.
 target_url=""
-if [[ -n "$push_dir" ]] && remote_operand=$(parse_push_remote_operand "$command"); then
+if [[ -n "$push_dir" ]] && remote_operand=$(parse_push_remote_operand "$push_command"); then
   target_url=$(push_destination_url "$push_dir" "$remote_operand") || target_url=""
 fi
 
@@ -114,20 +121,24 @@ trunk="${BASE_BRANCH:-${TRUNK_BRANCH:-main}}"
 # Parse the destination ref(s) the push would write to. Block if any of
 # them target the trunk (covers --all/--mirror via __ALL__/__MIRROR__).
 should_block=0
-found_ref=0
+parsed_refs=""
+if parsed_refs=$(parse_push_target_refspec "$push_command"); then
+  parse_rc=0
+else
+  parse_rc=$?
+fi
 while IFS= read -r ref; do
   [[ -z "$ref" ]] && continue
-  found_ref=1
   if is_trunk_ref "$ref" "$trunk"; then
     should_block=1
     break
   fi
-done < <(parse_push_target_refspec "$command")
+done <<<"$parsed_refs"
 
-# A matched but unsupported push with no parseable destination is UNKNOWN.
-# The hook's existing fail-closed contract must not turn parser uncertainty
-# into permission to push.
-if (( resolve_rc == 2 && found_ref == 0 )); then
+# Parser rc=1 means no literal push was found, while rc=2 means one was found
+# but its destination was unreadable. The resolver already proved this command
+# contains a push, so either non-zero parser result remains fail-closed.
+if (( parse_rc != 0 )); then
   should_block=1
 fi
 

--- a/skills/autonomous-common/hooks/block-push-to-main.sh
+++ b/skills/autonomous-common/hooks/block-push-to-main.sh
@@ -62,10 +62,20 @@ else
   push_dir=""
 fi
 
+substitution_push=0
+case "$command" in
+  *'$('*|*'`'*|*'<('*|*'>('*)
+    if _unsafe_shell_text_contains_git_operation "push" "$command"; then
+      substitution_push=1
+    fi
+    ;;
+esac
+
 # Most resolver no-matches are ordinary git-free commands. Only pay for the
 # structured second opinion when a cheap conservative scan still sees literal
 # push-shaped text that quoting or a data command may have hidden.
 if (( resolve_rc == 1 )) &&
+  (( substitution_push == 0 )) &&
   ! _conservative_shell_text_contains_git_operation "push" "$command" &&
   ! _push_shell_text_may_contain_executable_push_data "$command"; then
   exit 0
@@ -91,6 +101,9 @@ if parsed_refs=$(parse_push_target_refspec "$push_command"); then
   parse_rc=0
 else
   parse_rc=$?
+fi
+if (( substitution_push == 1 )); then
+  parse_rc=2
 fi
 if (( parse_rc == 1 )); then
   exit 0

--- a/skills/autonomous-common/hooks/block-push-to-main.sh
+++ b/skills/autonomous-common/hooks/block-push-to-main.sh
@@ -17,11 +17,6 @@ source "$SCRIPT_DIR/lib-push.sh"
 input=$(read_hook_stdin)
 command=$(parse_command "$input")
 
-# Only check git push commands
-if ! is_git_command "push" "$command"; then
-  exit 0
-fi
-
 # Trunk protection guards THIS project's REMOTE trunk, so the question it must
 # ask is "where does this push land?" — not "which local checkout issued it"
 # ([INV-148]). A push whose destination is a different repository is not this
@@ -55,13 +50,18 @@ if [[ -z "$anchor_dir" || ! -d "$anchor_dir" ]]; then
   anchor_dir="$(pwd -P)"
 fi
 
-# Which repository issues the push. rc=2 means a push matched but its context is
-# unresolvable ([INV-146]) — that is UNKNOWN, not "the cwd": the cwd is a
-# different repository than the command's real target, so substituting it would
-# compare the wrong repo in both directions. Only rc=0 yields a usable target.
+# Which repository issues the push. The resolver is also the operation detector:
+# rc=1 proves there is no push, rc=2 means a push matched but its context is
+# unresolvable ([INV-146]), and only rc=0 yields a usable target. Keeping this as
+# one parse avoids exhausting the hook's five-second budget.
 push_dir=""
-if resolved_dir=$(resolve_git_command_cwd "push" "$command" "$(pwd -P)"); then
-  push_dir="$resolved_dir"
+if push_dir=$(resolve_git_command_cwd "push" "$command" "$(pwd -P)"); then
+  resolve_rc=0
+else
+  resolve_rc=$?
+fi
+if [[ "$resolve_rc" -eq 1 ]]; then
+  exit 0
 fi
 
 # Both destinations must be PROVEN before the push may be waved through. Each
@@ -114,13 +114,22 @@ trunk="${BASE_BRANCH:-${TRUNK_BRANCH:-main}}"
 # Parse the destination ref(s) the push would write to. Block if any of
 # them target the trunk (covers --all/--mirror via __ALL__/__MIRROR__).
 should_block=0
+found_ref=0
 while IFS= read -r ref; do
   [[ -z "$ref" ]] && continue
+  found_ref=1
   if is_trunk_ref "$ref" "$trunk"; then
     should_block=1
     break
   fi
 done < <(parse_push_target_refspec "$command")
+
+# A matched but unsupported push with no parseable destination is UNKNOWN.
+# The hook's existing fail-closed contract must not turn parser uncertainty
+# into permission to push.
+if (( resolve_rc == 2 && found_ref == 0 )); then
+  should_block=1
+fi
 
 if (( should_block == 1 )); then
   cat >&2 <<EOF

--- a/skills/autonomous-common/hooks/block-push-to-main.sh
+++ b/skills/autonomous-common/hooks/block-push-to-main.sh
@@ -65,20 +65,34 @@ fi
 substitution_push=0
 case "$command" in
   *'$('*|*'`'*|*'<('*|*'>('*)
-    if _unsafe_shell_text_contains_git_operation "push" "$command"; then
-      substitution_push=1
+    # Resolver rc=1 already means its substitution-aware scanner found no push;
+    # do not repeat that bounded pass on large commands. Resolved or ambiguous
+    # commands still need the precise substitution check: benign process
+    # substitutions such as `>(cat)` also make the resolver return rc=2.
+    if (( resolve_rc != 1 )); then
+      if (( ${#command} >= 4096 )); then
+        substitution_scanner=_large_ambiguous_shell_text_contains_git_operation
+      else
+        substitution_scanner=_unsafe_shell_text_contains_git_operation
+      fi
+      if "$substitution_scanner" "push" "$command"; then
+        substitution_push=1
+      fi
     fi
     ;;
 esac
 
 # Most resolver no-matches are ordinary git-free commands. Only pay for the
 # structured second opinion when a cheap conservative scan still sees literal
-# push-shaped text that quoting or a data command may have hidden.
+# push-shaped text or data can flow into an executable consumer. Expansion-only
+# input reuses the resolver's substitution-aware negative result.
 if (( resolve_rc == 1 )) &&
   (( substitution_push == 0 )) &&
-  ! _conservative_shell_text_contains_git_operation "push" "$command" &&
-  ! _push_shell_text_may_contain_executable_push_data "$command"; then
-  exit 0
+  ! _conservative_shell_text_contains_git_operation "push" "$command"; then
+  if ! _push_shell_text_may_contain_executable_push_data "$command" ||
+    (( _PUSH_EXECUTABLE_DATA_HAS_PIPELINE == 0 )); then
+    exit 0
+  fi
 fi
 
 # Apply the resolver's non-executable-region policy to destination parsing too.

--- a/skills/autonomous-common/hooks/block-push-to-main.sh
+++ b/skills/autonomous-common/hooks/block-push-to-main.sh
@@ -50,6 +50,11 @@ if [[ -z "$anchor_dir" || ! -d "$anchor_dir" ]]; then
   anchor_dir="$(pwd -P)"
 fi
 
+# Trunk branch name (issue #478, [INV-131]): BASE_BRANCH (the wrapper
+# resolves+exports it once at startup) -> TRUNK_BRANCH (this hook's pre-#478
+# override, still honored standalone) -> "main" default.
+trunk="${BASE_BRANCH:-${TRUNK_BRANCH:-main}}"
+
 # Which repository issues the push. Only resolver rc=0 yields a usable target;
 # either non-zero result still receives the push parser's narrow executable-data
 # check below. Quoted text piped into a shell can be executable even when the
@@ -60,6 +65,13 @@ if push_dir=$(resolve_git_command_cwd "push" "$command" "$(pwd -P)"); then
 else
   resolve_rc=$?
   push_dir=""
+fi
+
+large_static_trunk_push=0
+if (( resolve_rc == 2 && ${#command} >= 4096 )) &&
+  _large_static_shell_text_contains_git_operation \
+    "push" "$command" "$trunk"; then
+  large_static_trunk_push=1
 fi
 
 substitution_push=0
@@ -89,6 +101,7 @@ esac
 if (( resolve_rc == 1 )) &&
   (( substitution_push == 0 )) &&
   ! _conservative_shell_text_contains_git_operation "push" "$command"; then
+  [[ "$command" == *'|'* ]] || exit 0
   if ! _push_shell_text_may_contain_executable_push_data "$command" ||
     (( _PUSH_EXECUTABLE_DATA_HAS_PIPELINE == 0 )); then
     exit 0
@@ -102,19 +115,22 @@ if stripped_push_command=$(_strip_shell_non_executable_regions "$command"); then
   push_command="$stripped_push_command"
 fi
 
-# Tokenize once in the parent shell. Both parser command substitutions inherit
-# this immutable snapshot, avoiding repeated character scans on large commands.
-_push_prepare_command_tokens "$push_command"
-
 # Parse destination refs before repository scoping. rc=1 positively means no
 # executable push exists; rc=2 remains unknown and therefore fail-closed after
 # scope evaluation. This second opinion is also what distinguishes quoted data
 # piped to a shell from inert documentation text when the resolver returns 1.
 parsed_refs=""
-if parsed_refs=$(parse_push_target_refspec "$push_command"); then
-  parse_rc=0
+if (( large_static_trunk_push == 1 )); then
+  parse_rc=2
 else
-  parse_rc=$?
+  # Tokenize once in the parent shell. Both parser command substitutions
+  # inherit this immutable snapshot, avoiding repeated character scans.
+  _push_prepare_command_tokens "$push_command"
+  if parsed_refs=$(parse_push_target_refspec "$push_command"); then
+    parse_rc=0
+  else
+    parse_rc=$?
+  fi
 fi
 if (( substitution_push == 1 )); then
   parse_rc=2
@@ -163,12 +179,6 @@ if [[ -n "${PUSH_ALLOWED_REMOTE_URLS:-}" && -n "$target_url" ]]; then
     fi
   done
 fi
-
-# Trunk branch name (issue #478, [INV-131]): BASE_BRANCH (the wrapper
-# resolves+exports it once at startup) → TRUNK_BRANCH (this hook's pre-#478
-# override, still honored standalone e.g. for a manually-run hook outside the
-# wrapper) → "main" default. Byte-identical to today when neither is set.
-trunk="${BASE_BRANCH:-${TRUNK_BRANCH:-main}}"
 
 # Parse the destination ref(s) the push would write to. Block if any of
 # them target the trunk (covers --all/--mirror via __ALL__/__MIRROR__).

--- a/skills/autonomous-common/hooks/block-push-to-main.sh
+++ b/skills/autonomous-common/hooks/block-push-to-main.sh
@@ -74,32 +74,11 @@ if (( resolve_rc == 2 && ${#command} >= 4096 )) &&
   large_static_trunk_push=1
 fi
 
-substitution_push=0
-case "$command" in
-  *'$('*|*'`'*|*'<('*|*'>('*)
-    # Resolver rc=1 already means its substitution-aware scanner found no push;
-    # do not repeat that bounded pass on large commands. Resolved or ambiguous
-    # commands still need the precise substitution check: benign process
-    # substitutions such as `>(cat)` also make the resolver return rc=2.
-    if (( resolve_rc != 1 )); then
-      if (( ${#command} >= 4096 )); then
-        substitution_scanner=_large_ambiguous_shell_text_contains_git_operation
-      else
-        substitution_scanner=_unsafe_shell_text_contains_git_operation
-      fi
-      if "$substitution_scanner" "push" "$command"; then
-        substitution_push=1
-      fi
-    fi
-    ;;
-esac
-
 # Most resolver no-matches are ordinary git-free commands. Only pay for the
 # structured second opinion when a cheap conservative scan still sees literal
 # push-shaped text or data can flow into an executable consumer. Expansion-only
 # input reuses the resolver's substitution-aware negative result.
 if (( resolve_rc == 1 )) &&
-  (( substitution_push == 0 )) &&
   ! _conservative_shell_text_contains_git_operation "push" "$command"; then
   [[ "$command" == *'|'* ]] || exit 0
   if ! _push_shell_text_may_contain_executable_push_data "$command" ||
@@ -109,10 +88,24 @@ if (( resolve_rc == 1 )) &&
 fi
 
 # Apply the resolver's non-executable-region policy to destination parsing too.
-# On uncertain syntax, retain the original text so parsing stays fail-closed.
+# Ambiguous input uses the resolver's bounded partial projection. The separate
+# substitution scan below keeps hidden pushes fail-closed without sending
+# masked prose through the destination parser.
 push_command="$command"
+substitution_scan_command="$command"
 if stripped_push_command=$(_strip_shell_non_executable_regions "$command"); then
   push_command="$stripped_push_command"
+  substitution_scan_command="$stripped_push_command"
+else
+  strip_push_rc=$?
+  # For large ambiguous input, the linear scanner consumes the same bounded
+  # partial projection as resolve_git_command_cwd. Substitution bodies receive
+  # their own semantic scan below, so ref parsing must never reinterpret masked
+  # heredoc prose as a top-level push destination.
+  if (( strip_push_rc == 2 )); then
+    substitution_scan_command="$stripped_push_command"
+    push_command="$stripped_push_command"
+  fi
 fi
 
 # Parse destination refs before repository scoping. rc=1 positively means no
@@ -132,8 +125,32 @@ else
     parse_rc=$?
   fi
 fi
-if (( substitution_push == 1 )); then
-  parse_rc=2
+
+# A statically readable trunk ref already proves the command must block, so do
+# not spend the remaining hook budget recursively classifying unrelated
+# substitutions. Feature-only refs still need that second opinion because
+# push_command has executable substitution bodies masked out; one of those
+# bodies may contain a separate trunk push. Resolver rc=1 already includes the
+# same substitution-aware negative result and does not need a duplicate scan.
+parsed_trunk_ref=0
+if (( parse_rc == 0 )); then
+  while IFS= read -r ref; do
+    [[ -z "$ref" ]] && continue
+    if is_trunk_ref "$ref" "$trunk"; then
+      parsed_trunk_ref=1
+      break
+    fi
+  done <<<"$parsed_refs"
+fi
+if (( parse_rc != 2 && parsed_trunk_ref == 0 && resolve_rc != 1 )); then
+  case "$command" in
+    *'$('*|*'`'*|*'<('*|*'>('*)
+      if _shell_substitutions_contain_git_operation \
+        "push" "$substitution_scan_command"; then
+        parse_rc=2
+      fi
+      ;;
+  esac
 fi
 if (( parse_rc == 1 )); then
   exit 0
@@ -182,14 +199,7 @@ fi
 
 # Parse the destination ref(s) the push would write to. Block if any of
 # them target the trunk (covers --all/--mirror via __ALL__/__MIRROR__).
-should_block=0
-while IFS= read -r ref; do
-  [[ -z "$ref" ]] && continue
-  if is_trunk_ref "$ref" "$trunk"; then
-    should_block=1
-    break
-  fi
-done <<<"$parsed_refs"
+should_block=$parsed_trunk_ref
 
 # Parser rc=2 means an executable push was found but its destination was
 # unreadable. rc=1 was handled above as a proven data-only resolver match.

--- a/skills/autonomous-common/hooks/block-push-to-main.sh
+++ b/skills/autonomous-common/hooks/block-push-to-main.sh
@@ -50,17 +50,24 @@ if [[ -z "$anchor_dir" || ! -d "$anchor_dir" ]]; then
   anchor_dir="$(pwd -P)"
 fi
 
-# Which repository issues the push. The resolver is also the operation detector:
-# rc=1 proves there is no push, rc=2 means a push matched but its context is
-# unresolvable ([INV-146]), and only rc=0 yields a usable target. Keeping this as
-# one parse avoids exhausting the hook's five-second budget.
+# Which repository issues the push. Only resolver rc=0 yields a usable target;
+# either non-zero result still receives the push parser's narrow executable-data
+# check below. Quoted text piped into a shell can be executable even when the
+# cwd resolver sees no direct invocation.
 push_dir=""
 if push_dir=$(resolve_git_command_cwd "push" "$command" "$(pwd -P)"); then
   resolve_rc=0
 else
   resolve_rc=$?
+  push_dir=""
 fi
-if [[ "$resolve_rc" -eq 1 ]]; then
+
+# Most resolver no-matches are ordinary git-free commands. Only pay for the
+# structured second opinion when a cheap conservative scan still sees literal
+# push-shaped text that quoting or a data command may have hidden.
+if (( resolve_rc == 1 )) &&
+  ! _conservative_shell_text_contains_git_operation "push" "$command" &&
+  ! _push_shell_text_may_contain_executable_push_data "$command"; then
   exit 0
 fi
 
@@ -75,9 +82,10 @@ fi
 # this immutable snapshot, avoiding repeated character scans on large commands.
 _push_prepare_command_tokens "$push_command"
 
-# Parse destination refs before repository scoping. rc=1 positively means the
-# resolver matched only non-executable data (for example `echo git push ...`);
-# rc=2 remains unknown and therefore fail-closed after scope evaluation.
+# Parse destination refs before repository scoping. rc=1 positively means no
+# executable push exists; rc=2 remains unknown and therefore fail-closed after
+# scope evaluation. This second opinion is also what distinguishes quoted data
+# piped to a shell from inert documentation text when the resolver returns 1.
 parsed_refs=""
 if parsed_refs=$(parse_push_target_refspec "$push_command"); then
   parse_rc=0

--- a/skills/autonomous-common/hooks/lib-push.sh
+++ b/skills/autonomous-common/hooks/lib-push.sh
@@ -5,8 +5,8 @@
 #   - block-push-to-main.sh (Claude PreToolUse hook, Layer 1 trunk protection)
 #   - install-git-pre-push.sh's emitted hook (Layer 2 git-side hook)
 #
-# Does not source other lib files. Self-contained pure functions; safe to
-# invoke from any context including a freshly-spawned hook process.
+# Parser functions reuse the sibling lib.sh tokenizer when the caller has not
+# already sourced it. URL normalization helpers remain self-contained.
 #
 # This file is sourced, not executed. No `set -e` (caller controls exit
 # semantics).
@@ -35,179 +35,359 @@
 # Bulk markers (__ALL__, __MIRROR__) are returned uppercase-bracketed so
 # callers can branch without ambiguity vs. a real ref named "all".
 #
-# Emit shell command segments without evaluating them. Unquoted newlines and
-# control operators terminate a segment; comments are discarded. Quotes stay
-# in the text so the bounded token parser can reject non-literal operands.
-_push_command_segments() {
+# Prepare one structured token stream for both push parsers. The hook sources
+# lib.sh first, so its bounded tokenizer is available and large commands are
+# scanned only once. The small fallback preserves standalone helper use.
+_push_prepare_command_tokens() {
   local command="$1"
-  local state="unquoted" segment="" character next
-  local word_start=1 i length=${#command}
+  local token library_dir
 
-  for ((i = 0; i < length; i++)); do
-    character="${command:i:1}"
-    next=""
-    (( i + 1 < length )) && next="${command:i+1:1}"
+  if [[ "${_PUSH_PREPARED_COMMAND+x}" == "x" &&
+    "$_PUSH_PREPARED_COMMAND" == "$command" ]]; then
+    return 0
+  fi
 
-    case "$state" in
-      single)
-        segment+="$character"
-        [[ "$character" == "'" ]] && state="unquoted"
+  _PUSH_TOKEN_TYPES=()
+  _PUSH_TOKEN_VALUES=()
+  _PUSH_TOKEN_QUOTES=()
+  _PUSH_TOKEN_ANSI=()
+  _PUSH_TOKEN_UNSAFE=()
+  _PUSH_TOKEN_MALFORMED=0
+
+  if ! declare -F _resolve_git_command_tokenize >/dev/null 2>&1; then
+    library_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    if [[ -r "$library_dir/lib.sh" ]]; then
+      # shellcheck source=lib.sh
+      source "$library_dir/lib.sh"
+    fi
+  fi
+
+  if declare -F _resolve_git_command_tokenize >/dev/null 2>&1; then
+    _resolve_git_command_tokenize "$command" 1
+    _PUSH_TOKEN_TYPES=("${_RGCC_TOKEN_TYPES[@]}")
+    _PUSH_TOKEN_VALUES=("${_RGCC_TOKEN_VALUES[@]}")
+    _PUSH_TOKEN_QUOTES=("${_RGCC_TOKEN_QUOTES[@]}")
+    _PUSH_TOKEN_ANSI=("${_RGCC_TOKEN_ANSI[@]}")
+    _PUSH_TOKEN_UNSAFE=("${_RGCC_TOKEN_UNQUOTED_UNSAFE[@]}")
+    _PUSH_TOKEN_MALFORMED="${_RGCC_MALFORMED:-0}"
+  else
+    read -ra _PUSH_TOKEN_VALUES <<<"$command"
+    for token in "${_PUSH_TOKEN_VALUES[@]}"; do
+      _PUSH_TOKEN_TYPES+=("word")
+      _PUSH_TOKEN_QUOTES+=("unquoted")
+      _PUSH_TOKEN_ANSI+=("0")
+      case "$token" in
+        *['$`\\']*) _PUSH_TOKEN_UNSAFE+=("1") ;;
+        *) _PUSH_TOKEN_UNSAFE+=("0") ;;
+      esac
+    done
+  fi
+
+  _PUSH_PREPARED_COMMAND="$command"
+}
+
+_push_token_static_value() {
+  local index="$1"
+  local value="${_PUSH_TOKEN_VALUES[index]:-}"
+  local quote_kind="${_PUSH_TOKEN_QUOTES[index]:-}"
+
+  [[ "${_PUSH_TOKEN_TYPES[index]:-}" == "word" ]] || return 1
+  [[ "${_PUSH_TOKEN_ANSI[index]:-0}" == "0" ]] || return 1
+  [[ "${_PUSH_TOKEN_UNSAFE[index]:-0}" == "0" ]] || return 1
+  [[ "$quote_kind" != "mixed" ]] || return 1
+  [[ "$value" != *'$'* && "$value" != *'`'* &&
+    "$value" != *$'\n'* && "$value" != *$'\r'* &&
+    "$value" != *$'\t'* ]] || return 1
+  _PUSH_STATIC_VALUE="$value"
+}
+
+_push_token_unquoted_static_value() {
+  [[ "${_PUSH_TOKEN_QUOTES[$1]:-}" == "unquoted" ]] || return 1
+  _push_token_static_value "$1"
+}
+
+_push_token_is_assignment() {
+  local index="$1"
+  local value="${_PUSH_TOKEN_VALUES[index]:-}"
+
+  [[ "${_PUSH_TOKEN_TYPES[index]:-}" == "word" ]] || return 1
+  [[ "${_PUSH_TOKEN_ANSI[index]:-0}" == "0" ]] || return 1
+  [[ "${_PUSH_TOKEN_UNSAFE[index]:-0}" == "0" ]] || return 1
+  [[ "$value" != *'$'* && "$value" != *'`'* ]] || return 1
+  [[ "$value" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]
+}
+
+_push_git_operation_index() {
+  local git_index="$1" end="$2"
+  local j=$((git_index + 1)) option
+
+  _push_token_static_value "$git_index" || return 1
+  [[ "$_PUSH_STATIC_VALUE" == "git" ]] || return 1
+
+  while (( j < end )); do
+    _push_token_static_value "$j" || return 2
+    option="$_PUSH_STATIC_VALUE"
+    case "$option" in
+      -c|-C|--git-dir|--work-tree|--namespace|--super-prefix)
+        (( j + 1 < end )) || return 2
+        _push_token_static_value "$((j + 1))" || return 2
+        j=$((j + 2))
         ;;
-      double)
-        segment+="$character"
-        if [[ "$character" == "\\" && -n "$next" ]]; then
-          segment+="$next"
-          ((i++))
-        elif [[ "$character" == '"' ]]; then
-          state="unquoted"
-        fi
-        ;;
-      unquoted)
-        case "$character" in
-          "'")
-            segment+="$character"
-            state="single"
-            word_start=0
-            ;;
-          '"')
-            segment+="$character"
-            state="double"
-            word_start=0
-            ;;
-          \\)
-            segment+="$character"
-            if [[ -n "$next" ]]; then
-              segment+="$next"
-              ((i++))
-            fi
-            word_start=0
-            ;;
-          '#')
-            if (( word_start == 1 )); then
-              while (( i + 1 < length )) &&
-                [[ "${command:i+1:1}" != $'\n' ]]; do
-                ((i++))
-              done
-            else
-              segment+="$character"
-              word_start=0
-            fi
-            ;;
-          $'\n'|$'\r'|';'|'|'|'&')
-            printf '%s\n' "$segment"
-            segment=""
-            word_start=1
-            if { [[ "$character" == '|' || "$character" == '&' ]]; } &&
-              [[ "$next" == "$character" ]]; then
-              ((i++))
-            fi
-            ;;
-          ' '|$'\t')
-            segment+="$character"
-            word_start=1
-            ;;
-          *)
-            segment+="$character"
-            word_start=0
-            ;;
-        esac
-        ;;
+      --*=*|--*|-*) ((j++)) ;;
+      *) break ;;
     esac
   done
-  printf '%s\n' "$segment"
+
+  (( j < end )) || return 1
+  _push_token_static_value "$j" || return 2
+  [[ "$_PUSH_STATIC_VALUE" == "push" ]] || return 1
+  _PUSH_OPERATION_INDEX="$j"
 }
 
-_push_decode_literal_token() {
-  local token="$1"
-  local first="${token:0:1}"
-  local last="${token: -1}"
+_push_segment_contains_possible_push() {
+  local start="$1" end="$2"
+  local i rc value next
 
-  if [[ ${#token} -ge 2 ]] &&
-    { [[ "$first" == "'" && "$last" == "'" ]] ||
-      [[ "$first" == '"' && "$last" == '"' ]]; }; then
-    token="${token:1:${#token}-2}"
-  elif [[ "$token" == *["'"]* ]]; then
-    return 1
-  fi
-  [[ "$token" != *['$`\\']* ]] || return 1
-  _PUSH_LITERAL_TOKEN="$token"
-}
-
-_push_find_git_command_start() {
-  local token i=0
-
-  for token in "$@"; do
-    if [[ "$token" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
-      ((i++))
-      continue
+  for ((i = start; i < end; i++)); do
+    [[ "${_PUSH_TOKEN_TYPES[i]:-}" == "word" ]] || continue
+    if _push_git_operation_index "$i" "$end"; then
+      return 0
+    else
+      rc=$?
+      (( rc == 2 )) && return 0
     fi
-    [[ "$token" == "git" ]] || return 1
-    _PUSH_GIT_INDEX="$i"
-    return 0
+    value="${_PUSH_TOKEN_VALUES[i]}"
+    if [[ "${_PUSH_TOKEN_UNSAFE[i]:-0}" == "1" ||
+      "$value" == *'$'* || "$value" == *'`'* ]]; then
+      next=$((i + 1))
+      if (( next < end )) && _push_token_static_value "$next" &&
+        [[ "$_PUSH_STATIC_VALUE" == "push" ]]; then
+        return 0
+      fi
+    fi
   done
   return 1
 }
 
-_push_decode_unquoted_literal_token() {
-  [[ "$1" != *\"* && "$1" != *\'* ]] || return 1
-  _push_decode_literal_token "$1"
+# Locate an executable git command in one control-operator-delimited segment.
+# Known shell keywords, assignments, and command wrappers are traversed.
+# Unknown prefixes that still contain a possible git push are rc=2 (unknown);
+# trusted data-only echo/printf segments are rc=1 (no executable push).
+_push_segment_git_start() {
+  local start="$1" end="$2"
+  local j="$start" value option
+
+  while (( j < end )); do
+    if _push_token_is_assignment "$j"; then
+      ((j++))
+      continue
+    fi
+    if ! _push_token_static_value "$j"; then
+      _push_segment_contains_possible_push "$start" "$end" && return 2
+      return 1
+    fi
+    value="$_PUSH_STATIC_VALUE"
+    case "$value" in
+      '!'|if|then|elif|else|do|while|until|'{')
+        ((j++))
+        ;;
+      git)
+        if _push_git_operation_index "$j" "$end"; then
+          _PUSH_GIT_INDEX="$j"
+          return 0
+        else
+          return $?
+        fi
+        ;;
+      echo|printf)
+        if [[ "$(type -t "$value" 2>/dev/null)" == "builtin" ]]; then
+          return 1
+        fi
+        _push_segment_contains_possible_push "$start" "$end" && return 2
+        return 1
+        ;;
+      command)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 2
+          case "$_PUSH_STATIC_VALUE" in
+            -p|--) ((j++)) ;;
+            -v|-V) return 1 ;;
+            *) break ;;
+          esac
+        done
+        ;;
+      exec)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 2
+          case "$_PUSH_STATIC_VALUE" in
+            -a)
+              (( j + 1 < end )) || return 2
+              j=$((j + 2))
+              ;;
+            -c|-l|--) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        ;;
+      nohup|time)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 2
+          [[ "$_PUSH_STATIC_VALUE" == -* ]] || break
+          case "$_PUSH_STATIC_VALUE" in
+            -o|--output|-f|--format)
+              (( j + 1 < end )) || return 2
+              j=$((j + 2))
+              ;;
+            *) ((j++)) ;;
+          esac
+        done
+        ;;
+      timeout)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 2
+          option="$_PUSH_STATIC_VALUE"
+          [[ "$option" == -* ]] || break
+          case "$option" in
+            -k|-s|--kill-after|--signal)
+              (( j + 1 < end )) || return 2
+              j=$((j + 2))
+              ;;
+            *) ((j++)) ;;
+          esac
+        done
+        (( j < end )) || return 2
+        ((j++))
+        ;;
+      stdbuf)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 2
+          option="$_PUSH_STATIC_VALUE"
+          case "$option" in
+            -i|-o|-e|--input|--output|--error)
+              (( j + 1 < end )) || return 2
+              j=$((j + 2))
+              ;;
+            -i*|-o*|-e*|--input=*|--output=*|--error=*|--) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        ;;
+      env)
+        ((j++))
+        while (( j < end )); do
+          if _push_token_is_assignment "$j"; then
+            ((j++))
+            continue
+          fi
+          _push_token_static_value "$j" || return 2
+          option="$_PUSH_STATIC_VALUE"
+          case "$option" in
+            -u|-C|-S|--unset|--chdir|--split-string)
+              (( j + 1 < end )) || return 2
+              j=$((j + 2))
+              ;;
+            --unset=*|--chdir=*|--split-string=*|-i|--ignore-environment|\
+              -0|--null|-v|--debug|--)
+              ((j++))
+              ;;
+            *) break ;;
+          esac
+        done
+        ;;
+      sudo)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 2
+          option="$_PUSH_STATIC_VALUE"
+          case "$option" in
+            -u|-g|-h|-p|-C|-T|-r|-t|--user|--group|--host|--prompt|\
+              --chdir|--command-timeout|--role|--type)
+              (( j + 1 < end )) || return 2
+              j=$((j + 2))
+              ;;
+            --*=*|-u*|-g*|-h*|-p*|-C*|-T*|-r*|-t*|--) ((j++)) ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        ;;
+      *)
+        _push_segment_contains_possible_push "$start" "$end" && return 2
+        return 1
+        ;;
+    esac
+  done
+  return 1
 }
 
 _push_token_is_single_shell_word() {
-  local token="$1"
-  local first="${token:0:1}"
-  local last="${token: -1}"
-
-  if _push_decode_literal_token "$token"; then
+  local index="$1"
+  if _push_token_static_value "$index"; then
     return 0
   fi
-  [[ ${#token} -ge 2 ]] &&
-    { [[ "$first" == "'" && "$last" == "'" ]] ||
-      [[ "$first" == '"' && "$last" == '"' ]]; }
+  [[ "${_PUSH_TOKEN_TYPES[index]:-}" == "word" ]] &&
+    { [[ "${_PUSH_TOKEN_QUOTES[index]:-}" == "single" ]] ||
+      [[ "${_PUSH_TOKEN_QUOTES[index]:-}" == "double" ]]; }
 }
 
 parse_push_target_refspec() {
   local command="$1"
-  local current_branch segment tok decoded r src dst
-  local i j n found_remote saw_all saw_mirror saw_tags_flag
+  local current_branch tok decoded r src dst
+  local segment_start=0 segment_end i j n rc
+  local found_remote saw_all saw_mirror saw_tags_flag
   local matched=0 unknown=0
-  local -a tokens refspecs
+  local -a refspecs
   current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  _push_prepare_command_tokens "$command"
+  n=${#_PUSH_TOKEN_VALUES[@]}
 
-  while IFS= read -r segment; do
-    read -ra tokens <<<"$segment"
-    n=${#tokens[@]}
-    if _push_find_git_command_start "${tokens[@]}"; then
+  for ((segment_end = 0; segment_end <= n; segment_end++)); do
+    if (( segment_end < n )) &&
+      [[ "${_PUSH_TOKEN_TYPES[segment_end]}" != "operator" ]]; then
+      continue
+    fi
+    if (( segment_start < segment_end )); then
+      if _push_segment_git_start "$segment_start" "$segment_end"; then
+        rc=0
+      else
+        rc=$?
+      fi
+      if (( rc == 2 )); then
+        unknown=1
+      elif (( rc == 0 )); then
       i="$_PUSH_GIT_INDEX"
-      j=$((i + 1))
-      while (( j < n )); do
-        case "${tokens[j]}" in
-          -c|-C|--git-dir|--work-tree|--namespace|--super-prefix)
-            (( j + 1 < n )) || { unknown=1; break; }
-            j=$((j + 2))
-            ;;
-          --*=*|--*|-*) ((j++)) ;;
-          *) break ;;
-        esac
-      done
-      (( j < n )) && [[ "${tokens[j]}" == "push" ]] || continue
+      j=$((_PUSH_OPERATION_INDEX + 1))
       matched=1
-      ((j++))
       found_remote=0
       saw_all=0
       saw_mirror=0
       saw_tags_flag=0
       refspecs=()
 
-      while (( j < n )); do
-        tok="${tokens[j]}"
+      while (( j < segment_end )); do
+        if ! _push_token_static_value "$j"; then
+          if (( found_remote == 0 )); then
+            found_remote=1
+            _push_token_is_single_shell_word "$j" || unknown=1
+          else
+            unknown=1
+          fi
+          ((j++))
+          continue
+        fi
+        tok="$_PUSH_STATIC_VALUE"
         case "$tok" in
           --all|--all=*) saw_all=1 ;;
           --mirror|--mirror=*) saw_mirror=1 ;;
           --tags|--tags=*) saw_tags_flag=1 ;;
           --delete|-d) ;;
           --repo|-o|--push-option|--receive-pack|--exec)
-            (( j + 1 < n )) || { unknown=1; break; }
+            (( j + 1 < segment_end )) || { unknown=1; break; }
             j=$((j + 2))
             continue
             ;;
@@ -216,21 +396,21 @@ parse_push_target_refspec() {
           *)
             if (( found_remote == 0 )); then
               found_remote=1
-              if ! _push_token_is_single_shell_word "$tok"; then
+              if ! _push_token_is_single_shell_word "$j"; then
                 unknown=1
               fi
               ((j++))
               continue
             fi
-            if ! _push_decode_literal_token "$tok"; then
+            if ! _push_token_static_value "$j"; then
               unknown=1
               ((j++))
               continue
             fi
-            decoded="$_PUSH_LITERAL_TOKEN"
-            if [[ "$decoded" == "tag" ]] && (( j + 1 < n )); then
-              if _push_decode_literal_token "${tokens[j+1]}"; then
-                refspecs+=("refs/tags/${_PUSH_LITERAL_TOKEN}")
+            decoded="$_PUSH_STATIC_VALUE"
+            if [[ "$decoded" == "tag" ]] && (( j + 1 < segment_end )); then
+              if _push_token_static_value "$((j + 1))"; then
+                refspecs+=("refs/tags/${_PUSH_STATIC_VALUE}")
               else
                 unknown=1
               fi
@@ -266,11 +446,14 @@ parse_push_target_refspec() {
           fi
         done
       fi
+      fi
     fi
-  done < <(_push_command_segments "$command")
+    segment_start=$((segment_end + 1))
+  done
 
-  (( matched == 1 )) || return 1
+  (( _PUSH_TOKEN_MALFORMED == 0 )) || unknown=1
   (( unknown == 0 )) || return 2
+  (( matched == 1 )) || return 1
   return 0
 }
 
@@ -333,9 +516,8 @@ is_trunk_ref() {
 #     a single answer cannot describe two destinations, and the trunk-ref
 #     parser reads refspecs from the whole line, so answering for only the
 #     first push would let the second one through unexamined
-#   - a quoted or expansion-bearing operand — `read -ra` does not process
-#     quotes, so the token still carries them and would canonicalize to a
-#     destination that is confidently wrong rather than merely unresolved
+#   - a quoted or expansion-bearing operand — repository scoping requires an
+#     unquoted static token; uncertainty leaves the trunk check armed
 #
 # Trunk protection compares push DESTINATIONS ([INV-148]), so it must ask which
 # remote the push writes to, not assume `origin`. Flag/value skipping mirrors
@@ -343,56 +525,56 @@ is_trunk_ref() {
 # positional.
 parse_push_remote_operand() {
   local command="$1"
-  local segment operand="" decoded
-  local n i j pushes=0 found=0
-  local -a tokens
+  local operand="" decoded option
+  local n segment_start=0 segment_end i j rc pushes=0 found=0
+  _push_prepare_command_tokens "$command"
+  n=${#_PUSH_TOKEN_VALUES[@]}
 
-  while IFS= read -r segment; do
-    read -ra tokens <<<"$segment"
-    n=${#tokens[@]}
-    if _push_find_git_command_start "${tokens[@]}"; then
+  for ((segment_end = 0; segment_end <= n; segment_end++)); do
+    if (( segment_end < n )) &&
+      [[ "${_PUSH_TOKEN_TYPES[segment_end]}" != "operator" ]]; then
+      continue
+    fi
+    if (( segment_start < segment_end )); then
+      if _push_segment_git_start "$segment_start" "$segment_end"; then
+        rc=0
+      else
+        rc=$?
+      fi
+      (( rc != 2 )) || return 1
+      if (( rc == 0 )); then
       i="$_PUSH_GIT_INDEX"
-      j=$((i + 1))
-      while (( j < n )); do
-        case "${tokens[j]}" in
-          -c|-C|--git-dir|--work-tree|--namespace|--super-prefix)
-            (( j + 1 < n )) || return 1
-            j=$((j + 2))
-            ;;
-          --*=*|--*|-*) ((j++)) ;;
-          *) break ;;
-        esac
-      done
-      (( j < n )) && [[ "${tokens[j]}" == "push" ]] || continue
+      j=$((_PUSH_OPERATION_INDEX + 1))
       ((pushes++))
       (( pushes <= 1 )) || return 1
-      ((j++))
-      while (( j < n )); do
-        case "${tokens[j]}" in
+      while (( j < segment_end )); do
+        _push_token_static_value "$j" || return 1
+        option="$_PUSH_STATIC_VALUE"
+        case "$option" in
           --repo)
-            (( j + 1 < n )) || return 1
-            _push_decode_unquoted_literal_token "${tokens[j+1]}" || return 1
-            operand="$_PUSH_LITERAL_TOKEN"
+            (( j + 1 < segment_end )) || return 1
+            _push_token_unquoted_static_value "$((j + 1))" || return 1
+            operand="$_PUSH_STATIC_VALUE"
             found=1
             j=$((j + 2))
             continue
             ;;
           --repo=*)
-            _push_decode_unquoted_literal_token "${tokens[j]#*=}" || return 1
-            operand="$_PUSH_LITERAL_TOKEN"
+            _push_token_unquoted_static_value "$j" || return 1
+            operand="${_PUSH_STATIC_VALUE#*=}"
             found=1
             ((j++))
             continue
             ;;
           -o|--push-option|--receive-pack|--exec)
-            (( j + 1 < n )) || return 1
+            (( j + 1 < segment_end )) || return 1
             j=$((j + 2))
             continue
             ;;
           -*) ;;
           *)
-            _push_decode_unquoted_literal_token "${tokens[j]}" || return 1
-            decoded="$_PUSH_LITERAL_TOKEN"
+            _push_token_unquoted_static_value "$j" || return 1
+            decoded="$_PUSH_STATIC_VALUE"
             operand="$decoded"
             found=1
             break
@@ -400,10 +582,12 @@ parse_push_remote_operand() {
         esac
         ((j++))
       done
+      fi
     fi
-  done < <(_push_command_segments "$command")
+    segment_start=$((segment_end + 1))
+  done
 
-  (( pushes == 1 )) || return 1
+  (( pushes == 1 && _PUSH_TOKEN_MALFORMED == 0 )) || return 1
 
   if (( found == 1 )); then
     printf '%s\n' "$operand"

--- a/skills/autonomous-common/hooks/lib-push.sh
+++ b/skills/autonomous-common/hooks/lib-push.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 # lib-push.sh — pure parsing helpers for git-push hook scripts.
 #
-# Used by:
-#   - block-push-to-main.sh (Claude PreToolUse hook, Layer 1 trunk protection)
-#   - install-git-pre-push.sh's emitted hook (Layer 2 git-side hook)
+# Used by block-push-to-main.sh (Claude PreToolUse hook, Layer 1 trunk
+# protection). The emitted Layer 2 git pre-push hook is self-contained.
 #
 # Parser functions reuse the sibling lib.sh tokenizer when the caller has not
 # already sourced it. URL normalization helpers remain self-contained.
@@ -374,8 +373,23 @@ _push_command_executes_standard_input() {
           esac
         done
         (( j < end )) || return 1
+        local _PUSH_XARGS_APPENDS_ARGS=1
         _push_command_executes_standard_input "$j" "$end"
         return
+        ;;
+      awk|gawk|mawk|nawk)
+        for ((j = j + 1; j < end; j++)); do
+          if _push_token_static_value "$j"; then
+            value="$_PUSH_STATIC_VALUE"
+          elif [[ "${_PUSH_TOKEN_QUOTES[j]:-}" == "single" &&
+            "${_PUSH_TOKEN_ANSI[j]:-0}" == "0" ]]; then
+            value="${_PUSH_TOKEN_VALUES[j]:-}"
+          else
+            return 0
+          fi
+          [[ "$value" =~ system[[:space:]]*\( ]] && return 0
+        done
+        return 1
         ;;
       *)
         _push_shell_command_name_executes_input "$command_name"
@@ -383,7 +397,92 @@ _push_command_executes_standard_input() {
         ;;
     esac
   done
+  [[ "${_PUSH_XARGS_APPENDS_ARGS:-0}" == "1" ]] && return 0
   return 1
+}
+
+_push_process_substitution_executes_input() {
+  local opener_index="$1"
+  local paren_index=$((opener_index + 1))
+  local body_start=$((opener_index + 2))
+  local i depth=1 n=${#_PUSH_TOKEN_VALUES[@]}
+
+  [[ "${_PUSH_TOKEN_TYPES[opener_index]:-}" == "word" &&
+    "${_PUSH_TOKEN_VALUES[opener_index]:-}" == ">" ]] || return 1
+  [[ "${_PUSH_TOKEN_TYPES[paren_index]:-}" == "operator" &&
+    "${_PUSH_TOKEN_VALUES[paren_index]:-}" == "(" ]] || return 1
+
+  for ((i = body_start; i < n; i++)); do
+    [[ "${_PUSH_TOKEN_TYPES[i]:-}" == "operator" ]] || continue
+    case "${_PUSH_TOKEN_VALUES[i]:-}" in
+      '(') ((depth++)) ;;
+      ')')
+        ((depth--))
+        if (( depth == 0 )); then
+          (( body_start < i )) || return 0
+          _push_command_executes_standard_input "$body_start" "$i"
+          return
+        fi
+        ;;
+    esac
+  done
+  return 0
+}
+
+_push_pipeline_has_executing_process_substitution() {
+  local pipe_index="$1"
+  local i n=${#_PUSH_TOKEN_VALUES[@]}
+
+  for ((i = pipe_index + 1; i + 1 < n; i++)); do
+    if _push_process_substitution_executes_input "$i"; then
+      return 0
+    fi
+    if [[ "${_PUSH_TOKEN_TYPES[i]:-}" == "operator" ]]; then
+      case "${_PUSH_TOKEN_VALUES[i]:-}" in
+        '|'|'|&'|'&&'|'||'|';'|'&') return 1 ;;
+      esac
+    fi
+  done
+  return 1
+}
+
+_push_pipeline_loop_executes_input() {
+  local pipe_index="$1"
+  local i start end n=${#_PUSH_TOKEN_VALUES[@]}
+
+  start=$((pipe_index + 1))
+  _push_token_static_value "$start" || return 1
+  [[ "$_PUSH_STATIC_VALUE" == "while" ||
+    "$_PUSH_STATIC_VALUE" == "until" ]] || return 1
+
+  for ((i = start + 1; i < n; i++)); do
+    if _push_token_static_value "$i" &&
+      [[ "$_PUSH_STATIC_VALUE" == "do" ]]; then
+      start=$((i + 1))
+      break
+    fi
+  done
+  (( start < n )) || return 0
+
+  while (( start < n )); do
+    while (( start < n )) &&
+      [[ "${_PUSH_TOKEN_TYPES[start]:-}" == "operator" ]]; do
+      ((start++))
+    done
+    (( start < n )) || return 0
+    if _push_token_static_value "$start" &&
+      [[ "$_PUSH_STATIC_VALUE" == "done" ]]; then
+      return 1
+    fi
+    end="$start"
+    while (( end < n )) &&
+      [[ "${_PUSH_TOKEN_TYPES[end]:-}" != "operator" ]]; do
+      ((end++))
+    done
+    _push_command_executes_standard_input "$start" "$end" && return 0
+    start=$((end + 1))
+  done
+  return 0
 }
 
 _push_pipeline_consumer_executes_input() {
@@ -391,6 +490,8 @@ _push_pipeline_consumer_executes_input() {
   local end=$((pipe_index + 1))
   local n=${#_PUSH_TOKEN_VALUES[@]}
 
+  _push_pipeline_has_executing_process_substitution "$pipe_index" && return 0
+  _push_pipeline_loop_executes_input "$pipe_index" && return 0
   while (( end < n )) &&
     [[ "${_PUSH_TOKEN_TYPES[end]:-}" != "operator" ]]; do
     ((end++))
@@ -438,9 +539,20 @@ _push_data_segment_is_safe() {
   local start="$1" end="$2" terminator="${3:-}"
   local i rc value
 
+  _PUSH_DATA_SEGMENT_DYNAMIC_INPUT=0
   case "$terminator" in
     '|'|'|&')
-      _push_pipeline_consumer_executes_input "$end" && return 1
+      if _push_pipeline_consumer_executes_input "$end"; then
+        _PUSH_DATA_SEGMENT_DYNAMIC_INPUT=1
+        return 1
+      fi
+      ;;
+    '(')
+      if (( end > start + 1 )) &&
+        _push_process_substitution_executes_input "$((end - 1))"; then
+        _PUSH_DATA_SEGMENT_DYNAMIC_INPUT=1
+        return 1
+      fi
       ;;
   esac
 
@@ -456,10 +568,6 @@ _push_data_segment_is_safe() {
     if _push_token_has_executable_expansion "$i"; then
       return 1
     fi
-    if [[ "$terminator" == "(" &&
-      "${_PUSH_TOKEN_UNSAFE[i]:-0}" == "1" ]]; then
-      return 1
-    fi
     [[ "$value" != *$'\n'* && "$value" != *$'\r'* ]] || return 1
   done
   return 0
@@ -473,7 +581,10 @@ _push_data_segment_contains_possible_push() {
     text+="${text:+ }${_PUSH_TOKEN_VALUES[i]:-}"
   done
   [[ -n "$text" ]] || return 1
-  [[ "$text" == *'$'* || "$text" == *'`'* ]] && return 0
+  [[ "${_PUSH_DATA_SEGMENT_DYNAMIC_INPUT:-0}" == "1" ]] || return 1
+  if [[ "$text" == *'$'* || "$text" == *'`'* ]]; then
+    return 0
+  fi
   if declare -F _conservative_shell_text_contains_git_operation \
     >/dev/null 2>&1; then
     _conservative_shell_text_contains_git_operation "push" "$text"

--- a/skills/autonomous-common/hooks/lib-push.sh
+++ b/skills/autonomous-common/hooks/lib-push.sh
@@ -14,9 +14,10 @@
 # ---------------------------------------------------------------------------
 # parse_push_target_refspec <command>
 #
-# Given a git-push command line, echoes the destination ref-name(s) the push
-# would write to, one per line. Returns 0 if at least one destination was
-# identified, 1 if the command is not a push or could not be parsed.
+# Given shell command text, echoes every destination ref-name written by each
+# literal `git push`, one per line. Returns 0 when all matched pushes were
+# parsed, 1 when no push was found, and 2 when a push was found but one of its
+# destinations could not be determined.
 #
 # Handles:
 #   git push                                → <current_branch>
@@ -34,117 +35,243 @@
 # Bulk markers (__ALL__, __MIRROR__) are returned uppercase-bracketed so
 # callers can branch without ambiguity vs. a real ref named "all".
 #
-# Caller is expected to have already verified `is_git_command "push" ...`.
-parse_push_target_refspec() {
+# Emit shell command segments without evaluating them. Unquoted newlines and
+# control operators terminate a segment; comments are discarded. Quotes stay
+# in the text so the bounded token parser can reject non-literal operands.
+_push_command_segments() {
   local command="$1"
-  local current_branch
-  current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  local state="unquoted" segment="" character next
+  local word_start=1 i length=${#command}
 
-  # Tokenize. Strip leading `cd ... &&` etc. by trimming up to the `git` token.
-  # Match is_git_command's quote-stripping minimally — quotes around a refspec
-  # are valid (e.g. "git push origin 'feat:bar'") but rare; treat them as
-  # literal here.
-  local -a tokens
-  read -ra tokens <<<"$command"
+  for ((i = 0; i < length; i++)); do
+    character="${command:i:1}"
+    next=""
+    (( i + 1 < length )) && next="${command:i+1:1}"
 
-  # Find the `git` token
-  local i=0 n=${#tokens[@]}
-  while (( i < n )) && [[ "${tokens[i]}" != "git" ]]; do
-    i=$((i+1))
-  done
-  if (( i >= n )); then return 1; fi
-  i=$((i+1))
-
-  # Skip git global flags (same logic as is_git_command's flag-skip).
-  while (( i < n )); do
-    case "${tokens[i]}" in
-      -c|-C|--git-dir|--work-tree|--namespace|--super-prefix)
-        i=$(( i + 2 > n ? n : i + 2 ))
+    case "$state" in
+      single)
+        segment+="$character"
+        [[ "$character" == "'" ]] && state="unquoted"
         ;;
-      --*=*|--*)
-        i=$((i+1))
-        ;;
-      *)
-        break
-        ;;
-    esac
-  done
-
-  # Expect `push`
-  if (( i >= n )); then return 1; fi
-  if [[ "${tokens[i]}" != "push" ]]; then return 1; fi
-  i=$((i+1))
-
-  # Walk push args. Track state.
-  local found_remote=0
-  local -a refspecs=()
-  local saw_all=0 saw_mirror=0 saw_tags_flag=0 saw_delete=0
-  while (( i < n )); do
-    local tok="${tokens[i]}"
-    case "$tok" in
-      --all|--all=*)        saw_all=1 ;;
-      --mirror|--mirror=*)  saw_mirror=1 ;;
-      --tags|--tags=*)      saw_tags_flag=1 ;;
-      --delete|-d)          saw_delete=1 ;;
-      # Skip flags that take a separate value. Bare --signed is one token.
-      --repo|-o|--push-option|--receive-pack|--exec)
-        i=$(( i + 2 > n ? n : i + 2 )); continue ;;
-      # Remaining short, long, or --flag=value options consume 1 token.
-      -*) ;;
-      # Positional: first one is the remote, rest are refspecs (or
-      # `tag <name>` pair).
-      *)
-        if (( found_remote == 0 )); then
-          found_remote=1
-        elif [[ "$tok" == "tag" ]] && (( i + 1 < n )); then
-          refspecs+=("refs/tags/${tokens[i+1]}")
-          i=$((i+1))
-        else
-          refspecs+=("$tok")
+      double)
+        segment+="$character"
+        if [[ "$character" == "\\" && -n "$next" ]]; then
+          segment+="$next"
+          ((i++))
+        elif [[ "$character" == '"' ]]; then
+          state="unquoted"
         fi
         ;;
+      unquoted)
+        case "$character" in
+          "'")
+            segment+="$character"
+            state="single"
+            word_start=0
+            ;;
+          '"')
+            segment+="$character"
+            state="double"
+            word_start=0
+            ;;
+          \\)
+            segment+="$character"
+            if [[ -n "$next" ]]; then
+              segment+="$next"
+              ((i++))
+            fi
+            word_start=0
+            ;;
+          '#')
+            if (( word_start == 1 )); then
+              while (( i + 1 < length )) &&
+                [[ "${command:i+1:1}" != $'\n' ]]; do
+                ((i++))
+              done
+            else
+              segment+="$character"
+              word_start=0
+            fi
+            ;;
+          $'\n'|$'\r'|';'|'|'|'&')
+            printf '%s\n' "$segment"
+            segment=""
+            word_start=1
+            if { [[ "$character" == '|' || "$character" == '&' ]]; } &&
+              [[ "$next" == "$character" ]]; then
+              ((i++))
+            fi
+            ;;
+          ' '|$'\t')
+            segment+="$character"
+            word_start=1
+            ;;
+          *)
+            segment+="$character"
+            word_start=0
+            ;;
+        esac
+        ;;
     esac
-    i=$((i+1))
   done
+  printf '%s\n' "$segment"
+}
 
-  # --all / --mirror / --tags shortcut
-  if (( saw_all == 1 )); then echo "__ALL__"; return 0; fi
-  if (( saw_mirror == 1 )); then echo "__MIRROR__"; return 0; fi
-  if (( saw_tags_flag == 1 )) && (( ${#refspecs[@]} == 0 )); then
-    echo "__TAGS__"; return 0
-  fi
+_push_decode_literal_token() {
+  local token="$1"
+  local first="${token:0:1}"
+  local last="${token: -1}"
 
-  # No explicit refspec: implicit destination is the *current branch*'s
-  # configured upstream (matrix or default). For our purposes, treat that as
-  # the current branch name — `git push` with default config pushes
-  # HEAD → <upstream of HEAD>, where upstream typically matches the current
-  # branch name on origin.
-  if (( ${#refspecs[@]} == 0 )); then
-    if [[ -n "$current_branch" && "$current_branch" != "HEAD" ]]; then
-      echo "$current_branch"
-      return 0
-    fi
+  if [[ ${#token} -ge 2 ]] &&
+    { [[ "$first" == "'" && "$last" == "'" ]] ||
+      [[ "$first" == '"' && "$last" == '"' ]]; }; then
+    token="${token:1:${#token}-2}"
+  elif [[ "$token" == *["'"]* ]]; then
     return 1
   fi
+  [[ "$token" != *['$`\\']* ]] || return 1
+  _PUSH_LITERAL_TOKEN="$token"
+}
 
-  # Walk refspecs. Each can be:
-  #   src:dst   → echo dst
-  #   :dst      → echo :dst (delete)
-  #   ref       → echo ref (src=dst)
-  for r in "${refspecs[@]}"; do
-    if [[ "$r" == *:* ]]; then
-      local dst="${r#*:}"
-      local src="${r%%:*}"
-      if [[ -z "$src" ]]; then
-        # Delete form: prefix with `:` so caller can detect.
-        echo ":${dst}"
-      else
-        echo "$dst"
-      fi
-    else
-      echo "$r"
+_push_find_git_command_start() {
+  local token i=0
+
+  for token in "$@"; do
+    if [[ "$token" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+      ((i++))
+      continue
     fi
+    [[ "$token" == "git" ]] || return 1
+    _PUSH_GIT_INDEX="$i"
+    return 0
   done
+  return 1
+}
+
+_push_decode_unquoted_literal_token() {
+  [[ "$1" != *\"* && "$1" != *\'* ]] || return 1
+  _push_decode_literal_token "$1"
+}
+
+_push_token_is_single_shell_word() {
+  local token="$1"
+  local first="${token:0:1}"
+  local last="${token: -1}"
+
+  if _push_decode_literal_token "$token"; then
+    return 0
+  fi
+  [[ ${#token} -ge 2 ]] &&
+    { [[ "$first" == "'" && "$last" == "'" ]] ||
+      [[ "$first" == '"' && "$last" == '"' ]]; }
+}
+
+parse_push_target_refspec() {
+  local command="$1"
+  local current_branch segment tok decoded r src dst
+  local i j n found_remote saw_all saw_mirror saw_tags_flag
+  local matched=0 unknown=0
+  local -a tokens refspecs
+  current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+  while IFS= read -r segment; do
+    read -ra tokens <<<"$segment"
+    n=${#tokens[@]}
+    if _push_find_git_command_start "${tokens[@]}"; then
+      i="$_PUSH_GIT_INDEX"
+      j=$((i + 1))
+      while (( j < n )); do
+        case "${tokens[j]}" in
+          -c|-C|--git-dir|--work-tree|--namespace|--super-prefix)
+            (( j + 1 < n )) || { unknown=1; break; }
+            j=$((j + 2))
+            ;;
+          --*=*|--*|-*) ((j++)) ;;
+          *) break ;;
+        esac
+      done
+      (( j < n )) && [[ "${tokens[j]}" == "push" ]] || continue
+      matched=1
+      ((j++))
+      found_remote=0
+      saw_all=0
+      saw_mirror=0
+      saw_tags_flag=0
+      refspecs=()
+
+      while (( j < n )); do
+        tok="${tokens[j]}"
+        case "$tok" in
+          --all|--all=*) saw_all=1 ;;
+          --mirror|--mirror=*) saw_mirror=1 ;;
+          --tags|--tags=*) saw_tags_flag=1 ;;
+          --delete|-d) ;;
+          --repo|-o|--push-option|--receive-pack|--exec)
+            (( j + 1 < n )) || { unknown=1; break; }
+            j=$((j + 2))
+            continue
+            ;;
+          -*)
+            ;;
+          *)
+            if (( found_remote == 0 )); then
+              found_remote=1
+              if ! _push_token_is_single_shell_word "$tok"; then
+                unknown=1
+              fi
+              ((j++))
+              continue
+            fi
+            if ! _push_decode_literal_token "$tok"; then
+              unknown=1
+              ((j++))
+              continue
+            fi
+            decoded="$_PUSH_LITERAL_TOKEN"
+            if [[ "$decoded" == "tag" ]] && (( j + 1 < n )); then
+              if _push_decode_literal_token "${tokens[j+1]}"; then
+                refspecs+=("refs/tags/${_PUSH_LITERAL_TOKEN}")
+              else
+                unknown=1
+              fi
+              ((j++))
+            else
+              refspecs+=("$decoded")
+            fi
+            ;;
+        esac
+        ((j++))
+      done
+
+      if (( saw_all == 1 )); then
+        printf '%s\n' "__ALL__"
+      elif (( saw_mirror == 1 )); then
+        printf '%s\n' "__MIRROR__"
+      elif (( saw_tags_flag == 1 && ${#refspecs[@]} == 0 )); then
+        printf '%s\n' "__TAGS__"
+      elif (( ${#refspecs[@]} == 0 )); then
+        if [[ -n "$current_branch" && "$current_branch" != "HEAD" ]]; then
+          printf '%s\n' "$current_branch"
+        else
+          unknown=1
+        fi
+      else
+        for r in "${refspecs[@]}"; do
+          if [[ "$r" == *:* ]]; then
+            dst="${r#*:}"
+            src="${r%%:*}"
+            [[ -z "$src" ]] && printf ':%s\n' "$dst" || printf '%s\n' "$dst"
+          else
+            printf '%s\n' "$r"
+          fi
+        done
+      fi
+    fi
+  done < <(_push_command_segments "$command")
+
+  (( matched == 1 )) || return 1
+  (( unknown == 0 )) || return 2
+  return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -216,62 +343,69 @@ is_trunk_ref() {
 # positional.
 parse_push_remote_operand() {
   local command="$1"
+  local segment operand="" decoded
+  local n i j pushes=0 found=0
   local -a tokens
-  read -ra tokens <<<"$command"
 
-  local n=${#tokens[@]}
-  local i=0 pushes=0 operand="" found=0
-
-  # Scan the WHOLE line: a second `git push` must be detected, not ignored.
-  while (( i < n )); do
-    [[ "${tokens[i]}" == "git" ]] || { i=$((i+1)); continue; }
-    local j=$((i+1))
-    while (( j < n )); do
-      case "${tokens[j]}" in
-        -c|-C|--git-dir|--work-tree|--namespace|--super-prefix)
-          j=$(( j + 2 > n ? n : j + 2 )) ;;
-        --*=*|--*) j=$((j+1)) ;;
-        *) break ;;
-      esac
-    done
-    if (( j < n )) && [[ "${tokens[j]}" == "push" ]]; then
-      pushes=$((pushes+1))
-      (( pushes > 1 )) && return 1
-      j=$((j+1))
+  while IFS= read -r segment; do
+    read -ra tokens <<<"$segment"
+    n=${#tokens[@]}
+    if _push_find_git_command_start "${tokens[@]}"; then
+      i="$_PUSH_GIT_INDEX"
+      j=$((i + 1))
       while (( j < n )); do
         case "${tokens[j]}" in
-          # --repo supplies a repository, but a later positional repository
-          # overrides it. Preserve both forms of Git's precedence.
+          -c|-C|--git-dir|--work-tree|--namespace|--super-prefix)
+            (( j + 1 < n )) || return 1
+            j=$((j + 2))
+            ;;
+          --*=*|--*|-*) ((j++)) ;;
+          *) break ;;
+        esac
+      done
+      (( j < n )) && [[ "${tokens[j]}" == "push" ]] || continue
+      ((pushes++))
+      (( pushes <= 1 )) || return 1
+      ((j++))
+      while (( j < n )); do
+        case "${tokens[j]}" in
           --repo)
             (( j + 1 < n )) || return 1
-            operand="${tokens[j+1]}"
+            _push_decode_unquoted_literal_token "${tokens[j+1]}" || return 1
+            operand="$_PUSH_LITERAL_TOKEN"
             found=1
-            j=$((j+2))
+            j=$((j + 2))
             continue
             ;;
           --repo=*)
-            operand="${tokens[j]#*=}"
+            _push_decode_unquoted_literal_token "${tokens[j]#*=}" || return 1
+            operand="$_PUSH_LITERAL_TOKEN"
             found=1
-            j=$((j+1))
+            ((j++))
             continue
             ;;
           -o|--push-option|--receive-pack|--exec)
-            j=$(( j + 2 > n ? n : j + 2 )); continue ;;
+            (( j + 1 < n )) || return 1
+            j=$((j + 2))
+            continue
+            ;;
           -*) ;;
-          *) operand="${tokens[j]}"; found=1; break ;;
+          *)
+            _push_decode_unquoted_literal_token "${tokens[j]}" || return 1
+            decoded="$_PUSH_LITERAL_TOKEN"
+            operand="$decoded"
+            found=1
+            break
+            ;;
         esac
-        j=$((j+1))
+        ((j++))
       done
     fi
-    i=$((i+1))
-  done
+  done < <(_push_command_segments "$command")
 
   (( pushes == 1 )) || return 1
 
   if (( found == 1 )); then
-    # A quote or expansion character means the token is not the literal value
-    # git will receive. Unknown, not "as written".
-    [[ "$operand" != *[\"\'\$\`\\]* ]] || return 1
     printf '%s\n' "$operand"
   fi
   return 0

--- a/skills/autonomous-common/hooks/lib-push.sh
+++ b/skills/autonomous-common/hooks/lib-push.sh
@@ -37,7 +37,9 @@
 #
 # Prepare one structured token stream for both push parsers. The hook sources
 # lib.sh first, so its bounded tokenizer is available and large commands are
-# scanned only once. The small fallback preserves standalone helper use.
+# scanned only once. If a copied standalone lib-push.sh cannot find lib.sh, its
+# minimal split is marked malformed so target parsing fails closed rather than
+# treating the first physical line as authoritative.
 _push_prepare_command_tokens() {
   local command="$1"
   local token library_dir
@@ -72,6 +74,7 @@ _push_prepare_command_tokens() {
     _PUSH_TOKEN_MALFORMED="${_RGCC_MALFORMED:-0}"
   else
     read -ra _PUSH_TOKEN_VALUES <<<"$command"
+    _PUSH_TOKEN_MALFORMED=1
     for token in "${_PUSH_TOKEN_VALUES[@]}"; do
       _PUSH_TOKEN_TYPES+=("word")
       _PUSH_TOKEN_QUOTES+=("unquoted")
@@ -117,20 +120,172 @@ _push_token_is_assignment() {
   [[ "$value" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]
 }
 
+_push_token_raw_unquoted_is() {
+  [[ "${_PUSH_TOKEN_TYPES[$1]:-}" == "word" ]] &&
+    [[ "${_PUSH_TOKEN_QUOTES[$1]:-}" == "unquoted" ]] &&
+    [[ "${_PUSH_TOKEN_VALUES[$1]:-}" == "$2" ]]
+}
+
+_push_token_is_redirection() {
+  local index="$1"
+  local value="${_PUSH_TOKEN_VALUES[index]:-}"
+  local exact_re='^([0-9]+|\{[A-Za-z_][A-Za-z0-9_]*\})?(>>|>\||>|<<-|<<<|<<|<>|<|>&|<&|&>>|&>)$'
+  local attached_re='^([0-9]+|\{[A-Za-z_][A-Za-z0-9_]*\})?(>>|>\||>|<<-|<<<|<<|<>|<|>&|<&|&>>|&>).+$'
+
+  [[ "${_PUSH_TOKEN_TYPES[index]:-}" == "word" ]] || return 1
+  [[ "${_PUSH_TOKEN_QUOTES[index]:-}" == "unquoted" ]] || return 1
+  if [[ "$value" =~ $exact_re ]]; then
+    _PUSH_REDIRECTION_CONSUMES_NEXT=1
+    return 0
+  fi
+  if [[ "$value" =~ $attached_re ]]; then
+    _PUSH_REDIRECTION_CONSUMES_NEXT=0
+    return 0
+  fi
+  return 1
+}
+
+_push_token_has_executable_expansion() {
+  local value="${_PUSH_TOKEN_VALUES[$1]:-}"
+  [[ "$value" == *'$('* || "$value" == *'`'* ||
+    "$value" == *'<('* || "$value" == *'>('* ]]
+}
+
+_push_skip_redirection() {
+  local index="$1" end="$2"
+
+  _push_token_is_redirection "$index" || return 1
+  _PUSH_AFTER_REDIRECTION=$((index + 1))
+  if (( _PUSH_REDIRECTION_CONSUMES_NEXT == 1 )); then
+    (( index + 1 < end )) || return 2
+    _push_token_is_redirection "$((index + 1))" && return 2
+    _push_token_has_executable_expansion "$((index + 1))" && return 2
+    _PUSH_AFTER_REDIRECTION=$((index + 2))
+  elif _push_token_has_executable_expansion "$index"; then
+    return 2
+  fi
+  return 0
+}
+
+_push_next_token_is_definite_other_operation() {
+  local index="$1" end="$2"
+  local i candidate
+
+  (( index < end )) || return 1
+  _push_token_static_value "$index" || return 1
+  candidate="$_PUSH_STATIC_VALUE"
+  [[ -n "$candidate" && "$candidate" != -* && "$candidate" != "push" ]] ||
+    return 1
+  for ((i = index + 1; i < end; i++)); do
+    _push_token_static_value "$i" || continue
+    [[ "$_PUSH_STATIC_VALUE" == "push" ]] && return 1
+  done
+  return 0
+}
+
+_push_data_segment_is_safe() {
+  local start="$1" end="$2" terminator="${3:-}"
+  local i rc value
+
+  case "$terminator" in
+    '|'|'|&') return 1 ;;
+  esac
+
+  for ((i = start + 1; i < end; i++)); do
+    if _push_skip_redirection "$i" "$end"; then
+      i=$((_PUSH_AFTER_REDIRECTION - 1))
+      continue
+    else
+      rc=$?
+      (( rc != 2 )) || return 1
+    fi
+    value="${_PUSH_TOKEN_VALUES[i]:-}"
+    if _push_token_has_executable_expansion "$i"; then
+      return 1
+    fi
+    if [[ "$terminator" == "(" &&
+      "${_PUSH_TOKEN_UNSAFE[i]:-0}" == "1" ]]; then
+      return 1
+    fi
+    [[ "$value" != *$'\n'* && "$value" != *$'\r'* ]] || return 1
+  done
+  return 0
+}
+
+_push_data_segment_contains_possible_push() {
+  local start="$1" end="$2"
+  local i text=""
+
+  for ((i = start + 1; i < end; i++)); do
+    text+="${text:+ }${_PUSH_TOKEN_VALUES[i]:-}"
+  done
+  [[ -n "$text" ]] || return 1
+  [[ "$text" == *'$'* || "$text" == *'`'* ]] && return 0
+  if declare -F _conservative_shell_text_contains_git_operation \
+    >/dev/null 2>&1; then
+    _conservative_shell_text_contains_git_operation "push" "$text"
+    return
+  fi
+  text="${text//[\(\)\{\}\[\]]/ }"
+  local -a words
+  read -ra words <<<"$text"
+  for ((i = 0; i + 1 < ${#words[@]}; i++)); do
+    if [[ "${words[i]}" == "git" && "${words[i+1]}" == "push" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+_push_shell_text_may_contain_executable_push_data() {
+  local command="$1"
+  local normalized="$command"
+
+  normalized="${normalized//\\/}"
+  normalized="${normalized//\"/}"
+  normalized="${normalized//\'/}"
+  if [[ "$normalized" == *git* && "$normalized" == *push* ]]; then
+    return 0
+  fi
+  if [[ "$command" == *['|<>']* &&
+    ( "$command" == *'$'* || "$command" == *'`'* ) ]]; then
+    return 0
+  fi
+  return 1
+}
+
 _push_git_operation_index() {
   local git_index="$1" end="$2"
-  local j=$((git_index + 1)) option
+  local j=$((git_index + 1)) option rc
 
   _push_token_static_value "$git_index" || return 1
   [[ "$_PUSH_STATIC_VALUE" == "git" ]] || return 1
 
   while (( j < end )); do
-    _push_token_static_value "$j" || return 2
+    if _push_skip_redirection "$j" "$end"; then
+      j="$_PUSH_AFTER_REDIRECTION"
+      continue
+    else
+      rc=$?
+      (( rc != 2 )) || return 2
+    fi
+    if ! _push_token_static_value "$j"; then
+      if _push_next_token_is_definite_other_operation "$((j + 1))" "$end"; then
+        return 1
+      fi
+      return 2
+    fi
     option="$_PUSH_STATIC_VALUE"
     case "$option" in
       -c|-C|--git-dir|--work-tree|--namespace|--super-prefix)
         (( j + 1 < end )) || return 2
-        _push_token_static_value "$((j + 1))" || return 2
+        if ! _push_token_static_value "$((j + 1))"; then
+          if _push_next_token_is_definite_other_operation \
+            "$((j + 2))" "$end"; then
+            return 1
+          fi
+          return 2
+        fi
         j=$((j + 2))
         ;;
       --*=*|--*|-*) ((j++)) ;;
@@ -174,10 +329,24 @@ _push_segment_contains_possible_push() {
 # Unknown prefixes that still contain a possible git push are rc=2 (unknown);
 # trusted data-only echo/printf segments are rc=1 (no executable push).
 _push_segment_git_start() {
-  local start="$1" end="$2"
-  local j="$start" value option
+  local start="$1" end="$2" terminator="${3:-}"
+  local j="$start" value option rc
 
   while (( j < end )); do
+    if _push_token_raw_unquoted_is "$j" "{"; then
+      ((j++))
+      continue
+    fi
+    if _push_token_raw_unquoted_is "$j" "}"; then
+      return 1
+    fi
+    if _push_skip_redirection "$j" "$end"; then
+      j="$_PUSH_AFTER_REDIRECTION"
+      continue
+    else
+      rc=$?
+      (( rc != 2 )) || return 2
+    fi
     if _push_token_is_assignment "$j"; then
       ((j++))
       continue
@@ -201,7 +370,10 @@ _push_segment_git_start() {
         ;;
       echo|printf)
         if [[ "$(type -t "$value" 2>/dev/null)" == "builtin" ]]; then
-          return 1
+          if _push_data_segment_is_safe "$j" "$end" "$terminator"; then
+            return 1
+          fi
+          _push_data_segment_contains_possible_push "$j" "$end" && return 2
         fi
         _push_segment_contains_possible_push "$start" "$end" && return 2
         return 1
@@ -337,8 +509,8 @@ _push_token_is_single_shell_word() {
 
 parse_push_target_refspec() {
   local command="$1"
-  local current_branch tok decoded r src dst
-  local segment_start=0 segment_end i j n rc
+  local current_branch tok decoded r src dst terminator
+  local segment_start=0 segment_end i j n rc redirect_rc
   local found_remote saw_all saw_mirror saw_tags_flag
   local matched=0 unknown=0
   local -a refspecs
@@ -352,7 +524,11 @@ parse_push_target_refspec() {
       continue
     fi
     if (( segment_start < segment_end )); then
-      if _push_segment_git_start "$segment_start" "$segment_end"; then
+      terminator=""
+      (( segment_end < n )) &&
+        terminator="${_PUSH_TOKEN_VALUES[segment_end]}"
+      if _push_segment_git_start \
+        "$segment_start" "$segment_end" "$terminator"; then
         rc=0
       else
         rc=$?
@@ -370,6 +546,16 @@ parse_push_target_refspec() {
       refspecs=()
 
       while (( j < segment_end )); do
+        if _push_skip_redirection "$j" "$segment_end"; then
+          j="$_PUSH_AFTER_REDIRECTION"
+          continue
+        else
+          redirect_rc=$?
+          if (( redirect_rc == 2 )); then
+            unknown=1
+            break
+          fi
+        fi
         if ! _push_token_static_value "$j"; then
           if (( found_remote == 0 )); then
             found_remote=1
@@ -525,8 +711,8 @@ is_trunk_ref() {
 # positional.
 parse_push_remote_operand() {
   local command="$1"
-  local operand="" decoded option
-  local n segment_start=0 segment_end i j rc pushes=0 found=0
+  local operand="" decoded option terminator
+  local n segment_start=0 segment_end i j rc pushes=0 found=0 redirect_rc
   _push_prepare_command_tokens "$command"
   n=${#_PUSH_TOKEN_VALUES[@]}
 
@@ -536,7 +722,11 @@ parse_push_remote_operand() {
       continue
     fi
     if (( segment_start < segment_end )); then
-      if _push_segment_git_start "$segment_start" "$segment_end"; then
+      terminator=""
+      (( segment_end < n )) &&
+        terminator="${_PUSH_TOKEN_VALUES[segment_end]}"
+      if _push_segment_git_start \
+        "$segment_start" "$segment_end" "$terminator"; then
         rc=0
       else
         rc=$?
@@ -548,6 +738,13 @@ parse_push_remote_operand() {
       ((pushes++))
       (( pushes <= 1 )) || return 1
       while (( j < segment_end )); do
+        if _push_skip_redirection "$j" "$segment_end"; then
+          j="$_PUSH_AFTER_REDIRECTION"
+          continue
+        else
+          redirect_rc=$?
+          (( redirect_rc != 2 )) || return 1
+        fi
         _push_token_static_value "$j" || return 1
         option="$_PUSH_STATIC_VALUE"
         case "$option" in

--- a/skills/autonomous-common/hooks/lib-push.sh
+++ b/skills/autonomous-common/hooks/lib-push.sh
@@ -15,9 +15,9 @@
 # parse_push_target_refspec <command>
 #
 # Given shell command text, echoes every destination ref-name written by each
-# literal `git push`, one per line. Returns 0 when all matched pushes were
-# parsed, 1 when no push was found, and 2 when a push was found but one of its
-# destinations could not be determined.
+# executable `git push`, one per line. Returns 0 when all matched pushes were
+# parsed, 1 when no executable push was found, and 2 when a possible executable
+# push or one of its destinations could not be determined.
 #
 # Handles:
 #   git push                                → <current_branch>
@@ -147,7 +147,8 @@ _push_token_is_redirection() {
 
 _push_token_has_executable_expansion() {
   local value="${_PUSH_TOKEN_VALUES[$1]:-}"
-  [[ "$value" == *'$('* || "$value" == *'`'* ||
+  local without_arithmetic="${value//\$\(\(/}"
+  [[ "$without_arithmetic" == *'$('* || "$value" == *'`'* ||
     "$value" == *'<('* || "$value" == *'>('* ]]
 }
 
@@ -167,19 +168,269 @@ _push_skip_redirection() {
   return 0
 }
 
+_push_shell_command_name_executes_input() {
+  case "$1" in
+    sh|*/sh|bash|*/bash|dash|*/dash|ksh|*/ksh|zsh|*/zsh|\
+      eval|source|'.'|python|python[0-9]*|*/python|*/python[0-9]*|\
+      node|*/node|ruby|*/ruby|perl|*/perl)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+_push_static_command_text_executes_input() {
+  local command="$1"
+  local n
+  local _PUSH_PREPARED_COMMAND=""
+  local _PUSH_TOKEN_MALFORMED=0
+  local -a _PUSH_TOKEN_TYPES=()
+  local -a _PUSH_TOKEN_VALUES=()
+  local -a _PUSH_TOKEN_QUOTES=()
+  local -a _PUSH_TOKEN_ANSI=()
+  local -a _PUSH_TOKEN_UNSAFE=()
+
+  _push_prepare_command_tokens "$command"
+  n=${#_PUSH_TOKEN_VALUES[@]}
+  (( n > 0 )) || return 1
+  _push_command_executes_standard_input 0 "$n"
+}
+
+_push_command_executes_standard_input() {
+  local j="$1" end="$2"
+  local value command_name option rc
+
+  while (( j < end )); do
+    if _push_skip_redirection "$j" "$end"; then
+      j="$_PUSH_AFTER_REDIRECTION"
+      continue
+    else
+      rc=$?
+      (( rc != 2 )) || return 0
+    fi
+    if _push_token_is_assignment "$j"; then
+      ((j++))
+      continue
+    fi
+    _push_token_static_value "$j" || return 0
+    value="$_PUSH_STATIC_VALUE"
+    command_name="${value##*/}"
+    case "$command_name" in
+      '!'|if|then|elif|else|do|while|until|'{')
+        ((j++))
+        ;;
+      command)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 0
+          case "$_PUSH_STATIC_VALUE" in
+            -p|--) ((j++)) ;;
+            -v|-V) return 1 ;;
+            *) break ;;
+          esac
+        done
+        ;;
+      exec)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 0
+          case "$_PUSH_STATIC_VALUE" in
+            -a)
+              (( j + 1 < end )) || return 0
+              j=$((j + 2))
+              ;;
+            -c|-l|--) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        ;;
+      nohup|time)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 0
+          option="$_PUSH_STATIC_VALUE"
+          [[ "$option" == -* ]] || break
+          case "$option" in
+            -o|--output|-f|--format)
+              (( j + 1 < end )) || return 0
+              j=$((j + 2))
+              ;;
+            *) ((j++)) ;;
+          esac
+        done
+        ;;
+      timeout)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 0
+          option="$_PUSH_STATIC_VALUE"
+          [[ "$option" == -* ]] || break
+          case "$option" in
+            -k|-s|--kill-after|--signal)
+              (( j + 1 < end )) || return 0
+              j=$((j + 2))
+              ;;
+            *) ((j++)) ;;
+          esac
+        done
+        (( j < end )) || return 0
+        ((j++))
+        ;;
+      stdbuf)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 0
+          option="$_PUSH_STATIC_VALUE"
+          case "$option" in
+            -i|-o|-e|--input|--output|--error)
+              (( j + 1 < end )) || return 0
+              j=$((j + 2))
+              ;;
+            -i*|-o*|-e*|--input=*|--output=*|--error=*|--) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        ;;
+      env)
+        ((j++))
+        while (( j < end )); do
+          if _push_token_is_assignment "$j"; then
+            ((j++))
+            continue
+          fi
+          _push_token_static_value "$j" || return 0
+          option="$_PUSH_STATIC_VALUE"
+          case "$option" in
+            -u|-C|-S|--unset|--chdir|--split-string)
+              (( j + 1 < end )) || return 0
+              j=$((j + 2))
+              ;;
+            --unset=*|--chdir=*|--split-string=*|-i|--ignore-environment|\
+              -0|--null|-v|--debug|--)
+              ((j++))
+              ;;
+            *) break ;;
+          esac
+        done
+        ;;
+      sudo)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 0
+          option="$_PUSH_STATIC_VALUE"
+          case "$option" in
+            -u|-g|-h|-p|-C|-T|-r|-t|--user|--group|--host|--prompt|\
+              --chdir|--command-timeout|--role|--type)
+              (( j + 1 < end )) || return 0
+              j=$((j + 2))
+              ;;
+            --*=*|-u*|-g*|-h*|-p*|-C*|-T*|-r*|-t*|--) ((j++)) ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        ;;
+      ssh)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 0
+          option="$_PUSH_STATIC_VALUE"
+          [[ "$option" == -* ]] || break
+          case "$option" in
+            -B|-b|-c|-D|-E|-e|-F|-I|-i|-J|-L|-l|-m|-O|-o|-p|-Q|-R|-S|-W|-w)
+              (( j + 1 < end )) || return 0
+              j=$((j + 2))
+              ;;
+            -*) ((j++)) ;;
+          esac
+        done
+        (( j < end )) || return 0
+        ((j++))
+        (( j < end )) || return 0
+        if (( j + 1 == end )) &&
+          _push_token_static_value "$j" &&
+          [[ "$_PUSH_STATIC_VALUE" == *[[:space:]]* ]]; then
+          _push_static_command_text_executes_input "$_PUSH_STATIC_VALUE"
+          return
+        fi
+        _push_command_executes_standard_input "$j" "$end"
+        return
+        ;;
+      xargs)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 0
+          option="$_PUSH_STATIC_VALUE"
+          [[ "$option" == -* ]] || break
+          case "$option" in
+            -a|-E|-I|-L|-n|-P|-s|-d|--arg-file|--eof|--replace|\
+              --max-lines|--max-args|--max-procs|--max-chars|--delimiter|\
+              --process-slot-var)
+              (( j + 1 < end )) || return 0
+              j=$((j + 2))
+              ;;
+            -a*|-E*|-I*|-L*|-n*|-P*|-s*|-d*|--*=*|--) ((j++)) ;;
+            -*) ((j++)) ;;
+          esac
+        done
+        (( j < end )) || return 1
+        _push_command_executes_standard_input "$j" "$end"
+        return
+        ;;
+      *)
+        _push_shell_command_name_executes_input "$command_name"
+        return
+        ;;
+    esac
+  done
+  return 1
+}
+
+_push_pipeline_consumer_executes_input() {
+  local pipe_index="$1"
+  local end=$((pipe_index + 1))
+  local n=${#_PUSH_TOKEN_VALUES[@]}
+
+  while (( end < n )) &&
+    [[ "${_PUSH_TOKEN_TYPES[end]:-}" != "operator" ]]; do
+    ((end++))
+  done
+  (( pipe_index + 1 < end )) || return 0
+  _push_command_executes_standard_input "$((pipe_index + 1))" "$end"
+}
+
 _push_next_token_is_definite_other_operation() {
   local index="$1" end="$2"
-  local i candidate
+  local i candidate rc
 
   (( index < end )) || return 1
-  _push_token_static_value "$index" || return 1
-  candidate="$_PUSH_STATIC_VALUE"
-  [[ -n "$candidate" && "$candidate" != -* && "$candidate" != "push" ]] ||
-    return 1
-  for ((i = index + 1; i < end; i++)); do
+  for ((i = index; i < end; i++)); do
     _push_token_static_value "$i" || continue
     [[ "$_PUSH_STATIC_VALUE" == "push" ]] && return 1
   done
+
+  i="$index"
+  while (( i < end )); do
+    if _push_skip_redirection "$i" "$end"; then
+      i="$_PUSH_AFTER_REDIRECTION"
+      continue
+    else
+      rc=$?
+      (( rc != 2 )) || return 1
+    fi
+    _push_token_static_value "$i" || return 1
+    candidate="$_PUSH_STATIC_VALUE"
+    case "$candidate" in
+      -c|-C|--git-dir|--work-tree|--namespace|--super-prefix)
+        (( i + 1 < end )) || return 1
+        i=$((i + 2))
+        ;;
+      --*=*|--*|-*) ((i++)) ;;
+      *) break ;;
+    esac
+  done
+  (( i < end )) || return 1
+  [[ -n "$candidate" && "$candidate" != "push" ]] || return 1
   return 0
 }
 
@@ -188,7 +439,9 @@ _push_data_segment_is_safe() {
   local i rc value
 
   case "$terminator" in
-    '|'|'|&') return 1 ;;
+    '|'|'|&')
+      _push_pipeline_consumer_executes_input "$end" && return 1
+      ;;
   esac
 
   for ((i = start + 1; i < end; i++)); do
@@ -239,18 +492,21 @@ _push_data_segment_contains_possible_push() {
 
 _push_shell_text_may_contain_executable_push_data() {
   local command="$1"
-  local normalized="$command"
+  local i n
 
-  normalized="${normalized//\\/}"
-  normalized="${normalized//\"/}"
-  normalized="${normalized//\'/}"
-  if [[ "$normalized" == *git* && "$normalized" == *push* ]]; then
-    return 0
-  fi
-  if [[ "$command" == *['|<>']* &&
-    ( "$command" == *'$'* || "$command" == *'`'* ) ]]; then
-    return 0
-  fi
+  _push_prepare_command_tokens "$command"
+  n=${#_PUSH_TOKEN_VALUES[@]}
+  for ((i = 0; i < n; i++)); do
+    if [[ "${_PUSH_TOKEN_TYPES[i]:-}" == "operator" ]]; then
+      case "${_PUSH_TOKEN_VALUES[i]:-}" in
+        '|'|'|&')
+          _push_pipeline_consumer_executes_input "$i" && return 0
+          ;;
+      esac
+      continue
+    fi
+    _push_token_has_executable_expansion "$i" && return 0
+  done
   return 1
 }
 
@@ -270,6 +526,9 @@ _push_git_operation_index() {
       (( rc != 2 )) || return 2
     fi
     if ! _push_token_static_value "$j"; then
+      if [[ "${_PUSH_TOKEN_VALUES[j]:-}" == "push" ]]; then
+        return 2
+      fi
       if _push_next_token_is_definite_other_operation "$((j + 1))" "$end"; then
         return 1
       fi

--- a/skills/autonomous-common/hooks/lib-push.sh
+++ b/skills/autonomous-common/hooks/lib-push.sh
@@ -54,9 +54,15 @@ _push_prepare_command_tokens() {
   _PUSH_TOKEN_ANSI=()
   _PUSH_TOKEN_UNSAFE=()
   _PUSH_TOKEN_MALFORMED=0
-  _PUSH_ENCLOSING_PIPELINE_CACHE_START=-1
-  _PUSH_ENCLOSING_PIPELINE_CACHE_END=-1
-  _PUSH_ENCLOSING_PIPELINE_CACHE_RESULT=1
+  _PUSH_STAGE_TABLE_READY=0
+  _PUSH_STAGE_BY_TOKEN=()
+  _PUSH_STAGE_NEXT_PIPES=()
+  _PUSH_STAGE_PROCESS_SUBS=()
+  _PUSH_STAGE_RESULTS=()
+  _PUSH_PIPE_RESULT_LIMITS=()
+  _PUSH_PIPE_RESULTS=()
+  _PUSH_PIPE_SCAN_ENDS=()
+  _PUSH_PROCESS_SUB_RESULTS=()
 
   if ! declare -F _resolve_git_command_tokenize >/dev/null 2>&1; then
     library_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -185,8 +191,11 @@ _push_shell_command_name_executes_input() {
 
 _push_shell_command_name_is_data_only() {
   case "$1" in
-    ':'|'['|'[['|cat|comm|cut|diff|echo|false|fmt|fold|gh|grep|egrep|fgrep|\
-      head|jq|nl|paste|printf|read|sed|sort|tail|tee|test|tr|true|uniq|wc)
+    ':'|'['|'[['|base32|base64|cat|cd|cksum|column|comm|cut|dd|diff|echo|\
+      expand|false|fmt|fold|gh|grep|egrep|fgrep|head|hexdump|iconv|jq|\
+      md5sum|nl|od|paste|printf|read|rev|sha1sum|sha224sum|sha256sum|\
+      sha384sum|sha512sum|sort|strings|tac|tail|tee|test|tr|true|\
+      unexpand|uniq|wc|xxd)
       return 0
       ;;
   esac
@@ -203,6 +212,15 @@ _push_static_command_text_executes_input() {
   local -a _PUSH_TOKEN_QUOTES=()
   local -a _PUSH_TOKEN_ANSI=()
   local -a _PUSH_TOKEN_UNSAFE=()
+  local _PUSH_STAGE_TABLE_READY=0
+  local -a _PUSH_STAGE_BY_TOKEN=()
+  local -a _PUSH_STAGE_NEXT_PIPES=()
+  local -a _PUSH_STAGE_PROCESS_SUBS=()
+  local -a _PUSH_STAGE_RESULTS=()
+  local -a _PUSH_PIPE_RESULT_LIMITS=()
+  local -a _PUSH_PIPE_RESULTS=()
+  local -a _PUSH_PIPE_SCAN_ENDS=()
+  local -a _PUSH_PROCESS_SUB_RESULTS=()
 
   _push_prepare_command_tokens "$command"
   n=${#_PUSH_TOKEN_VALUES[@]}
@@ -265,6 +283,123 @@ _push_env_split_option_command() {
   _push_env_split_command_text "$split_text" "$start" "$end" || return 2
 }
 
+_push_sed_command_executes_standard_input() {
+  local j="$1" end="$2"
+  local value script
+  local program_supplied=0
+
+  ((j++))
+  while (( j < end )); do
+    _push_token_static_value "$j" || return 0
+    value="$_PUSH_STATIC_VALUE"
+    case "$value" in
+      -e|--expression)
+        (( j + 1 < end )) || return 0
+        _push_token_static_value "$((j + 1))" || return 0
+        script="$_PUSH_STATIC_VALUE"
+        # sed's lowercase e command/flag executes generated shell text.
+        [[ "$script" != *e* ]] || return 0
+        program_supplied=1
+        j=$((j + 2))
+        ;;
+      --expression=*)
+        script="${value#*=}"
+        [[ "$script" != *e* ]] || return 0
+        program_supplied=1
+        ((j++))
+        ;;
+      -f|--file|-f?*|--file=*)
+        return 0
+        ;;
+      -l|--line-length)
+        (( j + 1 < end )) || return 0
+        _push_token_static_value "$((j + 1))" || return 0
+        j=$((j + 2))
+        ;;
+      -i|--in-place)
+        return 0
+        ;;
+      -l?*|--line-length=*|-n|--quiet|--silent|-E|-r|\
+        --regexp-extended|-s|--separate|-u|--unbuffered|-z|--null-data|\
+        --debug|--sandbox|-i?*|--in-place=*)
+        ((j++))
+        ;;
+      --)
+        ((j++))
+        if (( program_supplied == 0 )); then
+          (( j < end )) || return 0
+          _push_token_static_value "$j" || return 0
+          script="$_PUSH_STATIC_VALUE"
+          [[ "$script" != *e* ]] || return 0
+          program_supplied=1
+          ((j++))
+        fi
+        ;;
+      -*)
+        return 0
+        ;;
+      *)
+        if (( program_supplied == 0 )); then
+          script="$value"
+          [[ "$script" != *e* ]] || return 0
+          program_supplied=1
+        fi
+        ((j++))
+        ;;
+    esac
+  done
+  (( program_supplied == 1 )) || return 0
+  return 1
+}
+
+_push_awk_command_executes_standard_input() {
+  local j="$1" end="$2"
+  local value program
+  local options=1
+
+  ((j++))
+  while (( j < end )); do
+    if _push_token_static_value "$j"; then
+      value="$_PUSH_STATIC_VALUE"
+    elif [[ "${_PUSH_TOKEN_QUOTES[j]:-}" == "single" &&
+      "${_PUSH_TOKEN_ANSI[j]:-0}" == "0" ]]; then
+      value="${_PUSH_TOKEN_VALUES[j]:-}"
+    else
+      return 0
+    fi
+
+    if (( options == 1 )); then
+      case "$value" in
+        -F|--field-separator|-v|--assign)
+          (( j + 1 < end )) || return 0
+          _push_token_static_value "$((j + 1))" || return 0
+          j=$((j + 2))
+          continue
+          ;;
+        -F?*|-v?*|--field-separator=*|--assign=*)
+          ((j++))
+          continue
+          ;;
+        --)
+          options=0
+          ((j++))
+          continue
+          ;;
+        -*)
+          return 0
+          ;;
+      esac
+    fi
+
+    program="$value"
+    [[ "$program" != *@include* && "$program" != *@load* ]] || return 0
+    [[ ! "$program" =~ system[[:space:]]*\( && "$program" != *'|'* ]] ||
+      return 0
+    return 1
+  done
+  return 0
+}
+
 _push_static_command_text_contains_push() {
   if declare -F _shell_static_code_contains_git_operation >/dev/null 2>&1; then
     _shell_static_code_contains_git_operation "push" "$1"
@@ -275,7 +410,7 @@ _push_static_command_text_contains_push() {
 
 _push_simple_command_executes_standard_input() {
   local j="$1" end="$2"
-  local value command_name option rc candidate
+  local value command_name option rc
 
   while (( j < end )); do
     if _push_skip_redirection "$j" "$end"; then
@@ -463,29 +598,77 @@ _push_simple_command_executes_standard_input() {
         _push_command_executes_standard_input "$j" "$end"
         return
         ;;
-      awk|gawk|mawk|nawk)
-        for ((j = j + 1; j < end; j++)); do
-          if _push_token_static_value "$j"; then
-            value="$_PUSH_STATIC_VALUE"
-          elif [[ "${_PUSH_TOKEN_QUOTES[j]:-}" == "single" &&
-            "${_PUSH_TOKEN_ANSI[j]:-0}" == "0" ]]; then
-            value="${_PUSH_TOKEN_VALUES[j]:-}"
-          else
-            return 0
-          fi
-          [[ "$value" =~ system[[:space:]]*\( ]] && return 0
+      nice)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 0
+          option="$_PUSH_STATIC_VALUE"
+          case "$option" in
+            -n|--adjustment)
+              (( j + 1 < end )) || return 0
+              j=$((j + 2))
+              ;;
+            -n?*|--adjustment=*|-[0-9]*|--) ((j++)) ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
         done
-        return 1
+        (( j < end )) || return 1
+        _push_command_executes_standard_input "$j" "$end"
+        return
+        ;;
+      setsid)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 0
+          option="$_PUSH_STATIC_VALUE"
+          case "$option" in
+            -c|-f|-w|--ctty|--fork|--wait|--) ((j++)) ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        (( j < end )) || return 1
+        _push_command_executes_standard_input "$j" "$end"
+        return
+        ;;
+      ionice)
+        ((j++))
+        while (( j < end )); do
+          _push_token_static_value "$j" || return 0
+          option="$_PUSH_STATIC_VALUE"
+          case "$option" in
+            -c|-n|-p|-P|-u|--class|--classdata|--pid|--pgid|--uid)
+              (( j + 1 < end )) || return 0
+              j=$((j + 2))
+              ;;
+            -c?*|-n?*|-p?*|-P?*|-u?*|--*=*|-t|--ignore|--) ((j++)) ;;
+            -*) ((j++)) ;;
+            *) break ;;
+          esac
+        done
+        (( j < end )) || return 1
+        _push_command_executes_standard_input "$j" "$end"
+        return
+        ;;
+      busybox)
+        ((j++))
+        (( j < end )) || return 1
+        _push_command_executes_standard_input "$j" "$end"
+        return
+        ;;
+      sed)
+        _push_sed_command_executes_standard_input "$j" "$end"
+        return
+        ;;
+      awk|gawk|mawk|nawk)
+        _push_awk_command_executes_standard_input "$j" "$end"
+        return
         ;;
       *)
         _push_shell_command_name_executes_input "$command_name" && return 0
         _push_shell_command_name_is_data_only "$command_name" && return 1
-        for ((j = j + 1; j < end; j++)); do
-          _push_token_static_value "$j" || return 0
-          candidate="${_PUSH_STATIC_VALUE##*/}"
-          _push_shell_command_name_executes_input "$candidate" && return 0
-        done
-        return 1
+        return 0
         ;;
     esac
   done
@@ -611,7 +794,7 @@ _push_command_executes_standard_input() {
   return 1
 }
 
-_push_process_substitution_executes_input() {
+_push_process_substitution_executes_input_uncached() {
   local opener_index="$1"
   local paren_index=$((opener_index + 1))
   local body_start=$((opener_index + 2))
@@ -649,6 +832,23 @@ _push_process_substitution_executes_input() {
   return 0
 }
 
+_push_process_substitution_executes_input() {
+  local opener_index="$1"
+  local cached="${_PUSH_PROCESS_SUB_RESULTS[opener_index]:--1}"
+  local result
+
+  if (( cached >= 0 )); then
+    return "$cached"
+  fi
+  if _push_process_substitution_executes_input_uncached "$opener_index"; then
+    result=0
+  else
+    result=1
+  fi
+  _PUSH_PROCESS_SUB_RESULTS[opener_index]="$result"
+  return "$result"
+}
+
 _push_pipeline_has_executing_process_substitution() {
   local pipe_index="$1"
   local n="${2:-${#_PUSH_TOKEN_VALUES[@]}}"
@@ -675,11 +875,13 @@ _push_pipeline_stage_bounds() {
   local value top_end top_index
   local paren_depth=0
   local command_position=1
+  local has_executing_process_sub=0
   local -a compound_ends=()
 
   _PUSH_PIPELINE_STAGE_START="$start"
   _PUSH_PIPELINE_STAGE_END="$n"
   _PUSH_PIPELINE_NEXT_PIPE=-1
+  _PUSH_PIPELINE_STAGE_PROCESS_SUB=0
 
   for ((i = start; i < n; i++)); do
     if [[ "${_PUSH_TOKEN_TYPES[i]:-}" == "operator" ]]; then
@@ -697,6 +899,7 @@ _push_pipeline_stage_bounds() {
           fi
           if (( ${#compound_ends[@]} == 0 )); then
             _PUSH_PIPELINE_STAGE_END="$i"
+            _PUSH_PIPELINE_STAGE_PROCESS_SUB="$has_executing_process_sub"
             return 0
           fi
           ;;
@@ -707,10 +910,12 @@ _push_pipeline_stage_bounds() {
           '|'|'|&')
             _PUSH_PIPELINE_STAGE_END="$i"
             _PUSH_PIPELINE_NEXT_PIPE="$i"
+            _PUSH_PIPELINE_STAGE_PROCESS_SUB="$has_executing_process_sub"
             return 0
             ;;
           '&&'|'||'|';'|'&')
             _PUSH_PIPELINE_STAGE_END="$i"
+            _PUSH_PIPELINE_STAGE_PROCESS_SUB="$has_executing_process_sub"
             return 0
             ;;
         esac
@@ -719,6 +924,16 @@ _push_pipeline_stage_bounds() {
       continue
     fi
 
+    if (( paren_depth == 0 && ${#compound_ends[@]} == 0 )); then
+      if _push_process_substitution_executes_input "$i"; then
+        has_executing_process_sub=1
+      fi
+      # The nested scan reuses these output globals; restore this stage before
+      # continuing its boundary walk.
+      _PUSH_PIPELINE_STAGE_START="$start"
+      _PUSH_PIPELINE_STAGE_END="$n"
+      _PUSH_PIPELINE_NEXT_PIPE=-1
+    fi
     (( paren_depth == 0 && command_position == 1 )) || {
       command_position=0
       continue
@@ -758,64 +973,102 @@ _push_pipeline_stage_bounds() {
     fi
     command_position=0
   done
+  _PUSH_PIPELINE_STAGE_PROCESS_SUB="$has_executing_process_sub"
 }
 
 _push_pipeline_consumer_executes_input() {
   local pipe_index="$1"
   local limit="${2:-${#_PUSH_TOKEN_VALUES[@]}}"
-  local start end next_pipe
+  local start end next_pipe result=1 scan_end="$limit"
+  local cached_limit="${_PUSH_PIPE_RESULT_LIMITS[pipe_index]:--1}"
+  local cached_result="${_PUSH_PIPE_RESULTS[pipe_index]:--1}"
 
-  _PUSH_PIPELINE_SCAN_END="$limit"
-  while (( pipe_index >= 0 )); do
-    _push_pipeline_stage_bounds "$pipe_index" "$limit"
-    start="$_PUSH_PIPELINE_STAGE_START"
-    end="$_PUSH_PIPELINE_STAGE_END"
-    next_pipe="$_PUSH_PIPELINE_NEXT_PIPE"
-
-    _push_pipeline_has_executing_process_substitution \
-      "$pipe_index" "$limit" && return 0
-    (( start < end )) || return 0
-    _push_command_executes_standard_input "$start" "$end" && return 0
-    if (( next_pipe < 0 )); then
-      _PUSH_PIPELINE_SCAN_END="$end"
-    fi
-    pipe_index="$next_pipe"
-  done
-  return 1
-}
-
-_push_enclosing_pipeline_consumer_executes_input() {
-  local segment_start="$1"
-  local n="${#_PUSH_TOKEN_VALUES[@]}"
-  local boundary=-1 start end next_pipe
-  local cached_start="${_PUSH_ENCLOSING_PIPELINE_CACHE_START:--1}"
-  local cached_end="${_PUSH_ENCLOSING_PIPELINE_CACHE_END:--1}"
-  local cached_result="${_PUSH_ENCLOSING_PIPELINE_CACHE_RESULT:-1}"
-
-  if (( cached_start >= 0 &&
-    segment_start >= cached_start && segment_start < cached_end )); then
+  # Each pipe token belongs to one pipeline. Memoizing its transitive consumer
+  # result keeps both top-level and grouped pipelines linear.
+  if (( cached_limit == limit && cached_result >= 0 )); then
+    _PUSH_PIPELINE_SCAN_END="${_PUSH_PIPE_SCAN_ENDS[pipe_index]:-$limit}"
     return "$cached_result"
   fi
+  _PUSH_PIPELINE_SCAN_END="$limit"
+  _push_pipeline_stage_bounds "$pipe_index" "$limit"
+  start="$_PUSH_PIPELINE_STAGE_START"
+  end="$_PUSH_PIPELINE_STAGE_END"
+  next_pipe="$_PUSH_PIPELINE_NEXT_PIPE"
+
+  if _push_pipeline_has_executing_process_substitution \
+    "$pipe_index" "$limit"; then
+    result=0
+  elif (( start >= end )); then
+    result=0
+  elif _push_command_executes_standard_input "$start" "$end"; then
+    result=0
+  elif (( next_pipe >= 0 )); then
+    if _push_pipeline_consumer_executes_input "$next_pipe" "$limit"; then
+      result=0
+    fi
+    scan_end="$_PUSH_PIPELINE_SCAN_END"
+  else
+    scan_end="$end"
+  fi
+
+  _PUSH_PIPE_RESULT_LIMITS[pipe_index]="$limit"
+  _PUSH_PIPE_RESULTS[pipe_index]="$result"
+  _PUSH_PIPE_SCAN_ENDS[pipe_index]="$scan_end"
+  _PUSH_PIPELINE_SCAN_END="$scan_end"
+  return "$result"
+}
+
+_push_prepare_pipeline_stage_table() {
+  local n="${#_PUSH_TOKEN_VALUES[@]}"
+  local boundary=-1 start end next_pipe process_sub
+  local stage_index=0 i
+
+  (( ${_PUSH_STAGE_TABLE_READY:-0} == 0 )) || return 0
 
   while (( boundary < n )); do
     _push_pipeline_stage_bounds "$boundary" "$n"
     start="$_PUSH_PIPELINE_STAGE_START"
     end="$_PUSH_PIPELINE_STAGE_END"
     next_pipe="$_PUSH_PIPELINE_NEXT_PIPE"
-    if (( segment_start >= start && segment_start < end )); then
-      _PUSH_ENCLOSING_PIPELINE_CACHE_START="$start"
-      _PUSH_ENCLOSING_PIPELINE_CACHE_END="$end"
-      _PUSH_ENCLOSING_PIPELINE_CACHE_RESULT=1
-      if (( next_pipe >= 0 )) &&
-        _push_pipeline_consumer_executes_input "$next_pipe" "$n"; then
-        _PUSH_ENCLOSING_PIPELINE_CACHE_RESULT=0
-      fi
-      return "$_PUSH_ENCLOSING_PIPELINE_CACHE_RESULT"
-    fi
-    (( end > boundary )) || return 1
+    process_sub="${_PUSH_PIPELINE_STAGE_PROCESS_SUB:-0}"
+    (( end > boundary )) || break
+    _PUSH_STAGE_NEXT_PIPES[stage_index]="$next_pipe"
+    _PUSH_STAGE_PROCESS_SUBS[stage_index]="$process_sub"
+    _PUSH_STAGE_RESULTS[stage_index]=-1
+    for ((i = start; i < end; i++)); do
+      _PUSH_STAGE_BY_TOKEN[i]="$stage_index"
+    done
+    ((stage_index++))
     boundary="$end"
   done
-  return 1
+  _PUSH_STAGE_TABLE_READY=1
+}
+
+_push_enclosing_pipeline_consumer_executes_input() {
+  local segment_start="$1"
+  local n="${#_PUSH_TOKEN_VALUES[@]}"
+  local stage_index result next_pipe
+
+  _push_prepare_pipeline_stage_table
+  stage_index="${_PUSH_STAGE_BY_TOKEN[segment_start]:--1}"
+  (( stage_index >= 0 )) || return 1
+  result="${_PUSH_STAGE_RESULTS[stage_index]:--1}"
+  if (( result >= 0 )); then
+    return "$result"
+  fi
+
+  result=1
+  if (( ${_PUSH_STAGE_PROCESS_SUBS[stage_index]:-0} == 1 )); then
+    result=0
+  else
+    next_pipe="${_PUSH_STAGE_NEXT_PIPES[stage_index]:--1}"
+    if (( next_pipe >= 0 )) &&
+      _push_pipeline_consumer_executes_input "$next_pipe" "$n"; then
+      result=0
+    fi
+  fi
+  _PUSH_STAGE_RESULTS[stage_index]="$result"
+  return "$result"
 }
 
 _push_next_token_is_definite_other_operation() {
@@ -872,13 +1125,11 @@ _push_data_segment_is_safe() {
         return 1
       fi
       ;;
-    *)
-      if _push_enclosing_pipeline_consumer_executes_input "$start"; then
-        _PUSH_DATA_SEGMENT_DYNAMIC_INPUT=1
-        return 1
-      fi
-      ;;
   esac
+  if _push_enclosing_pipeline_consumer_executes_input "$start"; then
+    _PUSH_DATA_SEGMENT_DYNAMIC_INPUT=1
+    return 1
+  fi
 
   for ((i = start + 1; i < end; i++)); do
     if _push_skip_redirection "$i" "$end"; then

--- a/skills/autonomous-common/hooks/lib-push.sh
+++ b/skills/autonomous-common/hooks/lib-push.sh
@@ -54,6 +54,9 @@ _push_prepare_command_tokens() {
   _PUSH_TOKEN_ANSI=()
   _PUSH_TOKEN_UNSAFE=()
   _PUSH_TOKEN_MALFORMED=0
+  _PUSH_ENCLOSING_PIPELINE_CACHE_START=-1
+  _PUSH_ENCLOSING_PIPELINE_CACHE_END=-1
+  _PUSH_ENCLOSING_PIPELINE_CACHE_RESULT=1
 
   if ! declare -F _resolve_git_command_tokenize >/dev/null 2>&1; then
     library_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -169,7 +172,9 @@ _push_skip_redirection() {
 
 _push_shell_command_name_executes_input() {
   case "$1" in
-    sh|*/sh|bash|*/bash|dash|*/dash|ksh|*/ksh|zsh|*/zsh|\
+    sh|*/sh|ash|*/ash|bash|*/bash|csh|*/csh|dash|*/dash|fish|*/fish|\
+      hush|*/hush|ksh|*/ksh|mksh|*/mksh|posh|*/posh|tcsh|*/tcsh|\
+      yash|*/yash|zsh|*/zsh|\
       eval|source|'.'|python|python[0-9]*|*/python|*/python[0-9]*|\
       node|*/node|ruby|*/ruby|perl|*/perl)
       return 0
@@ -215,6 +220,49 @@ _push_env_split_command_text() {
     printf -v quoted '%q' "$_PUSH_STATIC_VALUE"
     _PUSH_ENV_SPLIT_COMMAND+=" $quoted"
   done
+}
+
+_push_env_split_option_command() {
+  local index="$1" end="$2"
+  local option="${_PUSH_TOKEN_VALUES[index]:-}"
+  local body prefix split_text start
+
+  [[ "${_PUSH_TOKEN_TYPES[index]:-}" == "word" &&
+    "${_PUSH_TOKEN_ANSI[index]:-0}" == "0" &&
+    "${_PUSH_TOKEN_UNSAFE[index]:-0}" == "0" &&
+    "$option" != *'$'* && "$option" != *'`'* ]] || return 2
+
+  start=$((index + 1))
+  case "$option" in
+    --split-string=*)
+      split_text="${option#*=}"
+      ;;
+    -S|--split-string)
+      (( start < end )) || return 2
+      _push_token_static_value "$start" || return 2
+      split_text="$_PUSH_STATIC_VALUE"
+      ((start++))
+      ;;
+    -?*)
+      [[ "$option" != --* ]] || return 1
+      body="${option#-}"
+      [[ "$body" == *S* ]] || return 1
+      prefix="${body%%S*}"
+      [[ "$prefix" != *[!i0v]* ]] || return 1
+      split_text="${body#*S}"
+      if [[ -z "$split_text" ]]; then
+        (( start < end )) || return 2
+        _push_token_static_value "$start" || return 2
+        split_text="$_PUSH_STATIC_VALUE"
+        ((start++))
+      fi
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  _push_env_split_command_text "$split_text" "$start" "$end" || return 2
 }
 
 _push_static_command_text_contains_push() {
@@ -327,32 +375,22 @@ _push_simple_command_executes_standard_input() {
             ((j++))
             continue
           fi
-          value="${_PUSH_TOKEN_VALUES[j]:-}"
-          if [[ "$value" == --split-string=* &&
-            "${_PUSH_TOKEN_ANSI[j]:-0}" == "0" &&
-            "${_PUSH_TOKEN_UNSAFE[j]:-0}" == "0" &&
-            "$value" != *'$'* && "$value" != *'`'* ]]; then
-            _push_env_split_command_text "${value#*=}" "$((j + 1))" "$end" ||
-              return 0
+          if _push_env_split_option_command "$j" "$end"; then
             _push_static_command_text_executes_input "$_PUSH_ENV_SPLIT_COMMAND"
             return
+          else
+            rc=$?
+            (( rc != 2 )) || return 0
           fi
           _push_token_static_value "$j" || return 0
           option="$_PUSH_STATIC_VALUE"
           case "$option" in
-            -S|--split-string)
-              (( j + 1 < end )) || return 0
-              _push_token_static_value "$((j + 1))" || return 0
-              _push_env_split_command_text \
-                "$_PUSH_STATIC_VALUE" "$((j + 2))" "$end" || return 0
-              _push_static_command_text_executes_input "$_PUSH_ENV_SPLIT_COMMAND"
-              return
-              ;;
-            -u|-C|--unset|--chdir)
+            -u|-C|-a|-f|--unset|--chdir|--argv0|--file)
               (( j + 1 < end )) || return 0
               j=$((j + 2))
               ;;
-            --unset=*|--chdir=*|-i|--ignore-environment|\
+            -u?*|-C?*|-a?*|-f?*|--unset=*|--chdir=*|--argv0=*|--file=*|\
+              -i|--ignore-environment|\
               -0|--null|-v|--debug|--)
               ((j++))
               ;;
@@ -685,6 +723,22 @@ _push_pipeline_stage_bounds() {
       command_position=0
       continue
     }
+    if _push_token_raw_unquoted_is "$i" "{"; then
+      compound_ends+=("}")
+      command_position=1
+      continue
+    fi
+    if _push_token_raw_unquoted_is "$i" "}"; then
+      if (( ${#compound_ends[@]} > 0 )); then
+        top_index=$((${#compound_ends[@]} - 1))
+        top_end="${compound_ends[top_index]}"
+        if [[ "$top_end" == "}" ]]; then
+          unset 'compound_ends[top_index]'
+        fi
+      fi
+      command_position=0
+      continue
+    fi
     if _push_token_static_value "$i"; then
       value="$_PUSH_STATIC_VALUE"
       if (( ${#compound_ends[@]} > 0 )); then
@@ -700,7 +754,6 @@ _push_pipeline_stage_bounds() {
         while|until|for|select) compound_ends+=("done") ;;
         if) compound_ends+=("fi") ;;
         case) compound_ends+=("esac") ;;
-        '{') compound_ends+=("}") ;;
       esac
     fi
     command_position=0
@@ -727,6 +780,40 @@ _push_pipeline_consumer_executes_input() {
       _PUSH_PIPELINE_SCAN_END="$end"
     fi
     pipe_index="$next_pipe"
+  done
+  return 1
+}
+
+_push_enclosing_pipeline_consumer_executes_input() {
+  local segment_start="$1"
+  local n="${#_PUSH_TOKEN_VALUES[@]}"
+  local boundary=-1 start end next_pipe
+  local cached_start="${_PUSH_ENCLOSING_PIPELINE_CACHE_START:--1}"
+  local cached_end="${_PUSH_ENCLOSING_PIPELINE_CACHE_END:--1}"
+  local cached_result="${_PUSH_ENCLOSING_PIPELINE_CACHE_RESULT:-1}"
+
+  if (( cached_start >= 0 &&
+    segment_start >= cached_start && segment_start < cached_end )); then
+    return "$cached_result"
+  fi
+
+  while (( boundary < n )); do
+    _push_pipeline_stage_bounds "$boundary" "$n"
+    start="$_PUSH_PIPELINE_STAGE_START"
+    end="$_PUSH_PIPELINE_STAGE_END"
+    next_pipe="$_PUSH_PIPELINE_NEXT_PIPE"
+    if (( segment_start >= start && segment_start < end )); then
+      _PUSH_ENCLOSING_PIPELINE_CACHE_START="$start"
+      _PUSH_ENCLOSING_PIPELINE_CACHE_END="$end"
+      _PUSH_ENCLOSING_PIPELINE_CACHE_RESULT=1
+      if (( next_pipe >= 0 )) &&
+        _push_pipeline_consumer_executes_input "$next_pipe" "$n"; then
+        _PUSH_ENCLOSING_PIPELINE_CACHE_RESULT=0
+      fi
+      return "$_PUSH_ENCLOSING_PIPELINE_CACHE_RESULT"
+    fi
+    (( end > boundary )) || return 1
+    boundary="$end"
   done
   return 1
 }
@@ -781,6 +868,12 @@ _push_data_segment_is_safe() {
     '(')
       if (( end > start + 1 )) &&
         _push_process_substitution_executes_input "$((end - 1))"; then
+        _PUSH_DATA_SEGMENT_DYNAMIC_INPUT=1
+        return 1
+      fi
+      ;;
+    *)
+      if _push_enclosing_pipeline_consumer_executes_input "$start"; then
         _PUSH_DATA_SEGMENT_DYNAMIC_INPUT=1
         return 1
       fi
@@ -1067,34 +1160,23 @@ _push_segment_git_start() {
             ((j++))
             continue
           fi
-          value="${_PUSH_TOKEN_VALUES[j]:-}"
-          if [[ "$value" == --split-string=* &&
-            "${_PUSH_TOKEN_ANSI[j]:-0}" == "0" &&
-            "${_PUSH_TOKEN_UNSAFE[j]:-0}" == "0" &&
-            "$value" != *'$'* && "$value" != *'`'* ]]; then
-            _push_env_split_command_text "${value#*=}" "$((j + 1))" "$end" ||
-              return 2
+          if _push_env_split_option_command "$j" "$end"; then
             _push_static_command_text_contains_push \
               "$_PUSH_ENV_SPLIT_COMMAND" && return 2
             return 1
+          else
+            rc=$?
+            (( rc != 2 )) || return 2
           fi
           _push_token_static_value "$j" || return 2
           option="$_PUSH_STATIC_VALUE"
           case "$option" in
-            -S|--split-string)
-              (( j + 1 < end )) || return 2
-              _push_token_static_value "$((j + 1))" || return 2
-              _push_env_split_command_text \
-                "$_PUSH_STATIC_VALUE" "$((j + 2))" "$end" || return 2
-              _push_static_command_text_contains_push \
-                "$_PUSH_ENV_SPLIT_COMMAND" && return 2
-              return 1
-              ;;
-            -u|-C|--unset|--chdir)
+            -u|-C|-a|-f|--unset|--chdir|--argv0|--file)
               (( j + 1 < end )) || return 2
               j=$((j + 2))
               ;;
-            --unset=*|--chdir=*|-i|--ignore-environment|\
+            -u?*|-C?*|-a?*|-f?*|--unset=*|--chdir=*|--argv0=*|--file=*|\
+              -i|--ignore-environment|\
               -0|--null|-v|--debug|--)
               ((j++))
               ;;

--- a/skills/autonomous-common/hooks/lib-push.sh
+++ b/skills/autonomous-common/hooks/lib-push.sh
@@ -178,6 +178,16 @@ _push_shell_command_name_executes_input() {
   return 1
 }
 
+_push_shell_command_name_is_data_only() {
+  case "$1" in
+    ':'|'['|'[['|cat|comm|cut|diff|echo|false|fmt|fold|gh|grep|egrep|fgrep|\
+      head|jq|nl|paste|printf|read|sed|sort|tail|tee|test|tr|true|uniq|wc)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 _push_static_command_text_executes_input() {
   local command="$1"
   local n
@@ -195,9 +205,29 @@ _push_static_command_text_executes_input() {
   _push_command_executes_standard_input 0 "$n"
 }
 
-_push_command_executes_standard_input() {
+_push_env_split_command_text() {
+  local split_text="$1" start="$2" end="$3"
+  local i quoted
+
+  _PUSH_ENV_SPLIT_COMMAND="$split_text"
+  for ((i = start; i < end; i++)); do
+    _push_token_static_value "$i" || return 1
+    printf -v quoted '%q' "$_PUSH_STATIC_VALUE"
+    _PUSH_ENV_SPLIT_COMMAND+=" $quoted"
+  done
+}
+
+_push_static_command_text_contains_push() {
+  if declare -F _shell_static_code_contains_git_operation >/dev/null 2>&1; then
+    _shell_static_code_contains_git_operation "push" "$1"
+    return
+  fi
+  _conservative_shell_text_contains_git_operation "push" "$1"
+}
+
+_push_simple_command_executes_standard_input() {
   local j="$1" end="$2"
-  local value command_name option rc
+  local value command_name option rc candidate
 
   while (( j < end )); do
     if _push_skip_redirection "$j" "$end"; then
@@ -297,14 +327,32 @@ _push_command_executes_standard_input() {
             ((j++))
             continue
           fi
+          value="${_PUSH_TOKEN_VALUES[j]:-}"
+          if [[ "$value" == --split-string=* &&
+            "${_PUSH_TOKEN_ANSI[j]:-0}" == "0" &&
+            "${_PUSH_TOKEN_UNSAFE[j]:-0}" == "0" &&
+            "$value" != *'$'* && "$value" != *'`'* ]]; then
+            _push_env_split_command_text "${value#*=}" "$((j + 1))" "$end" ||
+              return 0
+            _push_static_command_text_executes_input "$_PUSH_ENV_SPLIT_COMMAND"
+            return
+          fi
           _push_token_static_value "$j" || return 0
           option="$_PUSH_STATIC_VALUE"
           case "$option" in
-            -u|-C|-S|--unset|--chdir|--split-string)
+            -S|--split-string)
+              (( j + 1 < end )) || return 0
+              _push_token_static_value "$((j + 1))" || return 0
+              _push_env_split_command_text \
+                "$_PUSH_STATIC_VALUE" "$((j + 2))" "$end" || return 0
+              _push_static_command_text_executes_input "$_PUSH_ENV_SPLIT_COMMAND"
+              return
+              ;;
+            -u|-C|--unset|--chdir)
               (( j + 1 < end )) || return 0
               j=$((j + 2))
               ;;
-            --unset=*|--chdir=*|--split-string=*|-i|--ignore-environment|\
+            --unset=*|--chdir=*|-i|--ignore-environment|\
               -0|--null|-v|--debug|--)
               ((j++))
               ;;
@@ -392,12 +440,136 @@ _push_command_executes_standard_input() {
         return 1
         ;;
       *)
-        _push_shell_command_name_executes_input "$command_name"
-        return
+        _push_shell_command_name_executes_input "$command_name" && return 0
+        _push_shell_command_name_is_data_only "$command_name" && return 1
+        for ((j = j + 1; j < end; j++)); do
+          _push_token_static_value "$j" || return 0
+          candidate="${_PUSH_STATIC_VALUE##*/}"
+          _push_shell_command_name_executes_input "$candidate" && return 0
+        done
+        return 1
         ;;
     esac
   done
   [[ "${_PUSH_XARGS_APPENDS_ARGS:-0}" == "1" ]] && return 0
+  return 1
+}
+
+_push_command_executes_standard_input() {
+  local start="$1" end="$2"
+  local i="$start" simple_end value
+  local command_position=1
+  local loop_header=0
+  local case_depth=0
+  local case_pattern=0
+
+  while (( i < end )); do
+    if [[ "${_PUSH_TOKEN_TYPES[i]:-}" == "operator" ]]; then
+      value="${_PUSH_TOKEN_VALUES[i]:-}"
+      if (( case_pattern == 1 )); then
+        if [[ "$value" == ")" ]]; then
+          case_pattern=0
+          command_position=1
+        fi
+        ((i++))
+        continue
+      fi
+      case "$value" in
+        '('|'&&'|'||'|'|'|'|&'|'&')
+          command_position=1
+          ;;
+        ')')
+          command_position=0
+          ;;
+        ';')
+          if (( case_depth > 0 && i + 1 < end )) &&
+            [[ "${_PUSH_TOKEN_TYPES[i+1]:-}" == "operator" &&
+              "${_PUSH_TOKEN_VALUES[i+1]:-}" == ";" ]]; then
+            case_pattern=1
+            command_position=0
+            i=$((i + 2))
+            continue
+          fi
+          command_position=1
+          ;;
+      esac
+      ((i++))
+      continue
+    fi
+
+    if (( case_pattern == 1 )); then
+      if _push_token_static_value "$i" &&
+        [[ "$_PUSH_STATIC_VALUE" == "esac" ]]; then
+        (( case_depth > 0 )) && ((case_depth--))
+        case_pattern=0
+      fi
+      command_position=0
+      ((i++))
+      continue
+    fi
+
+    if (( loop_header == 1 )); then
+      if _push_token_static_value "$i" &&
+        [[ "$_PUSH_STATIC_VALUE" == "do" ]]; then
+        loop_header=0
+        command_position=1
+      fi
+      ((i++))
+      continue
+    fi
+
+    (( command_position == 1 )) || {
+      ((i++))
+      continue
+    }
+    if _push_token_raw_unquoted_is "$i" "{"; then
+      command_position=1
+      ((i++))
+      continue
+    fi
+    if _push_token_raw_unquoted_is "$i" "}"; then
+      command_position=0
+      ((i++))
+      continue
+    fi
+    _push_token_static_value "$i" || return 0
+    value="$_PUSH_STATIC_VALUE"
+    case "$value" in
+      for|select)
+        loop_header=1
+        command_position=0
+        ((i++))
+        ;;
+      case)
+        ((case_depth++))
+        case_pattern=1
+        command_position=0
+        ((i++))
+        ;;
+      '!'|if|then|elif|else|do|while|until)
+        command_position=1
+        ((i++))
+        ;;
+      fi|done|'esac')
+        if (( case_depth > 0 )) && [[ "$value" == "esac" ]]; then
+          ((case_depth--))
+        fi
+        command_position=0
+        ((i++))
+        ;;
+      *)
+        simple_end=$((i + 1))
+        while (( simple_end < end )) &&
+          [[ "${_PUSH_TOKEN_TYPES[simple_end]:-}" != "operator" ]]; do
+          ((simple_end++))
+        done
+        _push_simple_command_executes_standard_input \
+          "$i" "$simple_end" && return 0
+        i="$simple_end"
+        command_position=0
+        ;;
+    esac
+  done
   return 1
 }
 
@@ -457,46 +629,6 @@ _push_pipeline_has_executing_process_substitution() {
   return 1
 }
 
-_push_pipeline_loop_executes_input() {
-  local pipe_index="$1"
-  local n="${2:-${#_PUSH_TOKEN_VALUES[@]}}"
-  local i start end
-
-  start=$((pipe_index + 1))
-  _push_token_static_value "$start" || return 1
-  [[ "$_PUSH_STATIC_VALUE" == "while" ||
-    "$_PUSH_STATIC_VALUE" == "until" ]] || return 1
-
-  for ((i = start + 1; i < n; i++)); do
-    if _push_token_static_value "$i" &&
-      [[ "$_PUSH_STATIC_VALUE" == "do" ]]; then
-      start=$((i + 1))
-      break
-    fi
-  done
-  (( start < n )) || return 0
-
-  while (( start < n )); do
-    while (( start < n )) &&
-      [[ "${_PUSH_TOKEN_TYPES[start]:-}" == "operator" ]]; do
-      ((start++))
-    done
-    (( start < n )) || return 0
-    if _push_token_static_value "$start" &&
-      [[ "$_PUSH_STATIC_VALUE" == "done" ]]; then
-      return 1
-    fi
-    end="$start"
-    while (( end < n )) &&
-      [[ "${_PUSH_TOKEN_TYPES[end]:-}" != "operator" ]]; do
-      ((end++))
-    done
-    _push_command_executes_standard_input "$start" "$end" && return 0
-    start=$((end + 1))
-  done
-  return 0
-}
-
 _push_pipeline_stage_bounds() {
   local pipe_index="$1"
   local n="${2:-${#_PUSH_TOKEN_VALUES[@]}}"
@@ -524,6 +656,10 @@ _push_pipeline_stage_bounds() {
           if (( paren_depth > 0 )); then
             ((paren_depth--))
             continue
+          fi
+          if (( ${#compound_ends[@]} == 0 )); then
+            _PUSH_PIPELINE_STAGE_END="$i"
+            return 0
           fi
           ;;
       esac
@@ -576,6 +712,7 @@ _push_pipeline_consumer_executes_input() {
   local limit="${2:-${#_PUSH_TOKEN_VALUES[@]}}"
   local start end next_pipe
 
+  _PUSH_PIPELINE_SCAN_END="$limit"
   while (( pipe_index >= 0 )); do
     _push_pipeline_stage_bounds "$pipe_index" "$limit"
     start="$_PUSH_PIPELINE_STAGE_START"
@@ -584,9 +721,11 @@ _push_pipeline_consumer_executes_input() {
 
     _push_pipeline_has_executing_process_substitution \
       "$pipe_index" "$limit" && return 0
-    _push_pipeline_loop_executes_input "$pipe_index" "$limit" && return 0
     (( start < end )) || return 0
     _push_command_executes_standard_input "$start" "$end" && return 0
+    if (( next_pipe < 0 )); then
+      _PUSH_PIPELINE_SCAN_END="$end"
+    fi
     pipe_index="$next_pipe"
   done
   return 1
@@ -695,7 +834,7 @@ _push_data_segment_contains_possible_push() {
 
 _push_shell_text_may_contain_executable_push_data() {
   local command="$1"
-  local i n
+  local i n pipeline_scanned_until=-1
 
   _PUSH_EXECUTABLE_DATA_HAS_EXPANSION=0
   _PUSH_EXECUTABLE_DATA_HAS_PIPELINE=0
@@ -705,10 +844,12 @@ _push_shell_text_may_contain_executable_push_data() {
     if [[ "${_PUSH_TOKEN_TYPES[i]:-}" == "operator" ]]; then
       case "${_PUSH_TOKEN_VALUES[i]:-}" in
         '|'|'|&')
+          (( i < pipeline_scanned_until )) && continue
           if _push_pipeline_consumer_executes_input "$i"; then
             _PUSH_EXECUTABLE_DATA_HAS_PIPELINE=1
             return 0
           fi
+          pipeline_scanned_until="$_PUSH_PIPELINE_SCAN_END"
           ;;
       esac
       continue
@@ -926,14 +1067,34 @@ _push_segment_git_start() {
             ((j++))
             continue
           fi
+          value="${_PUSH_TOKEN_VALUES[j]:-}"
+          if [[ "$value" == --split-string=* &&
+            "${_PUSH_TOKEN_ANSI[j]:-0}" == "0" &&
+            "${_PUSH_TOKEN_UNSAFE[j]:-0}" == "0" &&
+            "$value" != *'$'* && "$value" != *'`'* ]]; then
+            _push_env_split_command_text "${value#*=}" "$((j + 1))" "$end" ||
+              return 2
+            _push_static_command_text_contains_push \
+              "$_PUSH_ENV_SPLIT_COMMAND" && return 2
+            return 1
+          fi
           _push_token_static_value "$j" || return 2
           option="$_PUSH_STATIC_VALUE"
           case "$option" in
-            -u|-C|-S|--unset|--chdir|--split-string)
+            -S|--split-string)
+              (( j + 1 < end )) || return 2
+              _push_token_static_value "$((j + 1))" || return 2
+              _push_env_split_command_text \
+                "$_PUSH_STATIC_VALUE" "$((j + 2))" "$end" || return 2
+              _push_static_command_text_contains_push \
+                "$_PUSH_ENV_SPLIT_COMMAND" && return 2
+              return 1
+              ;;
+            -u|-C|--unset|--chdir)
               (( j + 1 < end )) || return 2
               j=$((j + 2))
               ;;
-            --unset=*|--chdir=*|--split-string=*|-i|--ignore-environment|\
+            --unset=*|--chdir=*|-i|--ignore-environment|\
               -0|--null|-v|--debug|--)
               ((j++))
               ;;

--- a/skills/autonomous-common/hooks/lib-push.sh
+++ b/skills/autonomous-common/hooks/lib-push.sh
@@ -406,6 +406,7 @@ _push_process_substitution_executes_input() {
   local paren_index=$((opener_index + 1))
   local body_start=$((opener_index + 2))
   local i depth=1 n=${#_PUSH_TOKEN_VALUES[@]}
+  local start end next_pipe
 
   [[ "${_PUSH_TOKEN_TYPES[opener_index]:-}" == "word" &&
     "${_PUSH_TOKEN_VALUES[opener_index]:-}" == ">" ]] || return 1
@@ -420,8 +421,17 @@ _push_process_substitution_executes_input() {
         ((depth--))
         if (( depth == 0 )); then
           (( body_start < i )) || return 0
-          _push_command_executes_standard_input "$body_start" "$i"
-          return
+          _push_pipeline_stage_bounds "$((body_start - 1))" "$i"
+          start="$_PUSH_PIPELINE_STAGE_START"
+          end="$_PUSH_PIPELINE_STAGE_END"
+          next_pipe="$_PUSH_PIPELINE_NEXT_PIPE"
+          (( start < end )) || return 0
+          _push_command_executes_standard_input "$start" "$end" && return 0
+          if (( next_pipe >= 0 )); then
+            _push_pipeline_consumer_executes_input "$next_pipe" "$i"
+            return
+          fi
+          return 1
         fi
         ;;
     esac
@@ -431,7 +441,8 @@ _push_process_substitution_executes_input() {
 
 _push_pipeline_has_executing_process_substitution() {
   local pipe_index="$1"
-  local i n=${#_PUSH_TOKEN_VALUES[@]}
+  local n="${2:-${#_PUSH_TOKEN_VALUES[@]}}"
+  local i
 
   for ((i = pipe_index + 1; i + 1 < n; i++)); do
     if _push_process_substitution_executes_input "$i"; then
@@ -448,7 +459,8 @@ _push_pipeline_has_executing_process_substitution() {
 
 _push_pipeline_loop_executes_input() {
   local pipe_index="$1"
-  local i start end n=${#_PUSH_TOKEN_VALUES[@]}
+  local n="${2:-${#_PUSH_TOKEN_VALUES[@]}}"
+  local i start end
 
   start=$((pipe_index + 1))
   _push_token_static_value "$start" || return 1
@@ -485,19 +497,99 @@ _push_pipeline_loop_executes_input() {
   return 0
 }
 
+_push_pipeline_stage_bounds() {
+  local pipe_index="$1"
+  local n="${2:-${#_PUSH_TOKEN_VALUES[@]}}"
+  local start=$((pipe_index + 1))
+  local i
+  local value top_end top_index
+  local paren_depth=0
+  local command_position=1
+  local -a compound_ends=()
+
+  _PUSH_PIPELINE_STAGE_START="$start"
+  _PUSH_PIPELINE_STAGE_END="$n"
+  _PUSH_PIPELINE_NEXT_PIPE=-1
+
+  for ((i = start; i < n; i++)); do
+    if [[ "${_PUSH_TOKEN_TYPES[i]:-}" == "operator" ]]; then
+      value="${_PUSH_TOKEN_VALUES[i]:-}"
+      case "$value" in
+        '(')
+          ((paren_depth++))
+          command_position=1
+          continue
+          ;;
+        ')')
+          if (( paren_depth > 0 )); then
+            ((paren_depth--))
+            continue
+          fi
+          ;;
+      esac
+      (( paren_depth == 0 )) || continue
+      if (( ${#compound_ends[@]} == 0 )); then
+        case "$value" in
+          '|'|'|&')
+            _PUSH_PIPELINE_STAGE_END="$i"
+            _PUSH_PIPELINE_NEXT_PIPE="$i"
+            return 0
+            ;;
+          '&&'|'||'|';'|'&')
+            _PUSH_PIPELINE_STAGE_END="$i"
+            return 0
+            ;;
+        esac
+      fi
+      command_position=1
+      continue
+    fi
+
+    (( paren_depth == 0 && command_position == 1 )) || {
+      command_position=0
+      continue
+    }
+    if _push_token_static_value "$i"; then
+      value="$_PUSH_STATIC_VALUE"
+      if (( ${#compound_ends[@]} > 0 )); then
+        top_index=$((${#compound_ends[@]} - 1))
+        top_end="${compound_ends[top_index]}"
+        if [[ "$value" == "$top_end" ]]; then
+          unset 'compound_ends[top_index]'
+          command_position=0
+          continue
+        fi
+      fi
+      case "$value" in
+        while|until|for|select) compound_ends+=("done") ;;
+        if) compound_ends+=("fi") ;;
+        case) compound_ends+=("esac") ;;
+        '{') compound_ends+=("}") ;;
+      esac
+    fi
+    command_position=0
+  done
+}
+
 _push_pipeline_consumer_executes_input() {
   local pipe_index="$1"
-  local end=$((pipe_index + 1))
-  local n=${#_PUSH_TOKEN_VALUES[@]}
+  local limit="${2:-${#_PUSH_TOKEN_VALUES[@]}}"
+  local start end next_pipe
 
-  _push_pipeline_has_executing_process_substitution "$pipe_index" && return 0
-  _push_pipeline_loop_executes_input "$pipe_index" && return 0
-  while (( end < n )) &&
-    [[ "${_PUSH_TOKEN_TYPES[end]:-}" != "operator" ]]; do
-    ((end++))
+  while (( pipe_index >= 0 )); do
+    _push_pipeline_stage_bounds "$pipe_index" "$limit"
+    start="$_PUSH_PIPELINE_STAGE_START"
+    end="$_PUSH_PIPELINE_STAGE_END"
+    next_pipe="$_PUSH_PIPELINE_NEXT_PIPE"
+
+    _push_pipeline_has_executing_process_substitution \
+      "$pipe_index" "$limit" && return 0
+    _push_pipeline_loop_executes_input "$pipe_index" "$limit" && return 0
+    (( start < end )) || return 0
+    _push_command_executes_standard_input "$start" "$end" && return 0
+    pipe_index="$next_pipe"
   done
-  (( pipe_index + 1 < end )) || return 0
-  _push_command_executes_standard_input "$((pipe_index + 1))" "$end"
+  return 1
 }
 
 _push_next_token_is_definite_other_operation() {
@@ -605,19 +697,27 @@ _push_shell_text_may_contain_executable_push_data() {
   local command="$1"
   local i n
 
+  _PUSH_EXECUTABLE_DATA_HAS_EXPANSION=0
+  _PUSH_EXECUTABLE_DATA_HAS_PIPELINE=0
   _push_prepare_command_tokens "$command"
   n=${#_PUSH_TOKEN_VALUES[@]}
   for ((i = 0; i < n; i++)); do
     if [[ "${_PUSH_TOKEN_TYPES[i]:-}" == "operator" ]]; then
       case "${_PUSH_TOKEN_VALUES[i]:-}" in
         '|'|'|&')
-          _push_pipeline_consumer_executes_input "$i" && return 0
+          if _push_pipeline_consumer_executes_input "$i"; then
+            _PUSH_EXECUTABLE_DATA_HAS_PIPELINE=1
+            return 0
+          fi
           ;;
       esac
       continue
     fi
-    _push_token_has_executable_expansion "$i" && return 0
+    if _push_token_has_executable_expansion "$i"; then
+      _PUSH_EXECUTABLE_DATA_HAS_EXPANSION=1
+    fi
   done
+  (( _PUSH_EXECUTABLE_DATA_HAS_EXPANSION == 0 )) || return 0
   return 1
 }
 

--- a/skills/autonomous-common/hooks/lib.sh
+++ b/skills/autonomous-common/hooks/lib.sh
@@ -299,11 +299,19 @@ parse_edit_file_paths() {
 # remaining input unchanged so callers retain their fail-closed behavior.
 _strip_shell_non_executable_regions() {
   local cat_is_external=0
+  local gh_is_external=0
+  # Only external binaries have fixed stdin behavior. A shell function named
+  # cat or gh could evaluate the heredoc body and must remain fail-closed.
   if [[ "$(type -t cat 2>/dev/null)" == "file" ]]; then
     cat_is_external=1
   fi
+  if [[ "$(type -t gh 2>/dev/null)" == "file" ]]; then
+    gh_is_external=1
+  fi
 
-  printf '%s' "$1" | awk -v cat_is_external="$cat_is_external" '
+  printf '%s' "$1" | awk \
+    -v cat_is_external="$cat_is_external" \
+    -v gh_is_external="$gh_is_external" '
     BEGIN {
       state = "unquoted"
       word_start = 1
@@ -396,6 +404,18 @@ _strip_shell_non_executable_regions() {
                    (character == "$" && following == "(")) {
           return 1
         }
+      }
+      return 0
+    }
+
+    function is_trusted_heredoc_consumer(line) {
+      if (cat_is_external && line ~ /^[ \t]*cat([ \t<>]|$)/) {
+        return 1
+      }
+      if (gh_is_external &&
+          line ~ /^[ \t]*gh[ \t]+pr[ \t]+(create|comment|edit)([ \t]|$)/ &&
+          line ~ /--body-file([ \t]+|=)-([ \t<]|$)/) {
+        return 1
       }
       return 0
     }
@@ -508,8 +528,8 @@ _strip_shell_non_executable_regions() {
               previous != "<" && after != "<") {
             if (!record_heredoc(line, i)) {
               pending_ambiguous = 1
-            } else if (!cat_is_external || command_seen ||
-                       line !~ /^[ \t]*cat([ \t<>]|$)/ ||
+            } else if (command_seen ||
+                       !is_trusted_heredoc_consumer(line) ||
                        logical_control_seen) {
               pending_ambiguous = 1
             }
@@ -658,9 +678,19 @@ _shell_static_code_contains_git_operation() {
 _shell_code_executor_contains_git_operation() {
   local operation="$1"
   local command="$2"
+  local conservative_result="${3:--1}"
   local i j n executor code option saw_c skip_candidate
   local _SHELL_DATA_BUILTINS_TRUSTED=0
   local -a token_types token_values
+
+  if (( conservative_result < 0 )); then
+    if _conservative_shell_text_contains_git_operation \
+      "$operation" "$command"; then
+      conservative_result=0
+    else
+      conservative_result=1
+    fi
+  fi
 
   _resolve_git_command_tokenize "$command"
   token_types=("${_RGCC_TOKEN_TYPES[@]}")
@@ -690,8 +720,7 @@ _shell_code_executor_contains_git_operation() {
           while (( j < n )) && [[ "${token_types[j]}" == "word" ]]; do
             option="${token_values[j]}"
             if _shell_code_is_dynamic "$option"; then
-              if _conservative_shell_text_contains_git_operation \
-                "$operation" "$command"; then
+              if (( conservative_result == 0 )); then
                 return 0
               fi
               skip_candidate=1
@@ -724,8 +753,7 @@ _shell_code_executor_contains_git_operation() {
           while (( j < n )) && [[ "${token_types[j]}" == "word" ]]; do
             option="${token_values[j]}"
             if _shell_code_is_dynamic "$option"; then
-              if _conservative_shell_text_contains_git_operation \
-                "$operation" "$command"; then
+              if (( conservative_result == 0 )); then
                 return 0
               fi
               skip_candidate=1
@@ -765,8 +793,7 @@ _shell_code_executor_contains_git_operation() {
           while (( j < n )) && [[ "${token_types[j]}" == "word" ]]; do
             option="${token_values[j]}"
             if _shell_code_is_dynamic "$option"; then
-              if _conservative_shell_text_contains_git_operation \
-                "$operation" "$command"; then
+              if (( conservative_result == 0 )); then
                 return 0
               fi
               skip_candidate=1
@@ -809,8 +836,7 @@ _shell_code_executor_contains_git_operation() {
     (( j < n )) && [[ "${token_types[j]}" == "word" ]] || continue
     executor="${token_values[j]}"
     if _shell_code_is_dynamic "$executor"; then
-      if _conservative_shell_text_contains_git_operation \
-        "$operation" "$command"; then
+      if (( conservative_result == 0 )); then
         return 0
       fi
       continue
@@ -829,8 +855,7 @@ _shell_code_executor_contains_git_operation() {
         return 0
       fi
       if _shell_code_is_dynamic "$code" &&
-        _conservative_shell_text_contains_git_operation \
-          "$operation" "$command"; then
+        (( conservative_result == 0 )); then
         return 0
       fi
       continue
@@ -846,8 +871,7 @@ _shell_code_executor_contains_git_operation() {
       [[ "${token_types[j]}" == "word" ]] || break
       option="${token_values[j]}"
       if _shell_code_is_dynamic "$option"; then
-        if _conservative_shell_text_contains_git_operation \
-          "$operation" "$command"; then
+        if (( conservative_result == 0 )); then
           return 0
         fi
         skip_candidate=1
@@ -894,8 +918,7 @@ _shell_code_executor_contains_git_operation() {
       return 0
     fi
     if _shell_code_is_dynamic "$code" &&
-      _conservative_shell_text_contains_git_operation \
-        "$operation" "$command"; then
+      (( conservative_result == 0 )); then
       return 0
     fi
   done
@@ -932,13 +955,32 @@ _shell_code_is_trusted_data_builtin() {
 _shell_code_contains_git_operation() {
   local operation="$1"
   local code="$2"
+  local preprocessed="${3:-0}"
+  local conservative_result
+  local stripped_code strip_rc
 
+  if (( preprocessed == 0 )); then
+    if stripped_code=$(_strip_shell_non_executable_regions "$code"); then
+      code="$stripped_code"
+    else
+      strip_rc=$?
+      if (( strip_rc == 2 )); then
+        code="$stripped_code"
+      fi
+    fi
+  fi
   _shell_code_is_trusted_data_builtin "$code" && return 1
-  if _shell_static_code_contains_git_operation "$operation" "$code" ||
-    _shell_code_executor_contains_git_operation "$operation" "$code"; then
+  _shell_static_code_contains_git_operation "$operation" "$code" && return 0
+  if _conservative_shell_text_contains_git_operation "$operation" "$code"; then
+    conservative_result=0
+  else
+    conservative_result=1
+  fi
+  if _shell_code_executor_contains_git_operation \
+    "$operation" "$code" "$conservative_result"; then
     return 0
   fi
-  if _conservative_shell_text_contains_git_operation "$operation" "$code"; then
+  if (( conservative_result == 0 )); then
     _shell_code_is_trusted_data_builtin "$code" && return 1
     return 0
   fi
@@ -948,9 +990,11 @@ _shell_code_contains_git_operation() {
 _conservative_shell_text_contains_git_operation() {
   local operation="$1"
   local command="$2"
+  local backtick='`'
 
   command="${command//\"/ }"
   command="${command//\'/ }"
+  command="${command//$backtick/ }"
   command="${command//\(/ }"
   command="${command//\)/ }"
   command="${command//\{/ }"
@@ -973,6 +1017,7 @@ _large_static_shell_text_contains_git_operation() {
       started = 0
       count = 0
       single_quote = sprintf("%c", 39)
+      backtick = sprintf("%c", 96)
     }
 
     function emit_word() {
@@ -1049,7 +1094,7 @@ _large_static_shell_text_contains_git_operation() {
           emit_word()
         } else if (character == "&" || character == "|" ||
                    character == ";" || character == "(" ||
-                   character == ")") {
+                   character == ")" || character == backtick) {
           emit_operator()
         } else {
           started = 1
@@ -1177,6 +1222,357 @@ _large_ambiguous_shell_text_contains_git_operation() {
   _conservative_shell_text_contains_git_operation "$operation" "$command"
 }
 
+# Emit the byte spans of executable shell substitutions without copying their
+# bodies through a delimiter-based protocol. Each B record is:
+#   B <start> <length> <top-level> <opener-width> <closing-position>
+# A leading S record reports 0 for balanced input or 2 for malformed input;
+# balanced input then emits at most 4096 B records. LC_ALL=C keeps awk and Bash
+# byte offsets aligned.
+_large_shell_substitution_spans() {
+  local command="$1"
+
+  LC_ALL=C printf '%s' "$command" | LC_ALL=C awk '
+    BEGIN {
+      level = 0
+      type[0] = "root"
+      state[0] = "unquoted"
+      context_start[0] = 0
+      group_depth[0] = 0
+      position = 0
+      malformed = 0
+      single_quote = sprintf("%c", 39)
+      backtick = sprintf("%c", 96)
+    }
+
+    function open_context(kind, body_start, width) {
+      level++
+      type[level] = kind
+      state[level] = "unquoted"
+      context_start[level] = body_start
+      group_depth[level] = 0
+      opener_width[level] = width
+      pending_tag[level] = ""
+      active_tag[level] = ""
+      strip_tabs[level] = 0
+    }
+
+    function close_context(closing_position,   body_length, top) {
+      body_length = closing_position - context_start[level]
+      top = level == 1 ? 1 : 0
+      if (record_count >= 4096) {
+        malformed = 1
+      } else {
+        record_count++
+        record_start[record_count] = context_start[level]
+        record_length[record_count] = body_length
+        record_top[record_count] = top
+        record_width[record_count] = opener_width[level]
+        record_close[record_count] = closing_position
+      }
+      delete type[level]
+      delete state[level]
+      delete context_start[level]
+      delete group_depth[level]
+      delete opener_width[level]
+      delete pending_tag[level]
+      delete active_tag[level]
+      delete strip_tabs[level]
+      level--
+    }
+
+    function record_heredoc(line, opener_index,   cursor, first, quote, start, tag,
+                            boundary, tabs) {
+      cursor = opener_index + 2
+      tabs = 0
+      if (substr(line, cursor, 1) == "-") {
+        tabs = 1
+        cursor++
+      }
+      while (substr(line, cursor, 1) == " " ||
+             substr(line, cursor, 1) == "\t") {
+        cursor++
+      }
+      first = substr(line, cursor, 1)
+      quote = ""
+      if (first == "\\") {
+        cursor++
+      } else if (first == single_quote || first == "\"") {
+        quote = first
+        cursor++
+      }
+      start = cursor
+      while (substr(line, cursor, 1) ~ /[A-Za-z0-9_]/) {
+        cursor++
+      }
+      tag = substr(line, start, cursor - start)
+      if (quote != "") {
+        if (substr(line, cursor, 1) != quote) {
+          return 0
+        }
+        cursor++
+      }
+      boundary = substr(line, cursor, 1)
+      if (tag !~ /^[A-Za-z_][A-Za-z0-9_]*$/ ||
+          (boundary != "" && boundary !~ /[ \t;&|()<>]/)) {
+        return 0
+      }
+      if (pending_tag[level] != "") {
+        malformed = 1
+        return 0
+      }
+      pending_tag[level] = tag
+      pending_strip_tabs[level] = tabs
+      heredoc_end = cursor - 1
+      return 1
+    }
+
+    {
+      line = $0
+      candidate = line
+      if (active_tag[level] != "") {
+        if (strip_tabs[level]) {
+          sub(/^\t+/, "", candidate)
+        }
+        if (candidate == active_tag[level]) {
+          active_tag[level] = ""
+          strip_tabs[level] = 0
+        }
+        position += length(line) + 1
+        next
+      }
+
+      for (i = 1; i <= length(line); i++) {
+        character = substr(line, i, 1)
+        following = substr(line, i + 1, 1)
+        previous = i > 1 ? substr(line, i - 1, 1) : "\n"
+        after = substr(line, i + 2, 1)
+        absolute = position + i - 1
+
+        if (type[level] == "backtick") {
+          if (character == "\\") {
+            i++
+          } else if (character == backtick) {
+            close_context(absolute)
+          }
+          continue
+        }
+
+        if (state[level] == "comment") {
+          continue
+        }
+        if (state[level] == "single") {
+          if (character == single_quote) {
+            state[level] = "unquoted"
+          }
+          continue
+        }
+        if (state[level] == "double") {
+          if (character == "\\") {
+            i++
+          } else if (character == "\"") {
+            state[level] = "unquoted"
+          } else if (character == "$" && following == "(") {
+            open_context("paren", absolute + 2, 2)
+            i++
+          } else if (character == backtick) {
+            open_context("backtick", absolute + 1, 1)
+          }
+          continue
+        }
+
+        if (character == "\\") {
+          i++
+        } else if (character == single_quote) {
+          state[level] = "single"
+        } else if (character == "\"") {
+          state[level] = "double"
+        } else if (character == "#" &&
+                   (absolute == context_start[level] ||
+                    previous == " " || previous == "\t" ||
+                    previous == "\n" || previous == ";" ||
+                    previous == "|" || previous == "&" ||
+                    previous == "(")) {
+          state[level] = "comment"
+        } else if (character == backtick) {
+          open_context("backtick", absolute + 1, 1)
+        } else if (following == "(" &&
+                   (character == "$" || character == "<" ||
+                    character == ">")) {
+          open_context("paren", absolute + 2, 2)
+          i++
+        } else if (level > 0 &&
+                   character == "<" && following == "<" &&
+                   previous != "<" && after != "<") {
+          if (!record_heredoc(line, i)) {
+            malformed = 1
+          } else {
+            i = heredoc_end
+          }
+        } else if (level > 0 && character == "(") {
+          group_depth[level]++
+        } else if (level > 0 && character == ")") {
+          if (group_depth[level] > 0) {
+            group_depth[level]--
+          } else {
+            close_context(absolute)
+          }
+        }
+      }
+
+      if (state[level] == "comment") {
+        state[level] = "unquoted"
+      }
+      if (pending_tag[level] != "") {
+        active_tag[level] = pending_tag[level]
+        strip_tabs[level] = pending_strip_tabs[level]
+        pending_tag[level] = ""
+        pending_strip_tabs[level] = 0
+      }
+      position += length(line) + 1
+    }
+
+    END {
+      if (level != 0 || state[0] == "single" || state[0] == "double" ||
+          active_tag[0] != "" || pending_tag[0] != "") {
+        malformed = 1
+      }
+      print "S\t" (malformed ? 2 : 0)
+      for (record_index = 1; record_index <= record_count; record_index++) {
+        print "B\t" record_start[record_index] \
+          "\t" record_length[record_index] \
+          "\t" record_top[record_index] \
+          "\t" record_width[record_index] \
+          "\t" record_close[record_index]
+      }
+    }
+  '
+}
+
+# Strip top-level comments after substitutions have been projected out. This
+# intentionally does not re-run heredoc recognition: the caller's first pass
+# already masked supported heredoc bodies, including their terminator lines.
+_strip_shell_comments() {
+  printf '%s' "$1" | awk '
+    BEGIN {
+      state = "unquoted"
+      word_start = 1
+      single_quote = sprintf("%c", 39)
+    }
+
+    {
+      cleaned = ""
+      for (i = 1; i <= length($0); i++) {
+        character = substr($0, i, 1)
+        following = substr($0, i + 1, 1)
+        if (state == "single") {
+          cleaned = cleaned character
+          if (character == single_quote) {
+            state = "unquoted"
+          }
+          continue
+        }
+        if (state == "double") {
+          cleaned = cleaned character
+          if (character == "\\") {
+            if (following != "") {
+              cleaned = cleaned following
+              i++
+            }
+          } else if (character == "\"") {
+            state = "unquoted"
+          }
+          continue
+        }
+        if (character == "\\") {
+          cleaned = cleaned character
+          if (following != "") {
+            cleaned = cleaned following
+            i++
+          }
+          word_start = 0
+        } else if (character == single_quote) {
+          cleaned = cleaned character
+          state = "single"
+          word_start = 0
+        } else if (character == "\"") {
+          cleaned = cleaned character
+          state = "double"
+          word_start = 0
+        } else if (character == "#" && word_start) {
+          break
+        } else {
+          cleaned = cleaned character
+          if (character == " " || character == "\t" ||
+              index(";&|(<>" , character) > 0) {
+            word_start = 1
+          } else {
+            word_start = 0
+          }
+        }
+      }
+      print cleaned
+      if (state == "unquoted") {
+        word_start = 1
+      }
+    }
+  '
+}
+
+# Substitution-bearing command strings use the linear span extractor above,
+# then reuse the normal semantic body analyzer. This avoids treating a readable
+# top-level feature push as evidence that an unrelated substitution pushes to
+# trunk.
+_shell_substitutions_contain_git_operation() {
+  local operation="$1"
+  local command="$2"
+  local LC_ALL=C
+  local kind start body_length top_level opener_width closing_position
+  local body prefix suffix data_builtins_trusted malformed=2
+  local projection="" projection_cursor=0 opener_start
+  local substitution_marker='${_ADT_SHELL_SUBSTITUTION}'
+  local _SHELL_DATA_BUILTINS_TRUSTED=0
+  local _SHELL_SUBSTITUTION_ANALYSIS_LIMIT=64
+  local _SHELL_SUBSTITUTION_ANALYSIS_COUNT=0
+  local _SHELL_SUBSTITUTION_ANALYSIS_BYTE_LIMIT=8192
+  local _SHELL_SUBSTITUTION_ANALYSIS_BYTES=0
+  local -a _SHELL_SUBSTITUTION_CACHE_BODIES=()
+  local -a _SHELL_SUBSTITUTION_CACHE_TRUST=()
+  local -a _SHELL_SUBSTITUTION_CACHE_RESULTS=()
+
+  while IFS=$'\t' read -r kind start body_length top_level opener_width \
+    closing_position; do
+    if [[ "$kind" == "S" ]]; then
+      malformed="$start"
+      (( malformed == 0 )) || return 0
+      continue
+    fi
+    [[ "$kind" == "B" ]] || continue
+    body="${command:start:body_length}"
+    data_builtins_trusted=0
+    if (( top_level == 1 )); then
+      opener_start=$((start - opener_width))
+      projection+=\
+"${command:projection_cursor:opener_start-projection_cursor}${substitution_marker}"
+      projection_cursor=$((closing_position + 1))
+      prefix="${command:0:start-opener_width}"
+      suffix="${command:closing_position+1}"
+      if _shell_substitution_data_output_is_safe "$prefix" &&
+        _shell_substitution_data_suffix_is_safe "$suffix"; then
+        data_builtins_trusted=1
+      fi
+    fi
+    if _shell_substitution_body_contains_git_operation \
+      "$operation" "$body" "$data_builtins_trusted"; then
+      return 0
+    fi
+  done < <(_large_shell_substitution_spans "$command")
+
+  (( malformed == 0 )) || return 0
+  projection+="${command:projection_cursor}"
+  _SHELL_SUBSTITUTION_REMAINDER=$(_strip_shell_comments "$projection")
+  return 1
+}
+
 _shell_substitution_data_output_is_safe() {
   local prefix="$1"
   local trimmed
@@ -1190,8 +1586,15 @@ _shell_substitution_data_output_is_safe() {
     "$prefix" != *"$arithmetic_expansion"* &&
     "$prefix" != *"$arithmetic_command"* ]] || return 1
   trimmed="${prefix#"${prefix%%[![:space:]]*}"}"
-  [[ "$trimmed" == "echo" || "$trimmed" == echo[[:space:]]* ]] || return 1
-  [[ "$(type -t echo 2>/dev/null)" == "builtin" ]]
+  if [[ "$trimmed" == "echo" || "$trimmed" == echo[[:space:]]* ]]; then
+    [[ "$(type -t echo 2>/dev/null)" == "builtin" ]]
+    return
+  fi
+  if [[ "$trimmed" =~ ^gh[[:space:]]+pr[[:space:]]+(create|comment|edit)([[:space:]].*)?[[:space:]]+--body(=|[[:space:]]+)[\"\']?$ ]]; then
+    [[ "$(type -t gh 2>/dev/null)" == "file" ]]
+    return
+  fi
+  return 1
 }
 
 _shell_substitution_data_suffix_is_safe() {
@@ -1201,228 +1604,61 @@ _shell_substitution_data_suffix_is_safe() {
     "$suffix" != *'<'* && "$suffix" != *'>'* ]]
 }
 
-# Inspect only executable substitution bodies. A context stack keeps ordinary
-# parentheses inside commands and quoted strings from truncating the body.
-_unsafe_shell_text_contains_git_operation() {
+_shell_substitution_body_contains_git_operation() {
   local operation="$1"
-  local command="$2"
-  local LC_ALL=C
-  local length=${#command}
-  local level=0 i character following previous state body
-  local comment_copy_start=0 top_level_comment=0
-  local prefix data_builtins_trusted
-  local backslash=$'\\'
-  local _SHELL_DATA_BUILTINS_TRUSTED=0
-  local -a context_type context_state context_start context_group_depth
-  local -a context_data_builtins_trusted
+  local body="$2"
+  local data_builtins_trusted="$3"
+  local analysis_body="$body"
+  local stripped_body strip_rc=0
+  local i result
 
-  context_type[0]="root"
-  context_state[0]="unquoted"
-  context_start[0]=0
-  context_group_depth[0]=0
-  _UNSAFE_SHELL_REMAINDER=""
-  _UNSAFE_SHELL_COMMENT_STRIPPED=""
-
-  for ((i = 0; i < length; i++)); do
-    character="${command:i:1}"
-    following=""
-    if (( i + 1 < length )); then
-      following="${command:i+1:1}"
+  for ((i = 0; i < ${#_SHELL_SUBSTITUTION_CACHE_BODIES[@]}; i++)); do
+    if [[ "${_SHELL_SUBSTITUTION_CACHE_BODIES[i]}" == "$body" &&
+      "${_SHELL_SUBSTITUTION_CACHE_TRUST[i]}" == "$data_builtins_trusted" ]]; then
+      return "${_SHELL_SUBSTITUTION_CACHE_RESULTS[i]}"
     fi
-    previous=""
-    if (( i > 0 )); then
-      previous="${command:i-1:1}"
-    fi
-
-    if [[ "${context_type[level]}" == "backtick" ]]; then
-      if [[ "$character" == "$backslash" ]]; then
-        ((i++))
-      elif [[ "$character" == '`' ]]; then
-        body="${command:${context_start[level]}:i-${context_start[level]}}"
-        _SHELL_DATA_BUILTINS_TRUSTED=\
-"${context_data_builtins_trusted[level]:-0}"
-        if [[ "$_SHELL_DATA_BUILTINS_TRUSTED" == "1" ]] &&
-          ! _shell_substitution_data_suffix_is_safe "${command:i+1}"; then
-          _SHELL_DATA_BUILTINS_TRUSTED=0
-        fi
-        if _shell_code_contains_git_operation "$operation" "$body"; then
-          return 0
-        fi
-        ((level--))
-      fi
-      continue
-    fi
-
-    state="${context_state[level]}"
-    case "$state" in
-      comment)
-        if [[ "$character" == $'\n' ]]; then
-          if (( level == 0 )); then
-            _UNSAFE_SHELL_COMMENT_STRIPPED+="$character"
-            _UNSAFE_SHELL_REMAINDER+="$character"
-            comment_copy_start=$((i + 1))
-            top_level_comment=0
-          fi
-          context_state[level]="unquoted"
-        fi
-        ;;
-      single)
-        if (( level == 0 )); then
-          _UNSAFE_SHELL_REMAINDER+="$character"
-        fi
-        if [[ "$character" == "'" ]]; then
-          context_state[level]="unquoted"
-        fi
-        ;;
-      double)
-        if [[ "$character" == "$backslash" ]]; then
-          if (( level == 0 )); then
-            _UNSAFE_SHELL_REMAINDER+="$character$following"
-          fi
-          ((i++))
-        elif [[ "$character" == '"' ]]; then
-          if (( level == 0 )); then
-            _UNSAFE_SHELL_REMAINDER+="$character"
-          fi
-          context_state[level]="unquoted"
-        elif [[ "$character" == '$' && "$following" == '(' ]]; then
-          data_builtins_trusted=0
-          if (( level == 0 )); then
-            prefix="${command:0:i}"
-            if _shell_substitution_data_output_is_safe "$prefix"; then
-              data_builtins_trusted=1
-            fi
-          fi
-          if (( level == 0 )); then
-            _UNSAFE_SHELL_REMAINDER+=" "
-          fi
-          ((level++))
-          context_type[level]="paren"
-          context_state[level]="unquoted"
-          context_start[level]=$((i + 2))
-          context_group_depth[level]=0
-          context_data_builtins_trusted[level]="$data_builtins_trusted"
-          ((i++))
-        elif [[ "$character" == '`' ]]; then
-          data_builtins_trusted=0
-          if (( level == 0 )); then
-            prefix="${command:0:i}"
-            if _shell_substitution_data_output_is_safe "$prefix"; then
-              data_builtins_trusted=1
-            fi
-          fi
-          if (( level == 0 )); then
-            _UNSAFE_SHELL_REMAINDER+=" "
-          fi
-          ((level++))
-          context_type[level]="backtick"
-          context_start[level]=$((i + 1))
-          context_data_builtins_trusted[level]="$data_builtins_trusted"
-        elif (( level == 0 )); then
-          _UNSAFE_SHELL_REMAINDER+="$character"
-        fi
-        ;;
-      unquoted)
-        if [[ "$character" == "$backslash" ]]; then
-          if (( level == 0 )); then
-            _UNSAFE_SHELL_REMAINDER+="$character$following"
-          fi
-          ((i++))
-        elif [[ "$character" == "'" ]]; then
-          if (( level == 0 )); then
-            _UNSAFE_SHELL_REMAINDER+="$character"
-          fi
-          context_state[level]="single"
-        elif [[ "$character" == '"' ]]; then
-          if (( level == 0 )); then
-            _UNSAFE_SHELL_REMAINDER+="$character"
-          fi
-          context_state[level]="double"
-        elif [[ "$character" == "#" ]] &&
-          { (( i == context_start[level] )) ||
-            [[ "$previous" == " " || "$previous" == $'\t' ||
-              "$previous" == $'\n' || "$previous" == ";" ||
-              "$previous" == "|" || "$previous" == "&" ||
-              "$previous" == "(" ]]; }; then
-          if (( level == 0 )); then
-            _UNSAFE_SHELL_COMMENT_STRIPPED+=\
-"${command:comment_copy_start:i-comment_copy_start}"
-            top_level_comment=1
-          fi
-          context_state[level]="comment"
-        elif [[ "$character" == '`' ]]; then
-          data_builtins_trusted=0
-          if (( level == 0 )); then
-            prefix="${command:0:i}"
-            if _shell_substitution_data_output_is_safe "$prefix"; then
-              data_builtins_trusted=1
-            fi
-          fi
-          if (( level == 0 )); then
-            _UNSAFE_SHELL_REMAINDER+=" "
-          fi
-          ((level++))
-          context_type[level]="backtick"
-          context_start[level]=$((i + 1))
-          context_data_builtins_trusted[level]="$data_builtins_trusted"
-        elif [[ "$following" == '(' &&
-          ( "$character" == '$' || "$character" == '<' ||
-            "$character" == '>' ) ]]; then
-          data_builtins_trusted=0
-          if (( level == 0 )); then
-            prefix="${command:0:i}"
-            if _shell_substitution_data_output_is_safe "$prefix"; then
-              data_builtins_trusted=1
-            fi
-          fi
-          if (( level == 0 )); then
-            _UNSAFE_SHELL_REMAINDER+=" "
-          fi
-          ((level++))
-          context_type[level]="paren"
-          context_state[level]="unquoted"
-          context_start[level]=$((i + 2))
-          context_group_depth[level]=0
-          context_data_builtins_trusted[level]="$data_builtins_trusted"
-          ((i++))
-        elif (( level > 0 )) && [[ "$character" == '(' ]]; then
-          context_group_depth[level]=$((context_group_depth[level] + 1))
-        elif (( level > 0 )) && [[ "$character" == ')' ]]; then
-          if (( context_group_depth[level] > 0 )); then
-            context_group_depth[level]=$((context_group_depth[level] - 1))
-          else
-            body="${command:${context_start[level]}:i-${context_start[level]}}"
-            _SHELL_DATA_BUILTINS_TRUSTED=\
-"${context_data_builtins_trusted[level]:-0}"
-            if [[ "$_SHELL_DATA_BUILTINS_TRUSTED" == "1" ]] &&
-              ! _shell_substitution_data_suffix_is_safe "${command:i+1}"; then
-              _SHELL_DATA_BUILTINS_TRUSTED=0
-            fi
-            if _shell_code_contains_git_operation "$operation" "$body"; then
-              return 0
-            fi
-            ((level--))
-          fi
-        elif (( level == 0 )); then
-          _UNSAFE_SHELL_REMAINDER+="$character"
-        fi
-        ;;
-    esac
   done
 
-  if (( top_level_comment == 0 )); then
-    _UNSAFE_SHELL_COMMENT_STRIPPED+=\
-"${command:comment_copy_start:length-comment_copy_start}"
+  if stripped_body=$(_strip_shell_non_executable_regions "$body"); then
+    analysis_body="$stripped_body"
+  else
+    strip_rc=$?
+    if (( strip_rc == 2 )); then
+      analysis_body="$stripped_body"
+    fi
   fi
-  if (( level != 0 )) ||
-    [[ "${context_state[0]}" == "single" ||
-      "${context_state[0]}" == "double" ]]; then
-    _UNSAFE_SHELL_REMAINDER="$command"
-    _UNSAFE_SHELL_COMMENT_STRIPPED="$command"
-    _conservative_shell_text_contains_git_operation "$operation" "$command"
-    return
+
+  local _SHELL_DATA_BUILTINS_TRUSTED="$data_builtins_trusted"
+  if _shell_code_is_trusted_data_builtin "$analysis_body"; then
+    result=1
+  else
+    # Bound both the number and cumulative size of nested parses per top-level
+    # scan. Excess work is unknown and therefore fails closed; repeated bodies
+    # reuse the cached result without consuming either budget. Proven static
+    # data builtins in a proven data context bypass this semantic-parse budget.
+    if (( _SHELL_SUBSTITUTION_ANALYSIS_COUNT >=
+        _SHELL_SUBSTITUTION_ANALYSIS_LIMIT ||
+      ${#analysis_body} > _SHELL_SUBSTITUTION_ANALYSIS_BYTE_LIMIT -
+        _SHELL_SUBSTITUTION_ANALYSIS_BYTES )); then
+      return 0
+    fi
+    _SHELL_SUBSTITUTION_ANALYSIS_COUNT=\
+$((_SHELL_SUBSTITUTION_ANALYSIS_COUNT + 1))
+    _SHELL_SUBSTITUTION_ANALYSIS_BYTES=\
+$((_SHELL_SUBSTITUTION_ANALYSIS_BYTES + ${#analysis_body}))
+
+    if _shell_code_contains_git_operation "$operation" "$analysis_body" 1; then
+      result=0
+    else
+      result=1
+    fi
   fi
-  return 1
+
+  i=${#_SHELL_SUBSTITUTION_CACHE_BODIES[@]}
+  _SHELL_SUBSTITUTION_CACHE_BODIES[i]="$body"
+  _SHELL_SUBSTITUTION_CACHE_TRUST[i]="$data_builtins_trusted"
+  _SHELL_SUBSTITUTION_CACHE_RESULTS[i]="$result"
+  return "$result"
 }
 
 # Check if command invokes a given git subcommand.
@@ -1447,8 +1683,6 @@ is_git_command() {
   local command="$2"
   local stripped_command
   local strip_rc=0
-  local _UNSAFE_SHELL_REMAINDER="$command"
-  local _UNSAFE_SHELL_COMMENT_STRIPPED="$command"
 
   if stripped_command=$(_strip_shell_non_executable_regions "$command"); then
     command="$stripped_command"
@@ -1461,20 +1695,25 @@ is_git_command() {
       "$operation" "$stripped_command"; then
       return 0
     fi
-    if (( ${#stripped_command} >= 4096 )); then
-      _large_ambiguous_shell_text_contains_git_operation \
+    if (( ${#command} >= 4096 )); then
+      if _large_ambiguous_shell_text_contains_git_operation \
+        "$operation" "$stripped_command"; then
+        return 0
+      fi
+      _shell_substitutions_contain_git_operation \
         "$operation" "$stripped_command"
       return
     fi
-    if _unsafe_shell_text_contains_git_operation "$operation" "$command"; then
+    if _shell_substitutions_contain_git_operation \
+      "$operation" "$stripped_command"; then
       return 0
     fi
-    _resolve_git_command_tokenize "$_UNSAFE_SHELL_COMMENT_STRIPPED"
+    _resolve_git_command_tokenize "$_SHELL_SUBSTITUTION_REMAINDER" 1
     if (( _RGCC_UNSAFE == 1 )) &&
       _resolve_git_unsafe_tokens_contain_operation "$operation"; then
       return 0
     fi
-    command="$_UNSAFE_SHELL_REMAINDER"
+    command="$_SHELL_SUBSTITUTION_REMAINDER"
   fi
 
   # Strip simple quoted regions so prose such as "see git push docs" cannot
@@ -2154,8 +2393,6 @@ resolve_git_command_cwd() {
   local canonical_base resolved stripped_command
   local strip_rc=0
   local command_preprocessed=0
-  local _UNSAFE_SHELL_REMAINDER="$command"
-  local _UNSAFE_SHELL_COMMENT_STRIPPED="$command"
   local separator=-1
   local i n
 
@@ -2171,22 +2408,28 @@ resolve_git_command_cwd() {
       "$operation" "$stripped_command"; then
       return 2
     fi
-    if (( ${#stripped_command} >= 4096 )); then
+    if (( ${#command} >= 4096 )); then
       if _large_ambiguous_shell_text_contains_git_operation \
+        "$operation" "$stripped_command"; then
+        return 2
+      fi
+      if _shell_substitutions_contain_git_operation \
         "$operation" "$stripped_command"; then
         return 2
       fi
       return 1
     fi
-    if _unsafe_shell_text_contains_git_operation "$operation" "$command"; then
+    if _shell_substitutions_contain_git_operation \
+      "$operation" "$stripped_command"; then
       return 2
     fi
-    _resolve_git_command_tokenize "$_UNSAFE_SHELL_COMMENT_STRIPPED"
+    _resolve_git_command_tokenize "$_SHELL_SUBSTITUTION_REMAINDER" 1
     if (( _RGCC_UNSAFE == 1 )) &&
       _resolve_git_unsafe_tokens_contain_operation "$operation"; then
       return 2
     fi
-    command="$_UNSAFE_SHELL_REMAINDER"
+    command="$_SHELL_SUBSTITUTION_REMAINDER"
+    command_preprocessed=1
   fi
   _resolve_git_command_tokenize "$command" "$command_preprocessed"
 

--- a/skills/autonomous-common/hooks/lib.sh
+++ b/skills/autonomous-common/hooks/lib.sh
@@ -1505,6 +1505,7 @@ _resolve_git_command_tokenize() {
               unquoted_unsafe=0
               started=0
             fi
+            _resolve_git_append_operator ";"
             ;;
           "'")
             if (( started == 1 )); then

--- a/skills/autonomous-common/hooks/lib.sh
+++ b/skills/autonomous-common/hooks/lib.sh
@@ -602,7 +602,7 @@ _git_command_tokens_contain_operation() {
         -c|-C|--git-dir|--work-tree|--namespace|--super-prefix)
           i=$(( i + 2 > n ? n : i + 2 ))
           ;;
-        --*=*|--*)
+        --*=*|--*|-*)
           ((i++))
           ;;
         *)
@@ -953,6 +953,24 @@ _conservative_shell_text_contains_git_operation() {
   _git_command_tokens_contain_operation "$operation" "$command"
 }
 
+# Large ambiguous command strings must not enter the quadratic character and
+# token fallback paths. Tokenize once, then use the bounded structured and
+# conservative scanners. A positive result is intentionally fail-closed.
+_large_ambiguous_shell_text_contains_git_operation() {
+  local operation="$1"
+  local command="$2"
+
+  _resolve_git_command_tokenize "$command" 1
+  if _resolve_git_tokens_contain_operation "$operation"; then
+    return 0
+  fi
+  if (( _RGCC_UNSAFE == 1 )) &&
+    _resolve_git_unsafe_tokens_contain_operation "$operation"; then
+    return 0
+  fi
+  _conservative_shell_text_contains_git_operation "$operation" "$command"
+}
+
 _shell_substitution_data_output_is_safe() {
   local prefix="$1"
   local trimmed
@@ -1236,6 +1254,11 @@ is_git_command() {
     if _shell_text_outside_simple_quotes_contains_git_operation \
       "$operation" "$stripped_command"; then
       return 0
+    fi
+    if (( ${#stripped_command} >= 4096 )); then
+      _large_ambiguous_shell_text_contains_git_operation \
+        "$operation" "$stripped_command"
+      return
     fi
     if _unsafe_shell_text_contains_git_operation "$operation" "$command"; then
       return 0
@@ -1633,7 +1656,7 @@ _resolve_git_static_token_value() {
     value="${value/"$match"/}"
   done
   value="${value//\\/}"
-  printf '%s\n' "$value"
+  _RGCC_STATIC_TOKEN_VALUE="$value"
 }
 
 _resolve_git_flag_token_has_unsafe_expansion() {
@@ -1655,17 +1678,42 @@ _resolve_git_flag_token_has_unsafe_expansion() {
   [[ "$value" == *"$braced"* ]]
 }
 
+_resolve_git_next_token_is_definite_other_operation() {
+  local index="$1"
+  local operation="$2"
+  local value candidate
+  local i n=${#_RGCC_TOKEN_TYPES[@]}
+
+  [[ "${_RGCC_TOKEN_TYPES[index]:-}" == "word" ]] || return 1
+  [[ "${_RGCC_TOKEN_ANSI[index]:-0}" != "1" ]] || return 1
+  [[ "${_RGCC_TOKEN_UNQUOTED_UNSAFE[index]:-0}" != "1" ]] || return 1
+  _resolve_git_static_token_value "$index"
+  value="$_RGCC_STATIC_TOKEN_VALUE"
+  [[ -n "$value" && "$value" != -* && "$value" != "$operation" ]] || return 1
+
+  for ((i = index + 1; i < n; i++)); do
+    [[ "${_RGCC_TOKEN_TYPES[i]}" == "word" ]] || break
+    _resolve_git_static_token_value "$i"
+    candidate="$_RGCC_STATIC_TOKEN_VALUE"
+    [[ "$candidate" == "$operation" ]] && return 1
+  done
+  return 0
+}
+
 # Identify operation words obscured only by rejected expansion/escape syntax.
 # A quoted variable token consumed by a git global flag is not an operation.
 # This is conservative static analysis; it never expands the input.
 _resolve_git_unsafe_tokens_contain_operation() {
   local operation="$1"
   local i j git_word operation_word option_word token_word
+  local dynamic_git_word
   local n=${#_RGCC_TOKEN_VALUES[@]}
 
   for ((i = 0; i < n; i++)); do
     [[ "${_RGCC_TOKEN_TYPES[i]}" == "word" ]] || continue
-    git_word=$(_resolve_git_static_token_value "$i")
+    dynamic_git_word=0
+    _resolve_git_static_token_value "$i"
+    git_word="$_RGCC_STATIC_TOKEN_VALUE"
     if [[ "$git_word" != "git" ]]; then
       if (( i != 0 )) && [[ "${_RGCC_TOKEN_TYPES[i-1]}" != "operator" ]]; then
         continue
@@ -1673,12 +1721,19 @@ _resolve_git_unsafe_tokens_contain_operation() {
       if [[ -n "$git_word" || "${_RGCC_TOKEN_ANSI[i]}" == "1" ]]; then
         continue
       fi
+      if [[ "${_RGCC_TOKEN_VALUES[i]}" != *'$'* &&
+        "${_RGCC_TOKEN_VALUES[i]}" != *'`'* &&
+        "${_RGCC_TOKEN_UNQUOTED_UNSAFE[i]}" != "1" ]]; then
+        continue
+      fi
+      dynamic_git_word=1
     fi
 
     j=$((i + 1))
     while (( j < n )) && [[ "${_RGCC_TOKEN_TYPES[j]}" == "word" ]]; do
       token_word="${_RGCC_TOKEN_VALUES[j]}"
-      option_word=$(_resolve_git_static_token_value "$j")
+      _resolve_git_static_token_value "$j"
+      option_word="$_RGCC_STATIC_TOKEN_VALUE"
       case "$option_word" in
         -c|-C|--git-dir|--work-tree|--namespace|--super-prefix)
           [[ "$token_word" != *'$'* && "$token_word" != *'`'* ]] || return 0
@@ -1686,7 +1741,14 @@ _resolve_git_unsafe_tokens_contain_operation() {
           [[ "${_RGCC_TOKEN_UNQUOTED_UNSAFE[j]}" != "1" ]] || return 0
           (( j + 1 < n )) &&
             [[ "${_RGCC_TOKEN_TYPES[j+1]}" == "word" ]] || return 0
-          [[ "${_RGCC_TOKEN_UNQUOTED_UNSAFE[j+1]}" != "1" ]] || return 0
+          if [[ "${_RGCC_TOKEN_UNQUOTED_UNSAFE[j+1]}" == "1" ]]; then
+            if _resolve_git_next_token_is_definite_other_operation \
+              "$((j + 2))" "$operation"; then
+              j=$((j + 2))
+              continue
+            fi
+            return 0
+          fi
           if _resolve_git_flag_token_has_unsafe_expansion \
             "${_RGCC_TOKEN_VALUES[j+1]}"; then
             return 0
@@ -1695,7 +1757,14 @@ _resolve_git_unsafe_tokens_contain_operation() {
           ;;
         --git-dir=*|--work-tree=*|--namespace=*|--super-prefix=*)
           [[ "${_RGCC_TOKEN_ANSI[j]}" != "1" ]] || return 0
-          [[ "${_RGCC_TOKEN_UNQUOTED_UNSAFE[j]}" != "1" ]] || return 0
+          if [[ "${_RGCC_TOKEN_UNQUOTED_UNSAFE[j]}" == "1" ]]; then
+            if _resolve_git_next_token_is_definite_other_operation \
+              "$((j + 1))" "$operation"; then
+              ((j++))
+              continue
+            fi
+            return 0
+          fi
           if _resolve_git_flag_token_has_unsafe_expansion "$token_word"; then
             return 0
           fi
@@ -1722,11 +1791,15 @@ _resolve_git_unsafe_tokens_contain_operation() {
       esac
     done
     (( j < n )) && [[ "${_RGCC_TOKEN_TYPES[j]}" == "word" ]] || continue
-    operation_word=$(_resolve_git_static_token_value "$j")
-    if [[ "$operation_word" == "$operation" ]] ||
-      [[ "${_RGCC_TOKEN_VALUES[j]}" == *'$'* ]] ||
-      [[ "${_RGCC_TOKEN_VALUES[j]}" == *'`'* ]] ||
-      [[ "${_RGCC_TOKEN_UNQUOTED_UNSAFE[j]}" == "1" ]]; then
+    _resolve_git_static_token_value "$j"
+    operation_word="$_RGCC_STATIC_TOKEN_VALUE"
+    if [[ "$operation_word" == "$operation" ]]; then
+      return 0
+    fi
+    if (( dynamic_git_word == 0 )) &&
+      { [[ "${_RGCC_TOKEN_VALUES[j]}" == *'$'* ]] ||
+        [[ "${_RGCC_TOKEN_VALUES[j]}" == *'`'* ]] ||
+        [[ "${_RGCC_TOKEN_UNQUOTED_UNSAFE[j]}" == "1" ]]; }; then
       return 0
     fi
   done
@@ -1854,6 +1927,13 @@ resolve_git_command_cwd() {
     if _shell_text_outside_simple_quotes_contains_git_operation \
       "$operation" "$stripped_command"; then
       return 2
+    fi
+    if (( ${#stripped_command} >= 4096 )); then
+      if _large_ambiguous_shell_text_contains_git_operation \
+        "$operation" "$stripped_command"; then
+        return 2
+      fi
+      return 1
     fi
     if _unsafe_shell_text_contains_git_operation "$operation" "$command"; then
       return 2

--- a/skills/autonomous-common/hooks/lib.sh
+++ b/skills/autonomous-common/hooks/lib.sh
@@ -291,6 +291,835 @@ parse_edit_file_paths() {
   done <<< "$records"
 }
 
+# Remove shell regions that are definitively non-executable while preserving
+# executable text and line boundaries. The scanner handles simple shell words,
+# comments, and identifier-delimited heredocs. Once it sees syntax whose word
+# boundaries require a fuller parser (expansions, arithmetic, process
+# substitution, extended tests, or attached parentheses), it preserves the
+# remaining input unchanged so callers retain their fail-closed behavior.
+_strip_shell_non_executable_regions() {
+  local cat_is_external=0
+  if [[ "$(type -t cat 2>/dev/null)" == "file" ]]; then
+    cat_is_external=1
+  fi
+
+  printf '%s' "$1" | awk -v cat_is_external="$cat_is_external" '
+    BEGIN {
+      state = "unquoted"
+      word_start = 1
+      pending_count = 0
+      pending_ambiguous = 0
+      active_count = 0
+      active_index = 1
+      logical_control_seen = 0
+      command_seen = 0
+      single_quote = sprintf("%c", 39)
+    }
+
+    function clear_pending(   idx) {
+      for (idx = 1; idx <= pending_count; idx++) {
+        delete pending_tags[idx]
+        delete pending_strip_tabs[idx]
+        delete pending_expands[idx]
+      }
+      pending_count = 0
+      pending_ambiguous = 0
+    }
+
+    function activate_pending() {
+      active_count = pending_count
+      active_index = 1
+      pending_ambiguous = 0
+    }
+
+    function record_heredoc(line, position,
+                            strip_tabs, expands, idx, first, quote, start, tag,
+                            boundary) {
+      idx = position + 2
+      strip_tabs = 0
+      expands = 1
+      if (substr(line, idx, 1) == "-") {
+        strip_tabs = 1
+        idx++
+      }
+      while (substr(line, idx, 1) == " " ||
+             substr(line, idx, 1) == "\t") {
+        idx++
+      }
+
+      first = substr(line, idx, 1)
+      if (first == "\\") {
+        expands = 0
+        idx++
+      } else if (first == single_quote || first == "\"") {
+        expands = 0
+        quote = first
+        idx++
+      }
+
+      start = idx
+      while (substr(line, idx, 1) ~ /[A-Za-z0-9_]/) {
+        idx++
+      }
+      tag = substr(line, start, idx - start)
+      if (quote != "") {
+        if (substr(line, idx, 1) != quote) {
+          return 0
+        }
+        idx++
+      }
+
+      boundary = substr(line, idx, 1)
+      if (tag !~ /^[A-Za-z_][A-Za-z0-9_]*$/ ||
+          (boundary != "" && boundary !~ /[ \t;&|()<>]/)) {
+        return 0
+      }
+
+      pending_count++
+      pending_tags[pending_count] = tag
+      pending_strip_tabs[pending_count] = strip_tabs
+      pending_expands[pending_count] = expands
+      return 1
+    }
+
+    function has_executable_heredoc_expansion(line,   idx, character,
+                                              following) {
+      for (idx = 1; idx <= length(line); idx++) {
+        character = substr(line, idx, 1)
+        following = substr(line, idx + 1, 1)
+        if (character == "\\" &&
+            (following == "\\" || following == "$" ||
+             following == "`")) {
+          idx++
+        } else if (character == "`" ||
+                   (character == "$" && following == "(")) {
+          return 1
+        }
+      }
+      return 0
+    }
+
+    active_count > 0 {
+      if (pending_expands[active_index] &&
+          has_executable_heredoc_expansion($0)) {
+        exit 2
+      }
+      candidate = $0
+      if (pending_strip_tabs[active_index]) {
+        sub(/^\t+/, "", candidate)
+      }
+      print ""
+      if (candidate == pending_tags[active_index]) {
+        delete pending_tags[active_index]
+        delete pending_strip_tabs[active_index]
+        delete pending_expands[active_index]
+        active_index++
+        if (active_index > active_count) {
+          active_count = 0
+          active_index = 1
+          pending_count = 0
+        }
+      }
+      state = "unquoted"
+      word_start = 1
+      next
+    }
+
+    {
+      line = $0
+      cleaned = ""
+      line_continued = 0
+
+      for (i = 1; i <= length(line); i++) {
+        character = substr(line, i, 1)
+        following = substr(line, i + 1, 1)
+        previous = i > 1 ? substr(line, i - 1, 1) : ""
+        after = substr(line, i + 2, 1)
+
+        if (state == "single") {
+          cleaned = cleaned character
+          if (character == single_quote) {
+            state = "unquoted"
+          }
+          continue
+        }
+
+        if (state == "double") {
+          cleaned = cleaned character
+          if (character == "\\") {
+            if (following != "") {
+              cleaned = cleaned following
+              i++
+            }
+          } else if (character == "`" ||
+                     (character == "$" && following == "(")) {
+            exit 2
+          } else if (character == "\"") {
+            state = "unquoted"
+          }
+          continue
+        }
+
+        if (character == "\\") {
+          cleaned = cleaned character
+          if (following != "") {
+            cleaned = cleaned following
+            i++
+          } else {
+            line_continued = 1
+          }
+          word_start = 0
+        } else if (character == single_quote) {
+          cleaned = cleaned character
+          state = "single"
+          word_start = 0
+        } else if (character == "\"") {
+          cleaned = cleaned character
+          state = "double"
+          word_start = 0
+        } else if (character == "#" && word_start) {
+          break
+        } else if ((character == "$" &&
+                    (following == "(" || following == "{" ||
+                     following == "[")) ||
+                   character == "`" ||
+                   ((character == "<" || character == ">") &&
+                    following == "(") ||
+                   (character == "[" && following == "[") ||
+                   (character == "(" &&
+                    (following == "(" || !word_start))) {
+          exit 2
+        } else {
+          cleaned = cleaned character
+          if (character == "<" && following == "<" &&
+              previous != "<" && after != "<") {
+            if (!record_heredoc(line, i)) {
+              pending_ambiguous = 1
+            } else if (!cat_is_external || command_seen ||
+                       line !~ /^[ \t]*cat([ \t<>]|$)/ ||
+                       logical_control_seen) {
+              pending_ambiguous = 1
+            }
+          }
+
+          if (character == "|" || character == ";" ||
+              (character == "&" && previous != "<" && previous != ">" &&
+               following != ">")) {
+            logical_control_seen = 1
+            if (pending_count > 0) {
+              pending_ambiguous = 1
+            }
+          }
+
+          if (character == "|" &&
+              (following == "|" || following == "&")) {
+            cleaned = cleaned following
+            i++
+          } else if (character == "&" && following == "&") {
+            cleaned = cleaned following
+            i++
+          }
+
+          if (character == ")") {
+            word_start = 0
+          } else if (character == " " || character == "\t" ||
+                     index(";&|(<>" , character) > 0) {
+            word_start = 1
+          } else {
+            word_start = 0
+          }
+        }
+      }
+
+      if (cleaned !~ /^[ \t]*$/) {
+        command_seen = 1
+      }
+
+      if (state == "unquoted" && !line_continued) {
+        if (pending_count > 0 && !pending_ambiguous) {
+          activate_pending()
+        } else {
+          clear_pending()
+        }
+        word_start = 1
+        logical_control_seen = 0
+      } else if (state == "unquoted") {
+        if (pending_count > 0) {
+          pending_ambiguous = 1
+        }
+        word_start = 0
+      }
+      print cleaned
+    }
+  '
+}
+
+# Match git invocations in command text whose non-executable regions have
+# already been removed or deliberately exposed for fail-closed scanning.
+_git_command_tokens_contain_operation() {
+  local operation="$1"
+  local command="$2"
+  local normalised
+
+  normalised=$(printf '%s' "$command" | sed -E 's/(\|\||&&|;|\||&)/\n/g')
+
+  local segment
+  while IFS= read -r segment; do
+    local -a tokens
+    read -ra tokens <<<"$segment"
+    local i=0 n=${#tokens[@]}
+    while (( i < n )) && [[ "${tokens[i]}" != "git" ]]; do
+      ((i++))
+    done
+    (( i >= n )) && continue
+    ((i++))
+    while (( i < n )); do
+      case "${tokens[i]}" in
+        -c|-C|--git-dir|--work-tree|--namespace|--super-prefix)
+          i=$(( i + 2 > n ? n : i + 2 ))
+          ;;
+        --*=*|--*)
+          ((i++))
+          ;;
+        *)
+          break
+          ;;
+      esac
+    done
+    (( i >= n )) && continue
+    if [[ "${tokens[i]}" == "$operation" ]]; then
+      return 0
+    fi
+  done <<<"$normalised"
+  return 1
+}
+
+_shell_code_is_dynamic() {
+  local code="$1"
+  [[ "$code" == *'$'* || "$code" == *'`'* ||
+    "$code" == *'<('* || "$code" == *'>('* ]]
+}
+
+_shell_static_code_contains_git_operation() {
+  local operation="$1"
+  local code="$2"
+
+  _resolve_git_command_tokenize "$code"
+  _resolve_git_tokens_contain_operation "$operation"
+}
+
+# Inspect literal code passed to eval or a shell -c invocation. Dynamic code is
+# fail-closed because its operation cannot be determined without evaluation.
+_shell_code_executor_contains_git_operation() {
+  local operation="$1"
+  local command="$2"
+  local i j n executor code option saw_c skip_candidate
+  local _SHELL_DATA_BUILTINS_TRUSTED=0
+  local -a token_types token_values
+
+  _resolve_git_command_tokenize "$command"
+  token_types=("${_RGCC_TOKEN_TYPES[@]}")
+  token_values=("${_RGCC_TOKEN_VALUES[@]}")
+  n=${#token_values[@]}
+
+  for ((i = 0; i < n; i++)); do
+    [[ "${token_types[i]}" == "word" ]] || continue
+    if (( i > 0 )) && [[ "${token_types[i-1]}" != "operator" ]]; then
+      continue
+    fi
+
+    j=$i
+    while (( j < n )) && [[ "${token_types[j]}" == "word" ]] &&
+      [[ "${token_values[j]}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+      ((j++))
+    done
+
+    skip_candidate=0
+    while (( j < n )) && [[ "${token_types[j]}" == "word" ]]; do
+      case "${token_values[j]}" in
+        '!'|then|do|else|elif|'{')
+          ((j++))
+          ;;
+        exec)
+          ((j++))
+          while (( j < n )) && [[ "${token_types[j]}" == "word" ]]; do
+            option="${token_values[j]}"
+            _shell_code_is_dynamic "$option" && return 0
+            case "$option" in
+              --)
+                ((j++))
+                break
+                ;;
+              -a)
+                (( j + 1 < n )) &&
+                  [[ "${token_types[j+1]}" == "word" ]] || return 0
+                j=$((j + 2))
+                ;;
+              -c|-l)
+                ((j++))
+                ;;
+              -*)
+                return 0
+                ;;
+              *)
+                break
+                ;;
+            esac
+          done
+          ;;
+        command)
+          ((j++))
+          while (( j < n )) && [[ "${token_types[j]}" == "word" ]]; do
+            option="${token_values[j]}"
+            _shell_code_is_dynamic "$option" && return 0
+            case "$option" in
+              --)
+                ((j++))
+                break
+                ;;
+              -p)
+                ((j++))
+                ;;
+              -v|-V)
+                skip_candidate=1
+                break
+                ;;
+              -*)
+                return 0
+                ;;
+              *)
+                break
+                ;;
+            esac
+          done
+          ;;
+        builtin)
+          ((j++))
+          if (( j < n )) && [[ "${token_values[j]}" == "--" ]]; then
+            ((j++))
+          elif (( j < n )) && [[ "${token_values[j]}" == "-p" ]]; then
+            skip_candidate=1
+          fi
+          ;;
+        env)
+          ((j++))
+          while (( j < n )) && [[ "${token_types[j]}" == "word" ]]; do
+            option="${token_values[j]}"
+            _shell_code_is_dynamic "$option" && return 0
+            if [[ "$option" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+              ((j++))
+              continue
+            fi
+            case "$option" in
+              --|-)
+                ((j++))
+                break
+                ;;
+              -u|-C|-S|--unset|--chdir|--split-string)
+                (( j + 1 < n )) &&
+                  [[ "${token_types[j+1]}" == "word" ]] || return 0
+                j=$((j + 2))
+                ;;
+              --unset=*|--chdir=*|--split-string=*|-i|--ignore-environment|\
+                -0|--null|-v|--debug)
+                ((j++))
+                ;;
+              -*)
+                return 0
+                ;;
+              *)
+                break
+                ;;
+            esac
+          done
+          ;;
+        *)
+          break
+          ;;
+      esac
+    done
+    (( skip_candidate == 0 )) || continue
+
+    (( j < n )) && [[ "${token_types[j]}" == "word" ]] || continue
+    executor="${token_values[j]}"
+    if _shell_code_is_dynamic "$executor"; then
+      if _conservative_shell_text_contains_git_operation \
+        "$operation" "$command"; then
+        return 0
+      fi
+      continue
+    fi
+    executor="${executor//\\/}"
+    executor="${executor##*/}"
+
+    if [[ "$executor" == "eval" ]]; then
+      code=""
+      for ((j = j + 1; j < n; j++)); do
+        [[ "${token_types[j]}" == "word" ]] || break
+        code+="${code:+ }${token_values[j]}"
+      done
+      [[ -n "$code" ]] || continue
+      if _shell_code_contains_git_operation "$operation" "$code" ||
+        _shell_code_is_dynamic "$code"; then
+        return 0
+      fi
+      continue
+    fi
+
+    case "$executor" in
+      sh|bash|dash|ksh|zsh) ;;
+      *) continue ;;
+    esac
+
+    saw_c=0
+    for ((j = j + 1; j < n; j++)); do
+      [[ "${token_types[j]}" == "word" ]] || break
+      option="${token_values[j]}"
+      if _shell_code_is_dynamic "$option"; then
+        return 0
+      fi
+      if { [[ "$option" != -* ]] && [[ "$option" != +* ]]; } ||
+        [[ "$option" == "--" ]]; then
+        break
+      fi
+      case "$option" in
+        -O|+O|-o|+o|--rcfile|--init-file)
+          if (( j + 1 < n )) && [[ "${token_types[j+1]}" == "word" ]] &&
+            [[ "${token_values[j+1]}" != -* ]]; then
+            ((j++))
+          fi
+          continue
+          ;;
+        --rcfile=*|--init-file=*)
+          continue
+          ;;
+        --noprofile|--norc|--posix|--restricted|--verbose|--version|--help|\
+          --login|--debugger|--dump-po-strings|--dump-strings)
+          continue
+          ;;
+        --*)
+          return 0
+          ;;
+        +*)
+          return 0
+          ;;
+      esac
+      if [[ "$option" =~ ^-[^-]*c ]]; then
+        saw_c=1
+        ((j++))
+        break
+      fi
+    done
+    (( saw_c == 1 && j < n )) &&
+      [[ "${token_types[j]}" == "word" ]] || continue
+
+    code="${token_values[j]}"
+    if _shell_code_contains_git_operation "$operation" "$code" ||
+      _shell_code_is_dynamic "$code"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+_shell_code_contains_git_operation() {
+  local operation="$1"
+  local code="$2"
+
+  if _shell_static_code_contains_git_operation "$operation" "$code" ||
+    _shell_code_executor_contains_git_operation "$operation" "$code"; then
+    return 0
+  fi
+  if _conservative_shell_text_contains_git_operation "$operation" "$code"; then
+    _resolve_git_command_tokenize "$code"
+    if (( _RGCC_UNSAFE == 0 && _RGCC_MALFORMED == 0 )) &&
+      (( ${#_RGCC_TOKEN_VALUES[@]} > 0 )); then
+      local i
+      for ((i = 0; i < ${#_RGCC_TOKEN_TYPES[@]}; i++)); do
+        [[ "${_RGCC_TOKEN_TYPES[i]}" == "word" ]] || return 0
+      done
+      case "${_RGCC_TOKEN_VALUES[0]}" in
+        echo|printf)
+          if [[ "${_RGCC_TOKEN_VALUES[0]}" == "printf" ]] &&
+            (( ${#_RGCC_TOKEN_VALUES[@]} > 1 )) &&
+            [[ "${_RGCC_TOKEN_VALUES[1]}" == -v* ]]; then
+            return 0
+          fi
+          if [[ "${_SHELL_DATA_BUILTINS_TRUSTED:-0}" == "1" ]] &&
+            [[ "$(type -t "${_RGCC_TOKEN_VALUES[0]}" 2>/dev/null)" == \
+              "builtin" ]]; then
+            return 1
+          fi
+          ;;
+      esac
+    fi
+    return 0
+  fi
+  return 1
+}
+
+_conservative_shell_text_contains_git_operation() {
+  local operation="$1"
+  local command="$2"
+
+  command="${command//\"/ }"
+  command="${command//\'/ }"
+  command="${command//\(/ }"
+  command="${command//\)/ }"
+  command="${command//\{/ }"
+  command="${command//\}/ }"
+  command="${command//\[/ }"
+  command="${command//\]/ }"
+  _git_command_tokens_contain_operation "$operation" "$command"
+}
+
+_shell_substitution_data_output_is_safe() {
+  local prefix="$1"
+  local trimmed
+  # shellcheck disable=SC2016 # Literal expansion openers are parser markers.
+  local parameter_expansion='${' arithmetic_expansion='$[' arithmetic_command='$(('
+
+  [[ "$prefix" != *$'\n'* && "$prefix" != *';'* &&
+    "$prefix" != *'&'* && "$prefix" != *'|'* &&
+    "$prefix" != *'<'* && "$prefix" != *'>'* &&
+    "$prefix" != *"$parameter_expansion"* &&
+    "$prefix" != *"$arithmetic_expansion"* &&
+    "$prefix" != *"$arithmetic_command"* ]] || return 1
+  trimmed="${prefix#"${prefix%%[![:space:]]*}"}"
+  [[ "$trimmed" == "echo" || "$trimmed" == echo[[:space:]]* ]] || return 1
+  [[ "$(type -t echo 2>/dev/null)" == "builtin" ]]
+}
+
+_shell_substitution_data_suffix_is_safe() {
+  local suffix="$1"
+  [[ "$suffix" != *$'\n'* && "$suffix" != *';'* &&
+    "$suffix" != *'&'* && "$suffix" != *'|'* &&
+    "$suffix" != *'<'* && "$suffix" != *'>'* ]]
+}
+
+# Inspect only executable substitution bodies. A context stack keeps ordinary
+# parentheses inside commands and quoted strings from truncating the body.
+_unsafe_shell_text_contains_git_operation() {
+  local operation="$1"
+  local command="$2"
+  local length=${#command}
+  local level=0 i character following previous state body
+  local comment_copy_start=0 top_level_comment=0
+  local prefix data_builtins_trusted
+  local backslash=$'\\'
+  local _SHELL_DATA_BUILTINS_TRUSTED=0
+  local -a context_type context_state context_start context_group_depth
+  local -a context_data_builtins_trusted
+
+  context_type[0]="root"
+  context_state[0]="unquoted"
+  context_start[0]=0
+  context_group_depth[0]=0
+  _UNSAFE_SHELL_REMAINDER=""
+  _UNSAFE_SHELL_COMMENT_STRIPPED=""
+
+  for ((i = 0; i < length; i++)); do
+    character="${command:i:1}"
+    following=""
+    if (( i + 1 < length )); then
+      following="${command:i+1:1}"
+    fi
+    previous=""
+    if (( i > 0 )); then
+      previous="${command:i-1:1}"
+    fi
+
+    if [[ "${context_type[level]}" == "backtick" ]]; then
+      if [[ "$character" == "$backslash" ]]; then
+        ((i++))
+      elif [[ "$character" == '`' ]]; then
+        body="${command:${context_start[level]}:i-${context_start[level]}}"
+        _SHELL_DATA_BUILTINS_TRUSTED=\
+"${context_data_builtins_trusted[level]:-0}"
+        if [[ "$_SHELL_DATA_BUILTINS_TRUSTED" == "1" ]] &&
+          ! _shell_substitution_data_suffix_is_safe "${command:i+1}"; then
+          _SHELL_DATA_BUILTINS_TRUSTED=0
+        fi
+        if _shell_code_contains_git_operation "$operation" "$body"; then
+          return 0
+        fi
+        ((level--))
+      fi
+      continue
+    fi
+
+    state="${context_state[level]}"
+    case "$state" in
+      comment)
+        if [[ "$character" == $'\n' ]]; then
+          if (( level == 0 )); then
+            _UNSAFE_SHELL_COMMENT_STRIPPED+="$character"
+            _UNSAFE_SHELL_REMAINDER+="$character"
+            comment_copy_start=$((i + 1))
+            top_level_comment=0
+          fi
+          context_state[level]="unquoted"
+        fi
+        ;;
+      single)
+        if (( level == 0 )); then
+          _UNSAFE_SHELL_REMAINDER+="$character"
+        fi
+        if [[ "$character" == "'" ]]; then
+          context_state[level]="unquoted"
+        fi
+        ;;
+      double)
+        if [[ "$character" == "$backslash" ]]; then
+          if (( level == 0 )); then
+            _UNSAFE_SHELL_REMAINDER+="$character$following"
+          fi
+          ((i++))
+        elif [[ "$character" == '"' ]]; then
+          if (( level == 0 )); then
+            _UNSAFE_SHELL_REMAINDER+="$character"
+          fi
+          context_state[level]="unquoted"
+        elif [[ "$character" == '$' && "$following" == '(' ]]; then
+          data_builtins_trusted=0
+          if (( level == 0 )); then
+            prefix="${command:0:i}"
+            if _shell_substitution_data_output_is_safe "$prefix"; then
+              data_builtins_trusted=1
+            fi
+          fi
+          if (( level == 0 )); then
+            _UNSAFE_SHELL_REMAINDER+=" "
+          fi
+          ((level++))
+          context_type[level]="paren"
+          context_state[level]="unquoted"
+          context_start[level]=$((i + 2))
+          context_group_depth[level]=0
+          context_data_builtins_trusted[level]="$data_builtins_trusted"
+          ((i++))
+        elif [[ "$character" == '`' ]]; then
+          data_builtins_trusted=0
+          if (( level == 0 )); then
+            prefix="${command:0:i}"
+            if _shell_substitution_data_output_is_safe "$prefix"; then
+              data_builtins_trusted=1
+            fi
+          fi
+          if (( level == 0 )); then
+            _UNSAFE_SHELL_REMAINDER+=" "
+          fi
+          ((level++))
+          context_type[level]="backtick"
+          context_start[level]=$((i + 1))
+          context_data_builtins_trusted[level]="$data_builtins_trusted"
+        elif (( level == 0 )); then
+          _UNSAFE_SHELL_REMAINDER+="$character"
+        fi
+        ;;
+      unquoted)
+        if [[ "$character" == "$backslash" ]]; then
+          if (( level == 0 )); then
+            _UNSAFE_SHELL_REMAINDER+="$character$following"
+          fi
+          ((i++))
+        elif [[ "$character" == "'" ]]; then
+          if (( level == 0 )); then
+            _UNSAFE_SHELL_REMAINDER+="$character"
+          fi
+          context_state[level]="single"
+        elif [[ "$character" == '"' ]]; then
+          if (( level == 0 )); then
+            _UNSAFE_SHELL_REMAINDER+="$character"
+          fi
+          context_state[level]="double"
+        elif [[ "$character" == "#" ]] &&
+          { (( i == context_start[level] )) ||
+            [[ "$previous" == " " || "$previous" == $'\t' ||
+              "$previous" == $'\n' || "$previous" == ";" ||
+              "$previous" == "|" || "$previous" == "&" ||
+              "$previous" == "(" ]]; }; then
+          if (( level == 0 )); then
+            _UNSAFE_SHELL_COMMENT_STRIPPED+=\
+"${command:comment_copy_start:i-comment_copy_start}"
+            top_level_comment=1
+          fi
+          context_state[level]="comment"
+        elif [[ "$character" == '`' ]]; then
+          data_builtins_trusted=0
+          if (( level == 0 )); then
+            prefix="${command:0:i}"
+            if _shell_substitution_data_output_is_safe "$prefix"; then
+              data_builtins_trusted=1
+            fi
+          fi
+          if (( level == 0 )); then
+            _UNSAFE_SHELL_REMAINDER+=" "
+          fi
+          ((level++))
+          context_type[level]="backtick"
+          context_start[level]=$((i + 1))
+          context_data_builtins_trusted[level]="$data_builtins_trusted"
+        elif [[ "$following" == '(' &&
+          ( "$character" == '$' || "$character" == '<' ||
+            "$character" == '>' ) ]]; then
+          data_builtins_trusted=0
+          if (( level == 0 )); then
+            prefix="${command:0:i}"
+            if _shell_substitution_data_output_is_safe "$prefix"; then
+              data_builtins_trusted=1
+            fi
+          fi
+          if (( level == 0 )); then
+            _UNSAFE_SHELL_REMAINDER+=" "
+          fi
+          ((level++))
+          context_type[level]="paren"
+          context_state[level]="unquoted"
+          context_start[level]=$((i + 2))
+          context_group_depth[level]=0
+          context_data_builtins_trusted[level]="$data_builtins_trusted"
+          ((i++))
+        elif (( level > 0 )) && [[ "$character" == '(' ]]; then
+          context_group_depth[level]=$((context_group_depth[level] + 1))
+        elif (( level > 0 )) && [[ "$character" == ')' ]]; then
+          if (( context_group_depth[level] > 0 )); then
+            context_group_depth[level]=$((context_group_depth[level] - 1))
+          else
+            body="${command:${context_start[level]}:i-${context_start[level]}}"
+            _SHELL_DATA_BUILTINS_TRUSTED=\
+"${context_data_builtins_trusted[level]:-0}"
+            if [[ "$_SHELL_DATA_BUILTINS_TRUSTED" == "1" ]] &&
+              ! _shell_substitution_data_suffix_is_safe "${command:i+1}"; then
+              _SHELL_DATA_BUILTINS_TRUSTED=0
+            fi
+            if _shell_code_contains_git_operation "$operation" "$body"; then
+              return 0
+            fi
+            ((level--))
+          fi
+        elif (( level == 0 )); then
+          _UNSAFE_SHELL_REMAINDER+="$character"
+        fi
+        ;;
+    esac
+  done
+
+  if (( top_level_comment == 0 )); then
+    _UNSAFE_SHELL_COMMENT_STRIPPED+=\
+"${command:comment_copy_start:length-comment_copy_start}"
+  fi
+  if (( level != 0 )) ||
+    [[ "${context_state[0]}" == "single" ||
+      "${context_state[0]}" == "double" ]]; then
+    _UNSAFE_SHELL_REMAINDER="$command"
+    _UNSAFE_SHELL_COMMENT_STRIPPED="$command"
+    _conservative_shell_text_contains_git_operation "$operation" "$command"
+    return
+  fi
+  return 1
+}
+
 # Check if command invokes a given git subcommand.
 # Usage: is_git_command "commit" "$command"
 #
@@ -311,6 +1140,28 @@ parse_edit_file_paths() {
 is_git_command() {
   local operation="$1"
   local command="$2"
+  local stripped_command
+  local strip_rc=0
+  local _UNSAFE_SHELL_REMAINDER="$command"
+  local _UNSAFE_SHELL_COMMENT_STRIPPED="$command"
+
+  if stripped_command=$(_strip_shell_non_executable_regions "$command"); then
+    command="$stripped_command"
+  else
+    strip_rc=$?
+  fi
+
+  if [[ "$strip_rc" -eq 2 ]]; then
+    if _unsafe_shell_text_contains_git_operation "$operation" "$command"; then
+      return 0
+    fi
+    _resolve_git_command_tokenize "$_UNSAFE_SHELL_COMMENT_STRIPPED"
+    if (( _RGCC_UNSAFE == 1 )) &&
+      _resolve_git_unsafe_tokens_contain_operation "$operation"; then
+      return 0
+    fi
+    command="$_UNSAFE_SHELL_REMAINDER"
+  fi
 
   # Strip single- and double-quoted regions so mentions inside quoted
   # strings (e.g. `--body "see git push docs"`) cannot match.
@@ -330,44 +1181,7 @@ is_git_command() {
     stripped="${stripped/"${BASH_REMATCH[0]}"/ }"
   done
 
-  # Split on shell separators so each segment can be scanned independently.
-  local normalised
-  normalised=$(printf '%s' "$stripped" | sed -E 's/(\|\||&&|;|\||&)/\n/g')
-
-  local segment
-  while IFS= read -r segment; do
-    local -a tokens
-    read -ra tokens <<<"$segment"
-    local i=0 n=${#tokens[@]}
-    # Find the `git` token (as a whole token — not a substring).
-    while (( i < n )) && [[ "${tokens[i]}" != "git" ]]; do
-      ((i++))
-    done
-    (( i >= n )) && continue
-    ((i++))
-    # Skip git global flags before the subcommand. Two-token forms
-    # (-c key=val, -C path, --git-dir path) consume two slots;
-    # attached forms (--git-dir=path) consume one. Bounds are clamped
-    # to n so a stray trailing flag cannot skip past the end.
-    while (( i < n )); do
-      case "${tokens[i]}" in
-        -c|-C|--git-dir|--work-tree|--namespace|--super-prefix)
-          i=$(( i + 2 > n ? n : i + 2 ))
-          ;;
-        --*=*|--*)
-          ((i++))
-          ;;
-        *)
-          break
-          ;;
-      esac
-    done
-    (( i >= n )) && continue
-    if [[ "${tokens[i]}" == "$operation" ]]; then
-      return 0
-    fi
-  done <<<"$normalised"
-  return 1
+  _git_command_tokens_contain_operation "$operation" "$stripped"
 }
 
 # Canonicalize an existing directory without changing the caller's cwd.
@@ -398,6 +1212,7 @@ _resolve_git_append_operator() {
 # resolve_git_command_cwd. Unsafe expansion syntax is recorded, never expanded.
 _resolve_git_command_tokenize() {
   local command="$1"
+  local stripped_command
   local state="unquoted"
   local value=""
   local quote_kind=""
@@ -408,7 +1223,12 @@ _resolve_git_command_tokenize() {
   local character next operator decoded digits digit
   local codepoint max_digits offset
   local backslash=$'\\'
-  local i length=${#command}
+  local i length
+
+  if stripped_command=$(_strip_shell_non_executable_regions "$command"); then
+    command="$stripped_command"
+  fi
+  length=${#command}
 
   _RGCC_TOKEN_TYPES=()
   _RGCC_TOKEN_VALUES=()
@@ -941,11 +1761,30 @@ resolve_git_command_cwd() {
   local operation="$1"
   local command="$2"
   local base_dir="$3"
-  local canonical_base resolved
+  local canonical_base resolved stripped_command
+  local strip_rc=0
+  local _UNSAFE_SHELL_REMAINDER="$command"
+  local _UNSAFE_SHELL_COMMENT_STRIPPED="$command"
   local separator=-1
   local i n
 
   [[ "$operation" =~ ^[a-zA-Z0-9_-]+$ ]] || return 2
+  if stripped_command=$(_strip_shell_non_executable_regions "$command"); then
+    command="$stripped_command"
+  else
+    strip_rc=$?
+  fi
+  if [[ "$strip_rc" -eq 2 ]]; then
+    if _unsafe_shell_text_contains_git_operation "$operation" "$command"; then
+      return 2
+    fi
+    _resolve_git_command_tokenize "$_UNSAFE_SHELL_COMMENT_STRIPPED"
+    if (( _RGCC_UNSAFE == 1 )) &&
+      _resolve_git_unsafe_tokens_contain_operation "$operation"; then
+      return 2
+    fi
+    command="$_UNSAFE_SHELL_REMAINDER"
+  fi
   _resolve_git_command_tokenize "$command"
 
   if ! _resolve_git_tokens_contain_operation "$operation"; then

--- a/skills/autonomous-common/hooks/lib.sh
+++ b/skills/autonomous-common/hooks/lib.sh
@@ -1525,6 +1525,30 @@ _resolve_git_command_tokenize() {
             started=1
             state="double"
             ;;
+          \\)
+            next=""
+            if (( i + 1 < length )); then
+              next="${command:i+1:1}"
+            fi
+            if [[ "$next" == $'\n' ]]; then
+              i=$((i + 1))
+            elif [[ "$next" == $'\r' ]] &&
+              (( i + 2 < length )) &&
+              [[ "${command:i+2:1}" == $'\n' ]]; then
+              i=$((i + 2))
+            else
+              if (( started == 1 )) &&
+                [[ "$quote_kind" != "unquoted" && "$quote_kind" != "" ]]; then
+                quote_kind="mixed"
+              elif (( started == 0 )); then
+                quote_kind="unquoted"
+              fi
+              _RGCC_UNSAFE=1
+              unquoted_unsafe=1
+              started=1
+              value+="$character"
+            fi
+            ;;
           '$')
             next=""
             if (( i + 1 < length )); then
@@ -1555,6 +1579,25 @@ _resolve_git_command_tokenize() {
             fi
             ;;
           '&'|'|'|';'|'('|')')
+            next=""
+            if (( i + 1 < length )); then
+              next="${command:i+1:1}"
+            fi
+            if [[ "$character" == '&' && "$started" == "1" &&
+              ( "$value" == *'>' || "$value" == *'<' ) ]]; then
+              value+="$character"
+              continue
+            fi
+            if [[ "$character" == '&' && "$started" == "0" &&
+              "$next" == '>' ]]; then
+              quote_kind="unquoted"
+              _RGCC_UNSAFE=1
+              unquoted_unsafe=1
+              started=1
+              value="&>"
+              i=$((i + 1))
+              continue
+            fi
             if (( started == 1 )); then
               _resolve_git_append_word "$value" "${quote_kind:-unquoted}" \
                 "$ansi_syntax" "$unquoted_unsafe"
@@ -1567,11 +1610,8 @@ _resolve_git_command_tokenize() {
 
             operator="$character"
             if [[ "$character" == '&' || "$character" == '|' ]]; then
-              next=""
-              if (( i + 1 < length )); then
-                next="${command:i+1:1}"
-              fi
-              if [[ "$next" == "$character" ]]; then
+              if [[ "$next" == "$character" ||
+                ( "$character" == '|' && "$next" == '&' ) ]]; then
                 operator+="$next"
                 i=$((i + 1))
               fi
@@ -1587,10 +1627,6 @@ _resolve_git_command_tokenize() {
             fi
             case "$character" in
               '`'|'<'|'>'|'{'|'}')
-                _RGCC_UNSAFE=1
-                unquoted_unsafe=1
-                ;;
-              \\)
                 _RGCC_UNSAFE=1
                 unquoted_unsafe=1
                 ;;

--- a/skills/autonomous-common/hooks/lib.sh
+++ b/skills/autonomous-common/hooks/lib.sh
@@ -960,12 +960,211 @@ _conservative_shell_text_contains_git_operation() {
   _git_command_tokens_contain_operation "$operation" "$command"
 }
 
+_large_static_shell_text_contains_git_operation() {
+  local operation="$1"
+  local command="$2"
+  local target_ref="${3:-}"
+
+  printf '%s' "$command" | awk \
+    -v operation="$operation" -v target_ref="$target_ref" '
+    BEGIN {
+      state = "unquoted"
+      value = ""
+      started = 0
+      count = 0
+      single_quote = sprintf("%c", 39)
+    }
+
+    function emit_word() {
+      if (started) {
+        count++
+        types[count] = "word"
+        values[count] = value
+      }
+      value = ""
+      started = 0
+    }
+
+    function emit_operator() {
+      emit_word()
+      count++
+      types[count] = "operator"
+      values[count] = ";"
+    }
+
+    function targets_ref(ref, separator, destination) {
+      destination = ref
+      separator = index(ref, ":")
+      if (separator > 0) {
+        destination = substr(ref, separator + 1)
+      }
+      return destination == target_ref ||
+             destination == "refs/heads/" target_ref
+    }
+
+    {
+      line = $0
+      for (i = 1; i <= length(line); i++) {
+        character = substr(line, i, 1)
+        following = substr(line, i + 1, 1)
+        if (state == "single") {
+          if (character == single_quote) {
+            state = "unquoted"
+          } else {
+            value = value character
+          }
+          continue
+        }
+        if (state == "double") {
+          if (character == "\"") {
+            state = "unquoted"
+          } else if (character == "\\") {
+            if (following != "") {
+              value = value following
+              i++
+            } else {
+              value = value character
+            }
+          } else {
+            value = value character
+          }
+          continue
+        }
+
+        if (character == single_quote) {
+          state = "single"
+          started = 1
+        } else if (character == "\"") {
+          state = "double"
+          started = 1
+        } else if (character == "\\") {
+          started = 1
+          if (following != "") {
+            value = value following
+            i++
+          } else {
+            value = value character
+          }
+        } else if (character == " " || character == "\t") {
+          emit_word()
+        } else if (character == "&" || character == "|" ||
+                   character == ";" || character == "(" ||
+                   character == ")") {
+          emit_operator()
+        } else {
+          started = 1
+          value = value character
+        }
+      }
+      if (state == "unquoted") {
+        emit_operator()
+      } else {
+        value = value "\n"
+      }
+    }
+
+    END {
+      emit_word()
+      command_position = 1
+      for (i = 1; i <= count; i++) {
+        if (types[i] == "operator") {
+          command_position = 1
+          continue
+        }
+        if (!command_position) {
+          continue
+        }
+        if (values[i] == "!" || values[i] == "if" ||
+            values[i] == "then" || values[i] == "elif" ||
+            values[i] == "else" || values[i] == "do" ||
+            values[i] == "while" || values[i] == "until" ||
+            values[i] == "{" || values[i] == "}") {
+          continue
+        }
+        if (values[i] ~ /^[A-Za-z_][A-Za-z0-9_]*=/) {
+          continue
+        }
+        if (values[i] != "git") {
+          command_position = 0
+          continue
+        }
+        j = i + 1
+        while (j <= count && types[j] == "word") {
+          if (values[j] == "-c" || values[j] == "-C" ||
+              values[j] == "--git-dir" || values[j] == "--work-tree" ||
+              values[j] == "--namespace" ||
+              values[j] == "--super-prefix") {
+            j += 2
+          } else if (values[j] ~ /^-/) {
+            j++
+          } else {
+            break
+          }
+        }
+        if (j <= count && types[j] == "word" &&
+            values[j] == operation) {
+          if (target_ref == "") {
+            exit 0
+          }
+          found_remote = 0
+          for (j = j + 1; j <= count && types[j] == "word"; j++) {
+            option = values[j]
+            if (option == "--all" || option == "--mirror") {
+              exit 0
+            }
+            if (option == "--repo") {
+              j++
+              found_remote = 1
+              continue
+            }
+            if (option ~ /^--repo=/) {
+              found_remote = 1
+              continue
+            }
+            if (option == "-o" || option == "--push-option" ||
+                option == "--receive-pack" || option == "--exec") {
+              j++
+              continue
+            }
+            if (option ~ /^-/) {
+              continue
+            }
+            if (!found_remote) {
+              found_remote = 1
+              continue
+            }
+            if (targets_ref(option)) {
+              exit 0
+            }
+          }
+        }
+        command_position = 0
+      }
+      exit 1
+    }
+  '
+}
+
 # Large ambiguous command strings must not enter the quadratic character and
-# token fallback paths. Tokenize once, then use the bounded structured and
-# conservative scanners. A positive result is intentionally fail-closed.
+# token fallback paths unless a static or dynamic git-operation candidate
+# remains. The external pre-scan is linear and understands shell quote
+# concatenation; a positive result is intentionally fail-closed.
 _large_ambiguous_shell_text_contains_git_operation() {
   local operation="$1"
   local command="$2"
+
+  if _large_static_shell_text_contains_git_operation \
+    "$operation" "$command"; then
+    return 0
+  fi
+
+  # ANSI shell strings can encode either candidate word, so retain the full
+  # tokenizer for them. Other dynamic-git forms retain the operation word, and
+  # dynamic-operation forms retain the git word.
+  case "$command" in
+    *"\$'"*|*git*|*"$operation"*) ;;
+    *) return 1 ;;
+  esac
 
   _resolve_git_command_tokenize "$command" 1
   if _resolve_git_tokens_contain_operation "$operation"; then

--- a/skills/autonomous-common/hooks/lib.sh
+++ b/skills/autonomous-common/hooks/lib.sh
@@ -313,6 +313,7 @@ _strip_shell_non_executable_regions() {
       active_index = 1
       logical_control_seen = 0
       command_seen = 0
+      ambiguous = 0
       single_quote = sprintf("%c", 39)
     }
 
@@ -399,10 +400,17 @@ _strip_shell_non_executable_regions() {
       return 0
     }
 
+    ambiguous {
+      print
+      next
+    }
+
     active_count > 0 {
       if (pending_expands[active_index] &&
           has_executable_heredoc_expansion($0)) {
-        exit 2
+        ambiguous = 1
+        print
+        next
       }
       candidate = $0
       if (pending_strip_tabs[active_index]) {
@@ -453,7 +461,10 @@ _strip_shell_non_executable_regions() {
             }
           } else if (character == "`" ||
                      (character == "$" && following == "(")) {
-            exit 2
+            ambiguous = 1
+            cleaned = cleaned substr(line, i + 1)
+            state = "unquoted"
+            break
           } else if (character == "\"") {
             state = "unquoted"
           }
@@ -488,7 +499,9 @@ _strip_shell_non_executable_regions() {
                    (character == "[" && following == "[") ||
                    (character == "(" &&
                     (following == "(" || !word_start))) {
-          exit 2
+          ambiguous = 1
+          cleaned = cleaned substr(line, i)
+          break
         } else {
           cleaned = cleaned character
           if (character == "<" && following == "<" &&
@@ -531,6 +544,11 @@ _strip_shell_non_executable_regions() {
         }
       }
 
+      if (ambiguous) {
+        print cleaned
+        next
+      }
+
       if (cleaned !~ /^[ \t]*$/) {
         command_seen = 1
       }
@@ -550,6 +568,12 @@ _strip_shell_non_executable_regions() {
         word_start = 0
       }
       print cleaned
+    }
+
+    END {
+      if (ambiguous) {
+        exit 2
+      }
     }
   '
 }
@@ -594,6 +618,26 @@ _git_command_tokens_contain_operation() {
   return 1
 }
 
+_shell_text_outside_simple_quotes_contains_git_operation() {
+  local operation="$1"
+  local stripped="$2"
+
+  # Quote BASH_REMATCH[0] in the substitution. It is literal matched text, but
+  # an unquoted replacement pattern containing `\`, `[`, `?`, or `*` could
+  # leave the string unchanged and make these loops spin forever. See #266.
+  while [[ "$stripped" =~ \"[^\"]*\" ]]; do
+    stripped="${stripped/"${BASH_REMATCH[0]}"/ }"
+  done
+  while [[ "$stripped" =~ \'[^\']*\' ]]; do
+    stripped="${stripped/"${BASH_REMATCH[0]}"/ }"
+  done
+  stripped=$(
+    printf '%s' "$stripped" |
+      sed -E 's/(^|[[:space:];|&(])#.*/\1/'
+  )
+  _git_command_tokens_contain_operation "$operation" "$stripped"
+}
+
 _shell_code_is_dynamic() {
   local code="$1"
   [[ "$code" == *'$'* || "$code" == *'`'* ||
@@ -608,8 +652,9 @@ _shell_static_code_contains_git_operation() {
   _resolve_git_tokens_contain_operation "$operation"
 }
 
-# Inspect literal code passed to eval or a shell -c invocation. Dynamic code is
-# fail-closed because its operation cannot be determined without evaluation.
+# Inspect literal code passed to eval or a shell -c invocation. Dynamic text is
+# never evaluated; retain it for a conservative literal operation scan instead
+# of treating every expansion as a git operation.
 _shell_code_executor_contains_git_operation() {
   local operation="$1"
   local command="$2"
@@ -644,7 +689,14 @@ _shell_code_executor_contains_git_operation() {
           ((j++))
           while (( j < n )) && [[ "${token_types[j]}" == "word" ]]; do
             option="${token_values[j]}"
-            _shell_code_is_dynamic "$option" && return 0
+            if _shell_code_is_dynamic "$option"; then
+              if _conservative_shell_text_contains_git_operation \
+                "$operation" "$command"; then
+                return 0
+              fi
+              skip_candidate=1
+              break
+            fi
             case "$option" in
               --)
                 ((j++))
@@ -671,7 +723,14 @@ _shell_code_executor_contains_git_operation() {
           ((j++))
           while (( j < n )) && [[ "${token_types[j]}" == "word" ]]; do
             option="${token_values[j]}"
-            _shell_code_is_dynamic "$option" && return 0
+            if _shell_code_is_dynamic "$option"; then
+              if _conservative_shell_text_contains_git_operation \
+                "$operation" "$command"; then
+                return 0
+              fi
+              skip_candidate=1
+              break
+            fi
             case "$option" in
               --)
                 ((j++))
@@ -705,7 +764,14 @@ _shell_code_executor_contains_git_operation() {
           ((j++))
           while (( j < n )) && [[ "${token_types[j]}" == "word" ]]; do
             option="${token_values[j]}"
-            _shell_code_is_dynamic "$option" && return 0
+            if _shell_code_is_dynamic "$option"; then
+              if _conservative_shell_text_contains_git_operation \
+                "$operation" "$command"; then
+                return 0
+              fi
+              skip_candidate=1
+              break
+            fi
             if [[ "$option" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
               ((j++))
               continue
@@ -759,8 +825,12 @@ _shell_code_executor_contains_git_operation() {
         code+="${code:+ }${token_values[j]}"
       done
       [[ -n "$code" ]] || continue
-      if _shell_code_contains_git_operation "$operation" "$code" ||
-        _shell_code_is_dynamic "$code"; then
+      if _shell_code_contains_git_operation "$operation" "$code"; then
+        return 0
+      fi
+      if _shell_code_is_dynamic "$code" &&
+        _conservative_shell_text_contains_git_operation \
+          "$operation" "$command"; then
         return 0
       fi
       continue
@@ -776,7 +846,12 @@ _shell_code_executor_contains_git_operation() {
       [[ "${token_types[j]}" == "word" ]] || break
       option="${token_values[j]}"
       if _shell_code_is_dynamic "$option"; then
-        return 0
+        if _conservative_shell_text_contains_git_operation \
+          "$operation" "$command"; then
+          return 0
+        fi
+        skip_candidate=1
+        break
       fi
       if { [[ "$option" != -* ]] && [[ "$option" != +* ]]; } ||
         [[ "$option" == "--" ]]; then
@@ -810,12 +885,17 @@ _shell_code_executor_contains_git_operation() {
         break
       fi
     done
+    (( skip_candidate == 0 )) || continue
     (( saw_c == 1 && j < n )) &&
       [[ "${token_types[j]}" == "word" ]] || continue
 
     code="${token_values[j]}"
-    if _shell_code_contains_git_operation "$operation" "$code" ||
-      _shell_code_is_dynamic "$code"; then
+    if _shell_code_contains_git_operation "$operation" "$code"; then
+      return 0
+    fi
+    if _shell_code_is_dynamic "$code" &&
+      _conservative_shell_text_contains_git_operation \
+        "$operation" "$command"; then
       return 0
     fi
   done
@@ -902,6 +982,7 @@ _shell_substitution_data_suffix_is_safe() {
 _unsafe_shell_text_contains_git_operation() {
   local operation="$1"
   local command="$2"
+  local LC_ALL=C
   local length=${#command}
   local level=0 i character following previous state body
   local comment_copy_start=0 top_level_comment=0
@@ -1152,6 +1233,10 @@ is_git_command() {
   fi
 
   if [[ "$strip_rc" -eq 2 ]]; then
+    if _shell_text_outside_simple_quotes_contains_git_operation \
+      "$operation" "$stripped_command"; then
+      return 0
+    fi
     if _unsafe_shell_text_contains_git_operation "$operation" "$command"; then
       return 0
     fi
@@ -1163,25 +1248,10 @@ is_git_command() {
     command="$_UNSAFE_SHELL_REMAINDER"
   fi
 
-  # Strip single- and double-quoted regions so mentions inside quoted
-  # strings (e.g. `--body "see git push docs"`) cannot match.
-  #
-  # The match MUST be quoted inside the substitution — `${var/"$x"/ }`, not
-  # `${var/$x/ }`. The first operand of `${var/pattern/repl}` is interpreted as
-  # a glob pattern, but BASH_REMATCH[0] is literal matched text. An unquoted
-  # match containing a glob-significant char (a backslash from an escaped quote
-  # `\"`, or `[`, `?`, `*`) would match nothing, leave `stripped` unchanged, and
-  # the `while [[ … =~ … ]]` test would re-match the same region forever — a
-  # 100%-CPU infinite loop. Quoting forces a literal substitution. See #266.
-  local stripped="$command"
-  while [[ "$stripped" =~ \"[^\"]*\" ]]; do
-    stripped="${stripped/"${BASH_REMATCH[0]}"/ }"
-  done
-  while [[ "$stripped" =~ \'[^\']*\' ]]; do
-    stripped="${stripped/"${BASH_REMATCH[0]}"/ }"
-  done
-
-  _git_command_tokens_contain_operation "$operation" "$stripped"
+  # Strip simple quoted regions so prose such as "see git push docs" cannot
+  # match an executable operation.
+  _shell_text_outside_simple_quotes_contains_git_operation \
+    "$operation" "$command"
 }
 
 # Canonicalize an existing directory without changing the caller's cwd.
@@ -1212,6 +1282,8 @@ _resolve_git_append_operator() {
 # resolve_git_command_cwd. Unsafe expansion syntax is recorded, never expanded.
 _resolve_git_command_tokenize() {
   local command="$1"
+  local already_preprocessed="${2:-0}"
+  local LC_ALL=C
   local stripped_command
   local state="unquoted"
   local value=""
@@ -1225,8 +1297,10 @@ _resolve_git_command_tokenize() {
   local backslash=$'\\'
   local i length
 
-  if stripped_command=$(_strip_shell_non_executable_regions "$command"); then
-    command="$stripped_command"
+  if [[ "$already_preprocessed" != "1" ]]; then
+    if stripped_command=$(_strip_shell_non_executable_regions "$command"); then
+      command="$stripped_command"
+    fi
   fi
   length=${#command}
 
@@ -1763,6 +1837,7 @@ resolve_git_command_cwd() {
   local base_dir="$3"
   local canonical_base resolved stripped_command
   local strip_rc=0
+  local command_preprocessed=0
   local _UNSAFE_SHELL_REMAINDER="$command"
   local _UNSAFE_SHELL_COMMENT_STRIPPED="$command"
   local separator=-1
@@ -1771,10 +1846,15 @@ resolve_git_command_cwd() {
   [[ "$operation" =~ ^[a-zA-Z0-9_-]+$ ]] || return 2
   if stripped_command=$(_strip_shell_non_executable_regions "$command"); then
     command="$stripped_command"
+    command_preprocessed=1
   else
     strip_rc=$?
   fi
   if [[ "$strip_rc" -eq 2 ]]; then
+    if _shell_text_outside_simple_quotes_contains_git_operation \
+      "$operation" "$stripped_command"; then
+      return 2
+    fi
     if _unsafe_shell_text_contains_git_operation "$operation" "$command"; then
       return 2
     fi
@@ -1785,7 +1865,7 @@ resolve_git_command_cwd() {
     fi
     command="$_UNSAFE_SHELL_REMAINDER"
   fi
-  _resolve_git_command_tokenize "$command"
+  _resolve_git_command_tokenize "$command" "$command_preprocessed"
 
   if ! _resolve_git_tokens_contain_operation "$operation"; then
     if (( _RGCC_UNSAFE == 1 )) &&

--- a/skills/autonomous-common/hooks/lib.sh
+++ b/skills/autonomous-common/hooks/lib.sh
@@ -902,37 +902,44 @@ _shell_code_executor_contains_git_operation() {
   return 1
 }
 
+_shell_code_is_trusted_data_builtin() {
+  local code="$1"
+  local i
+
+  [[ "${_SHELL_DATA_BUILTINS_TRUSTED:-0}" == "1" ]] || return 1
+  _resolve_git_command_tokenize "$code"
+  (( _RGCC_UNSAFE == 0 && _RGCC_MALFORMED == 0 )) ||
+    return 1
+  (( ${#_RGCC_TOKEN_VALUES[@]} > 0 )) || return 1
+  for ((i = 0; i < ${#_RGCC_TOKEN_TYPES[@]}; i++)); do
+    [[ "${_RGCC_TOKEN_TYPES[i]}" == "word" ]] || return 1
+  done
+  case "${_RGCC_TOKEN_VALUES[0]}" in
+    echo)
+      [[ "$(type -t echo 2>/dev/null)" == "builtin" ]]
+      ;;
+    printf)
+      if (( ${#_RGCC_TOKEN_VALUES[@]} > 1 )) &&
+        [[ "${_RGCC_TOKEN_VALUES[1]}" == -v* ]]; then
+        return 1
+      fi
+      [[ "$(type -t printf 2>/dev/null)" == "builtin" ]]
+      ;;
+    *) return 1 ;;
+  esac
+}
+
 _shell_code_contains_git_operation() {
   local operation="$1"
   local code="$2"
 
+  _shell_code_is_trusted_data_builtin "$code" && return 1
   if _shell_static_code_contains_git_operation "$operation" "$code" ||
     _shell_code_executor_contains_git_operation "$operation" "$code"; then
     return 0
   fi
   if _conservative_shell_text_contains_git_operation "$operation" "$code"; then
-    _resolve_git_command_tokenize "$code"
-    if (( _RGCC_UNSAFE == 0 && _RGCC_MALFORMED == 0 )) &&
-      (( ${#_RGCC_TOKEN_VALUES[@]} > 0 )); then
-      local i
-      for ((i = 0; i < ${#_RGCC_TOKEN_TYPES[@]}; i++)); do
-        [[ "${_RGCC_TOKEN_TYPES[i]}" == "word" ]] || return 0
-      done
-      case "${_RGCC_TOKEN_VALUES[0]}" in
-        echo|printf)
-          if [[ "${_RGCC_TOKEN_VALUES[0]}" == "printf" ]] &&
-            (( ${#_RGCC_TOKEN_VALUES[@]} > 1 )) &&
-            [[ "${_RGCC_TOKEN_VALUES[1]}" == -v* ]]; then
-            return 0
-          fi
-          if [[ "${_SHELL_DATA_BUILTINS_TRUSTED:-0}" == "1" ]] &&
-            [[ "$(type -t "${_RGCC_TOKEN_VALUES[0]}" 2>/dev/null)" == \
-              "builtin" ]]; then
-            return 1
-          fi
-          ;;
-      esac
-    fi
+    _shell_code_is_trusted_data_builtin "$code" && return 1
     return 0
   fi
   return 1

--- a/tests/unit/test-block-commit-outside-worktree.sh
+++ b/tests/unit/test-block-commit-outside-worktree.sh
@@ -307,6 +307,9 @@ assert_unsupported "z12" "ANSI-C control NUL inside git word" \
   "$'git\\c@ignored' commit --dry-run"
 assert_unsupported "z13" "ANSI-C invalid Unicode escape inside git word" \
   "$'g\\U80000067it' commit --dry-run"
+# shellcheck disable=SC2016
+assert_unsupported "z17" "dynamic git command word with literal operation" \
+  '$GIT commit --dry-run'
 
 for sentinel_case in \
   "TC-BCOW-010z14 command substitution:$COMMAND_SENTINEL" \

--- a/tests/unit/test-block-push-regex.sh
+++ b/tests/unit/test-block-push-regex.sh
@@ -72,6 +72,16 @@ run_hook() {
   echo $?
 }
 
+run_hook_bounded() {
+  local cmd="$1"
+  (
+    cd "$TMPDIR/repo" &&
+      CLAUDE_PROJECT_DIR="$TMPDIR/repo" timeout 5 bash "$HOOK" \
+        <<<"$(hook_input "$cmd")"
+  )
+  echo $?
+}
+
 run_remote_parser() {
   local cmd="$1"
   (
@@ -661,6 +671,21 @@ echo "=== TC-BP-34: --recurse-submodules no with no 'no' remote -> block ==="
 setup_repo feat/x
 out=$(run_hook "git push --recurse-submodules no origin main")
 assert_exit "unresolved mode-named destination leaves the trunk check armed" "2" "$out"
+
+# ===========================================================================
+# TC-BP-35: large ambiguous push stays fail-closed within the hook budget
+# ===========================================================================
+echo ""
+echo "=== TC-BP-35: large ambiguous push remains bounded and blocked ==="
+setup_repo main
+large_command=$'python3 - <<PY\n'
+for ((i = 0; i < 250; i++)); do
+  large_command+="def f$i(x):"$'\n'
+  large_command+="    return g(x)+$i"$'\n'
+done
+large_command+=$'PY\ngit push origin main'
+out=$(run_hook_bounded "$large_command")
+assert_exit "large uncertain trunk push blocks within five seconds" "2" "$out"
 
 # ===========================================================================
 # Summary

--- a/tests/unit/test-block-push-regex.sh
+++ b/tests/unit/test-block-push-regex.sh
@@ -1078,6 +1078,58 @@ do
 done
 
 # ===========================================================================
+# TC-BP-54: executable consumers remain visible through data-only stages
+# ===========================================================================
+echo ""
+echo "=== TC-BP-54: multi-stage pipelines preserve executable consumers ==="
+setup_repo feat/x
+for command in \
+  'echo git push origin main | cat | bash' \
+  'echo git push origin main | tee /tmp/push-copy | bash' \
+  'echo git push origin main | sort | sh' \
+  'echo git push origin main | grep push | bash' \
+  'echo git push origin main | tr a-z a-z | bash' \
+  'echo git push origin main | cat |& bash' \
+  'echo git push origin main | cat | python3 -' \
+  'echo git push origin main | cat | source /dev/stdin' \
+  'echo git push origin main | cat | while read -r l; do eval "$l"; done' \
+  'echo git push origin main | tee >(cat) | bash' \
+  'echo git push origin main | while read -r l; do echo "$l"; done | bash' \
+  'echo git push origin main | if read -r l; then echo "$l"; fi | bash' \
+  'echo git push origin main | tee >(cat | bash)' \
+  'echo git push origin main | cat | (bash)' \
+  'echo git push origin main | cat | { bash; }'
+do
+  out=$(run_hook "$command")
+  assert_exit "downstream executable consumer blocks trunk push: $command" "2" "$out"
+done
+for command in \
+  'echo git push origin main | cat | jq .' \
+  'echo git push origin main | sort | tee /tmp/push-copy' \
+  'echo git push origin main | tee >(cat) | grep push' \
+  'echo git push origin main | cat ; echo true | bash' \
+  'echo git push origin main | cat && echo true | bash'
+do
+  out=$(run_hook "$command")
+  assert_exit "multi-stage data-only pipeline remains allowed: $command" "0" "$out"
+done
+
+# ===========================================================================
+# TC-BP-55: large substitution-bearing input stays within the hook budget
+# ===========================================================================
+echo ""
+echo "=== TC-BP-55: large benign substitution input remains bounded ==="
+setup_repo feat/x
+large_command=$'python3 - <<PY\n'
+for ((i = 0; i < 625; i++)); do
+  large_command+="def f$i(x):"$'\n'
+  large_command+="    return g(x)+$i"$'\n'
+done
+large_command+=$'PY\nprintf "%s\\n" "$(date)"'
+out=$(run_hook_bounded "$large_command")
+assert_exit "large benign substitution command is allowed within five seconds" "0" "$out"
+
+# ===========================================================================
 # Summary
 # ===========================================================================
 echo ""

--- a/tests/unit/test-block-push-regex.sh
+++ b/tests/unit/test-block-push-regex.sh
@@ -73,10 +73,10 @@ run_hook() {
 }
 
 run_hook_bounded() {
-  local cmd="$1"
+  local cmd="$1" budget="${2:-5}"
   (
     cd "$TMPDIR/repo" &&
-      CLAUDE_PROJECT_DIR="$TMPDIR/repo" timeout 5 bash "$HOOK" \
+      CLAUDE_PROJECT_DIR="$TMPDIR/repo" timeout "$budget" bash "$HOOK" \
         <<<"$(hook_input "$cmd")"
   )
   echo $?
@@ -1193,6 +1193,130 @@ done
 dynamic_pipeline+=" | bash"
 out=$(run_hook_bounded "$dynamic_pipeline")
 assert_exit "two-hundred-stage dynamic pipeline reaches bash within five seconds" "2" "$out"
+
+# ===========================================================================
+# TC-BP-58: grouped producers and consumers preserve executable stdin flow
+# ===========================================================================
+echo ""
+echo "=== TC-BP-58: grouped stdin execution stays visible to the push parser ==="
+setup_repo feat/x
+for command in \
+  'echo git push origin main | { true; bash; }' \
+  'echo git push origin main | { :; bash; }' \
+  'echo git push origin main | { cd /tmp; bash; }' \
+  'echo git push origin main | { true && bash; }' \
+  'echo git push origin main | { { true; }; bash; }' \
+  'echo git push origin main | { (true); bash; }' \
+  'echo git push origin main | { true; { bash; }; }' \
+  'echo git push origin main | { true; source /dev/stdin; }' \
+  '( echo git push origin main ) | bash' \
+  '{ echo git push origin main; } | bash' \
+  'if true; then echo git push origin main; fi | bash' \
+  'for f in x; do echo git push origin main; done | bash' \
+  'case x in x) echo git push origin main;; esac | bash'
+do
+  out=$(run_hook "$command")
+  assert_exit "grouped executable stdin flow blocks: $command" "2" "$out"
+done
+for command in \
+  'echo git push origin main | { true; cat; }' \
+  'echo git push origin main | { :; cat; }' \
+  'echo git push origin main | { cd /tmp; cat; }' \
+  'echo git push origin main | { true && cat; }' \
+  'echo git push origin main | { { true; }; cat; }' \
+  'echo git push origin main | { (true); cat; }' \
+  'echo git push origin main | { true; { cat; }; }' \
+  'echo git push origin main | { true; cat; }' \
+  '( echo git push origin main ) | cat' \
+  '{ echo git push origin main; } | cat' \
+  'if true; then echo git push origin main; fi | cat' \
+  'for f in x; do echo git push origin main; done | cat' \
+  'case x in x) echo git push origin main;; esac | cat'
+do
+  out=$(run_hook "$command")
+  assert_exit "grouped data-only stdin flow allows: $command" "0" "$out"
+done
+
+# ===========================================================================
+# TC-BP-59: compact env options and shell applets execute stdin
+# ===========================================================================
+echo ""
+echo "=== TC-BP-59: compact env options and shell applets stay fail closed ==="
+setup_repo feat/x
+for command in \
+  'echo git push origin main | env -Sbash' \
+  'echo git push origin main | env -vSbash' \
+  'echo git push origin main | env -ivSbash' \
+  'echo git push origin main | env -i -Sbash' \
+  'echo git push origin main | env -C/tmp -Sbash' \
+  'echo git push origin main | env -uFOO -Sbash' \
+  'echo git push origin main | env FOO=1 -Sbash' \
+  'echo git push origin main | ash' \
+  'echo git push origin main | mksh' \
+  'echo git push origin main | yash' \
+  'echo git push origin main | posh' \
+  'echo git push origin main | csh' \
+  'echo git push origin main | tcsh' \
+  'echo git push origin main | fish' \
+  'echo git push origin main | hush' \
+  'echo git push origin main | busybox ash'
+do
+  out=$(run_hook "$command")
+  assert_exit "compact or alternate shell consumer blocks: $command" "2" "$out"
+done
+for command in \
+  'echo git push origin main | env -Scat' \
+  'echo git push origin main | env -vScat' \
+  'echo git push origin main | env -ivScat' \
+  'echo git push origin main | env -i -Scat' \
+  'echo git push origin main | env -C/tmp -Scat' \
+  'echo git push origin main | env -uFOO -Scat' \
+  'echo git push origin main | env FOO=1 -Scat' \
+  'echo git push origin main | busybox cat'
+do
+  out=$(run_hook "$command")
+  assert_exit "compact data-only consumer allows: $command" "0" "$out"
+done
+
+# ===========================================================================
+# TC-BP-60: large benign substitutions retain timeout headroom
+# ===========================================================================
+echo ""
+echo "=== TC-BP-60: larger benign substitution input retains hook headroom ==="
+setup_repo feat/x
+large_command=$'python3 - <<PY\n'
+for ((i = 0; i < 1250; i++)); do
+  large_command+="def f$i(x):"$'\n'
+  large_command+="    return g(x)+$i"$'\n'
+done
+large_command+=$'PY\n'
+large_prefix="$large_command"
+large_command+='printf "%s\n" "$(date)"'
+out=$(run_hook_bounded "$large_command" 3)
+assert_exit "approximately forty KiB benign substitution allows within three seconds" "0" "$out"
+large_command=$'cat > /tmp/issue547-large-doc <<EOF\n'
+for ((i = 0; i < 1500; i++)); do
+  large_command+="documentation line $i"$'\n'
+done
+large_command+=$'git push origin main\nEOF'
+out=$(run_hook_bounded "$large_command" 3)
+assert_exit "large heredoc trunk prose remains non-executable within three seconds" "0" "$out"
+large_command="${large_prefix}git push origin main"
+out=$(run_hook_bounded "$large_command" 3)
+assert_exit "approximately forty KiB literal trunk push blocks within three seconds" "2" "$out"
+large_command="${large_prefix}g'i't p'u'sh origin main"
+out=$(run_hook_bounded "$large_command" 3)
+assert_exit "approximately forty KiB split-quoted trunk push blocks within three seconds" "2" "$out"
+grouped_pipeline="{"
+for ((i = 0; i < 200; i++)); do
+  grouped_pipeline+=" echo git push origin main;"
+done
+grouped_pipeline+=" } | cat"
+out=$(run_hook_bounded "$grouped_pipeline" 3)
+assert_exit "two hundred grouped data segments allow within three seconds" "0" "$out"
+grouped_pipeline="${grouped_pipeline%cat}bash"
+out=$(run_hook_bounded "$grouped_pipeline" 3)
+assert_exit "two hundred grouped data segments reach bash within three seconds" "2" "$out"
 
 # ===========================================================================
 # Summary

--- a/tests/unit/test-block-push-regex.sh
+++ b/tests/unit/test-block-push-regex.sh
@@ -846,6 +846,95 @@ out=$(run_hook_bounded "$large_command")
 assert_exit "feature push with a large option stays within five seconds" "0" "$out"
 
 # ===========================================================================
+# TC-BP-45: data text becomes executable when routed into a shell
+# ===========================================================================
+echo ""
+echo "=== TC-BP-45: executable consumers keep push text fail closed ==="
+setup_repo feat/x
+out=$(run_hook "echo git push origin main | bash")
+assert_exit "echo output piped to bash remains blocked" "2" "$out"
+out=$(run_hook "echo git push origin main | sh")
+assert_exit "echo output piped to sh remains blocked" "2" "$out"
+out=$(run_hook "echo git push origin main | bash -s")
+assert_exit "echo output piped to bash stdin remains blocked" "2" "$out"
+out=$(run_hook "echo git push origin main | ssh host bash")
+assert_exit "echo output piped to a remote shell remains blocked" "2" "$out"
+out=$(run_hook "echo git push origin main |& bash")
+assert_exit "echo stdout/stderr pipe to bash remains blocked" "2" "$out"
+out=$(run_hook "printf 'git push origin main\\n' | bash")
+assert_exit "printf output piped to bash remains blocked" "2" "$out"
+out=$(run_hook "printf \$'git\\x20push origin main\\n' | bash")
+assert_exit "ANSI-quoted push text piped to bash remains blocked" "2" "$out"
+out=$(run_hook "echo g'it push origin main' | bash")
+assert_exit "quote-concatenated push text piped to bash remains blocked" "2" "$out"
+out=$(run_hook 'printf "%s\n" "$SCRIPT" | bash')
+assert_exit "dynamic shell input remains fail-closed" "2" "$out"
+out=$(run_hook "echo git push origin main > >(bash)")
+assert_exit "echo output redirected to a bash process substitution remains blocked" "2" "$out"
+out=$(run_hook 'echo "$(git push origin main)"')
+assert_exit "push inside an echo command substitution remains blocked" "2" "$out"
+out=$(run_hook 'echo "$PREFIX" git push origin main')
+assert_exit "a dynamic data argument without an executable consumer remains allowed" "0" "$out"
+out=$(run_hook "echo git push origin main > /tmp/push-doc")
+assert_exit "echo text redirected to a regular file remains data-only" "0" "$out"
+out=$(run_hook "printf hello | bash")
+assert_exit "git-free literal shell input remains allowed" "0" "$out"
+
+# ===========================================================================
+# TC-BP-46: shell syntax around a readable push is not a refspec
+# ===========================================================================
+echo ""
+echo "=== TC-BP-46: redirections, groups, and continuations remain readable ==="
+setup_repo feat/x
+for command in \
+  "git push origin feat/x > /tmp/log" \
+  "git push -u origin feat/x >/dev/null" \
+  "git push origin feat/x 2>&1 | tee /tmp/log" \
+  "git push -u origin feat/x 2>/dev/null" \
+  "git push origin feat/x < /dev/null" \
+  "git push origin feat/x &>/tmp/log" \
+  "git push origin feat/x 2>>/tmp/log" \
+  ">/tmp/log git push origin feat/x" \
+  "git 2>/dev/null push origin feat/x" \
+  "git push 2>/dev/null origin feat/x" \
+  "{ git push origin feat/x; }" \
+  $'git push \\\n  -u origin feat/x' \
+  $'git push -u \\\n  origin feat/x' \
+  $'git push origin \\\n  feat/x'
+do
+  out=$(run_hook "$command")
+  assert_exit "feature push with shell syntax allowed: ${command:0:42}" "0" "$out"
+done
+for command in \
+  "git push origin main > /tmp/log" \
+  "git push origin main &>/tmp/log" \
+  "{ git push origin main; }" \
+  $'git push origin \\\n  main'
+do
+  out=$(run_hook "$command")
+  assert_exit "trunk push with shell syntax blocked: ${command:0:42}" "2" "$out"
+done
+out=$(run_hook $'git \\\n  commit -m x')
+assert_exit "continued non-push git command is allowed" "0" "$out"
+out=$(run_hook 'git ${OPTS} status')
+assert_exit "dynamic global args before a definite non-push operation are allowed" "0" "$out"
+
+# ===========================================================================
+# TC-BP-47: dynamic refspecs are intentionally fail closed
+# ===========================================================================
+echo ""
+echo "=== TC-BP-47: dynamic refspecs remain fail closed ==="
+setup_repo feat/x
+for command in \
+  'git push -u origin "$BRANCH"' \
+  'git push --force-with-lease origin "$PR_BRANCH"' \
+  'git push -u origin "$(git branch --show-current)"'
+do
+  out=$(run_hook "$command")
+  assert_exit "dynamic refspec remains unreadable: $command" "2" "$out"
+done
+
+# ===========================================================================
 # Summary
 # ===========================================================================
 echo ""

--- a/tests/unit/test-block-push-regex.sh
+++ b/tests/unit/test-block-push-regex.sh
@@ -756,6 +756,96 @@ out=$(run_hook "echo git push origin feat/x && git push origin main")
 assert_exit "a real trunk push still blocks after benign push text" "2" "$out"
 
 # ===========================================================================
+# TC-BP-40: prefixed pushes cannot disappear from a multi-command parse
+# ===========================================================================
+echo ""
+echo "=== TC-BP-40: prefixed pushes remain visible and fail closed ==="
+setup_repo feat/x
+for command in \
+  "git push origin feat/x && ( git push origin main )" \
+  "git push origin feat/x && sudo git push origin main" \
+  "timeout 5 git push origin main && git push origin feat/x" \
+  'GIT_SSH_COMMAND="ssh -i k" git push origin main && git push origin feat/x' \
+  "nohup git push origin main & git push origin feat/x" \
+  "unknown-wrapper git push origin main && git push origin feat/x"
+do
+  out=$(run_hook "$command")
+  assert_exit "prefixed trunk push blocked: $command" "2" "$out"
+done
+git -C "$TMPDIR/repo" remote add other https://github.com/other-owner/other-repo.git
+out=$(run_hook "git push other feat/x && sudo git push origin main")
+assert_exit "unreadable second push cannot reuse the first push's remote scope" "2" "$out"
+
+# ===========================================================================
+# TC-BP-41: a supported prefix does not block a feature-only push
+# ===========================================================================
+echo ""
+echo "=== TC-BP-41: prefixed feature pushes remain allowed ==="
+setup_repo feat/x
+for command in \
+  "timeout 60 git push -u origin feat/x" \
+  "if git push origin feat/x; then echo ok; fi" \
+  "! git push origin feat/x" \
+  "sudo git push origin feat/x" \
+  "nohup git push origin feat/x" \
+  "command git push origin feat/x" \
+  "time git push origin feat/x" \
+  "stdbuf -oL git push origin feat/x" \
+  'GIT_SSH_COMMAND="ssh -i k" git push origin feat/x'
+do
+  out=$(run_hook "$command")
+  assert_exit "prefixed feature push allowed: $command" "0" "$out"
+done
+
+# ===========================================================================
+# TC-BP-42: a lone data-only push mention remains non-executable
+# ===========================================================================
+echo ""
+echo "=== TC-BP-42: lone non-executable push text remains allowed ==="
+setup_repo feat/x
+out=$(run_hook "echo git push origin feat/x")
+assert_exit "lone echo arguments mentioning a feature push are allowed" "0" "$out"
+out=$(run_hook "echo Running git push origin feat/x now")
+assert_exit "prose echo arguments mentioning a feature push are allowed" "0" "$out"
+out=$(run_hook "echo git push origin main")
+assert_exit "lone echo arguments mentioning a trunk push are allowed" "0" "$out"
+
+# ===========================================================================
+# TC-BP-43: mixed quote fragments cannot disguise the trunk destination
+# ===========================================================================
+echo ""
+echo "=== TC-BP-43: mixed quote fragments stay fail closed ==="
+setup_repo feat/x
+for command in \
+  'git push origin main""' \
+  'git push origin ""main' \
+  'git push origin ma"in"' \
+  'git push origin HEAD:main""'
+do
+  out=$(run_hook "$command")
+  assert_exit "mixed-quoted trunk refspec blocked: $command" "2" "$out"
+done
+
+# ===========================================================================
+# TC-BP-44: realistic large push commands stay within the hook budget
+# ===========================================================================
+echo ""
+echo "=== TC-BP-44: realistic large push commands remain bounded ==="
+setup_repo feat/x
+large_body=""
+for ((i = 0; i < 2500; i++)); do
+  large_body+="word$i "
+done
+large_command="git push -u origin feat/x && gh pr create --title t --body \"$large_body\""
+out=$(run_hook_bounded "$large_command")
+assert_exit "feature push chained to a large PR body is allowed within five seconds" "0" "$out"
+printf -v large_option '%*s' 21000 ''
+large_option="${large_option// /x}"
+large_command="git push origin feat/x --push-option=$large_option"
+out=$(run_hook_bounded "$large_command")
+assert_exit "feature push with a large option stays within five seconds" "0" "$out"
+
+# ===========================================================================
 # Summary
 # ===========================================================================
 echo ""

--- a/tests/unit/test-block-push-regex.sh
+++ b/tests/unit/test-block-push-regex.sh
@@ -1046,6 +1046,7 @@ for command in \
   'out="$(git push origin main)"' \
   'eval $(echo git push origin main)' \
   'echo "n=$(( $(git push origin main) + 1 ))"' \
+  'git push origin feat/x; echo "$(git push origin main)"' \
   'if $(echo git push origin main); then echo hi; fi'
 do
   out=$(run_hook "$command")
@@ -1060,6 +1061,23 @@ echo "=== TC-BP-53: stdin evaluators block code without blocking data controls =
 setup_repo feat/x
 for command in \
   "echo git push origin main | awk '{system(\$0)}'" \
+  "echo git push origin main | awk '{print | \"sh\"}'" \
+  "echo git push origin main | awk '{ \"sh\" | getline x }'" \
+  "echo git push origin main | sed 's/.*/&/e'" \
+  "echo git push origin main | sed 'e'" \
+  "echo git push origin main | sed -i '' 'e'" \
+  "echo git push origin main | awk -f script.awk" \
+  "echo git push origin main | gawk -i script.awk ''" \
+  "echo git push origin main | gawk --include=script.awk '{print}'" \
+  "echo git push origin main | gawk '@load \"filefuncs\"; {print}'" \
+  "echo git push origin main | gawk -E script.awk" \
+  "echo git push origin main | gawk --exec=script.awk" \
+  "echo git push origin main | gawk --fil=script.awk" \
+  "echo git push origin main | gawk --incl=script.awk '{print}'" \
+  "echo git push origin main | gawk --lo=plugin '{print}'" \
+  'echo git push origin main | parallel' \
+  'echo git push origin main | at now' \
+  'echo git push origin main | crontab -' \
   'echo git push origin main | while read l; do $l; done' \
   'echo git push origin main | tee >(bash)' \
   'echo git push origin main | xargs env'
@@ -1069,6 +1087,18 @@ do
 done
 for command in \
   "echo git push origin main | awk '{print \$0}'" \
+  "echo git push origin main | sed 's/x/y/'" \
+  "echo git push origin main | sed -e 's/x/y/'" \
+  "echo git push origin main | sed -n 'p'" \
+  "echo git push origin main | awk -F: '{print \$1}'" \
+  "echo git push origin main | awk --field-separator=: '{print \$1}'" \
+  "echo git push origin main | awk -v prefix=x '{print prefix \$0}'" \
+  "echo git push origin main | gawk --assign=prefix=x '{print prefix \$0}'" \
+  "echo git push origin main | awk -- '{print \$0}'" \
+  'echo git push origin main | rev' \
+  'echo git push origin main | base64' \
+  'echo git push origin main | tac' \
+  'echo git push origin main | dd of=/tmp/push-copy' \
   'echo git push origin main | while read l; do echo "$l"; done' \
   'echo git push origin main | tee >(cat >/tmp/push-copy)' \
   'echo git push origin main | xargs echo'
@@ -1193,6 +1223,33 @@ done
 dynamic_pipeline+=" | bash"
 out=$(run_hook_bounded "$dynamic_pipeline")
 assert_exit "two-hundred-stage dynamic pipeline reaches bash within five seconds" "2" "$out"
+producer_pipeline="echo git push origin main"
+for ((i = 0; i < 200; i++)); do
+  producer_pipeline+=" | echo a$i"
+done
+out=$(run_hook_bounded "$producer_pipeline" 3)
+assert_exit "two-hundred-stage producer pipeline is allowed within three seconds" "0" "$out"
+grouped_producer_pipeline="{ $producer_pipeline; } | cat"
+out=$(run_hook_bounded "$grouped_producer_pipeline" 3)
+assert_exit "grouped two-hundred-stage producer pipeline is allowed within three seconds" "0" "$out"
+grouped_producer_pipeline="${grouped_producer_pipeline%cat}bash"
+out=$(run_hook_bounded "$grouped_producer_pipeline" 3)
+assert_exit "grouped two-hundred-stage producer pipeline reaches bash within three seconds" "2" "$out"
+producer_pipeline+=" | bash"
+out=$(run_hook_bounded "$producer_pipeline" 3)
+assert_exit "two-hundred-stage producer pipeline reaches bash within three seconds" "2" "$out"
+deep_process_pipeline=""
+deep_process_closers=""
+for ((i = 0; i < 40; i++)); do
+  deep_process_pipeline+="cat > >("
+  deep_process_closers+=")"
+done
+deep_process_pipeline+="cat $deep_process_closers"
+out=$(run_hook_bounded \
+  "git push origin main; echo x | $deep_process_pipeline")
+assert_exit "forty nested process substitutions keep trunk push within five seconds" "2" "$out"
+out=$(run_hook_bounded "echo ok; echo x | $deep_process_pipeline")
+assert_exit "forty nested data-only process substitutions allow within five seconds" "0" "$out"
 
 # ===========================================================================
 # TC-BP-58: grouped producers and consumers preserve executable stdin flow
@@ -1213,7 +1270,21 @@ for command in \
   '{ echo git push origin main; } | bash' \
   'if true; then echo git push origin main; fi | bash' \
   'for f in x; do echo git push origin main; done | bash' \
-  'case x in x) echo git push origin main;; esac | bash'
+  'case x in x) echo git push origin main;; esac | bash' \
+  '{ echo git push origin main | cat; } | bash' \
+  '( echo git push origin main | cat ) | bash' \
+  '{ echo git push origin main | cat; } | sh' \
+  '{ echo git push origin main | cat; } | cat | bash' \
+  '{ echo git push origin main | cat; } | env -Sbash' \
+  '{ echo git push origin main | grep push; } | bash' \
+  '{ echo git push origin main | tee /dev/null | cat; } | bash' \
+  "{ printf '%s' git push origin main | cat; } | bash" \
+  '{ ( echo git push origin main | cat ); } | bash' \
+  'if true; then echo git push origin main | cat; fi | bash' \
+  'for f in x; do echo git push origin main | cat; done | bash' \
+  'while :; do echo git push origin main | cat; break; done | bash' \
+  'case x in x) echo git push origin main | cat;; esac | bash' \
+  '{ echo git push origin main | cat; } > >(bash)'
 do
   out=$(run_hook "$command")
   assert_exit "grouped executable stdin flow blocks: $command" "2" "$out"
@@ -1231,7 +1302,15 @@ for command in \
   '{ echo git push origin main; } | cat' \
   'if true; then echo git push origin main; fi | cat' \
   'for f in x; do echo git push origin main; done | cat' \
-  'case x in x) echo git push origin main;; esac | cat'
+  'case x in x) echo git push origin main;; esac | cat' \
+  '{ echo git push origin main | cat; } | cat' \
+  '( echo git push origin main | cat ) | cat' \
+  'if true; then echo git push origin main | cat; fi | cat' \
+  'for f in x; do echo git push origin main | cat; done | cat' \
+  'while :; do echo git push origin main | cat; break; done | cat' \
+  'case x in x) echo git push origin main | cat;; esac | cat' \
+  '{ echo git push origin main | cat; } > >(cat)' \
+  'echo a | cat; echo git push origin main | cat'
 do
   out=$(run_hook "$command")
   assert_exit "grouped data-only stdin flow allows: $command" "0" "$out"
@@ -1317,6 +1396,191 @@ assert_exit "two hundred grouped data segments allow within three seconds" "0" "
 grouped_pipeline="${grouped_pipeline%cat}bash"
 out=$(run_hook_bounded "$grouped_pipeline" 3)
 assert_exit "two hundred grouped data segments reach bash within three seconds" "2" "$out"
+distinct_stages='git push -u origin feat/x;'
+for ((i = 0; i < 400; i++)); do
+  distinct_stages+=" echo w$i;"
+done
+out=$(run_hook_bounded "$distinct_stages" 3)
+assert_exit "four hundred distinct data stages allow within three seconds" "0" "$out"
+substitution_dense='git push origin main'
+for ((i = 0; i < 450; i++)); do
+  substitution_dense+=' $(:)'
+done
+out=$(run_hook_bounded "$substitution_dense" 3)
+assert_exit "four hundred fifty repeated substitutions keep trunk push within three seconds" "2" "$out"
+substitution_dense='git push origin main'
+for ((i = 0; i < 700; i++)); do
+  substitution_dense+=' `:`'
+done
+out=$(run_hook_bounded "$substitution_dense" 3)
+assert_exit "seven hundred repeated backticks keep trunk push within three seconds" "2" "$out"
+substitution_dense='git push origin main'
+for ((i = 0; i < 500; i++)); do
+  substitution_dense+=' > >(:)'
+done
+out=$(run_hook_bounded "$substitution_dense" 3)
+assert_exit "five hundred process substitutions keep trunk push within three seconds" "2" "$out"
+substitution_dense='git push origin main'
+for ((i = 0; i < 300; i++)); do
+  substitution_dense+=" \$(:$i)"
+done
+out=$(run_hook_bounded "$substitution_dense" 3)
+assert_exit "three hundred unique substitutions fail closed within three seconds" "2" "$out"
+substitution_dense='echo ok'
+for ((i = 0; i < 64; i++)); do
+  substitution_dense+=" \$(:$i)"
+done
+out=$(run_hook_bounded "$substitution_dense")
+assert_exit "sixty-four unique benign substitutions remain allowed within five seconds" "0" "$out"
+substitution_dense+=' $(:64)'
+out=$(run_hook_bounded "$substitution_dense")
+assert_exit "sixty-fifth unique benign substitution fails closed within five seconds" "2" "$out"
+substitution_dense='echo ok'
+for ((i = 0; i < 450; i++)); do
+  substitution_dense+=' $(:)'
+done
+out=$(run_hook_bounded "$substitution_dense" 3)
+assert_exit "repeated benign substitutions remain allowed within three seconds" "0" "$out"
+executor_dense='git push origin main $('
+for ((i = 0; i < 500; i++)); do
+  executor_dense+='$a;'
+done
+executor_dense+=')'
+out=$(run_hook_bounded "$executor_dense")
+assert_exit "single dense substitution keeps trunk push within five seconds" "2" "$out"
+executor_dense="echo ok ${executor_dense#git push origin main }"
+out=$(run_hook_bounded "$executor_dense")
+assert_exit "single dense benign substitution remains allowed within five seconds" "0" "$out"
+deep_padding=$(printf 'x%.0s' {1..47})
+deep_substitution='date'
+for ((i = 1; i <= 62; i++)); do
+  deep_substitution="printf %s_${deep_padding}${i} \$($deep_substitution)"
+done
+deep_command="git push origin main; echo \$($deep_substitution)"
+out=$(run_hook_bounded "$deep_command")
+assert_exit "direct trunk push precedes deep benign substitutions within five seconds" "2" "$out"
+masked_large_command="cat > /tmp/issue547-masked-push <<'EOF'"$'\n'
+for ((i = 0; i < 1500; i++)); do
+  masked_large_command+="documentation line $i"$'\n'
+done
+masked_large_command+=$'EOF\n'
+out=$(run_hook_bounded "${masked_large_command}"'echo "$(date)"')
+assert_exit "large masked benign substitution allows within five seconds" "0" "$out"
+out=$(run_hook_bounded "${masked_large_command}"'echo "$(git push origin main)"')
+assert_exit "large masked hidden trunk push blocks within five seconds" "2" "$out"
+comment_padding=$(printf 'x%.0s' {1..47})
+large_comments=""
+for ((i = 0; i < 1000; i++)); do
+  large_comments+="# ${comment_padding}${i}"$'\n'
+done
+out=$(run_hook_bounded "${large_comments}"'echo "$(date)"')
+assert_exit "large comment-masked benign substitution allows within five seconds" "0" "$out"
+out=$(run_hook_bounded "${large_comments}"'echo "$(git push origin main)"')
+assert_exit "large comment-masked hidden trunk push blocks within five seconds" "2" "$out"
+out=$(run_hook_bounded "echo \$($deep_substitution)")
+assert_exit "deeply nested benign substitution terminates fail-closed within five seconds" "2" "$out"
+out=$(run_hook_bounded "echo \$(git push origin main; $deep_substitution)")
+assert_exit "deeply nested hidden trunk push blocks within five seconds" "2" "$out"
+large_backtick_padding=$(printf 'x%.0s' {1..5000})
+out=$(run_hook_bounded "echo $large_backtick_padding; echo \`date\`")
+assert_exit "large benign backtick substitution remains allowed" "0" "$out"
+out=$(run_hook_bounded "echo $large_backtick_padding; echo \`git push origin main\`")
+assert_exit "large hidden backtick trunk push remains blocked" "2" "$out"
+mixed_substitution='date'
+for ((i = 0; i < 1635; i++)); do
+  if (( i % 2 == 0 )); then
+    mixed_substitution="\$($mixed_substitution)"
+  else
+    mixed_substitution="\`$mixed_substitution\`"
+  fi
+done
+mixed_substitution="${mixed_substitution:0:4090}"
+out=$(run_hook_bounded "$mixed_substitution" 3)
+assert_exit "worst-case mixed substitution fails closed within three seconds" "2" "$out"
+
+# ===========================================================================
+# TC-BP-61: large substitutions preserve executable and data-only boundaries
+# ===========================================================================
+echo ""
+echo "=== TC-BP-61: large substitution scans stay scoped to executable bodies ==="
+setup_repo feat/x
+threshold_padding=$(printf 'x%.0s' {1..4100})
+out=$(run_hook_bounded \
+  "echo \`\$'git' \$'push' origin main\`; echo $threshold_padding")
+assert_exit "large ANSI-C quoted backtick trunk push remains blocked" "2" "$out"
+out=$(run_hook_bounded \
+  "git push origin feat/x; echo \$(date); echo $threshold_padding")
+assert_exit "large feature push beside benign command substitution remains allowed" "0" "$out"
+out=$(run_hook_bounded \
+  "git push origin feat/x; echo data > >(cat); echo $threshold_padding")
+assert_exit "large feature push beside data-only process substitution remains allowed" "0" "$out"
+
+near_threshold_padding=$(printf 'x%.0s' {1..3200})
+out=$(run_hook_bounded \
+  "echo git push origin main | tee >(cat); echo $near_threshold_padding")
+assert_exit "large data-only tee process substitution remains allowed" "0" "$out"
+out=$(run_hook_bounded \
+  "{ echo git push origin main; } > >(cat); echo $near_threshold_padding")
+assert_exit "large grouped data-only process substitution remains allowed" "0" "$out"
+out=$(run_hook_bounded \
+  "echo \"git push origin main\"; echo \$(date); echo $near_threshold_padding")
+assert_exit "large quoted push prose beside benign substitution remains allowed" "0" "$out"
+
+small_heredoc_command=$'cat > /tmp/issue547-push-doc <<\'EOF\'\n'
+small_heredoc_command+=$'git push origin main\n'
+small_heredoc_command+="$(printf 'documentation %.0s' {1..100})"
+small_heredoc_command+=$'\nEOF\necho "$(date)"'
+out=$(run_hook_bounded "$small_heredoc_command")
+assert_exit "sub-four-KiB heredoc push prose beside benign substitution remains allowed" "0" "$out"
+
+skill_pr_command=$'gh pr create --title "fix: example" --body "$(cat <<\'PRBODY\'\n'
+skill_pr_command+=$'- Feature work is published with `git push origin feat/x`.\n'
+skill_pr_command+=$'PRBODY\n)"'
+out=$(run_hook_bounded "$skill_pr_command")
+assert_exit "skill PR body feature-push prose remains allowed" "0" "$out"
+out=$(run_hook_bounded \
+  "${skill_pr_command}"'; echo "$(git push origin main)"')
+assert_exit "real trunk push beside skill PR body remains blocked" "2" "$out"
+compact_pr_command="git push -u origin feat/x && ${skill_pr_command}"
+out=$(run_hook_bounded "$compact_pr_command")
+assert_exit "compact feature push and generated PR body remain allowed" "0" "$out"
+
+large_pr_command=$'git push -u origin feat/x && gh pr create --body "$(cat <<\'PRBODY\'\n'
+for ((i = 0; i < 220; i++)); do
+  large_pr_command+="release note $i records feature branch publication"$'\n'
+done
+large_pr_command+=$'- Feature work is published with `git push origin feat/x`.\n'
+large_pr_command+=$'PRBODY\n)"'
+out=$(run_hook_bounded "$large_pr_command")
+assert_exit "large real-world feature push and generated PR body remain allowed" "0" "$out"
+
+unicode_prefix=$'\u2615\u2615\u2615\u2615'
+out=$(run_hook_bounded \
+  "echo \"$unicode_prefix\" && x=\$(eval \"git push origin main\")")
+assert_exit "UTF-8 text before hidden trunk push remains blocked" "2" "$out"
+for command in \
+  'git p$(echo ush) origin main' \
+  'git "pu"$(echo sh) origin main' \
+  'git -c a=b pu$(echo sh) origin main'
+do
+  out=$(run_hook_bounded "$command")
+  assert_exit "split dynamic trunk-push operation remains blocked: $command" "2" "$out"
+done
+
+large_inline_body=$(printf 'A%.0s' {1..8300})
+inline_pr_command="gh pr create --title x --body \"\$(printf '%s\\n' '$large_inline_body')\""
+out=$(run_hook_bounded "$inline_pr_command")
+assert_exit "greater-than-eight-KiB inline PR body remains allowed" "0" "$out"
+out=$(run_hook_bounded \
+  "${inline_pr_command}"'; echo "$(git push origin main)"')
+assert_exit "real trunk push beside large inline PR body remains blocked" "2" "$out"
+
+body_file_pr=$'gh pr comment 12 --body-file - <<\'EOF\'\n'
+body_file_pr+=$'Run `git push origin main` only through a pull request.\nEOF'
+out=$(run_hook_bounded "$body_file_pr")
+assert_exit "stdin PR body heredoc push prose remains allowed" "0" "$out"
+out=$(run_hook_bounded "${body_file_pr}"$'\ngit push origin main')
+assert_exit "real trunk push after stdin PR body heredoc remains blocked" "2" "$out"
 
 # ===========================================================================
 # Summary

--- a/tests/unit/test-block-push-regex.sh
+++ b/tests/unit/test-block-push-regex.sh
@@ -859,6 +859,10 @@ out=$(run_hook "echo git push origin main | bash -s")
 assert_exit "echo output piped to bash stdin remains blocked" "2" "$out"
 out=$(run_hook "echo git push origin main | ssh host bash")
 assert_exit "echo output piped to a remote shell remains blocked" "2" "$out"
+out=$(run_hook 'printf "%s\n" "$SCRIPT" | ssh host "bash -s"')
+assert_exit "dynamic input piped to a quoted remote shell remains fail-closed" "2" "$out"
+out=$(run_hook 'printf "%s\n" "$SCRIPT" | ssh host "env -i bash -s"')
+assert_exit "dynamic input piped to a wrapped quoted remote shell remains fail-closed" "2" "$out"
 out=$(run_hook "echo git push origin main |& bash")
 assert_exit "echo stdout/stderr pipe to bash remains blocked" "2" "$out"
 out=$(run_hook "printf 'git push origin main\\n' | bash")
@@ -869,6 +873,22 @@ out=$(run_hook "echo g'it push origin main' | bash")
 assert_exit "quote-concatenated push text piped to bash remains blocked" "2" "$out"
 out=$(run_hook 'printf "%s\n" "$SCRIPT" | bash')
 assert_exit "dynamic shell input remains fail-closed" "2" "$out"
+out=$(run_hook 'printf "%s\n" "$SCRIPT" | env -i bash -s')
+assert_exit "dynamic shell input through env remains fail-closed" "2" "$out"
+out=$(run_hook 'printf "%s\n" "$SCRIPT" | /bin/bash -s')
+assert_exit "dynamic shell input through an absolute shell path remains fail-closed" "2" "$out"
+out=$(run_hook 'printf "%s\n" "$SCRIPT" | /usr/bin/env bash -s')
+assert_exit "dynamic shell input through an absolute env path remains fail-closed" "2" "$out"
+out=$(run_hook 'printf "%s\n" "$SCRIPT" | source /dev/stdin')
+assert_exit "dynamic shell input sourced from stdin remains fail-closed" "2" "$out"
+out=$(run_hook 'printf "%s\n" "$SCRIPT" | . /dev/stdin')
+assert_exit "dynamic shell input dot-sourced from stdin remains fail-closed" "2" "$out"
+out=$(run_hook "echo git push origin main | command bash")
+assert_exit "shell input through command remains blocked" "2" "$out"
+out=$(run_hook "echo git push origin main | timeout 5 bash")
+assert_exit "shell input through timeout remains blocked" "2" "$out"
+out=$(run_hook "echo git push origin main | xargs -I{} bash -c '{}'")
+assert_exit "shell input through xargs remains blocked" "2" "$out"
 out=$(run_hook "echo git push origin main > >(bash)")
 assert_exit "echo output redirected to a bash process substitution remains blocked" "2" "$out"
 out=$(run_hook 'echo "$(git push origin main)"')
@@ -932,6 +952,70 @@ for command in \
 do
   out=$(run_hook "$command")
   assert_exit "dynamic refspec remains unreadable: $command" "2" "$out"
+done
+
+# ===========================================================================
+# TC-BP-48: ordinary variable data pipelines remain non-executable
+# ===========================================================================
+echo ""
+echo "=== TC-BP-48: variable data piped to non-shell consumers remains allowed ==="
+setup_repo feat/x
+for command in \
+  'echo "$json" | jq .' \
+  'echo "$msg" | tee -a /tmp/log' \
+  'printf "%s\n" "${arr[@]}" | sort' \
+  'echo "$body" | gh pr comment 12 --body-file -' \
+  'echo "$sha" | cut -c1-7' \
+  'echo "$json" | env jq .' \
+  'echo "$json" | ssh host cat' \
+  'echo "$json" | ssh host "cat > /tmp/data"' \
+  'echo "$json" | xargs jq .'
+do
+  out=$(run_hook "$command")
+  assert_exit "non-shell data pipeline allowed: $command" "0" "$out"
+done
+
+# ===========================================================================
+# TC-BP-49: arithmetic expansion is data, not executable command substitution
+# ===========================================================================
+echo ""
+echo "=== TC-BP-49: arithmetic expansion remains allowed in data commands ==="
+setup_repo feat/x
+for command in \
+  'echo "n=$((x + 1))" > /tmp/x' \
+  'printf "%d\n" "$((total))" > /tmp/y'
+do
+  out=$(run_hook "$command")
+  assert_exit "arithmetic data expansion allowed: $command" "0" "$out"
+done
+
+# ===========================================================================
+# TC-BP-50: dynamic git global values can precede more global flags
+# ===========================================================================
+echo ""
+echo "=== TC-BP-50: dynamic globals before definite non-push operations allow ==="
+setup_repo feat/x
+for command in \
+  'git -C "$D" -c a=b commit -m x 2>&1' \
+  'git -C "$D" -c user.email=t commit -m fix 2>&1' \
+  'git -C "$D" -c core.pager=cat log --oneline | head'
+do
+  out=$(run_hook "$command")
+  assert_exit "definite non-push after dynamic globals allowed: $command" "0" "$out"
+done
+
+# ===========================================================================
+# TC-BP-51: mixed quote fragments cannot disguise the push operation
+# ===========================================================================
+echo ""
+echo "=== TC-BP-51: mixed-quoted push operation remains fail closed ==="
+setup_repo feat/x
+for command in \
+  "git pu'sh' origin main" \
+  'git "pu""sh" origin main'
+do
+  out=$(run_hook "$command")
+  assert_exit "mixed-quoted trunk push operation blocked: $command" "2" "$out"
 done
 
 # ===========================================================================

--- a/tests/unit/test-block-push-regex.sh
+++ b/tests/unit/test-block-push-regex.sh
@@ -688,6 +688,74 @@ out=$(run_hook_bounded "$large_command")
 assert_exit "large uncertain trunk push blocks within five seconds" "2" "$out"
 
 # ===========================================================================
+# TC-BP-36: chained and multi-line feature pushes remain allowed
+# ===========================================================================
+echo ""
+echo "=== TC-BP-36: chained and multi-line feature pushes remain allowed ==="
+setup_repo feat/x
+out=$(run_hook "git add -A && git commit -m x && git push origin feat/x")
+assert_exit "feature push after add and commit is allowed" "0" "$out"
+out=$(run_hook "git rebase --autostash origin/main && git push --force-with-lease origin feat/x")
+assert_exit "feature push after rebase is allowed" "0" "$out"
+out=$(run_hook $'cd /tmp\ngit push origin feat/x')
+assert_exit "feature push on a later physical line is allowed" "0" "$out"
+out=$(run_hook $'git add a.txt\ngit commit -m "feat(x): y"\ngit push -u origin feat/x')
+assert_exit "documented multi-line feature workflow is allowed" "0" "$out"
+out=$(run_hook "git add -A && git commit -m x && git push origin main")
+assert_exit "equivalent chained trunk push remains blocked" "2" "$out"
+out=$(run_hook 'git push "$REMOTE" feat/x')
+assert_exit "quoted dynamic remote keeps the literal feature refspec readable" "0" "$out"
+out=$(run_hook 'git push $REMOTE feat/x')
+assert_exit "unquoted dynamic remote remains fail-closed" "2" "$out"
+
+# ===========================================================================
+# TC-BP-37: git-free expansion commands are not treated as pushes
+# ===========================================================================
+echo ""
+echo "=== TC-BP-37: git-free expansion commands remain allowed ==="
+for command in \
+  'git -C $dir status' \
+  '$PYTHON $SCRIPT' \
+  '"$PYTHON" "$SCRIPT"' \
+  '${TOOL} ${ARG}' \
+  '$CMD --flag $x' \
+  './run.sh && $CMD $ARG'
+do
+  out=$(run_hook "$command")
+  assert_exit "git-free command allowed: $command" "0" "$out"
+done
+out=$(run_hook '$GIT push origin main')
+assert_exit "dynamic git command with a literal trunk push stays fail-closed" "2" "$out"
+
+# ===========================================================================
+# TC-BP-38: large git-free ambiguous input stays within the hook budget
+# ===========================================================================
+echo ""
+echo "=== TC-BP-38: large git-free ambiguous input remains bounded ==="
+setup_repo feat/x
+large_command=$'python3 - <<PY\n'
+for ((i = 0; i < 625; i++)); do
+  large_command+="def f$i(x):"$'\n'
+  large_command+="    return g(x)+$i"$'\n'
+done
+large_command+=$'PY\nprintf done'
+out=$(run_hook_bounded "$large_command")
+assert_exit "large git-free ambiguous command is allowed within five seconds" "0" "$out"
+
+# ===========================================================================
+# TC-BP-39: non-executable push text does not override a real feature push
+# ===========================================================================
+echo ""
+echo "=== TC-BP-39: non-executable push text remains ignored ==="
+setup_repo feat/x
+out=$(run_hook "echo git push origin main && git push origin feat/x")
+assert_exit "echo arguments mentioning a trunk push stay non-executable" "0" "$out"
+out=$(run_hook $'cat <<EOF\ngit push origin main\nEOF\ngit push origin feat/x')
+assert_exit "heredoc data mentioning a trunk push stays non-executable" "0" "$out"
+out=$(run_hook "echo git push origin feat/x && git push origin main")
+assert_exit "a real trunk push still blocks after benign push text" "2" "$out"
+
+# ===========================================================================
 # Summary
 # ===========================================================================
 echo ""

--- a/tests/unit/test-block-push-regex.sh
+++ b/tests/unit/test-block-push-regex.sh
@@ -1019,6 +1019,65 @@ do
 done
 
 # ===========================================================================
+# TC-BP-52: substitution bodies are classified by what they execute
+# ===========================================================================
+echo ""
+echo "=== TC-BP-52: benign substitutions allow; executable push bodies block ==="
+setup_repo feat/x
+for command in \
+  'echo "$(date)"' \
+  'echo "started at $(date -u +%FT%TZ)"' \
+  'printf "%s\n" "$(cat /etc/hostname)"' \
+  'echo "HEAD is $(git rev-parse --short HEAD)"' \
+  'echo "$(cat notes.md)" > /tmp/notes.copy' \
+  'echo "$(cat x.json)" | jq .' \
+  'echo "$(echo git push origin main)"' \
+  'log() { echo "[tick] $(date -u +%H:%M:%S) $*"; }' \
+  'echo "`date`"'
+do
+  out=$(run_hook "$command")
+  assert_exit "benign substitution remains allowed: $command" "0" "$out"
+done
+for command in \
+  '$(echo git push origin main)' \
+  "bash <(echo 'git push origin main')" \
+  "source <(echo 'git push origin main')" \
+  ". <(echo 'git push origin main')" \
+  'out="$(git push origin main)"' \
+  'eval $(echo git push origin main)' \
+  'echo "n=$(( $(git push origin main) + 1 ))"' \
+  'if $(echo git push origin main); then echo hi; fi'
+do
+  out=$(run_hook "$command")
+  assert_exit "executable substitution push blocked: $command" "2" "$out"
+done
+
+# ===========================================================================
+# TC-BP-53: non-shell stdin evaluators distinguish code from data
+# ===========================================================================
+echo ""
+echo "=== TC-BP-53: stdin evaluators block code without blocking data controls ==="
+setup_repo feat/x
+for command in \
+  "echo git push origin main | awk '{system(\$0)}'" \
+  'echo git push origin main | while read l; do $l; done' \
+  'echo git push origin main | tee >(bash)' \
+  'echo git push origin main | xargs env'
+do
+  out=$(run_hook "$command")
+  assert_exit "stdin-evaluated trunk push blocked: $command" "2" "$out"
+done
+for command in \
+  "echo git push origin main | awk '{print \$0}'" \
+  'echo git push origin main | while read l; do echo "$l"; done' \
+  'echo git push origin main | tee >(cat >/tmp/push-copy)' \
+  'echo git push origin main | xargs echo'
+do
+  out=$(run_hook "$command")
+  assert_exit "stdin data-only control allowed: $command" "0" "$out"
+done
+
+# ===========================================================================
 # Summary
 # ===========================================================================
 echo ""

--- a/tests/unit/test-block-push-regex.sh
+++ b/tests/unit/test-block-push-regex.sh
@@ -1130,6 +1130,71 @@ out=$(run_hook_bounded "$large_command")
 assert_exit "large benign substitution command is allowed within five seconds" "0" "$out"
 
 # ===========================================================================
+# TC-BP-56: compound commands and execution wrappers inspect their bodies
+# ===========================================================================
+echo ""
+echo "=== TC-BP-56: compound and wrapped consumers distinguish code from data ==="
+setup_repo feat/x
+for command in \
+  'echo git push origin main | if true; then bash; fi' \
+  'echo git push origin main | if read -r l; then bash; fi' \
+  'echo git push origin main | for f in x; do bash; done' \
+  'echo git push origin main | select f in x; do bash; done' \
+  'echo git push origin main | case x in x) bash;; esac' \
+  'echo git push origin main | case y in x) if true; then cat; fi;; y) bash;; esac' \
+  'echo git push origin main | nice bash' \
+  'echo git push origin main | setsid bash' \
+  'echo git push origin main | ionice bash' \
+  "echo git push origin main | env -S 'bash -s'" \
+  "echo git push origin main | env --split-string='bash -s'" \
+  'echo git push origin main | cat | nice bash' \
+  'echo git push origin main | tee >(if true; then bash; fi)'
+do
+  out=$(run_hook "$command")
+  assert_exit "compound or wrapped executable consumer blocks: $command" "2" "$out"
+done
+for command in \
+  'echo git push origin main | if true; then cat; fi' \
+  'echo git push origin main | if read -r l; then cat; fi' \
+  'echo git push origin main | for f in x; do cat; done' \
+  'echo git push origin main | select f in x; do cat; done' \
+  'echo git push origin main | case x in x) cat;; esac' \
+  'echo git push origin main | case y in x) if true; then cat; fi;; y) cat;; esac' \
+  'echo git push origin main | nice cat' \
+  'echo git push origin main | setsid cat' \
+  'echo git push origin main | ionice cat' \
+  "echo git push origin main | env -S 'cat'" \
+  "echo git push origin main | env --split-string='cat'" \
+  'echo git push origin main | cat | nice cat' \
+  'echo git push origin main | tee >(if true; then cat; fi)' \
+  'echo git push origin main | cat | { cat; }' \
+  'echo git push origin main | cat | (cat)'
+do
+  out=$(run_hook "$command")
+  assert_exit "compound or wrapped data-only consumer allows: $command" "0" "$out"
+done
+
+# ===========================================================================
+# TC-BP-57: downstream pipeline scanning remains linear
+# ===========================================================================
+echo ""
+echo "=== TC-BP-57: long pipelines remain within the hook budget ==="
+setup_repo feat/x
+long_pipeline="echo hello"
+for ((i = 0; i < 200; i++)); do
+  long_pipeline+=" | cat"
+done
+out=$(run_hook_bounded "$long_pipeline")
+assert_exit "two-hundred-stage data pipeline is allowed within five seconds" "0" "$out"
+dynamic_pipeline='echo "$CMD"'
+for ((i = 0; i < 200; i++)); do
+  dynamic_pipeline+=" | cat"
+done
+dynamic_pipeline+=" | bash"
+out=$(run_hook_bounded "$dynamic_pipeline")
+assert_exit "two-hundred-stage dynamic pipeline reaches bash within five seconds" "2" "$out"
+
+# ===========================================================================
 # Summary
 # ===========================================================================
 echo ""

--- a/tests/unit/test-is-git-command-non-executable-regions.sh
+++ b/tests/unit/test-is-git-command-non-executable-regions.sh
@@ -155,6 +155,49 @@ assert_large_ambiguous_hook_bounded() {
   fi
 }
 
+assert_dense_detector_bounded() {
+  local id="$1"
+  local expected="$2"
+  local command="$3"
+  local budget="${4:-5}"
+  local rc
+
+  if timeout "$budget" bash -c '
+    source "$1"
+    if is_git_command commit "$2"; then
+      actual=0
+    else
+      actual=1
+    fi
+    [[ "$actual" -eq "$3" ]]
+  ' _ "$LIB" "$command" "$expected"; then
+    record_pass "$id (detector rc=$expected within ${budget}s)"
+  else
+    rc=$?
+    record_fail "$id (expected detector rc=$expected within ${budget}s, got rc=$rc)"
+  fi
+}
+
+assert_hook_bounded_rc() {
+  local id="$1"
+  local expected="$2"
+  local command="$3"
+  local budget="${4:-5}"
+  local payload output rc
+
+  payload=$(jq -cn --arg command "$command" '{tool_input:{command:$command}}')
+  output=$(
+    cd "$REPO_A" &&
+      printf '%s' "$payload" | timeout "$budget" bash "$HOOK" 2>&1
+  )
+  rc=$?
+  if [[ "$rc" -eq "$expected" ]]; then
+    record_pass "$id (hook rc=$rc within ${budget}s)"
+  else
+    record_fail "$id (expected hook rc=$expected within ${budget}s, got rc=$rc: $output)"
+  fi
+}
+
 assert_preprocessor_failure_detector() {
   local id="$1"
 
@@ -312,7 +355,7 @@ BENIGN_COMMAND_DYNAMIC_SCRIPT='echo "$(command bash "$f")"'
 BENIGN_DYNAMIC_EVAL='echo "$(eval "$generated")"'
 
 echo ""
-echo "=== TC-IGC-547-001..145: non-executable git mentions ==="
+echo "=== TC-IGC-547-001..175: non-executable git mentions ==="
 echo ""
 
 assert_detector_no_match \
@@ -756,6 +799,139 @@ assert_large_ambiguous_hook_bounded \
 assert_large_ambiguous_hook_bounded \
   "TC-IGC-547-145 git-free ambiguous input stays allowed within hook budget" \
   0 "printf '%s\n' done" 625
+dense_substitution='$('
+for ((i = 0; i < 500; i++)); do
+  dense_substitution+='$a;'
+done
+dense_substitution+=')'
+assert_dense_detector_bounded \
+  "TC-IGC-547-146 dense substitution keeps a real commit visible" 0 \
+  "git commit -m real $dense_substitution"
+assert_dense_detector_bounded \
+  "TC-IGC-547-147 dense benign substitution stays allowed" 1 \
+  "echo ok $dense_substitution"
+masked_large_command="cat > /tmp/issue547-masked-commit <<'EOF'"$'\n'
+for ((i = 0; i < 1500; i++)); do
+  masked_large_command+="documentation line $i"$'\n'
+done
+masked_large_command+=$'EOF\n'
+assert_dense_detector_bounded \
+  "TC-IGC-547-148 large masked benign substitution stays bounded" 1 \
+  "${masked_large_command}"'echo "$(date)"'
+assert_dense_detector_bounded \
+  "TC-IGC-547-149 large masked hidden commit stays visible" 0 \
+  "${masked_large_command}"'echo "$(git commit -m x)"'
+assert_hook_bounded_rc \
+  "TC-IGC-547-150 hook allows large masked benign substitution" 0 \
+  "${masked_large_command}"'echo "$(date)"'
+assert_hook_bounded_rc \
+  "TC-IGC-547-151 hook blocks large masked hidden commit" 2 \
+  "${masked_large_command}"'echo "$(git commit -m x)"'
+deep_padding=$(printf 'x%.0s' {1..47})
+deep_substitution='date'
+for ((i = 1; i <= 62; i++)); do
+  deep_substitution="printf %s_${deep_padding}${i} \$($deep_substitution)"
+done
+assert_dense_detector_bounded \
+  "TC-IGC-547-152 deeply nested benign substitution terminates fail-closed" 0 \
+  "echo \$($deep_substitution)"
+assert_dense_detector_bounded \
+  "TC-IGC-547-153 deeply nested hidden commit terminates fail-closed" 0 \
+  "echo \$(git commit -m x; $deep_substitution)"
+assert_hook_bounded_rc \
+  "TC-IGC-547-154 hook bounds deeply nested benign substitution" 2 \
+  "echo \$($deep_substitution)"
+assert_hook_bounded_rc \
+  "TC-IGC-547-155 hook blocks deeply nested hidden commit" 2 \
+  "echo \$(git commit -m x; $deep_substitution)"
+large_backtick_padding=$(printf 'x%.0s' {1..5000})
+assert_dense_detector_bounded \
+  "TC-IGC-547-156 large benign backtick substitution stays allowed" 1 \
+  "echo $large_backtick_padding; echo \`date\`"
+assert_dense_detector_bounded \
+  "TC-IGC-547-157 large hidden backtick commit stays visible" 0 \
+  "echo $large_backtick_padding; echo \`git commit -m x\`"
+assert_hook_bounded_rc \
+  "TC-IGC-547-158 hook allows large benign backtick substitution" 0 \
+  "echo $large_backtick_padding; echo \`date\`"
+assert_hook_bounded_rc \
+  "TC-IGC-547-159 hook blocks large hidden backtick commit" 2 \
+  "echo $large_backtick_padding; echo \`git commit -m x\`"
+mixed_substitution='date'
+for ((i = 0; i < 1635; i++)); do
+  if (( i % 2 == 0 )); then
+    mixed_substitution="\$($mixed_substitution)"
+  else
+    mixed_substitution="\`$mixed_substitution\`"
+  fi
+done
+mixed_substitution="${mixed_substitution:0:4090}"
+assert_dense_detector_bounded \
+  "TC-IGC-547-160 worst-case mixed substitution terminates fail-closed" 0 \
+  "$mixed_substitution" 3
+assert_hook_bounded_rc \
+  "TC-IGC-547-161 hook bounds worst-case mixed substitution" 2 \
+  "$mixed_substitution" 3
+
+large_ansi_padding=$(printf 'x%.0s' {1..4100})
+large_ansi_backtick="echo \`\$'git' \$'commit' -m x\`; echo $large_ansi_padding"
+assert_dense_detector_bounded \
+  "TC-IGC-547-162 large ANSI-C quoted backtick commit stays visible" 0 \
+  "$large_ansi_backtick"
+assert_hook_bounded_rc \
+  "TC-IGC-547-163 hook blocks large ANSI-C quoted backtick commit" 2 \
+  "$large_ansi_backtick"
+
+small_heredoc_substitution=$'cat > /tmp/issue547-commit-doc <<\'EOF\'\n'
+small_heredoc_substitution+=$'git commit -m documentation-only\n'
+small_heredoc_substitution+="$(printf 'documentation %.0s' {1..100})"
+small_heredoc_substitution+=$'\nEOF\necho "$(date)"'
+assert_detector_no_match \
+  "TC-IGC-547-164 heredoc commit prose beside benign substitution stays hidden" \
+  "$small_heredoc_substitution"
+assert_hook_rc \
+  "TC-IGC-547-165 hook allows heredoc commit prose beside benign substitution" 0 \
+  "$small_heredoc_substitution"
+
+commit_pr_body=$'gh pr create --title "fix: example" --body "$(cat <<\'PRBODY\'\n'
+commit_pr_body+=$'- The example workflow runs `git commit -m example` before review.\n'
+commit_pr_body+=$'PRBODY\n)"'
+assert_detector_no_match \
+  "TC-IGC-547-166 generated PR body commit prose stays hidden" \
+  "$commit_pr_body"
+assert_hook_rc \
+  "TC-IGC-547-167 hook allows generated PR body commit prose" 0 \
+  "$commit_pr_body"
+commit_pr_body_with_real_commit="${commit_pr_body}"'; echo "$(git commit -m real)"'
+assert_detector_match \
+  "TC-IGC-547-168 real commit beside generated PR body stays visible" \
+  "$commit_pr_body_with_real_commit"
+assert_hook_rc \
+  "TC-IGC-547-169 hook blocks real commit beside generated PR body" 2 \
+  "$commit_pr_body_with_real_commit"
+
+UNICODE_HIDDEN_COMMIT=$'echo "\u2615\u2615\u2615\u2615" && x=$(git commit -m real)'
+assert_detector_match \
+  "TC-IGC-547-170 UTF-8 prefix does not shift hidden commit body" \
+  "$UNICODE_HIDDEN_COMMIT"
+assert_hook_rc \
+  "TC-IGC-547-171 hook blocks hidden commit after UTF-8 prefix" 2 \
+  "$UNICODE_HIDDEN_COMMIT"
+
+SPLIT_COMMIT_OPERATION='git com$(echo mit) -m real'
+assert_detector_match \
+  "TC-IGC-547-172 dynamic suffix does not hide split commit operation" \
+  "$SPLIT_COMMIT_OPERATION"
+assert_hook_rc \
+  "TC-IGC-547-173 hook blocks split commit operation" 2 \
+  "$SPLIT_COMMIT_OPERATION"
+QUOTED_SPLIT_COMMIT_OPERATION='git "com"$(echo mit) -m real'
+assert_detector_match \
+  "TC-IGC-547-174 quoted prefix does not hide split commit operation" \
+  "$QUOTED_SPLIT_COMMIT_OPERATION"
+assert_hook_rc \
+  "TC-IGC-547-175 hook blocks quoted split commit operation" 2 \
+  "$QUOTED_SPLIT_COMMIT_OPERATION"
 
 echo ""
 echo "========================================"

--- a/tests/unit/test-is-git-command-non-executable-regions.sh
+++ b/tests/unit/test-is-git-command-non-executable-regions.sh
@@ -130,7 +130,9 @@ assert_large_heredoc_bounded() {
 
 assert_large_ambiguous_hook_bounded() {
   local id="$1"
-  local function_count="${2:-250}"
+  local expected="$2"
+  local tail="$3"
+  local function_count="${4:-250}"
   local command=$'python3 - <<PY\n'
   local payload output rc i
 
@@ -138,7 +140,7 @@ assert_large_ambiguous_hook_bounded() {
     command+="def f$i(x):"$'\n'
     command+="    return g(x)+$i"$'\n'
   done
-  command+=$'PY\ngit commit -m real'
+  command+=$'PY\n'"$tail"
   payload=$(jq -cn --arg command "$command" '{tool_input:{command:$command}}')
 
   output=$(
@@ -146,10 +148,10 @@ assert_large_ambiguous_hook_bounded() {
       printf '%s' "$payload" | timeout 5 bash "$HOOK" 2>&1
   )
   rc=$?
-  if [[ "$rc" -eq 2 ]]; then
+  if [[ "$rc" -eq "$expected" ]]; then
     record_pass "$id (hook rc=$rc within 5s)"
   else
-    record_fail "$id (expected hook rc=2 within 5s, got rc=$rc: $output)"
+    record_fail "$id (expected hook rc=$expected within 5s, got rc=$rc: $output)"
   fi
 }
 
@@ -310,7 +312,7 @@ BENIGN_COMMAND_DYNAMIC_SCRIPT='echo "$(command bash "$f")"'
 BENIGN_DYNAMIC_EVAL='echo "$(eval "$generated")"'
 
 echo ""
-echo "=== TC-IGC-547-001..141: non-executable git mentions ==="
+echo "=== TC-IGC-547-001..145: non-executable git mentions ==="
 echo ""
 
 assert_detector_no_match \
@@ -734,12 +736,26 @@ assert_hook_rc \
   "TC-IGC-547-138 hook allows dynamic eval without git text" 0 \
   "$BENIGN_DYNAMIC_EVAL"
 assert_large_ambiguous_hook_bounded \
-  "TC-IGC-547-139 large ambiguous command is blocked within hook budget"
+  "TC-IGC-547-139 large ambiguous command is blocked within hook budget" \
+  2 "git commit -m real"
 assert_resolver_uncertain_match \
   "TC-IGC-547-140 resolver keeps commit after masked heredoc visible" \
   "$HEREDOC_THEN_COMMIT"
 assert_large_ambiguous_hook_bounded \
-  "TC-IGC-547-141 twenty-kilobyte command is blocked within hook budget" 625
+  "TC-IGC-547-141 twenty-kilobyte command is blocked within hook budget" \
+  2 "git commit -m real" 625
+assert_large_ambiguous_hook_bounded \
+  "TC-IGC-547-142 generic short git flag is blocked within hook budget" \
+  2 "git -p commit -m real" 625
+assert_large_ambiguous_hook_bounded \
+  "TC-IGC-547-143 quoted commit word is blocked within hook budget" \
+  2 "git 'commit' -m real" 625
+assert_large_ambiguous_hook_bounded \
+  "TC-IGC-547-144 dynamic global argument is blocked within hook budget" \
+  2 'git ${G} commit -m real' 625
+assert_large_ambiguous_hook_bounded \
+  "TC-IGC-547-145 git-free ambiguous input stays allowed within hook budget" \
+  0 "printf '%s\n' done" 625
 
 echo ""
 echo "========================================"

--- a/tests/unit/test-is-git-command-non-executable-regions.sh
+++ b/tests/unit/test-is-git-command-non-executable-regions.sh
@@ -68,6 +68,20 @@ assert_resolver_no_match() {
   fi
 }
 
+assert_resolver_uncertain_match() {
+  local id="$1"
+  local command="$2"
+  local output rc
+
+  output=$(resolve_git_command_cwd commit "$command" "$REPO_A" 2>/dev/null)
+  rc=$?
+  if [[ "$rc" -eq 2 && -z "$output" ]]; then
+    record_pass "$id"
+  else
+    record_fail "$id (expected resolver rc=2/output='', got rc=$rc/output='$output')"
+  fi
+}
+
 run_hook() {
   local command="$1"
   local payload
@@ -111,6 +125,31 @@ assert_large_heredoc_bounded() {
   else
     rc=$?
     record_fail "$id (expected completion within 2s, got rc=$rc)"
+  fi
+}
+
+assert_large_ambiguous_hook_bounded() {
+  local id="$1"
+  local function_count="${2:-250}"
+  local command=$'python3 - <<PY\n'
+  local payload output rc i
+
+  for ((i = 0; i < function_count; i++)); do
+    command+="def f$i(x):"$'\n'
+    command+="    return g(x)+$i"$'\n'
+  done
+  command+=$'PY\ngit commit -m real'
+  payload=$(jq -cn --arg command "$command" '{tool_input:{command:$command}}')
+
+  output=$(
+    cd "$REPO_A" &&
+      printf '%s' "$payload" | timeout 5 bash "$HOOK" 2>&1
+  )
+  rc=$?
+  if [[ "$rc" -eq 2 ]]; then
+    record_pass "$id (hook rc=$rc within 5s)"
+  else
+    record_fail "$id (expected hook rc=2 within 5s, got rc=$rc: $output)"
   fi
 }
 
@@ -257,9 +296,21 @@ PIPE_OUTPUT_SUBSTITUTION='echo "$(echo '\''git commit -m real'\'')" | bash'
 PREFIX_REDIRECT_OUTPUT_SUBSTITUTION='echo > >(bash) "$(echo '\''git commit -m real'\'')"'
 # shellcheck disable=SC2016
 ARRAY_SUBSCRIPT_OUTPUT_SUBSTITUTION='echo "${arr[$(echo '\''x[$(git commit -m real; echo 0)]'\'')]}"'
+# shellcheck disable=SC2016
+BENIGN_DYNAMIC_SCRIPT_SUBSTITUTION='echo "$(bash "$f")"'
+# shellcheck disable=SC2016
+BENIGN_DYNAMIC_SHELL_CODE='n="$(sh -c "ls $dir")"'
+# shellcheck disable=SC2016
+BENIGN_ENV_DYNAMIC_VALUE='v="$(env FOO="$BAR" bash -c ls)"'
+# shellcheck disable=SC2016
+BENIGN_EXEC_DYNAMIC_SCRIPT='echo "$(exec bash "$f")"'
+# shellcheck disable=SC2016
+BENIGN_COMMAND_DYNAMIC_SCRIPT='echo "$(command bash "$f")"'
+# shellcheck disable=SC2016
+BENIGN_DYNAMIC_EVAL='echo "$(eval "$generated")"'
 
 echo ""
-echo "=== TC-IGC-547-001..126: non-executable git mentions ==="
+echo "=== TC-IGC-547-001..141: non-executable git mentions ==="
 echo ""
 
 assert_detector_no_match \
@@ -646,6 +697,49 @@ assert_detector_match \
 assert_hook_rc \
   "TC-IGC-547-126 array subscript consumer remains fail-closed" 2 \
   "$ARRAY_SUBSCRIPT_OUTPUT_SUBSTITUTION"
+assert_detector_no_match \
+  "TC-IGC-547-127 dynamic script path without git text stays allowed" \
+  "$BENIGN_DYNAMIC_SCRIPT_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-128 hook allows dynamic script path without git text" 0 \
+  "$BENIGN_DYNAMIC_SCRIPT_SUBSTITUTION"
+assert_detector_no_match \
+  "TC-IGC-547-129 dynamic shell code without git text stays allowed" \
+  "$BENIGN_DYNAMIC_SHELL_CODE"
+assert_hook_rc \
+  "TC-IGC-547-130 hook allows dynamic shell code without git text" 0 \
+  "$BENIGN_DYNAMIC_SHELL_CODE"
+assert_detector_no_match \
+  "TC-IGC-547-131 dynamic env value without git text stays allowed" \
+  "$BENIGN_ENV_DYNAMIC_VALUE"
+assert_hook_rc \
+  "TC-IGC-547-132 hook allows dynamic env value without git text" 0 \
+  "$BENIGN_ENV_DYNAMIC_VALUE"
+assert_detector_no_match \
+  "TC-IGC-547-133 exec dynamic script without git text stays allowed" \
+  "$BENIGN_EXEC_DYNAMIC_SCRIPT"
+assert_hook_rc \
+  "TC-IGC-547-134 hook allows exec dynamic script without git text" 0 \
+  "$BENIGN_EXEC_DYNAMIC_SCRIPT"
+assert_detector_no_match \
+  "TC-IGC-547-135 command dynamic script without git text stays allowed" \
+  "$BENIGN_COMMAND_DYNAMIC_SCRIPT"
+assert_hook_rc \
+  "TC-IGC-547-136 hook allows command dynamic script without git text" 0 \
+  "$BENIGN_COMMAND_DYNAMIC_SCRIPT"
+assert_detector_no_match \
+  "TC-IGC-547-137 dynamic eval without git text stays allowed" \
+  "$BENIGN_DYNAMIC_EVAL"
+assert_hook_rc \
+  "TC-IGC-547-138 hook allows dynamic eval without git text" 0 \
+  "$BENIGN_DYNAMIC_EVAL"
+assert_large_ambiguous_hook_bounded \
+  "TC-IGC-547-139 large ambiguous command is blocked within hook budget"
+assert_resolver_uncertain_match \
+  "TC-IGC-547-140 resolver keeps commit after masked heredoc visible" \
+  "$HEREDOC_THEN_COMMIT"
+assert_large_ambiguous_hook_bounded \
+  "TC-IGC-547-141 twenty-kilobyte command is blocked within hook budget" 625
 
 echo ""
 echo "========================================"

--- a/tests/unit/test-is-git-command-non-executable-regions.sh
+++ b/tests/unit/test-is-git-command-non-executable-regions.sh
@@ -1,0 +1,655 @@
+#!/bin/bash
+# Regression coverage for issue #547: non-executable shell regions must not
+# be treated as git invocations.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$PROJECT_ROOT/skills/autonomous-common/hooks/lib.sh"
+HOOK="$PROJECT_ROOT/skills/autonomous-common/hooks/block-commit-outside-worktree.sh"
+TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/issue-547-non-executable.XXXXXX")"
+REPO_A="$TMPROOT/repo-a"
+
+trap 'rm -rf "$TMPROOT"' EXIT
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# shellcheck source=/dev/null
+source "$LIB"
+
+record_pass() {
+  echo -e "  ${GREEN}PASS${NC}: $1"
+  PASS=$((PASS + 1))
+}
+
+record_fail() {
+  echo -e "  ${RED}FAIL${NC}: $1"
+  FAIL=$((FAIL + 1))
+}
+
+assert_detector_no_match() {
+  local id="$1"
+  local command="$2"
+
+  if ! is_git_command commit "$command"; then
+    record_pass "$id"
+  else
+    record_fail "$id (is_git_command incorrectly detected commit)"
+  fi
+}
+
+assert_detector_match() {
+  local id="$1"
+  local command="$2"
+
+  if is_git_command commit "$command"; then
+    record_pass "$id"
+  else
+    record_fail "$id (is_git_command missed a real commit)"
+  fi
+}
+
+assert_resolver_no_match() {
+  local id="$1"
+  local command="$2"
+  local output rc
+
+  output=$(resolve_git_command_cwd commit "$command" "$REPO_A" 2>/dev/null)
+  rc=$?
+  if [[ "$rc" -eq 1 && -z "$output" ]]; then
+    record_pass "$id"
+  else
+    record_fail "$id (expected resolver rc=1/output='', got rc=$rc/output='$output')"
+  fi
+}
+
+run_hook() {
+  local command="$1"
+  local payload
+
+  payload=$(jq -cn --arg command "$command" '{tool_input:{command:$command}}')
+  HOOK_OUTPUT=$(
+    cd "$REPO_A" &&
+      printf '%s' "$payload" | bash "$HOOK" 2>&1
+  )
+  HOOK_RC=$?
+}
+
+assert_hook_rc() {
+  local id="$1"
+  local expected="$2"
+  local command="$3"
+
+  run_hook "$command"
+  if [[ "$HOOK_RC" -eq "$expected" ]]; then
+    record_pass "$id (hook rc=$HOOK_RC)"
+  else
+    record_fail "$id (expected hook rc=$expected, got $HOOK_RC: $HOOK_OUTPUT)"
+  fi
+}
+
+assert_large_heredoc_bounded() {
+  local id="$1"
+  local rc
+
+  # shellcheck disable=SC2016
+  if timeout 2 bash -c '
+    source "$1"
+    payload=$(
+      printf "cat <<EOF\n"
+      head -c 1000000 /dev/zero | tr "\0" x
+      printf "\nEOF\n"
+    )
+    ! is_git_command commit "$payload"
+  ' _ "$LIB"; then
+    record_pass "$id"
+  else
+    rc=$?
+    record_fail "$id (expected completion within 2s, got rc=$rc)"
+  fi
+}
+
+assert_preprocessor_failure_detector() {
+  local id="$1"
+
+  if (
+    # shellcheck disable=SC2329
+    awk() { return 127; }
+    is_git_command commit "$REAL_COMMIT"
+  ); then
+    record_pass "$id"
+  else
+    record_fail "$id (detector did not retain the original command)"
+  fi
+}
+
+assert_preprocessor_failure_resolver() {
+  local id="$1"
+  local output rc
+
+  output=$(
+    (
+      # shellcheck disable=SC2329
+      awk() { return 127; }
+      resolve_git_command_cwd commit "$REAL_COMMIT" "$REPO_A"
+    )
+  )
+  rc=$?
+  if [[ "$rc" -eq 0 && "$output" == "$CANON_A" ]]; then
+    record_pass "$id"
+  else
+    record_fail "$id (expected rc=0/output='$CANON_A', got rc=$rc/output='$output')"
+  fi
+}
+
+mkdir -p "$REPO_A"
+git init -q -b main "$REPO_A"
+git -C "$REPO_A" config user.email "test@example.com"
+git -C "$REPO_A" config user.name "Hook Test"
+printf 'initial\n' > "$REPO_A/initial.txt"
+git -C "$REPO_A" add initial.txt
+git -C "$REPO_A" commit -qm "initial"
+CANON_A="$(cd "$REPO_A" && pwd -P)"
+
+HEREDOC_COMMIT=$'cat > /tmp/p.md <<\'EOF\'\ngit commit -m msg\nEOF'
+HEREDOC_CHAIN=$'cat > /tmp/p.md <<-EOF\n\tgit add . && git commit -m x\n\tEOF'
+COMMENT_ONLY='ls -l  # git commit -m x'
+QUOTED_MENTION='echo "run: git commit -m x"'
+REAL_COMMIT='git commit -m x'
+COMMENT_THEN_COMMIT=$'# git commit -m documentation-only\ngit commit -m x'
+QUOTED_HASH_THEN_COMMIT='echo "# not a comment" && git commit -m x'
+HEREDOC_THEN_COMMIT=$'cat > /tmp/p.md <<\'EOF\'\ndocument only\nEOF\ngit commit -m x'
+DOUBLE_QUOTED_HEREDOC=$'cat > /tmp/p.md <<"EOF"\ngit commit -m body\nEOF'
+HERE_STRING_THEN_COMMIT=$'cat <<<EOF\ngit commit -m real'
+ESCAPED_HASH_THEN_COMMIT='echo \# && git commit -m real'
+MIDWORD_HASH_THEN_COMMIT='echo value#suffix && git commit -m real'
+QUOTED_OPENER_THEN_COMMIT=$'echo "<<EOF"\ngit commit -m real'
+MULTILINE_QUOTE_THEN_COMMIT=$'echo "line\n# still quoted" && git commit -m real'
+TRAILING_REDIRECT_HEREDOC=$'cat <<EOF >/tmp/p.md\ngit commit -m body\nEOF'
+ESCAPED_DELIMITER_HEREDOC=$'cat <<\\EOF\ngit commit -m body\nEOF'
+MULTIPLE_HEREDOCS=$'cat <<FIRST <<SECOND\ngit commit -m first-body\nFIRST\ngit commit -m second-body\nSECOND'
+# shellcheck disable=SC2016
+COMMAND_SUB_HASH_THEN_COMMIT='echo $(printf x)#suffix; git commit -m real'
+ARITHMETIC_SHIFT_THEN_COMMIT=$'(( 1 <<EOF\n))\ngit commit -m real\nEOF'
+HEREDOC_LINE_THEN_COMMIT=$'cat <<EOF >/dev/null; git commit -m real\nbody\nEOF'
+PIPELINE_HEREDOC=$'cat <<EOF | bash\ngit commit -m real\nEOF'
+UNQUOTED_HEREDOC_SUBSTITUTION=$'cat <<EOF >/dev/null\n$(git commit -m real)\nEOF'
+ESCAPED_HEREDOC_SUBSTITUTION=$'cat <<EOF >/dev/null\n\\$(git commit -m prose)\nEOF'
+# shellcheck disable=SC2016
+DOUBLE_QUOTED_SUBSTITUTION='echo "$(git commit -m real)"'
+# shellcheck disable=SC2016
+DOUBLE_QUOTED_BACKTICK='echo "`git commit -m real`"'
+SHELL_CONSUMER_HEREDOC=$'bash <<\'EOF\'\ngit commit -m real\nEOF'
+SHADOWED_CAT_HEREDOC=$'function cat { bash; }\ncat <<\'EOF\'\ngit commit -m real\nEOF'
+CONTINUED_CAT_FUNCTION_HEREDOC=$'function \\\ncat { bash; }\ncat <<\'EOF\'\ngit commit -m real\nEOF'
+# shellcheck disable=SC2016
+BENIGN_QUOTED_SUBSTITUTION='echo "generated $(date); example: git commit -m docs"'
+EVAL_CAT_HEREDOC=$'eval \'cat() { bash; }\'\ncat <<\'EOF\'\ngit commit -m real\nEOF'
+# shellcheck disable=SC2016
+SHELL_C_SUBSTITUTION='echo "$(bash -c '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+EVAL_SUBSTITUTION='echo "$(eval '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+BENIGN_ECHO_SUBSTITUTION='echo "$(echo '\''git commit -m prose'\'')"'
+# shellcheck disable=SC2016
+PAREN_SUBSTITUTION='echo "$(printf '\''(%s)'\'' x; git commit -m real)"'
+# shellcheck disable=SC2016
+SHELL_C_GROUP_SUBSTITUTION='echo "$(bash -c '\''(git commit -m real)'\'')"'
+# shellcheck disable=SC2016
+SHELL_C_OPTION_SUBSTITUTION='echo "$(bash -O extglob -c '\''git commit -m real'\'')"'
+COMMENT_PAREN_SUBSTITUTION=$'echo "$(printf x # )\ngit commit -m real\n)"'
+# shellcheck disable=SC2016
+GROUPED_SUBSTITUTION='echo "$( (git commit -m real) )"'
+# shellcheck disable=SC2016
+SHELL_PLUS_O_SUBSTITUTION='echo "$(bash +O extglob -c '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+ENV_UNSET_SUBSTITUTION='echo "$(env -u X bash -c '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+COMMAND_P_SUBSTITUTION='echo "$(command -p bash -c '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+SUBSTITUTION_EOF_COMMENT='echo "$(date)" # git commit -m prose'
+# shellcheck disable=SC2016
+DYNAMIC_SHELL_SUBSTITUTION='echo "$($SHELL -c '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+EXEC_SHELL_SUBSTITUTION='echo "$(exec bash -c '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+IF_SHELL_SUBSTITUTION='echo "$(if true; then bash -c '\''git commit -m real'\''; fi)"'
+# shellcheck disable=SC2016
+ESCAPED_SHELL_SUBSTITUTION='echo "$(\bash -c '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+NEGATED_SHELL_SUBSTITUTION='echo "$(! bash -c '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+IF_CONDITION_SUBSTITUTION='echo "$(if bash -c '\''git commit -m real'\''; then :; fi)"'
+# shellcheck disable=SC2016
+TIME_SHELL_SUBSTITUTION='echo "$(time bash -c '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+REDIRECTED_SHELL_SUBSTITUTION='echo "$(>/dev/null bash -c '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+BASH_STDIN_SUBSTITUTION='echo "$(bash <<< '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+BASH_S_STDIN_SUBSTITUTION='echo "$(bash -s <<< '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+BENIGN_PRINTF_SUBSTITUTION='echo "$(printf '\''%s'\'' '\''git commit -m prose'\'')"'
+# shellcheck disable=SC2016
+SHADOWED_ECHO_SUBSTITUTION='echo(){ eval "$*"; }; : "$(echo '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+SHADOWED_PRINTF_SUBSTITUTION='printf(){ eval "$1"; }; : "$(printf '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+PATH_ECHO_SUBSTITUTION='echo "$(/tmp/echo '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+PATH_PRINTF_SUBSTITUTION='echo "$(/tmp/printf '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+PRINTF_V_SUBSTITUTION='echo "$(printf -v '\''x[$(git commit -m real; echo 0)]'\'' %s value)"'
+# shellcheck disable=SC2016
+EVAL_OUTPUT_SUBSTITUTION='eval "$(echo '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+BASH_C_OUTPUT_SUBSTITUTION='bash -c "$(echo '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+BASH_PROCESS_OUTPUT_SUBSTITUTION='bash <(echo '\''git commit -m real'\'')'
+# shellcheck disable=SC2016
+PIPE_OUTPUT_SUBSTITUTION='echo "$(echo '\''git commit -m real'\'')" | bash'
+# shellcheck disable=SC2016
+PREFIX_REDIRECT_OUTPUT_SUBSTITUTION='echo > >(bash) "$(echo '\''git commit -m real'\'')"'
+# shellcheck disable=SC2016
+ARRAY_SUBSCRIPT_OUTPUT_SUBSTITUTION='echo "${arr[$(echo '\''x[$(git commit -m real; echo 0)]'\'')]}"'
+
+echo ""
+echo "=== TC-IGC-547-001..126: non-executable git mentions ==="
+echo ""
+
+assert_detector_no_match \
+  "TC-IGC-547-001 heredoc body is not executable command text" \
+  "$HEREDOC_COMMIT"
+assert_detector_no_match \
+  "TC-IGC-547-002 indented heredoc body is not executable command text" \
+  "$HEREDOC_CHAIN"
+assert_detector_no_match \
+  "TC-IGC-547-003 shell comment is not executable command text" \
+  "$COMMENT_ONLY"
+assert_detector_no_match \
+  "TC-IGC-547-004 quoted mention remains ignored" \
+  "$QUOTED_MENTION"
+
+assert_resolver_no_match \
+  "TC-IGC-547-005 resolver ignores heredoc body" \
+  "$HEREDOC_COMMIT"
+assert_resolver_no_match \
+  "TC-IGC-547-006 resolver ignores shell comment" \
+  "$COMMENT_ONLY"
+
+assert_hook_rc \
+  "TC-IGC-547-007 hook allows heredoc file generation" 0 \
+  "$HEREDOC_COMMIT"
+assert_hook_rc \
+  "TC-IGC-547-008 hook allows indented heredoc file generation" 0 \
+  "$HEREDOC_CHAIN"
+assert_hook_rc \
+  "TC-IGC-547-009 hook allows comment-only mention" 0 \
+  "$COMMENT_ONLY"
+
+assert_detector_match \
+  "TC-IGC-547-010 genuine commit remains detected" \
+  "$REAL_COMMIT"
+assert_detector_match \
+  "TC-IGC-547-011 real commit after a comment remains detected" \
+  "$COMMENT_THEN_COMMIT"
+assert_hook_rc \
+  "TC-IGC-547-012 genuine commit from main workspace remains blocked" 2 \
+  "$REAL_COMMIT"
+assert_detector_match \
+  "TC-IGC-547-013 hash inside quotes does not hide a later commit" \
+  "$QUOTED_HASH_THEN_COMMIT"
+assert_detector_match \
+  "TC-IGC-547-014 commit after heredoc terminator remains detected" \
+  "$HEREDOC_THEN_COMMIT"
+assert_hook_rc \
+  "TC-IGC-547-015 hash inside quotes does not bypass the hook" 2 \
+  "$QUOTED_HASH_THEN_COMMIT"
+assert_hook_rc \
+  "TC-IGC-547-016 commit after heredoc terminator remains blocked" 2 \
+  "$HEREDOC_THEN_COMMIT"
+assert_detector_no_match \
+  "TC-IGC-547-017 double-quoted heredoc body is not executable" \
+  "$DOUBLE_QUOTED_HEREDOC"
+assert_hook_rc \
+  "TC-IGC-547-018 hook allows double-quoted heredoc file generation" 0 \
+  "$DOUBLE_QUOTED_HEREDOC"
+assert_detector_match \
+  "TC-IGC-547-019 here-string does not hide a later commit" \
+  "$HERE_STRING_THEN_COMMIT"
+assert_hook_rc \
+  "TC-IGC-547-020 here-string does not bypass the hook" 2 \
+  "$HERE_STRING_THEN_COMMIT"
+assert_detector_match \
+  "TC-IGC-547-021 escaped hash does not begin a comment" \
+  "$ESCAPED_HASH_THEN_COMMIT"
+assert_detector_match \
+  "TC-IGC-547-022 mid-word hash does not begin a comment" \
+  "$MIDWORD_HASH_THEN_COMMIT"
+assert_detector_match \
+  "TC-IGC-547-023 quoted heredoc opener does not hide a later commit" \
+  "$QUOTED_OPENER_THEN_COMMIT"
+assert_detector_match \
+  "TC-IGC-547-024 multiline quoted hash does not hide a later commit" \
+  "$MULTILINE_QUOTE_THEN_COMMIT"
+assert_large_heredoc_bounded \
+  "TC-IGC-547-025 one-megabyte heredoc completes within hook budget"
+assert_preprocessor_failure_detector \
+  "TC-IGC-547-026 detector fails closed when preprocessing is unavailable"
+assert_preprocessor_failure_resolver \
+  "TC-IGC-547-027 resolver fails closed when preprocessing is unavailable"
+assert_detector_no_match \
+  "TC-IGC-547-028 heredoc delimiter may precede a trailing redirect" \
+  "$TRAILING_REDIRECT_HEREDOC"
+assert_hook_rc \
+  "TC-IGC-547-029 hook allows heredoc with a trailing redirect" 0 \
+  "$TRAILING_REDIRECT_HEREDOC"
+assert_detector_no_match \
+  "TC-IGC-547-030 escaped heredoc delimiter is recognized" \
+  "$ESCAPED_DELIMITER_HEREDOC"
+assert_detector_no_match \
+  "TC-IGC-547-031 multiple heredoc bodies are non-executable" \
+  "$MULTIPLE_HEREDOCS"
+assert_hook_rc \
+  "TC-IGC-547-032 hook allows multiple heredoc bodies" 0 \
+  "$MULTIPLE_HEREDOCS"
+assert_detector_match \
+  "TC-IGC-547-033 command substitution suffix does not hide a real commit" \
+  "$COMMAND_SUB_HASH_THEN_COMMIT"
+assert_hook_rc \
+  "TC-IGC-547-034 command substitution suffix remains fail-closed" 2 \
+  "$COMMAND_SUB_HASH_THEN_COMMIT"
+assert_detector_match \
+  "TC-IGC-547-035 arithmetic shift is not treated as a heredoc" \
+  "$ARITHMETIC_SHIFT_THEN_COMMIT"
+assert_hook_rc \
+  "TC-IGC-547-036 arithmetic syntax remains fail-closed" 2 \
+  "$ARITHMETIC_SHIFT_THEN_COMMIT"
+assert_detector_match \
+  "TC-IGC-547-037 real commit on heredoc declaration line remains visible" \
+  "$HEREDOC_LINE_THEN_COMMIT"
+assert_detector_match \
+  "TC-IGC-547-038 pipeline consumer may execute heredoc body" \
+  "$PIPELINE_HEREDOC"
+assert_hook_rc \
+  "TC-IGC-547-039 pipeline heredoc remains fail-closed" 2 \
+  "$PIPELINE_HEREDOC"
+assert_detector_match \
+  "TC-IGC-547-040 unquoted heredoc command substitution remains visible" \
+  "$UNQUOTED_HEREDOC_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-041 unquoted heredoc substitution remains fail-closed" 2 \
+  "$UNQUOTED_HEREDOC_SUBSTITUTION"
+assert_detector_no_match \
+  "TC-IGC-547-042 escaped heredoc substitution is literal data" \
+  "$ESCAPED_HEREDOC_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-043 hook allows escaped heredoc substitution prose" 0 \
+  "$ESCAPED_HEREDOC_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-044 double-quoted command substitution remains visible" \
+  "$DOUBLE_QUOTED_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-045 double-quoted command substitution remains fail-closed" 2 \
+  "$DOUBLE_QUOTED_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-046 double-quoted backtick substitution remains visible" \
+  "$DOUBLE_QUOTED_BACKTICK"
+assert_hook_rc \
+  "TC-IGC-547-047 double-quoted backtick substitution remains fail-closed" 2 \
+  "$DOUBLE_QUOTED_BACKTICK"
+assert_detector_match \
+  "TC-IGC-547-048 shell interpreter may execute quoted heredoc body" \
+  "$SHELL_CONSUMER_HEREDOC"
+assert_hook_rc \
+  "TC-IGC-547-049 shell-consumer heredoc remains fail-closed" 2 \
+  "$SHELL_CONSUMER_HEREDOC"
+assert_detector_match \
+  "TC-IGC-547-050 in-command cat function keeps heredoc body visible" \
+  "$SHADOWED_CAT_HEREDOC"
+assert_hook_rc \
+  "TC-IGC-547-051 in-command cat function remains fail-closed" 2 \
+  "$SHADOWED_CAT_HEREDOC"
+if (
+  # shellcheck disable=SC2329
+  cat() { bash; }
+  is_git_command commit "$HEREDOC_COMMIT"
+); then
+  record_pass "TC-IGC-547-052 environment cat function keeps heredoc body visible"
+else
+  record_fail "TC-IGC-547-052 environment cat function hid a real commit"
+fi
+assert_detector_match \
+  "TC-IGC-547-053 continued cat function keeps heredoc body visible" \
+  "$CONTINUED_CAT_FUNCTION_HEREDOC"
+assert_hook_rc \
+  "TC-IGC-547-054 continued cat function remains fail-closed" 2 \
+  "$CONTINUED_CAT_FUNCTION_HEREDOC"
+assert_detector_no_match \
+  "TC-IGC-547-055 benign quoted substitution keeps git prose hidden" \
+  "$BENIGN_QUOTED_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-056 hook allows benign quoted substitution prose" 0 \
+  "$BENIGN_QUOTED_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-057 eval-defined cat keeps heredoc body visible" \
+  "$EVAL_CAT_HEREDOC"
+assert_hook_rc \
+  "TC-IGC-547-058 eval-defined cat remains fail-closed" 2 \
+  "$EVAL_CAT_HEREDOC"
+assert_detector_match \
+  "TC-IGC-547-059 shell -c substitution remains visible" \
+  "$SHELL_C_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-060 shell -c substitution remains fail-closed" 2 \
+  "$SHELL_C_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-061 eval substitution remains visible" \
+  "$EVAL_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-062 eval substitution remains fail-closed" 2 \
+  "$EVAL_SUBSTITUTION"
+assert_detector_no_match \
+  "TC-IGC-547-063 benign echo substitution keeps git prose hidden" \
+  "$BENIGN_ECHO_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-064 hook allows benign echo substitution prose" 0 \
+  "$BENIGN_ECHO_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-065 ordinary substitution parentheses keep commit visible" \
+  "$PAREN_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-066 ordinary substitution parentheses remain fail-closed" 2 \
+  "$PAREN_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-067 grouped shell -c commit remains visible" \
+  "$SHELL_C_GROUP_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-068 grouped shell -c commit remains fail-closed" 2 \
+  "$SHELL_C_GROUP_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-069 shell option argument does not hide -c code" \
+  "$SHELL_C_OPTION_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-070 shell option argument remains fail-closed" 2 \
+  "$SHELL_C_OPTION_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-071 comment parenthesis does not truncate substitution" \
+  "$COMMENT_PAREN_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-072 comment parenthesis remains fail-closed" 2 \
+  "$COMMENT_PAREN_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-073 grouped substitution commit remains visible" \
+  "$GROUPED_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-074 grouped substitution commit remains fail-closed" 2 \
+  "$GROUPED_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-075 shell +O argument does not hide -c code" \
+  "$SHELL_PLUS_O_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-076 shell +O argument remains fail-closed" 2 \
+  "$SHELL_PLUS_O_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-077 env option argument does not hide shell code" \
+  "$ENV_UNSET_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-078 env option argument remains fail-closed" 2 \
+  "$ENV_UNSET_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-079 command option does not hide shell code" \
+  "$COMMAND_P_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-080 command option remains fail-closed" 2 \
+  "$COMMAND_P_SUBSTITUTION"
+assert_detector_no_match \
+  "TC-IGC-547-081 EOF comment after substitution stays hidden" \
+  "$SUBSTITUTION_EOF_COMMENT"
+assert_hook_rc \
+  "TC-IGC-547-082 hook allows EOF comment after substitution" 0 \
+  "$SUBSTITUTION_EOF_COMMENT"
+assert_detector_match \
+  "TC-IGC-547-083 dynamic shell executor remains visible" \
+  "$DYNAMIC_SHELL_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-084 dynamic shell executor remains fail-closed" 2 \
+  "$DYNAMIC_SHELL_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-085 exec shell wrapper remains visible" \
+  "$EXEC_SHELL_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-086 exec shell wrapper remains fail-closed" 2 \
+  "$EXEC_SHELL_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-087 conditional shell execution remains visible" \
+  "$IF_SHELL_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-088 conditional shell execution remains fail-closed" 2 \
+  "$IF_SHELL_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-089 escaped shell command remains visible" \
+  "$ESCAPED_SHELL_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-090 escaped shell command remains fail-closed" 2 \
+  "$ESCAPED_SHELL_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-091 negated shell execution remains visible" \
+  "$NEGATED_SHELL_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-092 negated shell execution remains fail-closed" 2 \
+  "$NEGATED_SHELL_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-093 if condition shell execution remains visible" \
+  "$IF_CONDITION_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-094 if condition shell execution remains fail-closed" 2 \
+  "$IF_CONDITION_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-095 time-prefixed shell execution remains visible" \
+  "$TIME_SHELL_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-096 time-prefixed shell execution remains fail-closed" 2 \
+  "$TIME_SHELL_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-097 redirected shell execution remains visible" \
+  "$REDIRECTED_SHELL_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-098 redirected shell execution remains fail-closed" 2 \
+  "$REDIRECTED_SHELL_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-099 bash stdin code remains visible" \
+  "$BASH_STDIN_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-100 bash stdin code remains fail-closed" 2 \
+  "$BASH_STDIN_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-101 bash -s stdin code remains visible" \
+  "$BASH_S_STDIN_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-102 bash -s stdin code remains fail-closed" 2 \
+  "$BASH_S_STDIN_SUBSTITUTION"
+assert_detector_no_match \
+  "TC-IGC-547-103 simple printf keeps git prose as data" \
+  "$BENIGN_PRINTF_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-104 hook allows simple printf git prose" 0 \
+  "$BENIGN_PRINTF_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-105 shadowed echo remains executable" \
+  "$SHADOWED_ECHO_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-106 shadowed echo remains fail-closed" 2 \
+  "$SHADOWED_ECHO_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-107 shadowed printf remains executable" \
+  "$SHADOWED_PRINTF_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-108 shadowed printf remains fail-closed" 2 \
+  "$SHADOWED_PRINTF_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-109 path echo is not trusted as a builtin" \
+  "$PATH_ECHO_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-110 path echo remains fail-closed" 2 \
+  "$PATH_ECHO_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-111 path printf is not trusted as a builtin" \
+  "$PATH_PRINTF_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-112 path printf remains fail-closed" 2 \
+  "$PATH_PRINTF_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-113 printf -v array subscript remains executable" \
+  "$PRINTF_V_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-114 printf -v array subscript remains fail-closed" 2 \
+  "$PRINTF_V_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-115 eval consumer keeps generated commit visible" \
+  "$EVAL_OUTPUT_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-116 eval consumer remains fail-closed" 2 \
+  "$EVAL_OUTPUT_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-117 bash -c consumer keeps generated commit visible" \
+  "$BASH_C_OUTPUT_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-118 bash -c consumer remains fail-closed" 2 \
+  "$BASH_C_OUTPUT_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-119 process-substitution consumer keeps commit visible" \
+  "$BASH_PROCESS_OUTPUT_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-120 process-substitution consumer remains fail-closed" 2 \
+  "$BASH_PROCESS_OUTPUT_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-121 pipeline consumer keeps generated commit visible" \
+  "$PIPE_OUTPUT_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-122 pipeline consumer remains fail-closed" 2 \
+  "$PIPE_OUTPUT_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-123 prefix redirect consumer keeps commit visible" \
+  "$PREFIX_REDIRECT_OUTPUT_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-124 prefix redirect consumer remains fail-closed" 2 \
+  "$PREFIX_REDIRECT_OUTPUT_SUBSTITUTION"
+assert_detector_match \
+  "TC-IGC-547-125 array subscript consumer keeps commit visible" \
+  "$ARRAY_SUBSCRIPT_OUTPUT_SUBSTITUTION"
+assert_hook_rc \
+  "TC-IGC-547-126 array subscript consumer remains fail-closed" 2 \
+  "$ARRAY_SUBSCRIPT_OUTPUT_SUBSTITUTION"
+
+echo ""
+echo "========================================"
+echo -e "Results: ${GREEN}$PASS passed${NC}, ${RED}$FAIL failed${NC}"
+echo "========================================"
+
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- Ignore shell comments and proven data-only heredoc/command-substitution regions when detecting git commit and push operations.
- Preserve fail-closed behavior for executable substitutions, shell/eval consumers, dynamic bindings, control flow, redirects, pipelines, grouped commands, and ambiguous syntax.
- Add regression coverage for UTF-8 span offsets, split operation words, large generated PR bodies, stdin PR-body heredocs, and bounded parser behavior.

## Pipeline Docs (CONTRIBUTING.md Rule 1)

- [x] If this PR touches a watched path (any `skills/autonomous-*/scripts/*.sh`, `skills/autonomous-common/hooks/*.sh`, or `skills/autonomous-*/SKILL.md` — see [CONTRIBUTING.md](CONTRIBUTING.md#what-pipeline-behavior-means) for the full list), I have updated `docs/pipeline/` to match the new behavior — OR I have applied the `pipeline-docs:none` label with rationale below.

Updated `docs/pipeline/invariants.md` and the issue-specific matrix under `docs/test-cases/`.

## Test Plan

- [x] Local checks pass (ShellCheck, `bash -n`, `git diff --check`, and public-artifact scan)
- [x] CI checks pass

Local verification:
- `test-is-git-command-non-executable-regions.sh`: 175/175 passed
- `test-block-push-regex.sh`: 410/410 passed
- `test-block-commit-outside-worktree.sh`: 188/188 passed
- `test-is-git-command.sh`: 16/16 passed
- `test-is-git-command-quote-strip.sh`: 9/9 passed
- Full unit run: 244/248 passed. The four failures are unrelated process/timing tests: lane-GC and turn-limit failures reproduce on clean `main`, provider-cutover passes when rerun alone, and the lease test can hang on clean `main` at its FIFO fixture.
- Independent `cc --model 'Opus[1m]'` review verified the prior findings and returned `VERDICT: APPROVE`.
- GitHub CI: 5 checks passed; the label-gated live smoke check was skipped as expected.

## Linked Issues

Closes #547
