### PR TITLE
fix(hooks): distinguish unresolved commit targets

### DIFF
--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -9384,9 +9384,17 @@ paths from resolving to a repository different from the command's real target.
 canonical `git-common-dir` is outside the installing repository's policy and is
 allowed. A target in the same repository is blocked when canonical `git-dir ==
 git-common-dir` and allowed when they differ, which identifies a linked
-worktree. Helper rc `2`, a missing/non-git target, or a failed canonical probe
-falls back to evaluating the hook cwd; uncertainty never grants a commit. The
-blanket `--amend` exemption remains unchanged.
+worktree. The hook prints `BLOCKED - Must Use Git Worktree` only after those
+repository and worktree identities are positively verified.
+
+Helper rc `2`, a missing/non-git target, an unreadable installing-repository
+identity, or any failed target `git-common-dir` / `git-dir` canonical probe
+remains fail-closed with exit `2`, but prints
+`BLOCKED - Unable to Verify Target Repository`. The diagnostic directs the
+caller to use one supported command with a literal path to an existing Git
+repository; uncertainty is never reported as proof of a main-workspace
+violation and never grants a commit. The blanket `--amend` exemption remains
+unchanged.
 
 The supported grammar is intentionally not a general shell parser. Repeated
 `cd`, mixed `cd` plus `git -C`, wrappers, other git global options, control
@@ -9413,11 +9421,13 @@ command text.
 **Status**: **ENFORCED**.
 
 **Test**: `tests/unit/test-block-commit-outside-worktree.sh`
-(`TC-BCOW-001..015`) covers both repository identities and main/linked
+(`TC-BCOW-001..016`) covers both repository identities and main/linked
 worktrees, all supported path forms, helper return codes, the fail-closed
-syntax matrix, and non-execution sentinels. The exact unrelated-repository
-reproduction is red on the parent implementation and green with this
-invariant. `tests/unit/test-is-git-command-non-executable-regions.sh`
+syntax matrix, non-execution sentinels, and diagnostic selection for proven
+main-workspace violations versus unverified resolver or repository-probe
+context. The exact unrelated-repository reproduction is red on the parent
+implementation and green with this invariant.
+`tests/unit/test-is-git-command-non-executable-regions.sh`
 (`TC-IGC-547-001..175`) covers comment/heredoc false positives, dynamic
 git-free shell consumers, generic/quoted/dynamic operation forms, the
 five-second hook budget, and the fail-closed substitution, interpreter,

--- a/docs/pipeline/invariants.md
+++ b/docs/pipeline/invariants.md
@@ -9387,14 +9387,18 @@ git-common-dir` and allowed when they differ, which identifies a linked
 worktree. The hook prints `BLOCKED - Must Use Git Worktree` only after those
 repository and worktree identities are positively verified.
 
-Helper rc `2`, a missing/non-git target, an unreadable installing-repository
-identity, or any failed target `git-common-dir` / `git-dir` canonical probe
-remains fail-closed with exit `2`, but prints
+Helper rc `2` or a failed target `git-common-dir` probe preserves the existing
+decision contract by evaluating the inherited hook cwd. A positively identified
+linked-worktree cwd remains allowed; a main-workspace cwd remains blocked.
+Uncertainty does not grant an allow by itself, and is never reported as proof
+of a main-workspace violation.
+
+When that fallback decision blocks, or when the installing-repository identity
+or target `git-dir` cannot be probed, the hook exits `2` with
 `BLOCKED - Unable to Verify Target Repository`. The diagnostic directs the
-caller to use one supported command with a literal path to an existing Git
-repository; uncertainty is never reported as proof of a main-workspace
-violation and never grants a commit. The blanket `--amend` exemption remains
-unchanged.
+caller to run from the repository or linked worktree whose policy applies and
+use one supported command with a literal path to an existing Git repository.
+The blanket `--amend` exemption remains unchanged.
 
 The supported grammar is intentionally not a general shell parser. Repeated
 `cd`, mixed `cd` plus `git -C`, wrappers, other git global options, control

--- a/docs/test-cases/block-commit-command-context.md
+++ b/docs/test-cases/block-commit-command-context.md
@@ -17,7 +17,7 @@ so it is safe under the parallel unit runner.
 | `TC-BCOW-006` | Explicit `cd` to repo B linked worktree | Hook exits `0` |
 | `TC-BCOW-007` | Relative, single-quoted, double-quoted, literal/escaped-backslash, escaped-quote, symlinked, tilde, and symlink-plus-`..` paths | Helper returns the canonical target; double-quote escapes are decoded without expansion, and `cd` applies logical dot-segment handling before canonicalization |
 | `TC-BCOW-008` | One two-token `git -C <repo-B> commit`, with absolute/quoted, relative, and symlink-plus-`..` paths | Hook exits `0`; helper resolves from its base directory using physical filesystem traversal |
-| `TC-BCOW-009` | Missing path and existing non-git directory from repo A main | Target probing falls back to hook cwd; hook exits `2` |
+| `TC-BCOW-009` | Missing path and existing non-git directory from repo A main | Target probing remains fail-closed without falling back to hook cwd; hook exits `2` |
 | `TC-BCOW-011` | Bare commit with hook cwd in repo A linked worktree | Hook exits `0` |
 | `TC-BCOW-012` | A command containing `--amend` from repo A main | Existing blanket exemption remains; hook exits `0` |
 
@@ -33,6 +33,7 @@ These assertions cover all rows of the repository decision table: A main
 | `TC-BCOW-013` | Direct helper contract | Supported match returns canonical cwd/`0`; deterministic ANSI-C non-git input, a NUL segment followed by a non-git suffix, and ordinary no-match input return empty/`1`; unsupported or missing-path match returns empty/`2` |
 | `TC-BCOW-014` | Variable-bearing arguments to `-C`, `-c`, `--git-dir`, `--work-tree`, `--namespace`, and `--super-prefix`, including long `--flag=value` forms and compound statements | Non-commit operations return empty/`1` and the hook exits `0`; variable-bearing or command-substitution operation words return empty/`2` and the hook exits `2` |
 | `TC-BCOW-015` | Bare, looped, chained, and nested-substitution commits; escaped or dynamic global flag spellings; field-splitting, process-substitution, escaped-space, quoted-multiword, and indirect flag operands; dynamic operation words; plus unchanged literal-path, no-global-flag, and linked-worktree contexts | Real or hidden commits remain blocked from repo A main, including commits injected or executed by unsafe option syntax; read-only commands and linked-worktree commits retain their previous outcomes |
+| `TC-BCOW-016` | Proven main-workspace commits from main or linked callers, uncertain resolver context from main or linked callers, missing/non-Git literal targets, and allowed linked/unrelated repositories | The worktree heading appears only for a positively proven main workspace. Resolver rc `2` and repository-probe failures use the unable-to-verify heading. Allowed cases emit no diagnostic |
 
 `TC-BCOW-010` passes all command strings as inert JSON data to the hook. The
 sentinel assertions prove the hook does not execute path-producing input.
@@ -48,3 +49,17 @@ sentinel assertions prove the hook does not execute path-producing input.
 | Helper exit contract | `TC-BCOW-007` and `TC-BCOW-013` |
 | Variable global-flag arguments are not operation words | `TC-BCOW-014` |
 | Real and hidden commits remain fail-closed | `TC-BCOW-014` and `TC-BCOW-015` |
+| Blocked diagnostics distinguish proven policy violations from unverified context | `TC-BCOW-016` |
+
+## Blocked diagnostic contract
+
+Both blocked outcomes exit `2`, but their operator guidance reflects different
+facts:
+
+| Verified state | Heading | Recovery |
+|---|---|---|
+| Target `git-common-dir` matches the installing repository and target `git-dir == git-common-dir` | `## BLOCKED - Must Use Git Worktree` | Commit from a linked worktree |
+| Resolver returns rc `2`, or a target/common/git-dir probe cannot verify an existing Git repository and worktree state | `## BLOCKED - Unable to Verify Target Repository` | Rewrite as one supported command using a literal path to an existing Git repository |
+
+The unable-to-verify path remains fail-closed. It does not execute command
+text, expand variables, or broaden the resolver grammar.

--- a/docs/test-cases/block-commit-command-context.md
+++ b/docs/test-cases/block-commit-command-context.md
@@ -1,6 +1,6 @@
 # Test cases: block-commit command context
 
-Issues #534 and #537 are covered by
+Issues #534, #537, and #548 are covered by
 `tests/unit/test-block-commit-outside-worktree.sh`. The test creates two
 independent repositories and linked worktrees under a fresh `mktemp` directory,
 so it is safe under the parallel unit runner.
@@ -17,7 +17,7 @@ so it is safe under the parallel unit runner.
 | `TC-BCOW-006` | Explicit `cd` to repo B linked worktree | Hook exits `0` |
 | `TC-BCOW-007` | Relative, single-quoted, double-quoted, literal/escaped-backslash, escaped-quote, symlinked, tilde, and symlink-plus-`..` paths | Helper returns the canonical target; double-quote escapes are decoded without expansion, and `cd` applies logical dot-segment handling before canonicalization |
 | `TC-BCOW-008` | One two-token `git -C <repo-B> commit`, with absolute/quoted, relative, and symlink-plus-`..` paths | Hook exits `0`; helper resolves from its base directory using physical filesystem traversal |
-| `TC-BCOW-009` | Missing path and existing non-git directory from repo A main | Target probing remains fail-closed without falling back to hook cwd; hook exits `2` |
+| `TC-BCOW-009` | Missing path and existing non-git directory from repo A main | Target probing falls back to the hook cwd for the existing verdict; repo A main remains blocked with exit `2` |
 | `TC-BCOW-011` | Bare commit with hook cwd in repo A linked worktree | Hook exits `0` |
 | `TC-BCOW-012` | A command containing `--amend` from repo A main | Existing blanket exemption remains; hook exits `0` |
 
@@ -33,7 +33,7 @@ These assertions cover all rows of the repository decision table: A main
 | `TC-BCOW-013` | Direct helper contract | Supported match returns canonical cwd/`0`; deterministic ANSI-C non-git input, a NUL segment followed by a non-git suffix, and ordinary no-match input return empty/`1`; unsupported or missing-path match returns empty/`2` |
 | `TC-BCOW-014` | Variable-bearing arguments to `-C`, `-c`, `--git-dir`, `--work-tree`, `--namespace`, and `--super-prefix`, including long `--flag=value` forms and compound statements | Non-commit operations return empty/`1` and the hook exits `0`; variable-bearing or command-substitution operation words return empty/`2` and the hook exits `2` |
 | `TC-BCOW-015` | Bare, looped, chained, and nested-substitution commits; escaped or dynamic global flag spellings; field-splitting, process-substitution, escaped-space, quoted-multiword, and indirect flag operands; dynamic operation words; plus unchanged literal-path, no-global-flag, and linked-worktree contexts | Real or hidden commits remain blocked from repo A main, including commits injected or executed by unsafe option syntax; read-only commands and linked-worktree commits retain their previous outcomes |
-| `TC-BCOW-016` | Proven main-workspace commits from main or linked callers, uncertain resolver context from main or linked callers, missing/non-Git literal targets, and allowed linked/unrelated repositories | The worktree heading appears only for a positively proven main workspace. Resolver rc `2` and repository-probe failures use the unable-to-verify heading. Allowed cases emit no diagnostic |
+| `TC-BCOW-016` | Proven main-workspace commits from main or linked callers, uncertain variable/compound context from main or linked callers, missing/non-Git literal targets from main or linked callers, installing-repository and `git-dir` probe failures, and allowed linked/unrelated repositories | The worktree heading appears only for a positively proven main workspace. An uncertain target preserves the inherited-cwd verdict: main remains blocked with the unable-to-verify heading, while linked remains allowed. Probe failures that cannot establish an allowed state use the unable-to-verify heading, whose remediation content is also pinned |
 
 `TC-BCOW-010` passes all command strings as inert JSON data to the hook. The
 sentinel assertions prove the hook does not execute path-producing input.
@@ -59,7 +59,9 @@ facts:
 | Verified state | Heading | Recovery |
 |---|---|---|
 | Target `git-common-dir` matches the installing repository and target `git-dir == git-common-dir` | `## BLOCKED - Must Use Git Worktree` | Commit from a linked worktree |
-| Resolver returns rc `2`, or a target/common/git-dir probe cannot verify an existing Git repository and worktree state | `## BLOCKED - Unable to Verify Target Repository` | Rewrite as one supported command using a literal path to an existing Git repository |
+| Resolver returns rc `2` or a target probe is uncertain, and the inherited-cwd fallback still blocks; or an installing-repository / `git-dir` probe cannot establish an allowed state | `## BLOCKED - Unable to Verify Target Repository` | Run from the repository or linked worktree whose policy applies, then rewrite as one supported command using a literal path to an existing Git repository |
 
-The unable-to-verify path remains fail-closed. It does not execute command
-text, expand variables, or broaden the resolver grammar.
+The unable-to-verify path does not execute command text, expand variables, or
+broaden the resolver grammar. Resolver and target-probe uncertainty preserves
+the pre-existing inherited-cwd decision: a linked-worktree fallback is still
+allowed, while a blocking fallback selects the unable-to-verify diagnostic.

--- a/skills/autonomous-common/hooks/block-commit-outside-worktree.sh
+++ b/skills/autonomous-common/hooks/block-commit-outside-worktree.sh
@@ -12,6 +12,10 @@ command=$(parse_command "$input")
 
 # Capture the installing repository identity before evaluating command context.
 base_dir=$(pwd -P)
+hook_common_dir=""
+if hook_common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null); then
+  hook_common_dir=$(_canonical_existing_directory "$hook_common_dir") || hook_common_dir=""
+fi
 
 # The resolver is the single source of truth: rc=0 is a supported commit,
 # rc=1 is a proven no-match, and rc=2 is a matching but uncertain command that
@@ -37,10 +41,10 @@ block_unverified_target() {
   cat >&2 <<'EOF'
 ## BLOCKED - Unable to Verify Target Repository
 
-The commit was blocked because this hook could not statically verify an existing Git repository target without executing the command.
+The commit was blocked because this hook could not statically verify the repository and worktree context without executing the command.
 
 ### Re-issue as One Supported Command:
-Use a literal path to an existing Git repository:
+Run from the repository or linked worktree whose policy applies, and use a literal path to an existing Git repository:
 
 ```bash
 git -C /absolute/path/to/repo commit -F /path/to/message
@@ -52,40 +56,46 @@ or:
 cd /absolute/path/to/repo && git commit -F /path/to/message
 ```
 
-Variables, substitutions, wrappers, pipelines, multiple commit invocations, missing paths, and non-Git directories remain blocked.
+Variables, substitutions, wrappers, pipelines, and multiple commit invocations are unsupported as repository evidence. Other compound command shapes, such as a bare `git add ... && git commit ...`, must be rewritten as one supported command. Missing paths and non-Git directories cannot be verified.
 
-If the intended target is this repository, create or switch to a linked worktree and commit there.
+If the intended target is this repository, create or switch to a linked worktree and issue the commit as one supported command there.
 EOF
   exit 2
 }
 
+verification_uncertain=false
 if [[ "$resolve_rc" -ne 0 ]]; then
-  block_unverified_target
-fi
-
-hook_common_dir=""
-if hook_common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null); then
-  hook_common_dir=$(_canonical_existing_directory "$hook_common_dir") || hook_common_dir=""
+  verification_uncertain=true
+  resolved_dir="$base_dir"
 fi
 
 target_common_dir=""
-if [[ -z "$hook_common_dir" ]] ||
-  ! target_common_dir=$(git -C "$resolved_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) ||
-  ! target_common_dir=$(_canonical_existing_directory "$target_common_dir"); then
-  block_unverified_target
-fi
-if [[ "$target_common_dir" != "$hook_common_dir" ]]; then
-  exit 0
+if [[ -n "$hook_common_dir" ]] &&
+  target_common_dir=$(git -C "$resolved_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) &&
+  target_common_dir=$(_canonical_existing_directory "$target_common_dir"); then
+  if [[ "$target_common_dir" != "$hook_common_dir" ]]; then
+    exit 0
+  fi
+else
+  verification_uncertain=true
+  resolved_dir="$base_dir"
+  target_common_dir="$hook_common_dir"
 fi
 
 # For repo A, git-dir differs from git-common-dir only in a linked worktree.
 target_git_dir=""
-if ! target_git_dir=$(git -C "$resolved_dir" rev-parse --path-format=absolute --git-dir 2>/dev/null) ||
-  ! target_git_dir=$(_canonical_existing_directory "$target_git_dir"); then
-  block_unverified_target
+if [[ -n "$target_common_dir" ]] &&
+  target_git_dir=$(git -C "$resolved_dir" rev-parse --path-format=absolute --git-dir 2>/dev/null) &&
+  target_git_dir=$(_canonical_existing_directory "$target_git_dir"); then
+  if [[ "$target_git_dir" != "$target_common_dir" ]]; then
+    exit 0
+  fi
+else
+  verification_uncertain=true
 fi
-if [[ "$target_git_dir" != "$target_common_dir" ]]; then
-  exit 0
+
+if [[ "$verification_uncertain" == true ]]; then
+  block_unverified_target
 fi
 
 # The target is positively proven to be this repository's main workspace.

--- a/skills/autonomous-common/hooks/block-commit-outside-worktree.sh
+++ b/skills/autonomous-common/hooks/block-commit-outside-worktree.sh
@@ -12,10 +12,6 @@ command=$(parse_command "$input")
 
 # Capture the installing repository identity before evaluating command context.
 base_dir=$(pwd -P)
-hook_common_dir=""
-if hook_common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null); then
-  hook_common_dir=$(_canonical_existing_directory "$hook_common_dir") || hook_common_dir=""
-fi
 
 # The resolver is the single source of truth: rc=0 is a supported commit,
 # rc=1 is a proven no-match, and rc=2 is a matching but uncertain command that
@@ -37,33 +33,62 @@ if [[ "$command" =~ --amend ]]; then
   exit 0
 fi
 
-# Any mismatch or resolution uncertainty falls back to the inherited cwd.
+block_unverified_target() {
+  cat >&2 <<'EOF'
+## BLOCKED - Unable to Verify Target Repository
+
+The commit was blocked because this hook could not statically verify an existing Git repository target without executing the command.
+
+### Re-issue as One Supported Command:
+Use a literal path to an existing Git repository:
+
+```bash
+git -C /absolute/path/to/repo commit -F /path/to/message
+```
+
+or:
+
+```bash
+cd /absolute/path/to/repo && git commit -F /path/to/message
+```
+
+Variables, substitutions, wrappers, pipelines, multiple commit invocations, missing paths, and non-Git directories remain blocked.
+
+If the intended target is this repository, create or switch to a linked worktree and commit there.
+EOF
+  exit 2
+}
+
 if [[ "$resolve_rc" -ne 0 ]]; then
-  resolved_dir="$base_dir"
+  block_unverified_target
+fi
+
+hook_common_dir=""
+if hook_common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null); then
+  hook_common_dir=$(_canonical_existing_directory "$hook_common_dir") || hook_common_dir=""
 fi
 
 target_common_dir=""
-if [[ -n "$hook_common_dir" ]] &&
-  target_common_dir=$(git -C "$resolved_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) &&
-  target_common_dir=$(_canonical_existing_directory "$target_common_dir"); then
-  if [[ "$target_common_dir" != "$hook_common_dir" ]]; then
-    exit 0
-  fi
-else
-  resolved_dir="$base_dir"
-  target_common_dir="$hook_common_dir"
+if [[ -z "$hook_common_dir" ]] ||
+  ! target_common_dir=$(git -C "$resolved_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) ||
+  ! target_common_dir=$(_canonical_existing_directory "$target_common_dir"); then
+  block_unverified_target
+fi
+if [[ "$target_common_dir" != "$hook_common_dir" ]]; then
+  exit 0
 fi
 
 # For repo A, git-dir differs from git-common-dir only in a linked worktree.
 target_git_dir=""
-if [[ -n "$target_common_dir" ]] &&
-  target_git_dir=$(git -C "$resolved_dir" rev-parse --path-format=absolute --git-dir 2>/dev/null) &&
-  target_git_dir=$(_canonical_existing_directory "$target_git_dir") &&
-  [[ "$target_git_dir" != "$target_common_dir" ]]; then
+if ! target_git_dir=$(git -C "$resolved_dir" rev-parse --path-format=absolute --git-dir 2>/dev/null) ||
+  ! target_git_dir=$(_canonical_existing_directory "$target_git_dir"); then
+  block_unverified_target
+fi
+if [[ "$target_git_dir" != "$target_common_dir" ]]; then
   exit 0
 fi
 
-# Block the commit
+# The target is positively proven to be this repository's main workspace.
 cat >&2 <<'EOF'
 ## BLOCKED - Must Use Git Worktree
 

--- a/tests/unit/test-block-commit-outside-worktree.sh
+++ b/tests/unit/test-block-commit-outside-worktree.sh
@@ -127,7 +127,7 @@ assert_resolver() {
 }
 
 echo ""
-echo "=== TC-BCOW-001..015: block-commit command context ==="
+echo "=== TC-BCOW-001..016: block-commit command context ==="
 echo ""
 
 assert_hook_rc \
@@ -566,6 +566,87 @@ assert_resolver \
 assert_hook_rc \
   "TC-BCOW-015t nested command in quoted operand remains blocked" 2 "$REPO_A" \
   'unset p; git -C "${p:-$(git commit -m nested)}" log'
+
+WORKTREE_HEADING="## BLOCKED - Must Use Git Worktree"
+UNVERIFIED_HEADING="## BLOCKED - Unable to Verify Target Repository"
+
+assert_hook_diagnostic() {
+  local id="$1"
+  local cwd="$2"
+  local command="$3"
+  local expected_heading="$4"
+  local forbidden_heading="$5"
+
+  run_hook "$cwd" "$command"
+  if [[ "$HOOK_RC" -ne 2 ]]; then
+    record_fail "$id (expected hook rc=2, got $HOOK_RC: $HOOK_OUTPUT)"
+  elif [[ "$HOOK_OUTPUT" != *"$expected_heading"* ]]; then
+    record_fail "$id (missing diagnostic '$expected_heading': $HOOK_OUTPUT)"
+  elif [[ "$HOOK_OUTPUT" == *"$forbidden_heading"* ]]; then
+    record_fail "$id (unexpected diagnostic '$forbidden_heading': $HOOK_OUTPUT)"
+  else
+    record_pass "$id (hook rc=$HOOK_RC, diagnostic selected)"
+  fi
+}
+
+assert_hook_silent() {
+  local id="$1"
+  local cwd="$2"
+  local command="$3"
+
+  run_hook "$cwd" "$command"
+  if [[ "$HOOK_RC" -eq 0 && -z "$HOOK_OUTPUT" ]]; then
+    record_pass "$id (hook rc=0, no diagnostic)"
+  else
+    record_fail "$id (expected hook rc=0/no output, got rc=$HOOK_RC: $HOOK_OUTPUT)"
+  fi
+}
+
+echo ""
+echo "=== TC-BCOW-016: blocked diagnostic selection ==="
+echo ""
+
+assert_hook_diagnostic \
+  "TC-BCOW-016a bare main-workspace commit uses worktree diagnostic" \
+  "$REPO_A" 'git commit -m main' "$WORKTREE_HEADING" "$UNVERIFIED_HEADING"
+assert_hook_diagnostic \
+  "TC-BCOW-016b explicit main-workspace commit uses worktree diagnostic" \
+  "$REPO_A" "git -C $REPO_A commit -m main" \
+  "$WORKTREE_HEADING" "$UNVERIFIED_HEADING"
+assert_hook_diagnostic \
+  "TC-BCOW-016c linked caller targeting main uses worktree diagnostic" \
+  "$REPO_A_LINKED" "git -C $REPO_A commit -m main" \
+  "$WORKTREE_HEADING" "$UNVERIFIED_HEADING"
+# shellcheck disable=SC2016 # The hook must receive the variable reference literally.
+assert_hook_diagnostic \
+  "TC-BCOW-016d variable target uses unable-to-verify diagnostic" \
+  "$REPO_A" 'git -C "$TARGET_REPO" commit -m variable' \
+  "$UNVERIFIED_HEADING" "$WORKTREE_HEADING"
+# shellcheck disable=SC2016 # The hook must receive the variable reference literally.
+assert_hook_diagnostic \
+  "TC-BCOW-016e linked caller with variable target uses unable-to-verify diagnostic" \
+  "$REPO_A_LINKED" 'git -C "$TARGET_REPO" commit -m variable' \
+  "$UNVERIFIED_HEADING" "$WORKTREE_HEADING"
+assert_hook_diagnostic \
+  "TC-BCOW-016f missing literal target uses unable-to-verify diagnostic" \
+  "$REPO_A" "git -C $MISSING commit -m missing" \
+  "$UNVERIFIED_HEADING" "$WORKTREE_HEADING"
+assert_hook_diagnostic \
+  "TC-BCOW-016g existing non-git target uses unable-to-verify diagnostic" \
+  "$REPO_A" "git -C $NON_GIT commit -m non-git" \
+  "$UNVERIFIED_HEADING" "$WORKTREE_HEADING"
+assert_hook_silent \
+  "TC-BCOW-016h linked-worktree commit remains allowed without diagnostic" \
+  "$REPO_A_LINKED" 'git commit -m linked'
+assert_hook_silent \
+  "TC-BCOW-016i literal unrelated-repo commit remains allowed without diagnostic" \
+  "$REPO_A" "git -C $REPO_B commit -m unrelated"
+assert_hook_silent \
+  "TC-BCOW-016j non-commit command remains allowed without diagnostic" \
+  "$REPO_A" 'git status --short'
+assert_hook_silent \
+  "TC-BCOW-016k amend exemption remains allowed without diagnostic" \
+  "$REPO_A" 'git commit --amend --no-edit'
 
 echo ""
 echo "========================================"

--- a/tests/unit/test-block-commit-outside-worktree.sh
+++ b/tests/unit/test-block-commit-outside-worktree.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Regression coverage for issues #534 and #537 command-context resolution.
+# Regression coverage for issues #534, #537, and #548 command-context resolution.
 
 set -uo pipefail
 
@@ -22,6 +22,8 @@ LOGICAL_LINK="$REPO_A/link-to-b-subdir"
 DASH_REPO="$REPO_A/-"
 NON_GIT="$TMPROOT/not-a-repo"
 MISSING="$TMPROOT/missing-repo"
+GIT_DIR_FAIL_BIN="$TMPROOT/git-dir-fail-bin"
+REAL_GIT="$(command -v git)"
 
 trap 'rm -rf "$TMPROOT"' EXIT
 
@@ -44,6 +46,21 @@ init_repo() {
 }
 
 mkdir -p "$TEST_HOME" "$NON_GIT"
+mkdir -p "$GIT_DIR_FAIL_BIN"
+cat > "$GIT_DIR_FAIL_BIN/git" <<'EOF'
+#!/bin/bash
+is_rev_parse=false
+is_git_dir=false
+for arg in "$@"; do
+  [[ "$arg" == "rev-parse" ]] && is_rev_parse=true
+  [[ "$arg" == "--git-dir" ]] && is_git_dir=true
+done
+if [[ "$is_rev_parse" == true && "$is_git_dir" == true ]]; then
+  exit 1
+fi
+exec "$REAL_GIT" "$@"
+EOF
+chmod +x "$GIT_DIR_FAIL_BIN/git"
 init_repo "$REPO_A"
 init_repo "$REPO_B"
 init_repo "$REPO_BACKSLASH"
@@ -81,6 +98,21 @@ run_hook() {
   HOOK_OUTPUT=$(
     cd "$cwd" &&
       printf '%s' "$payload" | HOME="$TEST_HOME" bash "$HOOK" 2>&1
+  )
+  HOOK_RC=$?
+}
+
+run_hook_with_git_dir_probe_failure() {
+  local cwd="$1"
+  local command="$2"
+  local payload
+
+  payload=$(jq -cn --arg command "$command" '{tool_input:{command:$command}}')
+  HOOK_OUTPUT=$(
+    cd "$cwd" &&
+      printf '%s' "$payload" |
+        HOME="$TEST_HOME" REAL_GIT="$REAL_GIT" PATH="$GIT_DIR_FAIL_BIN:$PATH" \
+          bash "$HOOK" 2>&1
   )
   HOOK_RC=$?
 }
@@ -589,6 +621,37 @@ assert_hook_diagnostic() {
   fi
 }
 
+assert_hook_diagnostic_content() {
+  local id="$1"
+  local cwd="$2"
+  local command="$3"
+  local expected_heading="$4"
+  local forbidden_heading="$5"
+  local expected_text
+  shift 5
+
+  run_hook "$cwd" "$command"
+  if [[ "$HOOK_RC" -ne 2 ]]; then
+    record_fail "$id (expected hook rc=2, got $HOOK_RC: $HOOK_OUTPUT)"
+    return
+  fi
+  if [[ "$HOOK_OUTPUT" != *"$expected_heading"* ]]; then
+    record_fail "$id (missing diagnostic '$expected_heading': $HOOK_OUTPUT)"
+    return
+  fi
+  if [[ "$HOOK_OUTPUT" == *"$forbidden_heading"* ]]; then
+    record_fail "$id (unexpected diagnostic '$forbidden_heading': $HOOK_OUTPUT)"
+    return
+  fi
+  for expected_text in "$@"; do
+    if [[ "$HOOK_OUTPUT" != *"$expected_text"* ]]; then
+      record_fail "$id (missing remediation text '$expected_text': $HOOK_OUTPUT)"
+      return
+    fi
+  done
+  record_pass "$id (hook rc=$HOOK_RC, diagnostic and remediation selected)"
+}
+
 assert_hook_silent() {
   local id="$1"
   local cwd="$2"
@@ -618,35 +681,71 @@ assert_hook_diagnostic \
   "$REPO_A_LINKED" "git -C $REPO_A commit -m main" \
   "$WORKTREE_HEADING" "$UNVERIFIED_HEADING"
 # shellcheck disable=SC2016 # The hook must receive the variable reference literally.
-assert_hook_diagnostic \
+assert_hook_diagnostic_content \
   "TC-BCOW-016d variable target uses unable-to-verify diagnostic" \
   "$REPO_A" 'git -C "$TARGET_REPO" commit -m variable' \
-  "$UNVERIFIED_HEADING" "$WORKTREE_HEADING"
+  "$UNVERIFIED_HEADING" "$WORKTREE_HEADING" \
+  "could not statically verify the repository and worktree context without executing the command" \
+  "git -C /absolute/path/to/repo commit -F /path/to/message" \
+  "cd /absolute/path/to/repo && git commit -F /path/to/message" \
+  "Variables, substitutions, wrappers, pipelines, and multiple commit invocations are unsupported as repository evidence" \
+  'bare `git add ... && git commit ...`' \
+  "Missing paths and non-Git directories cannot be verified" \
+  "create or switch to a linked worktree"
 # shellcheck disable=SC2016 # The hook must receive the variable reference literally.
+assert_hook_silent \
+  "TC-BCOW-016e linked caller with variable target preserves fallback allow" \
+  "$REPO_A_LINKED" 'git -C "$TARGET_REPO" commit -m variable'
+assert_hook_silent \
+  "TC-BCOW-016f linked caller with compound commit preserves fallback allow" \
+  "$REPO_A_LINKED" 'git add -A && git commit -m linked'
 assert_hook_diagnostic \
-  "TC-BCOW-016e linked caller with variable target uses unable-to-verify diagnostic" \
-  "$REPO_A_LINKED" 'git -C "$TARGET_REPO" commit -m variable' \
-  "$UNVERIFIED_HEADING" "$WORKTREE_HEADING"
-assert_hook_diagnostic \
-  "TC-BCOW-016f missing literal target uses unable-to-verify diagnostic" \
+  "TC-BCOW-016g missing literal target uses unable-to-verify diagnostic" \
   "$REPO_A" "git -C $MISSING commit -m missing" \
   "$UNVERIFIED_HEADING" "$WORKTREE_HEADING"
 assert_hook_diagnostic \
-  "TC-BCOW-016g existing non-git target uses unable-to-verify diagnostic" \
+  "TC-BCOW-016h existing non-git target uses unable-to-verify diagnostic" \
   "$REPO_A" "git -C $NON_GIT commit -m non-git" \
   "$UNVERIFIED_HEADING" "$WORKTREE_HEADING"
 assert_hook_silent \
-  "TC-BCOW-016h linked-worktree commit remains allowed without diagnostic" \
+  "TC-BCOW-016i linked-worktree commit remains allowed without diagnostic" \
   "$REPO_A_LINKED" 'git commit -m linked'
 assert_hook_silent \
-  "TC-BCOW-016i literal unrelated-repo commit remains allowed without diagnostic" \
+  "TC-BCOW-016j literal unrelated-repo commit remains allowed without diagnostic" \
   "$REPO_A" "git -C $REPO_B commit -m unrelated"
 assert_hook_silent \
-  "TC-BCOW-016j non-commit command remains allowed without diagnostic" \
+  "TC-BCOW-016k non-commit command remains allowed without diagnostic" \
   "$REPO_A" 'git status --short'
 assert_hook_silent \
-  "TC-BCOW-016k amend exemption remains allowed without diagnostic" \
+  "TC-BCOW-016l amend exemption remains allowed without diagnostic" \
   "$REPO_A" 'git commit --amend --no-edit'
+assert_hook_diagnostic \
+  "TC-BCOW-016m unreadable installing-repository identity uses unable-to-verify diagnostic" \
+  "$NON_GIT" "git -C $REPO_A commit -m outside" \
+  "$UNVERIFIED_HEADING" "$WORKTREE_HEADING"
+run_hook_with_git_dir_probe_failure "$REPO_A" 'git commit -m probe-failure'
+if [[ "$HOOK_RC" -ne 2 ]]; then
+  record_fail \
+    "TC-BCOW-016n git-dir probe failure (expected hook rc=2, got $HOOK_RC: $HOOK_OUTPUT)"
+elif [[ "$HOOK_OUTPUT" != *"$UNVERIFIED_HEADING"* ]]; then
+  record_fail \
+    "TC-BCOW-016n git-dir probe failure (missing diagnostic '$UNVERIFIED_HEADING': $HOOK_OUTPUT)"
+elif [[ "$HOOK_OUTPUT" == *"$WORKTREE_HEADING"* ]]; then
+  record_fail \
+    "TC-BCOW-016n git-dir probe failure (unexpected diagnostic '$WORKTREE_HEADING': $HOOK_OUTPUT)"
+else
+  record_pass "TC-BCOW-016n git-dir probe failure uses unable-to-verify diagnostic"
+fi
+assert_hook_diagnostic \
+  "TC-BCOW-016o main caller with compound commit uses unable-to-verify diagnostic" \
+  "$REPO_A" 'git add -A && git commit -m main' \
+  "$UNVERIFIED_HEADING" "$WORKTREE_HEADING"
+assert_hook_silent \
+  "TC-BCOW-016p linked caller with missing target preserves fallback allow" \
+  "$REPO_A_LINKED" "git -C $MISSING commit -m missing"
+assert_hook_silent \
+  "TC-BCOW-016q linked caller with non-git target preserves fallback allow" \
+  "$REPO_A_LINKED" "git -C $NON_GIT commit -m non-git"
 
 echo ""
 echo "========================================"


### PR DESCRIPTION
## Summary

- distinguish unresolved or unprobeable commit targets from positively verified main-workspace violations
- preserve every existing allow/deny result, including inherited-cwd allows for uncertain commands issued from linked worktrees
- document the diagnostic contract and pin headings, remediation text, fallback parity, and repository-probe failures

## Pipeline Docs (CONTRIBUTING.md Rule 1)

- [x] If this PR touches a watched path (any `skills/autonomous-*/scripts/*.sh`, `skills/autonomous-common/hooks/*.sh`, or `skills/autonomous-*/SKILL.md`), I have updated `docs/pipeline/` to match the new behavior.

## Test Plan

- [x] `TMPDIR=/data/tmp/issue548 bash tests/unit/test-block-commit-outside-worktree.sh` (205 passed)
- [x] `TMPDIR=/data/tmp/issue548 bash tests/unit/test-is-git-command-non-executable-regions.sh` (175 passed)
- [x] Bash syntax, ShellCheck error-level checks, and `git diff --check`
- [x] Independent Opus 5 review reports no blocking findings
- [x] CI checks pass on current HEAD

The full parallel unit runner was not repeated after the review follow-up because unrelated tests hardcode the inode-exhausted shared `/tmp` filesystem. The focused suites run under `/data/tmp`, and GitHub CI provides the hermetic full-suite gate.

## Linked Issues

Closes #548

